### PR TITLE
(tests): make rdbms search methods more generic

### DIFF
--- a/qa/src/test/java/io/camunda/migrator/qa/history/HistoryMigrationAbstractTest.java
+++ b/qa/src/test/java/io/camunda/migrator/qa/history/HistoryMigrationAbstractTest.java
@@ -26,6 +26,12 @@ import io.camunda.search.entities.ProcessDefinitionEntity;
 import io.camunda.search.entities.ProcessInstanceEntity;
 import io.camunda.search.entities.UserTaskEntity;
 import io.camunda.search.entities.VariableEntity;
+import io.camunda.search.filter.FlowNodeInstanceFilter;
+import io.camunda.search.filter.IncidentFilter;
+import io.camunda.search.filter.ProcessDefinitionFilter;
+import io.camunda.search.filter.ProcessInstanceFilter;
+import io.camunda.search.filter.UserTaskFilter;
+import io.camunda.search.filter.VariableFilter;
 import io.camunda.search.query.FlowNodeInstanceQuery;
 import io.camunda.search.query.IncidentQuery;
 import io.camunda.search.query.ProcessDefinitionQuery;
@@ -78,51 +84,45 @@ public abstract class HistoryMigrationAbstractTest extends AbstractMigratorTest 
     rdbmsPurger.purgeRdbms();
   }
 
-  public List<ProcessDefinitionEntity> searchHistoricProcessDefinitions(String processDefinitionId) {
+  public List<ProcessDefinitionEntity> searchHistoricProcessDefinitions(ProcessDefinitionFilter.Builder filter) {
     return rdbmsService.getProcessDefinitionReader()
         .search(ProcessDefinitionQuery.of(queryBuilder ->
-            queryBuilder.filter(filterBuilder ->
-                filterBuilder.processDefinitionIds(processDefinitionId))))
+            queryBuilder.filter(filterBuilder -> filter)))
         .items();
   }
 
-  public List<ProcessInstanceEntity> searchHistoricProcessInstances(String processDefinitionId) {
+  public List<ProcessInstanceEntity> searchHistoricProcessInstances(ProcessInstanceFilter.Builder filter) {
     return rdbmsService.getProcessInstanceReader()
         .search(ProcessInstanceQuery.of(queryBuilder ->
-            queryBuilder.filter(filterBuilder ->
-                filterBuilder.processDefinitionIds(processDefinitionId))))
+            queryBuilder.filter(filterBuilder -> filter)))
         .items();
   }
 
-  public List<UserTaskEntity> searchHistoricUserTasks(long processInstanceKey) {
+  public List<UserTaskEntity> searchHistoricUserTasks(UserTaskFilter.Builder filter) {
     return rdbmsService.getUserTaskReader()
         .search(UserTaskQuery.of(queryBuilder ->
-            queryBuilder.filter(filterBuilder ->
-                filterBuilder.processInstanceKeys(processInstanceKey))))
+            queryBuilder.filter(filterBuilder -> filter)))
         .items();
   }
 
-  public List<FlowNodeInstanceEntity> searchHistoricFlowNodesForType(long processInstanceKey, FlowNodeInstanceEntity.FlowNodeType type) {
+  public List<FlowNodeInstanceEntity> searchHistoricFlowNodes(FlowNodeInstanceFilter.Builder filter) {
     return rdbmsService.getFlowNodeInstanceReader()
         .search(FlowNodeInstanceQuery.of(queryBuilder ->
-            queryBuilder.filter(filterBuilder ->
-                filterBuilder.processInstanceKeys(processInstanceKey).types(type))))
+            queryBuilder.filter(filterBuilder -> filter)))
         .items();
   }
 
-  public List<IncidentEntity> searchHistoricIncidents(String processDefinitionId) {
+  public List<IncidentEntity> searchHistoricIncidents(IncidentFilter.Builder filter) {
     return rdbmsService.getIncidentReader()
         .search(IncidentQuery.of(queryBuilder ->
-            queryBuilder.filter(filterBuilder ->
-                filterBuilder.processDefinitionIds(processDefinitionId))))
+            queryBuilder.filter(filterBuilder -> filter)))
         .items();
   }
 
