### PR TITLE
fix(exceptionUtils): clear context after migrator runs

### DIFF
--- a/core/src/main/java/io/camunda/migrator/HistoryMigrator.java
+++ b/core/src/main/java/io/camunda/migrator/HistoryMigrator.java
@@ -118,15 +118,19 @@ public class HistoryMigrator {
   protected MigratorMode mode = MIGRATE;
 
   public void start() {
-    if (LIST_SKIPPED.equals(mode)) {
-      // TODO: list entities
-    } else {
-      migrate();
+    try {
+      ExceptionUtils.setContext(ExceptionUtils.ExceptionContext.HISTORY);
+      if (LIST_SKIPPED.equals(mode)) {
+        // TODO: list entities
+      } else {
+        migrate();
+      }
+    } finally {
+      ExceptionUtils.clearContext();
     }
   }
 
   public void migrate() {
-    ExceptionUtils.setContext(ExceptionUtils.ExceptionContext.HISTORY);
     migrateProcessDefinitions();
     migrateProcessInstances();
     migrateFlowNodes();

--- a/core/src/main/java/io/camunda/migrator/RuntimeMigrator.java
+++ b/core/src/main/java/io/camunda/migrator/RuntimeMigrator.java
@@ -61,12 +61,16 @@ public class RuntimeMigrator {
   protected MigratorMode mode = MIGRATE;
 
   public void start() {
-    ExceptionUtils.setContext(ExceptionUtils.ExceptionContext.RUNTIME);
-    if (LIST_SKIPPED.equals(mode)) {
-      PrintUtils.printSkippedInstancesHeader(dbClient.countSkippedByType(TYPE.RUNTIME_PROCESS_INSTANCE));
-      dbClient.listSkippedRuntimeProcessInstances();
-    } else {
-      migrate();
+    try {
+      ExceptionUtils.setContext(ExceptionUtils.ExceptionContext.RUNTIME);
+      if (LIST_SKIPPED.equals(mode)) {
+        PrintUtils.printSkippedInstancesHeader(dbClient.countSkippedByType(TYPE.RUNTIME_PROCESS_INSTANCE));
+        dbClient.listSkippedRuntimeProcessInstances();
+      } else {
+        migrate();
+      }
+    } finally {
+      ExceptionUtils.clearContext();
     }
   }
 

--- a/core/src/main/java/io/camunda/migrator/impl/util/ExceptionUtils.java
+++ b/core/src/main/java/io/camunda/migrator/impl/util/ExceptionUtils.java
@@ -19,7 +19,7 @@ import org.slf4j.LoggerFactory;
 
 public class ExceptionUtils {
 
-  private static final ThreadLocal<ExceptionContext> EXCEPTION_CONTEXT = new ThreadLocal<>();
+  private static final ThreadLocal<ExceptionContext> EXCEPTION_CONTEXT = ThreadLocal.withInitial(() -> null);
 
   public enum ExceptionContext {
     RUNTIME,


### PR DESCRIPTION
related to[ #5308](https://github.com/camunda/camunda-bpm-platform/issues/5308#issuecomment-3150488391)

Follows up on PR comments from https://github.com/camunda/camunda-7-to-8-data-migrator/pull/153