### PR TITLE
fix(test): Make WithSpringProfile extendable and other fixes

### DIFF
--- a/qa/src/test/java/io/camunda/migrator/qa/runtime/variables/YamlVariableInterceptorTest.java
+++ b/qa/src/test/java/io/camunda/migrator/qa/runtime/variables/YamlVariableInterceptorTest.java
@@ -15,6 +15,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.camunda.migrator.config.property.MigratorProperties;
 import io.camunda.migrator.interceptor.VariableInterceptor;
 import io.camunda.migrator.qa.runtime.RuntimeMigrationAbstractTest;
+import io.camunda.migrator.qa.util.WithSpringProfile;
 import io.camunda.process.test.api.CamundaAssert;
 import java.util.List;
 import java.util.regex.Matcher;
@@ -22,14 +23,11 @@ import java.util.regex.Pattern;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.system.CapturedOutput;
 import org.springframework.boot.test.system.OutputCaptureExtension;
-import org.springframework.test.context.ActiveProfiles;
 
 @ExtendWith(OutputCaptureExtension.class)
-@ActiveProfiles("interceptor-test")
-@SpringBootTest
+@WithSpringProfile("interceptor-test")
 public class YamlVariableInterceptorTest extends RuntimeMigrationAbstractTest {
 
   @Autowired

--- a/qa/src/test/java/io/camunda/migrator/qa/util/MultiDbExtension.java
+++ b/qa/src/test/java/io/camunda/migrator/qa/util/MultiDbExtension.java
@@ -34,11 +34,12 @@ public class MultiDbExtension implements BeforeAllCallback {
   }
 
   protected static void startContainer() {
-    String activeProfile = System.getProperty("spring.profiles.active", "");
-    LOGGER.info("Running tests with spring profile [{}]", activeProfile);
-    JdbcDatabaseContainer<?> container = containers.get(activeProfile);
+    List<String> activeProfiles = SpringProfileResolver.getActiveProfiles();
+    String dbProfile = activeProfiles.stream().filter(containers.keySet()::contains).findFirst().orElse("default");
+    LOGGER.info("Running tests with DB profile [{}]", dbProfile);
+    JdbcDatabaseContainer<?> container = containers.get(dbProfile);
     if (container != null) {
-      LOGGER.info("Starting container [{}]", activeProfile);
+      LOGGER.info("Starting container [{}]", dbProfile);
       container.start();
     }
   }

--- a/qa/src/test/java/io/camunda/migrator/qa/util/SpringProfileResolver.java
+++ b/qa/src/test/java/io/camunda/migrator/qa/util/SpringProfileResolver.java
@@ -8,8 +8,11 @@
 package io.camunda.migrator.qa.util;
 
 import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.jetbrains.annotations.NotNull;
-import org.junit.platform.commons.util.AnnotationUtils;
+import org.springframework.core.annotation.AnnotatedElementUtils;
 import org.springframework.test.context.ActiveProfilesResolver;
 
 /**
@@ -19,10 +22,15 @@ public final class SpringProfileResolver implements ActiveProfilesResolver {
 
   @Override
   public String @NotNull [] resolve(@NotNull Class<?> testClass) {
-    WithSpringProfile annotation = AnnotationUtils.findAnnotation(testClass, WithSpringProfile.class).orElse(null);
-    String activeProfiles = System.getProperty("spring.profiles.active", "");
-    String profile = annotation == null ? "" : annotation.value();
-    activeProfiles = activeProfiles + "," + profile;
-    return Arrays.stream(activeProfiles.split("\\s*,\\s*")).toArray(String[]::new);
+    var activeProfiles = getActiveProfiles();
+    var annotatedProfiles = AnnotatedElementUtils.findAllMergedAnnotations(testClass, WithSpringProfile.class).stream().map(WithSpringProfile::value).collect(Collectors.toSet());
+    return Stream.concat(activeProfiles.stream(), annotatedProfiles.stream()).distinct().toArray(String[]::new);
+  }
+
+  public static @NotNull List<String> getActiveProfiles() {
+    return Arrays.stream(System.getProperty("spring.profiles.active", "")
+        .split("\\s*,\\s*"))
+        .filter(s -> !s.isBlank())
+        .toList();
   }
 }

--- a/qa/src/test/java/io/camunda/migrator/qa/util/WithSpringProfile.java
+++ b/qa/src/test/java/io/camunda/migrator/qa/util/WithSpringProfile.java
@@ -21,4 +21,5 @@ import org.springframework.test.context.ActiveProfiles;
 public @interface WithSpringProfile {
 
   String value();
+
 }


### PR DESCRIPTION
Related to https://github.com/camunda/camunda-bpm-platform/issues/5262

Allow a class annotated with `@WithSpringProfile` to extend a class also annotated with `@WithSpringProfile` by merging the two profiles.