-  public List<VariableEntity> searchHistoricVariables(String varName) {
+  public List<VariableEntity> searchHistoricVariables(VariableFilter.Builder filter) {
     return rdbmsService.getVariableReader()
         .search(VariableQuery.of(queryBuilder ->
-            queryBuilder.filter(filterBuilder ->
-                filterBuilder.names(varName))))
+            queryBuilder.filter(filterBuilder -> filter)))
         .items();
   }
 

--- a/qa/src/test/java/io/camunda/migrator/qa/history/HistoryMigrationRetryTest.java
+++ b/qa/src/test/java/io/camunda/migrator/qa/history/HistoryMigrationRetryTest.java
@@ -7,6 +7,11 @@
  */
 package io.camunda.migrator.qa.history;
 
+import static io.camunda.migrator.qa.util.FilterFactory.incFilter;
+import static io.camunda.migrator.qa.util.FilterFactory.procDefFilter;
+import static io.camunda.migrator.qa.util.FilterFactory.procInstFilter;
+import static io.camunda.migrator.qa.util.FilterFactory.userTasksFilter;
+import static io.camunda.migrator.qa.util.FilterFactory.varFilter;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.migrator.MigratorMode;
@@ -40,7 +45,7 @@ public class HistoryMigrationRetryTest extends HistoryMigrationAbstractTest {
         historyMigrator.migrate();
 
         // then process definition is migrated and no longer skipped
-        assertThat(searchHistoricProcessDefinitions("userTaskProcessId").size()).isEqualTo(1);
+        assertThat(searchHistoricProcessDefinitions(procDefFilter().processDefinitionIds("userTaskProcessId")).size()).isEqualTo(1);
         assertThat(dbClient.countSkippedByType(IdKeyMapper.TYPE.HISTORY_PROCESS_DEFINITION)).isEqualTo(0);
     }
 
