### PR TITLE
fix(core): refactor DB queries to select / update by id & type

### DIFF
--- a/core/src/main/java/io/camunda/migrator/HistoryMigrator.java
+++ b/core/src/main/java/io/camunda/migrator/HistoryMigrator.java
@@ -532,7 +532,7 @@ public class HistoryMigrator {
   }
 
   private boolean shouldMigrate(String id, IdKeyMapper.TYPE type) {
-     if (mode == RETRY_SKIPPED) {
+    if (mode == RETRY_SKIPPED) {
       return !dbClient.checkHasKeyByIdAndType(id, type);
     }
     return !dbClient.checkExistsByIdAndType(id, type);

--- a/core/src/main/java/io/camunda/migrator/HistoryMigrator.java
+++ b/core/src/main/java/io/camunda/migrator/HistoryMigrator.java
@@ -219,7 +219,7 @@ public class HistoryMigrator {
       Long processDefinitionKey = findProcessDefinitionKey(legacyProcessInstance.getProcessDefinitionId());
       String processDefinitionId = legacyProcessInstance.getProcessDefinitionId();
 
-      if(isMigrated(processDefinitionId, HISTORY_PROCESS_DEFINITION)) {
+      if (isMigrated(processDefinitionId, HISTORY_PROCESS_DEFINITION)) {
         String legacySuperProcessInstanceId = legacyProcessInstance.getSuperProcessInstanceId();
         Long parentProcessInstanceKey = null;
         if (legacySuperProcessInstanceId != null) {

--- a/core/src/main/java/io/camunda/migrator/HistoryMigrator.java
+++ b/core/src/main/java/io/camunda/migrator/HistoryMigrator.java
@@ -540,7 +540,7 @@ public class HistoryMigrator {
 
   protected void saveRecord(String entityId, Long entityKey, IdKeyMapper.TYPE type) {
     if (RETRY_SKIPPED.equals(mode)) {
-      dbClient.updateKeyById(entityId, entityKey, type);
+      dbClient.updateKeyByIdAndType(entityId, entityKey, type);
     } else if (MIGRATE.equals(mode)) {
       dbClient.insert(entityId, entityKey, type);
     }
@@ -548,7 +548,7 @@ public class HistoryMigrator {
 
   protected void saveRecord(String entityId, Date date, Long entityKey, IdKeyMapper.TYPE type) {
     if (RETRY_SKIPPED.equals(mode)) {
-      dbClient.updateKeyById(entityId, date, entityKey, type);
+      dbClient.updateKeyByIdAndType(entityId, entityKey, type);
     } else if (MIGRATE.equals(mode)) {
       dbClient.insert(entityId, date, entityKey, type);
     }

--- a/core/src/main/java/io/camunda/migrator/HistoryMigrator.java
+++ b/core/src/main/java/io/camunda/migrator/HistoryMigrator.java
@@ -290,7 +290,7 @@ public class HistoryMigrator {
       Long decisionRequirementsKey = null;
 
       if (legacyDecisionDefinition.getDecisionRequirementsDefinitionId() != null) {
-        decisionRequirementsKey = dbClient.findKeyById(legacyDecisionDefinition.getDecisionRequirementsDefinitionId());
+        decisionRequirementsKey = dbClient.findKeyByIdAndType(legacyDecisionDefinition.getDecisionRequirementsDefinitionId(), HISTORY_DECISION_REQUIREMENTS);
 
         if (decisionRequirementsKey == null) {
           saveRecord(legacyId, null, HISTORY_DECISION_DEFINITION);
@@ -471,7 +471,7 @@ public class HistoryMigrator {
     if (processInstanceId == null)
       return null;
 
-    Long key = dbClient.findKeyById(processInstanceId);
+    Long key = dbClient.findKeyByIdAndType(processInstanceId, HISTORY_PROCESS_INSTANCE);
     if (key == null) {
       return null;
     }
@@ -480,7 +480,7 @@ public class HistoryMigrator {
   }
 
   private Long findProcessDefinitionKey(String processDefinitionId) {
-    Long key = dbClient.findKeyById(processDefinitionId);
+    Long key = dbClient.findKeyByIdAndType(processDefinitionId, HISTORY_PROCESS_DEFINITION);
     if (key == null) {
       return null;
     }
@@ -496,7 +496,7 @@ public class HistoryMigrator {
   }
 
   private Long findFlowNodeKey(String activityId, String processInstanceId) {
-    Long key = dbClient.findKeyById(processInstanceId);
+    Long key = dbClient.findKeyByIdAndType(processInstanceId, HISTORY_PROCESS_INSTANCE);
     if (key == null) {
       return null;
     }
@@ -512,7 +512,7 @@ public class HistoryMigrator {
   }
 
   private Long findFlowNodeKey(String activityInstanceId) {
-    Long key = dbClient.findKeyById(activityInstanceId);
+    Long key = dbClient.findKeyByIdAndType(activityInstanceId, HISTORY_FLOW_NODE);
     if (key == null) {
       return null;
     }

--- a/core/src/main/java/io/camunda/migrator/RuntimeMigrator.java
+++ b/core/src/main/java/io/camunda/migrator/RuntimeMigrator.java
@@ -130,7 +130,7 @@ public class RuntimeMigrator {
 
   protected void saveRecord(String legacyProcessInstanceId, Date startDate, Long processInstanceKey) {
     if (RETRY_SKIPPED.equals(mode)) {
-      dbClient.updateKeyById(legacyProcessInstanceId, processInstanceKey, TYPE.RUNTIME_PROCESS_INSTANCE);
+      dbClient.updateKeyByIdAndType(legacyProcessInstanceId, processInstanceKey, TYPE.RUNTIME_PROCESS_INSTANCE);
     } else if (MIGRATE.equals(mode)) {
       dbClient.insert(legacyProcessInstanceId, startDate, processInstanceKey, TYPE.RUNTIME_PROCESS_INSTANCE);
     }

--- a/core/src/main/java/io/camunda/migrator/RuntimeMigrator.java
+++ b/core/src/main/java/io/camunda/migrator/RuntimeMigrator.java
@@ -10,6 +10,7 @@ package io.camunda.migrator;
 import static io.camunda.migrator.MigratorMode.LIST_SKIPPED;
 import static io.camunda.migrator.MigratorMode.MIGRATE;
 import static io.camunda.migrator.MigratorMode.RETRY_SKIPPED;
+import static io.camunda.migrator.impl.persistence.IdKeyMapper.TYPE.RUNTIME_PROCESS_INSTANCE;
 
 import io.camunda.migrator.impl.logging.RuntimeMigratorLogs;
 import static io.camunda.migrator.impl.persistence.IdKeyMapper.TYPE;
@@ -100,7 +101,7 @@ public class RuntimeMigrator {
   }
 
   protected boolean isUnknown(String legacyProcessInstanceId) {
-    return MIGRATE.equals(mode) && !dbClient.checkExists(legacyProcessInstanceId);
+    return MIGRATE.equals(mode) && !dbClient.checkExistsByIdAndType(legacyProcessInstanceId, RUNTIME_PROCESS_INSTANCE);
   }
 
   protected void startProcessInstance(String legacyProcessInstanceId, Date startDate) {

--- a/core/src/main/java/io/camunda/migrator/impl/clients/DbClient.java
+++ b/core/src/main/java/io/camunda/migrator/impl/clients/DbClient.java
@@ -79,10 +79,10 @@ public class DbClient {
   }
 
   /**
-   * Finds the key by legacy ID.
+   * Finds the key by legacy ID and type.
    */
-  public Long findKeyById(String legacyId) {
-    return callApi(() -> idKeyMapper.findKeyById(legacyId), FAILED_TO_FIND_KEY_BY_ID + legacyId);
+  public Long findKeyByIdAndType(String legacyId, TYPE type) {
+    return callApi(() -> idKeyMapper.findKeysByIdAndType(legacyId, type), FAILED_TO_FIND_KEY_BY_ID + legacyId);
   }
 
   /**

--- a/core/src/main/java/io/camunda/migrator/impl/clients/DbClient.java
+++ b/core/src/main/java/io/camunda/migrator/impl/clients/DbClient.java
@@ -14,12 +14,12 @@ import static io.camunda.migrator.impl.logging.DbClientLogs.FAILED_TO_FIND_ALL;
 import static io.camunda.migrator.impl.logging.DbClientLogs.FAILED_TO_FIND_ALL_SKIPPED;
 import static io.camunda.migrator.impl.logging.DbClientLogs.FAILED_TO_FIND_KEY_BY_ID;
 import static io.camunda.migrator.impl.logging.DbClientLogs.FAILED_TO_FIND_LATEST_ID;
+import static io.camunda.migrator.impl.util.ExceptionUtils.callApi;
 import static io.camunda.migrator.impl.logging.DbClientLogs.FAILED_TO_FIND_LATEST_START_DATE;
 import static io.camunda.migrator.impl.logging.DbClientLogs.FAILED_TO_FIND_SKIPPED_COUNT;
 import static io.camunda.migrator.impl.logging.DbClientLogs.FAILED_TO_INSERT_RECORD;
 import static io.camunda.migrator.impl.logging.DbClientLogs.FAILED_TO_UPDATE_KEY;
 import static io.camunda.migrator.impl.persistence.IdKeyMapper.TYPE;
-import static io.camunda.migrator.impl.util.ExceptionUtils.callApi;
 
 import io.camunda.migrator.config.property.MigratorProperties;
 import io.camunda.migrator.impl.Pagination;
@@ -55,10 +55,24 @@ public class DbClient {
   }
 
   /**
-   * Checks if a process instance exists in the mapping table.
+   * Checks if an entity exists in the mapping table by type and id.
+   */
+  public boolean checkExistsByIdAndType(String legacyId, TYPE type) {
+    return callApi(() -> idKeyMapper.checkExistsByIdAndType(type, legacyId), FAILED_TO_CHECK_EXISTENCE + legacyId);
+  }
+
+  /**
+   * Checks if an entity exists in the mapping table.
    */
   public boolean checkHasKey(String legacyId) {
     return callApi(() -> idKeyMapper.checkHasKey(legacyId), FAILED_TO_CHECK_KEY + legacyId);
+  }
+
+  /**
+   * Checks if an entity exists in the mapping table by type and id.
+   */
+  public boolean checkHasKeyByIdAndType(String legacyId, TYPE type) {
+    return callApi(() -> idKeyMapper.checkHasKeyByIdAndType(type, legacyId), FAILED_TO_CHECK_KEY + legacyId);
   }
 
   /**

--- a/core/src/main/java/io/camunda/migrator/impl/clients/DbClient.java
+++ b/core/src/main/java/io/camunda/migrator/impl/clients/DbClient.java
@@ -14,12 +14,12 @@ import static io.camunda.migrator.impl.logging.DbClientLogs.FAILED_TO_FIND_ALL;
 import static io.camunda.migrator.impl.logging.DbClientLogs.FAILED_TO_FIND_ALL_SKIPPED;
 import static io.camunda.migrator.impl.logging.DbClientLogs.FAILED_TO_FIND_KEY_BY_ID;
 import static io.camunda.migrator.impl.logging.DbClientLogs.FAILED_TO_FIND_LATEST_ID;
-import static io.camunda.migrator.impl.util.ExceptionUtils.callApi;
 import static io.camunda.migrator.impl.logging.DbClientLogs.FAILED_TO_FIND_LATEST_START_DATE;
 import static io.camunda.migrator.impl.logging.DbClientLogs.FAILED_TO_FIND_SKIPPED_COUNT;
 import static io.camunda.migrator.impl.logging.DbClientLogs.FAILED_TO_INSERT_RECORD;
 import static io.camunda.migrator.impl.logging.DbClientLogs.FAILED_TO_UPDATE_KEY;
 import static io.camunda.migrator.impl.persistence.IdKeyMapper.TYPE;
+import static io.camunda.migrator.impl.util.ExceptionUtils.callApi;
 
 import io.camunda.migrator.config.property.MigratorProperties;
 import io.camunda.migrator.impl.Pagination;

--- a/core/src/main/java/io/camunda/migrator/impl/clients/DbClient.java
+++ b/core/src/main/java/io/camunda/migrator/impl/clients/DbClient.java
@@ -48,24 +48,10 @@ public class DbClient {
   protected IdKeyMapper idKeyMapper;
 
   /**
-   * Checks if a process instance exists in the mapping table.
-   */
-  public boolean checkExists(String legacyEntityId) {
-    return callApi(() -> idKeyMapper.checkExists(legacyEntityId), FAILED_TO_CHECK_EXISTENCE + legacyEntityId);
-  }
-
-  /**
    * Checks if an entity exists in the mapping table by type and id.
    */
   public boolean checkExistsByIdAndType(String legacyId, TYPE type) {
     return callApi(() -> idKeyMapper.checkExistsByIdAndType(type, legacyId), FAILED_TO_CHECK_EXISTENCE + legacyId);
-  }
-
-  /**
-   * Checks if an entity exists in the mapping table.
-   */
-  public boolean checkHasKey(String legacyId) {
-    return callApi(() -> idKeyMapper.checkHasKey(legacyId), FAILED_TO_CHECK_KEY + legacyId);
   }
 
   /**

--- a/core/src/main/java/io/camunda/migrator/impl/clients/DbClient.java
+++ b/core/src/main/java/io/camunda/migrator/impl/clients/DbClient.java
@@ -93,21 +93,12 @@ public class DbClient {
   }
 
   /**
-   * Updates a record by setting the key for an existing ID.
+   * Updates a record by setting the key for an existing ID and type.
    */
-  public void updateKeyById(String legacyId, Long entityKey, TYPE type) {
+  public void updateKeyByIdAndType(String legacyId, Long entityKey, TYPE type) {
     DbClientLogs.updatingKeyForLegacyId(legacyId, entityKey);
     var model = createIdKeyDbModel(legacyId, null, entityKey, type);
-    callApi(() -> idKeyMapper.updateKeyById(model), FAILED_TO_UPDATE_KEY + entityKey);
-  }
-
-  /**
-   * Updates a record by setting the key for an existing ID.
-   */
-  public void updateKeyById(String legacyId, Date startDate, Long entityKey, TYPE type) {
-    DbClientLogs.updatingKeyForLegacyId(legacyId, entityKey);
-    var model = createIdKeyDbModel(legacyId, startDate, entityKey, type);
-    callApi(() -> idKeyMapper.updateKeyById(model), FAILED_TO_UPDATE_KEY + entityKey);
+    callApi(() -> idKeyMapper.updateKeyByIdAndType(model), FAILED_TO_UPDATE_KEY + entityKey);
   }
 
   /**

--- a/core/src/main/java/io/camunda/migrator/impl/persistence/IdKeyMapper.java
+++ b/core/src/main/java/io/camunda/migrator/impl/persistence/IdKeyMapper.java
@@ -39,11 +39,7 @@ public interface IdKeyMapper {
 
   String findLatestIdByType(TYPE type);
 
-  boolean checkExists(String id);
-
   boolean checkExistsByIdAndType(@Param("type") TYPE type, @Param("id") String id);
-
-  boolean checkHasKey(String id);
 
   boolean checkHasKeyByIdAndType(@Param("type") TYPE type, @Param("id") String id);
 

--- a/core/src/main/java/io/camunda/migrator/impl/persistence/IdKeyMapper.java
+++ b/core/src/main/java/io/camunda/migrator/impl/persistence/IdKeyMapper.java
@@ -57,7 +57,7 @@ public interface IdKeyMapper {
 
   List<String> findAllIds();
 
-  void updateKeyById(IdKeyDbModel idKeyDbModel);
+  void updateKeyByIdAndType(IdKeyDbModel idKeyDbModel);
 
   void delete(String id);
 }

--- a/core/src/main/java/io/camunda/migrator/impl/persistence/IdKeyMapper.java
+++ b/core/src/main/java/io/camunda/migrator/impl/persistence/IdKeyMapper.java
@@ -45,7 +45,7 @@ public interface IdKeyMapper {
 
   Date findLatestStartDateByType(TYPE type);
 
-  Long findKeyById(String id);
+  Long findKeysByIdAndType(@Param("id") String id, @Param("type") TYPE type);
 
   void insert(IdKeyDbModel idKeyDbModel);
 

--- a/core/src/main/java/io/camunda/migrator/impl/persistence/IdKeyMapper.java
+++ b/core/src/main/java/io/camunda/migrator/impl/persistence/IdKeyMapper.java
@@ -41,7 +41,11 @@ public interface IdKeyMapper {
 
   boolean checkExists(String id);
 
+  boolean checkExistsByIdAndType(@Param("type") TYPE type, @Param("id") String id);
+
   boolean checkHasKey(String id);
+
+  boolean checkHasKeyByIdAndType(@Param("type") TYPE type, @Param("id") String id);
 
   Date findLatestStartDateByType(TYPE type);
 

--- a/core/src/main/resources/db/changelog/migrator/db.0.0.1.xml
+++ b/core/src/main/resources/db/changelog/migrator/db.0.0.1.xml
@@ -15,12 +15,18 @@
   <changeSet id="create_migration_mapping_table" author="Camunda">
     <createTable tableName="${prefix}MIGRATION_MAPPING">
       <column name="ID" type="VARCHAR(64)">
-        <constraints primaryKey="true"/>
+        <constraints nullable="false"/>
       </column>
       <column name="INSTANCE_KEY" type="BIGINT" />
-      <column name="TYPE" type="VARCHAR(255)" />
+      <column name="TYPE" type="VARCHAR(255)">
+        <constraints nullable="false"/>
+      </column>
       <column name="START_DATE" type="TIMESTAMP WITH TIME ZONE(3)" />
     </createTable>
+
+    <addPrimaryKey tableName="${prefix}MIGRATION_MAPPING"
+                  columnNames="ID, TYPE"
+                  constraintName="${prefix}PK_MIGRATION_MAPPING"/>
 
     <createIndex tableName="${prefix}MIGRATION_MAPPING" indexName="${prefix}IDX_MIGRATION_MAPPING_INSTANCE_KEY">
       <column name="INSTANCE_KEY" />

--- a/core/src/main/resources/mapper/IdKey.xml
+++ b/core/src/main/resources/mapper/IdKey.xml
@@ -75,8 +75,9 @@
     <include refid="io.camunda.migrator.Commons.singleResultSql"/>
   </select>
 
-  <select id="findKeyById" parameterType="java.lang.String">
-    SELECT INSTANCE_KEY FROM ${prefix}MIGRATION_MAPPING WHERE ID = #{id}
+  <select id="findKeysByIdAndType" resultType="java.lang.Long">
+    SELECT INSTANCE_KEY FROM ${prefix}MIGRATION_MAPPING
+    WHERE ID = #{id, jdbcType=VARCHAR} AND TYPE = #{type, jdbcType=VARCHAR}
     <include refid="io.camunda.migrator.Commons.singleResultSql"/>
   </select>
 

--- a/core/src/main/resources/mapper/IdKey.xml
+++ b/core/src/main/resources/mapper/IdKey.xml
@@ -43,10 +43,10 @@
     FROM ${prefix}MIGRATION_MAPPING
   </select>
 
-  <update id="updateKeyById" parameterType="io.camunda.migrator.impl.persistence.IdKeyDbModel">
+  <update id="updateKeyByIdAndType" parameterType="io.camunda.migrator.impl.persistence.IdKeyDbModel">
     UPDATE ${prefix}MIGRATION_MAPPING
     SET INSTANCE_KEY = #{instanceKey, jdbcType=BIGINT}
-    WHERE ID = #{id, jdbcType=VARCHAR}
+    WHERE ID = #{id, jdbcType=VARCHAR} AND TYPE = #{type, jdbcType=VARCHAR}
   </update>
 
   <select id="findLatestIdByType" parameterType="java.lang.String">

--- a/core/src/main/resources/mapper/IdKey.xml
+++ b/core/src/main/resources/mapper/IdKey.xml
@@ -61,10 +61,25 @@
     AND INSTANCE_KEY IS NOT NULL
   </select>
 
+  <select id="checkHasKeyByIdAndType" resultType="boolean">
+    SELECT CASE WHEN COUNT(*) > 0 THEN TRUE ELSE FALSE END
+    FROM ${prefix}MIGRATION_MAPPING
+    WHERE ID = #{id, jdbcType=VARCHAR}
+    AND TYPE = #{type, jdbcType=VARCHAR}
+    AND INSTANCE_KEY IS NOT NULL
+  </select>
+
   <select id="checkExists" resultType="boolean" parameterType="java.lang.String">
     SELECT CASE WHEN COUNT(*) > 0 THEN TRUE ELSE FALSE END
     FROM ${prefix}MIGRATION_MAPPING
     WHERE ID = #{id, jdbcType=VARCHAR}
+  </select>
+
+  <select id="checkExistsByIdAndType" resultType="boolean">
+    SELECT CASE WHEN COUNT(*) > 0 THEN TRUE ELSE FALSE END
+    FROM ${prefix}MIGRATION_MAPPING
+    WHERE ID = #{id, jdbcType=VARCHAR}
+    AND TYPE = #{type, jdbcType=VARCHAR}
   </select>
 
   <select id="findLatestStartDateByType" parameterType="java.lang.String">

--- a/core/src/main/resources/mapper/IdKey.xml
+++ b/core/src/main/resources/mapper/IdKey.xml
@@ -54,25 +54,12 @@
     <include refid="io.camunda.migrator.Commons.singleResultSql"/>
   </select>
 
-  <select id="checkHasKey" resultType="boolean" parameterType="java.lang.String">
-    SELECT CASE WHEN COUNT(*) > 0 THEN TRUE ELSE FALSE END
-    FROM ${prefix}MIGRATION_MAPPING
-    WHERE ID = #{id, jdbcType=VARCHAR}
-    AND INSTANCE_KEY IS NOT NULL
-  </select>
-
   <select id="checkHasKeyByIdAndType" resultType="boolean">
     SELECT CASE WHEN COUNT(*) > 0 THEN TRUE ELSE FALSE END
     FROM ${prefix}MIGRATION_MAPPING
     WHERE ID = #{id, jdbcType=VARCHAR}
     AND TYPE = #{type, jdbcType=VARCHAR}
     AND INSTANCE_KEY IS NOT NULL
-  </select>
-
-  <select id="checkExists" resultType="boolean" parameterType="java.lang.String">
-    SELECT CASE WHEN COUNT(*) > 0 THEN TRUE ELSE FALSE END
-    FROM ${prefix}MIGRATION_MAPPING
-    WHERE ID = #{id, jdbcType=VARCHAR}
   </select>
 
   <select id="checkExistsByIdAndType" resultType="boolean">

--- a/qa/src/test/java/io/camunda/migrator/qa/history/HistoryMigrationRetryTest.java
+++ b/qa/src/test/java/io/camunda/migrator/qa/history/HistoryMigrationRetryTest.java
@@ -132,12 +132,12 @@ public class HistoryMigrationRetryTest extends HistoryMigrationAbstractTest {
     assertThat(searchHistoricVariables("userTaskVar").size()).isEqualTo(1);
 
     // and nothing marked as skipped
-    assertThat(dbClient.checkHasKey(procDefId)).isTrue();
-    assertThat(dbClient.checkHasKey(procInstId)).isTrue();
-    assertThat(dbClient.checkHasKey(actInstId)).isTrue();
-    assertThat(dbClient.checkHasKey(taskId)).isTrue();
-    assertThat(dbClient.checkHasKey(incidentId)).isTrue();
-    assertThat(dbClient.checkHasKey(varId)).isTrue();
+    assertThat(dbClient.checkHasKeyByIdAndType(procDefId, HISTORY_PROCESS_DEFINITION)).isTrue();
+    assertThat(dbClient.checkHasKeyByIdAndType(procInstId, HISTORY_PROCESS_INSTANCE)).isTrue();
+    assertThat(dbClient.checkHasKeyByIdAndType(actInstId, HISTORY_FLOW_NODE)).isTrue();
+    assertThat(dbClient.checkHasKeyByIdAndType(taskId, HISTORY_USER_TASK)).isTrue();
+    assertThat(dbClient.checkHasKeyByIdAndType(incidentId, HISTORY_INCIDENT)).isTrue();
+    assertThat(dbClient.checkHasKeyByIdAndType(varId, HISTORY_VARIABLE)).isTrue();
   }
 
   @Test
@@ -176,9 +176,9 @@ public class HistoryMigrationRetryTest extends HistoryMigrationAbstractTest {
     assertThat(processInstances.size()).isEqualTo(4);
 
     // and skipped entities are still skipped
-    assertThat(dbClient.checkHasKey(procInstId)).isFalse();
-    assertThat(dbClient.checkHasKey(actInstId)).isFalse();
-    assertThat(dbClient.checkHasKey(taskId)).isFalse();
+    assertThat(dbClient.checkHasKeyByIdAndType(procInstId, HISTORY_PROCESS_INSTANCE)).isFalse();
+    assertThat(dbClient.checkHasKeyByIdAndType(actInstId, HISTORY_FLOW_NODE)).isFalse();
+    assertThat(dbClient.checkHasKeyByIdAndType(taskId, HISTORY_USER_TASK)).isFalse();
   }
 
   private void executeAllJobsWithRetry() {

--- a/qa/src/test/java/io/camunda/migrator/qa/history/HistoryMigrationSkippingTest.java
+++ b/qa/src/test/java/io/camunda/migrator/qa/history/HistoryMigrationSkippingTest.java
@@ -397,4 +397,40 @@ public class HistoryMigrationSkippingTest extends HistoryMigrationAbstractTest {
     assertThat(searchHistoricDecisionDefinitions("simpleDmnWithReqs2Id")).isEmpty();
     assertThat(dbClient.countSkippedByType(IdKeyMapper.TYPE.HISTORY_DECISION_DEFINITION)).isEqualTo(2);
   }
+
+    @Test
+    public void shouldNotSkipTaskVariablesWhenEntityWithSameIdButDifferentTypeIsSkipped() {
+        // given state in c7
+        deployer.deployCamunda7Process("userTaskProcess.bpmn");
+        runtimeService.startProcessInstanceByKey("userTaskProcessId");
+
+        var taskId = taskService.createTaskQuery().singleResult().getId();
+
+        // Simulate ID collision by manually inserting a record with the same ID as the task
+        // but with a different type (HISTORY_INCIDENT)
+        dbClient.insert(taskId, null, IdKeyMapper.TYPE.HISTORY_INCIDENT);
+        // Verify the collision record exists before completing the task
+        assertThat(dbClient.checkExists(taskId)).as("Record with task ID should exist").isTrue();
+
+        // when history is migrated
+        historyMigrator.migrate();
+
+        // then
+        // 1. Process instance should be migrated
+        var historicProcesses = searchHistoricProcessInstances("userTaskProcessId");
+        assertThat(historicProcesses).hasSize(1);
+        var processInstanceKey = historicProcesses.getFirst().processInstanceKey();
+
+        // 2. User task should be migrated (not skipped due to ID collision with HISTORY_INCIDENT)
+        var userTasks = searchHistoricUserTasks(processInstanceKey);
+        assertThat(userTasks)
+            .as("User task should be migrated despite ID collision with HISTORY_INCIDENT")
+            .hasSize(1);
+        assertThat(userTasks.getFirst().elementId())
+            .as("User task should have correct id")
+            .isEqualTo("userTaskId");
+
+        // 3. Verify no skip messages in logs for the task
+        logs.assertDoesNotContain("Migration of legacy user task with id [" + taskId + "] skipped");
+    }
 }

--- a/qa/src/test/java/io/camunda/migrator/qa/history/HistoryMigrationSkippingTest.java
+++ b/qa/src/test/java/io/camunda/migrator/qa/history/HistoryMigrationSkippingTest.java
@@ -429,8 +429,5 @@ public class HistoryMigrationSkippingTest extends HistoryMigrationAbstractTest {
         assertThat(userTasks.getFirst().elementId())
             .as("User task should have correct id")
             .isEqualTo("userTaskId");
-
-        // 3. Verify no skip messages in logs for the task
-        logs.assertDoesNotContain("Migration of legacy user task with id [" + taskId + "] skipped");
     }
 }

--- a/qa/src/test/java/io/camunda/migrator/qa/history/HistoryMigrationSkippingTest.java
+++ b/qa/src/test/java/io/camunda/migrator/qa/history/HistoryMigrationSkippingTest.java
@@ -410,7 +410,7 @@ public class HistoryMigrationSkippingTest extends HistoryMigrationAbstractTest {
         // but with a different type (HISTORY_INCIDENT)
         dbClient.insert(taskId, null, IdKeyMapper.TYPE.HISTORY_INCIDENT);
         // Verify the collision record exists before completing the task
-        assertThat(dbClient.checkExists(taskId)).as("Record with task ID should exist").isTrue();
+        assertThat(dbClient.checkExistsByIdAndType(taskId, IdKeyMapper.TYPE.HISTORY_INCIDENT)).as("Record with task ID should exist").isTrue();
 
         // when history is migrated
         historyMigrator.migrate();

--- a/qa/src/test/java/io/camunda/migrator/qa/runtime/SkipAndRetryProcessInstancesTest.java
+++ b/qa/src/test/java/io/camunda/migrator/qa/runtime/SkipAndRetryProcessInstancesTest.java
@@ -178,7 +178,7 @@ class SkipAndRetryProcessInstancesTest extends RuntimeMigrationAbstractTest {
     assertThat(processInstance.getProcessDefinitionId()).isEqualTo(process.getProcessDefinitionKey());
 
     // and the key updated
-    assertThat(dbClient.findKeyById(process.getId())).isNotNull();
+    assertThat(dbClient.findKeyByIdAndType(process.getId(), IdKeyMapper.TYPE.RUNTIME_PROCESS_INSTANCE)).isNotNull();
 
     // and no additional skipping logs (still 1, not 2 matches)
     Assertions.assertThat(events.stream()
@@ -264,8 +264,9 @@ class SkipAndRetryProcessInstancesTest extends RuntimeMigrationAbstractTest {
     historyMigrator.start();
 
     // then verify history process instance was migrated
-    assertThat(dbClient.findKeyById(processInstanceId)).isNotNull();
     assertThat(dbClient.checkHasKeyByIdAndType(processInstanceId, IdKeyMapper.TYPE.HISTORY_PROCESS_INSTANCE)).isTrue();
+    // then verify runtime process instance was not yet migrated
+    assertThat(dbClient.checkHasKeyByIdAndType(processInstanceId, IdKeyMapper.TYPE.RUNTIME_PROCESS_INSTANCE)).isFalse();
 
     // when running runtime migration afterwards
     runtimeMigrator.start();

--- a/qa/src/test/java/io/camunda/migrator/qa/runtime/SkipAndRetryProcessInstancesTest.java
+++ b/qa/src/test/java/io/camunda/migrator/qa/runtime/SkipAndRetryProcessInstancesTest.java
@@ -16,6 +16,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.camunda.bpm.engine.impl.util.EnsureUtil.ensureTrue;
 
 import io.camunda.client.api.search.response.ProcessInstance;
+import io.camunda.migrator.HistoryMigrator;
 import io.camunda.migrator.RuntimeMigrator;
 import io.camunda.migrator.impl.persistence.IdKeyDbModel;
 import io.camunda.migrator.impl.persistence.IdKeyMapper;
@@ -50,7 +51,7 @@ class SkipAndRetryProcessInstancesTest extends RuntimeMigrationAbstractTest {
   private TaskService taskService;
 
   @Autowired
-  private io.camunda.migrator.HistoryMigrator historyMigrator;
+  private HistoryMigrator historyMigrator;
 
   @Test
   public void shouldSkipMultiInstanceProcessMigration() {


### PR DESCRIPTION
related to: camunda/camunda-bpm-platform/issues/5325

### Pull Request Overview
#### Reason of change:
- In C7 ids are unique per entity but ids can collide in the migration mapping table which stores records for multiple entity types. See [comment on issue](https://github.com/camunda/camunda-bpm-platform/issues/5325#issuecomment-3160972390).
#### Key Changes
- Database schema update: Modified primary key from single ID column to composite (ID, TYPE) primary key
- Query method refactoring: Updated all database operations to include type parameter alongside ID
- Test improvements: Added comprehensive tests for ID collision scenarios and type-specific operations