### PR TITLE
chore(project): disable javadoc warnings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -144,6 +144,13 @@
             <stagingProgressTimeoutMinutes>40</stagingProgressTimeoutMinutes>
           </configuration>
         </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-javadoc-plugin</artifactId>
+          <configuration>
+            <doclint>none</doclint>
+          </configuration>
+        </plugin>
       </plugins>
     </pluginManagement>
 


### PR DESCRIPTION
disable javadoc warnings that fail the release build
https://github.com/camunda/camunda-7-to-8-data-migrator/actions/runs/16876568269/job/47802420727

related to
https://github.com/camunda/camunda-bpm-platform/issues/5276