@@ -74,12 +79,12 @@ public class HistoryMigrationRetryTest extends HistoryMigrationAbstractTest {
     historyMigrator.migrate();
 
     // then only previously skipped entities are migrated
-    assertThat(searchHistoricProcessDefinitions("allElementsProcessId").size()).isEqualTo(1);
-    List<ProcessInstanceEntity> processInstances = searchHistoricProcessInstances("allElementsProcessId");
+    assertThat(searchHistoricProcessDefinitions(procDefFilter().processDefinitionIds("allElementsProcessId")).size()).isEqualTo(1);
+    List<ProcessInstanceEntity> processInstances = searchHistoricProcessInstances(procInstFilter().processDefinitionIds("allElementsProcessId"));
     assertThat(processInstances.size()).isEqualTo(1);
-    assertThat(searchHistoricUserTasks(processInstances.getFirst().processInstanceKey()).size()).isEqualTo(1);
-    assertThat(searchHistoricIncidents("allElementsProcessId").size()).isEqualTo(1);
-    assertThat(searchHistoricVariables("userTaskVar").size()).isEqualTo(1);
+    assertThat(searchHistoricUserTasks(userTasksFilter().processInstanceKeys(processInstances.getFirst().processInstanceKey())).size()).isEqualTo(1);
+    assertThat(searchHistoricIncidents(incFilter().processDefinitionIds("allElementsProcessId")).size()).isEqualTo(1);
+    assertThat(searchHistoricVariables(varFilter().names("userTaskVar")).size()).isEqualTo(1);
 
     // and nothing marked as skipped
     assertThat(dbClient.checkHasKey(procDefId)).isTrue();
@@ -112,8 +117,8 @@ public class HistoryMigrationRetryTest extends HistoryMigrationAbstractTest {
         historyMigrator.migrate();
 
         // then only non skipped entities are migrated
-        assertThat(searchHistoricProcessDefinitions("userTaskProcessId").size()).isEqualTo(1);
-        List<ProcessInstanceEntity> processInstances = searchHistoricProcessInstances("userTaskProcessId");
+        assertThat(searchHistoricProcessDefinitions(procDefFilter().processDefinitionIds("userTaskProcessId")).size()).isEqualTo(1);
+        List<ProcessInstanceEntity> processInstances = searchHistoricProcessInstances(procInstFilter().processDefinitionIds("userTaskProcessId"));
         assertThat(processInstances.size()).isEqualTo(4);
 
         // and skipped entities are still skipped

--- a/qa/src/test/java/io/camunda/migrator/qa/history/HistoryTaskMigrationTest.java
+++ b/qa/src/test/java/io/camunda/migrator/qa/history/HistoryTaskMigrationTest.java
@@ -7,6 +7,9 @@
  */
 package io.camunda.migrator.qa.history;
 
+import static io.camunda.migrator.qa.util.FilterFactory.flowNodesFilter;
+import static io.camunda.migrator.qa.util.FilterFactory.procInstFilter;
+import static io.camunda.migrator.qa.util.FilterFactory.userTasksFilter;
 import static io.camunda.search.entities.FlowNodeInstanceEntity.FlowNodeType.END_EVENT;
 import static io.camunda.search.entities.FlowNodeInstanceEntity.FlowNodeType.START_EVENT;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -32,17 +35,17 @@ public class HistoryTaskMigrationTest extends HistoryMigrationAbstractTest {
     historyMigrator.migrate();
 
     // then expected number of historic process instances
-    List<ProcessInstanceEntity> processInstances = searchHistoricProcessInstances("userTaskProcessId");
+    List<ProcessInstanceEntity> processInstances = searchHistoricProcessInstances(procInstFilter().processDefinitionIds("userTaskProcessId"));
     assertThat(processInstances.size()).isEqualTo(5);
     for (ProcessInstanceEntity processInstance : processInstances) {
       // and process instance has expected state
       assertThat(processInstance.state()).isEqualTo(ProcessInstanceEntity.ProcessInstanceState.COMPLETED);
       Long processInstanceKey = processInstance.processInstanceKey();
-      List<UserTaskEntity> userTasks = searchHistoricUserTasks(processInstanceKey);
+      List<UserTaskEntity> userTasks = searchHistoricUserTasks(userTasksFilter().processInstanceKeys(processInstanceKey));
       assertThat(userTasks.size()).isEqualTo(1);
       assertThat(userTasks.getFirst().state()).isEqualTo(UserTaskEntity.UserTaskState.COMPLETED);
-      assertThat(searchHistoricFlowNodesForType(processInstanceKey, START_EVENT)).size().isEqualTo(1);
-      assertThat(searchHistoricFlowNodesForType(processInstanceKey, END_EVENT)).size().isEqualTo(1);
+      assertThat(searchHistoricFlowNodes(flowNodesFilter().processInstanceKeys(processInstanceKey).types(START_EVENT))).size().isEqualTo(1);
+      assertThat(searchHistoricFlowNodes(flowNodesFilter().processInstanceKeys(processInstanceKey).types(END_EVENT))).size().isEqualTo(1);
     }
   }
 }

--- a/qa/src/test/java/io/camunda/migrator/qa/util/FilterFactory.java
+++ b/qa/src/test/java/io/camunda/migrator/qa/util/FilterFactory.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.migrator.qa.util;
+
+import io.camunda.search.filter.FlowNodeInstanceFilter;
+import io.camunda.search.filter.IncidentFilter;
+import io.camunda.search.filter.ProcessDefinitionFilter;
+import io.camunda.search.filter.ProcessInstanceFilter;
+import io.camunda.search.filter.UserTaskFilter;
+import io.camunda.search.filter.VariableFilter;
+
+public class FilterFactory {
+
+  public static ProcessDefinitionFilter.Builder procDefFilter() {
+    return new ProcessDefinitionFilter.Builder();
+  }
+
+  public static ProcessInstanceFilter.Builder procInstFilter() {
+    return new ProcessInstanceFilter.Builder();
+  }
+
+  public static UserTaskFilter.Builder userTasksFilter() {
+    return new UserTaskFilter.Builder();
+  }
+
+  public static FlowNodeInstanceFilter.Builder flowNodesFilter() {
+    return new FlowNodeInstanceFilter.Builder();
+  }
+
+  public static IncidentFilter.Builder incFilter() {
+    return new IncidentFilter.Builder();
+  }
+
+  public static VariableFilter.Builder varFilter() {
+    return new VariableFilter.Builder();
+  }
+}


### PR DESCRIPTION
Related to https://github.com/camunda/camunda-bpm-platform/issues/5342

Make the search methods take a filter so tests can filter on anything they need, not only pre-determined criteria.