### PR TITLE
feat(history): migrate historic decision instance data

### DIFF
--- a/README.md
+++ b/README.md
@@ -568,7 +568,7 @@ When a process instance is skipped:
    - Ensure all active flow nodes in the C7 process have corresponding elements in the C8 process
    - Modify process instance to a supported state
 
-#### Limitations
+#### General Limitations
 
 - Multi-tenancy is currently not supported. I.e., a runtime process instance can only be migrated if it is not associated with a tenant.
   - See https://github.com/camunda/camunda-bpm-platform/issues/5315
@@ -688,6 +688,11 @@ When a process instance is skipped:
 - Tenant value `null` from Camunda 7 is migrated `<default>` in Camunda 8.
 Read more about tenant handling in Camunda 8 [here](https://docs.camunda.io/docs/self-managed/concepts/multi-tenancy/#the-tenant-identifier).
 All other tenantIds will be migrated as-is.
+- Decision Instance data
+  - the data migrator only migrates instances which are linked to process definition business rule tasks
+  - `evaluationFailure` and `evaluationFailureMessage` are not populated in migrated decision instances
+  - decision instance `inputs` an `outputs` are not yet migrated. This will be addressed with [issue #5364](https://github.com/camunda/camunda-bpm-platform/issues/5364)
+
 
 ## Troubleshooting
 

--- a/core/src/main/java/io/camunda/migrator/HistoryMigrator.java
+++ b/core/src/main/java/io/camunda/migrator/HistoryMigrator.java
@@ -11,6 +11,7 @@ import static io.camunda.migrator.MigratorMode.LIST_SKIPPED;
 import static io.camunda.migrator.MigratorMode.MIGRATE;
 import static io.camunda.migrator.MigratorMode.RETRY_SKIPPED;
 import static io.camunda.migrator.impl.persistence.IdKeyMapper.TYPE.HISTORY_DECISION_DEFINITION;
+import static io.camunda.migrator.impl.persistence.IdKeyMapper.TYPE.HISTORY_DECISION_INSTANCE;
 import static io.camunda.migrator.impl.persistence.IdKeyMapper.TYPE.HISTORY_DECISION_REQUIREMENT;
 import static io.camunda.migrator.impl.persistence.IdKeyMapper.TYPE.HISTORY_FLOW_NODE;
 import static io.camunda.migrator.impl.persistence.IdKeyMapper.TYPE.HISTORY_INCIDENT;
@@ -19,9 +20,12 @@ import static io.camunda.migrator.impl.persistence.IdKeyMapper.TYPE.HISTORY_PROC
 import static io.camunda.migrator.impl.persistence.IdKeyMapper.TYPE.HISTORY_USER_TASK;
 import static io.camunda.migrator.impl.persistence.IdKeyMapper.TYPE.HISTORY_VARIABLE;
 
+import io.camunda.db.rdbms.read.domain.DecisionDefinitionDbQuery;
+import io.camunda.db.rdbms.read.domain.DecisionInstanceDbQuery;
 import io.camunda.db.rdbms.read.domain.FlowNodeInstanceDbQuery;
 import io.camunda.db.rdbms.read.domain.ProcessDefinitionDbQuery;
 import io.camunda.db.rdbms.sql.DecisionDefinitionMapper;
+import io.camunda.db.rdbms.sql.DecisionInstanceMapper;
 import io.camunda.db.rdbms.sql.DecisionRequirementsMapper;
 import io.camunda.db.rdbms.sql.FlowNodeInstanceMapper;
 import io.camunda.db.rdbms.sql.IncidentMapper;
@@ -30,6 +34,7 @@ import io.camunda.db.rdbms.sql.ProcessInstanceMapper;
 import io.camunda.db.rdbms.sql.UserTaskMapper;
 import io.camunda.db.rdbms.sql.VariableMapper;
 import io.camunda.db.rdbms.write.domain.DecisionDefinitionDbModel;
+import io.camunda.db.rdbms.write.domain.DecisionInstanceDbModel;
 import io.camunda.db.rdbms.write.domain.DecisionRequirementsDbModel;
 import io.camunda.db.rdbms.write.domain.FlowNodeInstanceDbModel;
 import io.camunda.db.rdbms.write.domain.IncidentDbModel;
@@ -39,6 +44,7 @@ import io.camunda.db.rdbms.write.domain.UserTaskDbModel;
 import io.camunda.db.rdbms.write.domain.VariableDbModel;
 import io.camunda.migrator.config.C8DataSourceConfigured;
 import io.camunda.migrator.converter.DecisionDefinitionConverter;
+import io.camunda.migrator.converter.DecisionInstanceConverter;
 import io.camunda.migrator.converter.DecisionRequirementsDefinitionConverter;
 import io.camunda.migrator.converter.FlowNodeConverter;
 import io.camunda.migrator.converter.IncidentConverter;
@@ -52,12 +58,16 @@ import io.camunda.migrator.impl.logging.HistoryMigratorLogs;
 import io.camunda.migrator.impl.persistence.IdKeyMapper;
 import io.camunda.migrator.impl.util.ExceptionUtils;
 import io.camunda.migrator.impl.util.PrintUtils;
+import io.camunda.search.entities.DecisionDefinitionEntity;
+import io.camunda.search.entities.DecisionInstanceEntity;
 import io.camunda.search.entities.ProcessDefinitionEntity;
 import io.camunda.search.entities.ProcessInstanceEntity;
 import io.camunda.search.filter.FlowNodeInstanceFilter;
 import java.util.Date;
 import java.util.List;
+import java.util.Optional;
 import org.camunda.bpm.engine.history.HistoricActivityInstance;
+import org.camunda.bpm.engine.history.HistoricDecisionInstance;
 import org.camunda.bpm.engine.history.HistoricIncident;
 import org.camunda.bpm.engine.history.HistoricProcessInstance;
 import org.camunda.bpm.engine.history.HistoricTaskInstance;
@@ -77,6 +87,9 @@ public class HistoryMigrator {
 
   @Autowired
   private ProcessInstanceMapper processInstanceMapper;
+
+  @Autowired
+  private DecisionInstanceMapper decisionInstanceMapper;
 
   @Autowired
   private UserTaskMapper userTaskMapper;
@@ -111,6 +124,9 @@ public class HistoryMigrator {
 
   @Autowired
   private ProcessInstanceConverter processInstanceConverter;
+
+  @Autowired
+  private DecisionInstanceConverter decisionInstanceConverter;
 
   @Autowired
   private FlowNodeConverter flowNodeConverter;
@@ -172,6 +188,7 @@ public class HistoryMigrator {
     migrateIncidents();
     migrateDecisionRequirementsDefinitions();
     migrateDecisionDefinitions();
+    migrateDecisionInstances();
   }
 
   public void migrateProcessDefinitions() {
@@ -307,7 +324,81 @@ public class HistoryMigrator {
     }
   }
 
-  public void migrateIncidents() {
+  public void migrateDecisionInstances() {
+    HistoryMigratorLogs.migratingDecisionInstances();
+    if (RETRY_SKIPPED.equals(mode)) {
+      dbClient.fetchAndHandleSkippedForType(HISTORY_DECISION_INSTANCE, idKeyDbModel -> {
+        HistoricDecisionInstance historicDecisionInstance = c7Client.getHistoricDecisionInstance(idKeyDbModel.id());
+        migrateDecisionInstance(historicDecisionInstance);
+      });
+    } else {
+      c7Client.fetchAndHandleHistoricDecisionInstances(this::migrateDecisionInstance,
+          dbClient.findLatestStartDateByType((HISTORY_DECISION_INSTANCE)));
+    }
+  }
+
+  private void migrateDecisionInstance(HistoricDecisionInstance legacyDecisionInstance) {
+    if (legacyDecisionInstance.getProcessDefinitionKey() != null) {
+      // only migrate decision instances that were triggered by process definitions
+      String legacyDecisionInstanceId = legacyDecisionInstance.getId();
+      if (shouldMigrate(legacyDecisionInstanceId, IdKeyMapper.TYPE.HISTORY_DECISION_INSTANCE)) {
+        HistoryMigratorLogs.migratingDecisionInstance(legacyDecisionInstanceId);
+
+        if (!isMigrated(legacyDecisionInstance.getDecisionDefinitionId(), HISTORY_DECISION_DEFINITION)) {
+          saveRecord(legacyDecisionInstanceId, null, IdKeyMapper.TYPE.HISTORY_DECISION_INSTANCE);
+          HistoryMigratorLogs.skippingDecisionInstanceDueToMissingDecisionDefinition(legacyDecisionInstanceId);
+          return;
+        }
+
+        if (!isMigrated(legacyDecisionInstance.getProcessDefinitionId(), HISTORY_PROCESS_DEFINITION)) {
+          saveRecord(legacyDecisionInstanceId, null, IdKeyMapper.TYPE.HISTORY_DECISION_INSTANCE);
+          HistoryMigratorLogs.skippingDecisionInstanceDueToMissingProcessDefinition(legacyDecisionInstanceId);
+          return;
+        }
+
+        if (!isMigrated(legacyDecisionInstance.getProcessInstanceId(), HISTORY_PROCESS_INSTANCE)) {
+          saveRecord(legacyDecisionInstanceId, null, IdKeyMapper.TYPE.HISTORY_DECISION_INSTANCE);
+          HistoryMigratorLogs.skippingDecisionInstanceDueToMissingProcessInstance(legacyDecisionInstanceId);
+          return;
+        }
+
+        String legacyRootDecisionInstanceId = legacyDecisionInstance.getRootDecisionInstanceId();
+        Long parentDecisionDefinitionKey = null;
+        if (legacyRootDecisionInstanceId != null) {
+          if (!isMigrated(legacyRootDecisionInstanceId, HISTORY_DECISION_INSTANCE)) {
+            saveRecord(legacyDecisionInstanceId, null, IdKeyMapper.TYPE.HISTORY_DECISION_INSTANCE);
+            HistoryMigratorLogs.skippingDecisionInstanceDueToMissingParent(legacyDecisionInstanceId);
+            return;
+          }
+          parentDecisionDefinitionKey = findDecisionInstance(legacyRootDecisionInstanceId).decisionDefinitionKey();
+        }
+
+        if (!isMigrated(legacyDecisionInstance.getActivityInstanceId(), HISTORY_FLOW_NODE)) {
+          saveRecord(legacyDecisionInstanceId, null, IdKeyMapper.TYPE.HISTORY_DECISION_INSTANCE);
+          HistoryMigratorLogs.skippingDecisionInstanceDueToMissingFlowNodeInstanceInstance(legacyDecisionInstanceId);
+          return;
+        }
+
+        DecisionDefinitionEntity decisionDefinition = findDecisionDefinition(
+            legacyDecisionInstance.getDecisionDefinitionId());
+        Long processDefinitionKey = findProcessDefinitionKey(legacyDecisionInstance.getProcessDefinitionId());
+        Long processInstanceKey = findProcessInstanceByLegacyId(
+            legacyDecisionInstance.getProcessInstanceId()).processInstanceKey();
+        FlowNodeInstanceDbModel flowNode = findFlowNodeInstance(legacyDecisionInstance.getActivityInstanceId());
+
+        DecisionInstanceDbModel dbModel = decisionInstanceConverter.apply(legacyDecisionInstance,
+            decisionDefinition.decisionDefinitionKey(), processDefinitionKey,
+            decisionDefinition.decisionRequirementsKey(), processInstanceKey, parentDecisionDefinitionKey,
+            flowNode.flowNodeInstanceKey(), flowNode.flowNodeId());
+        decisionInstanceMapper.insert(dbModel);
+        saveRecord(legacyDecisionInstanceId, legacyDecisionInstance.getEvaluationTime(), dbModel.decisionInstanceKey(),
+            HISTORY_DECISION_INSTANCE);
+        HistoryMigratorLogs.migratingDecisionInstanceCompleted(legacyDecisionInstanceId);
+      }
+    }
+  }
+
+  private void migrateIncidents() {
     HistoryMigratorLogs.migratingHistoricIncidents();
     if (RETRY_SKIPPED.equals(mode)) {
       dbClient.fetchAndHandleSkippedForType(HISTORY_INCIDENT, idKeyDbModel -> {
@@ -327,7 +418,7 @@ public class HistoryMigrator {
       if (legacyProcessInstance != null) {
         Long processInstanceKey = legacyProcessInstance.processInstanceKey();
         if (processInstanceKey != null) {
-          Long flowNodeInstanceKey = findFlowNodeKey(legacyIncident.getActivityId(), legacyIncident.getProcessInstanceId());
+          Long flowNodeInstanceKey = findFlowNodeInstanceKey(legacyIncident.getActivityId(), legacyIncident.getProcessInstanceId());
           Long processDefinitionKey = findProcessDefinitionKey(legacyIncident.getProcessDefinitionId());
           Long jobDefinitionKey = null; // TODO Job table doesn't exist yet.
           IncidentDbModel dbModel = incidentConverter.apply(legacyIncident, processDefinitionKey, processInstanceKey, jobDefinitionKey, flowNodeInstanceKey);
@@ -376,7 +467,7 @@ public class HistoryMigrator {
         if (isMigrated(legacyVariable.getActivityInstanceId(), HISTORY_FLOW_NODE)) {
           ProcessInstanceEntity processInstance = findProcessInstanceByLegacyId(legacyProcessInstanceId);
           Long processInstanceKey = processInstance.processInstanceKey();
-          Long scopeKey = findFlowNodeKey(legacyVariable.getActivityInstanceId()); // TODO does this cover scope correctly?
+          Long scopeKey = findFlowNodeInstanceKey(legacyVariable.getActivityInstanceId()); // TODO does this cover scope correctly?
           if (scopeKey != null) {
             VariableDbModel dbModel = variableConverter.apply(legacyVariable, processInstanceKey, scopeKey);
             variableMapper.insert(dbModel);
@@ -417,7 +508,7 @@ public class HistoryMigrator {
       if (isMigrated(legacyUserTask.getProcessInstanceId(), HISTORY_PROCESS_INSTANCE)) {
         ProcessInstanceEntity processInstance = findProcessInstanceByLegacyId(legacyUserTask.getProcessInstanceId());
         if (isMigrated(legacyUserTask.getActivityInstanceId(), HISTORY_FLOW_NODE)) {
-          Long elementInstanceKey = findFlowNodeKey(legacyUserTask.getActivityInstanceId());
+          Long elementInstanceKey = findFlowNodeInstanceKey(legacyUserTask.getActivityInstanceId());
           Long processDefinitionKey = findProcessDefinitionKey(legacyUserTask.getProcessDefinitionId());
           UserTaskDbModel dbModel = userTaskConverter.apply(legacyUserTask, processDefinitionKey, processInstance, elementInstanceKey);
           userTaskMapper.insert(dbModel);
@@ -478,6 +569,35 @@ public class HistoryMigrator {
     return processInstanceMapper.findOne(key);
   }
 
+  protected DecisionInstanceEntity findDecisionInstance(String decisionInstanceId) {
+    if (decisionInstanceId == null)
+      return null;
+
+    Long key = dbClient.findKeyByIdAndType(decisionInstanceId, HISTORY_DECISION_INSTANCE);
+    if (key == null) {
+      return null;
+    }
+
+    return decisionInstanceMapper.search(
+            DecisionInstanceDbQuery.of(b -> b.filter(value -> value.decisionInstanceKeys(key))))
+        .stream()
+        .findFirst()
+        .orElse(null);
+  }
+
+  protected DecisionDefinitionEntity findDecisionDefinition(String decisionDefinitionId) {
+    Long key = dbClient.findKeyByIdAndType(decisionDefinitionId, HISTORY_DECISION_DEFINITION);
+    if (key == null) {
+      return null;
+    }
+
+    return decisionDefinitionMapper.search(
+            DecisionDefinitionDbQuery.of(b -> b.filter(value -> value.decisionDefinitionKeys(key))))
+        .stream()
+        .findFirst()
+        .orElse(null);
+  }
+
   private Long findProcessDefinitionKey(String processDefinitionId) {
     Long key = dbClient.findKeyByIdAndType(processDefinitionId, HISTORY_PROCESS_DEFINITION);
     if (key == null) {
@@ -494,7 +614,7 @@ public class HistoryMigrator {
     }
   }
 
-  private Long findFlowNodeKey(String activityId, String processInstanceId) {
+  private Long findFlowNodeInstanceKey(String activityId, String processInstanceId) {
     Long key = dbClient.findKeyByIdAndType(processInstanceId, HISTORY_PROCESS_INSTANCE);
     if (key == null) {
       return null;
@@ -510,20 +630,22 @@ public class HistoryMigrator {
     }
   }
 
-  private Long findFlowNodeKey(String activityInstanceId) {
+  protected Long findFlowNodeInstanceKey(String activityInstanceId) {
+    return Optional.ofNullable(findFlowNodeInstance(activityInstanceId))
+        .map(FlowNodeInstanceDbModel::flowNodeInstanceKey)
+        .orElse(null);
+  }
+
+  protected FlowNodeInstanceDbModel findFlowNodeInstance(String activityInstanceId) {
     Long key = dbClient.findKeyByIdAndType(activityInstanceId, HISTORY_FLOW_NODE);
     if (key == null) {
       return null;
     }
 
-    List<FlowNodeInstanceDbModel> flowNodes = flowNodeMapper.search(
-        FlowNodeInstanceDbQuery.of(b -> b.filter(f -> f.flowNodeInstanceKeys(key))));
-
-    if (!flowNodes.isEmpty()) {
-      return flowNodes.getFirst().flowNodeInstanceKey();
-    } else {
-      return null;
-    }
+    return flowNodeMapper.search(FlowNodeInstanceDbQuery.of(b -> b.filter(f -> f.flowNodeInstanceKeys(key))))
+        .stream()
+        .findFirst()
+        .orElse(null);
   }
 
   private boolean isMigrated(String id, IdKeyMapper.TYPE type) {

--- a/core/src/main/java/io/camunda/migrator/constants/MigratorConstants.java
+++ b/core/src/main/java/io/camunda/migrator/constants/MigratorConstants.java
@@ -11,6 +11,14 @@ public final class MigratorConstants {
 
   private MigratorConstants() {}
 
+  /**
+   * Partition ID used for history data migration from Camunda 7 to Camunda 8.
+   * Set to 4095 (maximum possible partition value) to ensure generated keys don't
+   * collide with actual Zeebe partition keys during migration.
+   */
+  public static int C7_HISTORY_PARTITION_ID = 4095;
+
   public static final String LEGACY_ID_VAR_NAME = "legacyId";
   public static final String USER_TASK_ID = "userTaskId";
+  public static final String C8_DEFAULT_TENANT = "<default>";
 }

--- a/core/src/main/java/io/camunda/migrator/converter/ConverterConfiguration.java
+++ b/core/src/main/java/io/camunda/migrator/converter/ConverterConfiguration.java
@@ -24,6 +24,11 @@ public class ConverterConfiguration {
   }
 
   @Bean
+  public DecisionInstanceConverter decisionInstanceConverter() {
+    return new DecisionInstanceConverter();
+  }
+
+  @Bean
   public FlowNodeConverter flowNodeConverter() {
     return new FlowNodeConverter();
   }

--- a/core/src/main/java/io/camunda/migrator/converter/DecisionDefinitionConverter.java
+++ b/core/src/main/java/io/camunda/migrator/converter/DecisionDefinitionConverter.java
@@ -8,9 +8,9 @@
 package io.camunda.migrator.converter;
 
 import static io.camunda.migrator.impl.util.ConverterUtil.getNextKey;
+import static io.camunda.migrator.impl.util.ConverterUtil.getTenantId;
 
 import io.camunda.db.rdbms.write.domain.DecisionDefinitionDbModel;
-import org.apache.commons.lang3.StringUtils;
 import org.camunda.bpm.engine.repository.DecisionDefinition;
 
 public class DecisionDefinitionConverter {
@@ -20,9 +20,7 @@ public class DecisionDefinitionConverter {
     return new DecisionDefinitionDbModel.DecisionDefinitionDbModelBuilder().decisionDefinitionKey(getNextKey())
         .name(legacyDecisionDefinition.getName())
         .decisionDefinitionId(legacyDecisionDefinition.getKey())
-        .tenantId(StringUtils.isEmpty(legacyDecisionDefinition.getTenantId())
-            ? "<default>"
-            : legacyDecisionDefinition.getTenantId())
+        .tenantId(getTenantId(legacyDecisionDefinition.getTenantId()))
         .version(legacyDecisionDefinition.getVersion())
         .decisionRequirementsId(legacyDecisionDefinition.getDecisionRequirementsDefinitionKey())
         .decisionRequirementsKey(decisionRequirementsKey)

--- a/core/src/main/java/io/camunda/migrator/converter/DecisionInstanceConverter.java
+++ b/core/src/main/java/io/camunda/migrator/converter/DecisionInstanceConverter.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+package io.camunda.migrator.converter;
+
+import static io.camunda.migrator.constants.MigratorConstants.C7_HISTORY_PARTITION_ID;
+import static io.camunda.migrator.impl.util.ConverterUtil.convertDate;
+import static io.camunda.migrator.impl.util.ConverterUtil.getNextKey;
+import static io.camunda.migrator.impl.util.ConverterUtil.getTenantId;
+
+import io.camunda.db.rdbms.write.domain.DecisionInstanceDbModel;
+import io.camunda.search.entities.DecisionInstanceEntity;
+import java.util.List;
+import org.camunda.bpm.engine.history.HistoricDecisionInputInstance;
+import org.camunda.bpm.engine.history.HistoricDecisionInstance;
+import org.camunda.bpm.engine.history.HistoricDecisionOutputInstance;
+
+public class DecisionInstanceConverter {
+
+  public DecisionInstanceDbModel apply(HistoricDecisionInstance decisionInstance,
+                                       Long decisionDefinitionKey,
+                                       Long processDefinitionKey,
+                                       Long decisionRequirementsDefinitionKey,
+                                       Long processInstanceKey,
+                                       Long rootDecisionDefinitionKey,
+                                       Long flowNodeInstanceKey,
+                                       String flowNodeId) {
+    Long decisionInstanceKey = getNextKey();
+    return new DecisionInstanceDbModel.Builder()
+        .partitionId(C7_HISTORY_PARTITION_ID)
+        .decisionInstanceId(String.format("%d-%s", decisionInstanceKey, decisionInstance.getId()))
+        .decisionInstanceKey(decisionInstanceKey)
+        .state(DecisionInstanceEntity.DecisionInstanceState.UNSPECIFIED) // TODO https://github.com/camunda/camunda-bpm-platform/issues/5370
+        .evaluationDate(convertDate(decisionInstance.getEvaluationTime()))
+        .evaluationFailure(null) // not stored in HistoricDecisionInstance
+        .evaluationFailureMessage(null) // not stored in HistoricDecisionInstance
+        .result(String.valueOf(decisionInstance.getCollectResultValue()))
+        .flowNodeInstanceKey(flowNodeInstanceKey)
+        .flowNodeId(flowNodeId)
+        .processInstanceKey(processInstanceKey)
+        .processDefinitionKey(processDefinitionKey)
+        .processDefinitionId(decisionInstance.getProcessDefinitionKey())
+        .decisionDefinitionKey(decisionDefinitionKey)
+        .decisionDefinitionId(decisionInstance.getDecisionDefinitionKey())
+        .decisionRequirementsKey(decisionRequirementsDefinitionKey)
+        .decisionRequirementsId(decisionInstance.getDecisionRequirementsDefinitionKey())
+        .rootDecisionDefinitionKey(rootDecisionDefinitionKey)
+        .decisionType(DecisionInstanceEntity.DecisionDefinitionType.UNSPECIFIED) // TODO https://github.com/camunda/camunda-bpm-platform/issues/5370
+        .tenantId(getTenantId(decisionInstance.getTenantId()))
+        .evaluatedInputs(mapInputs(decisionInstance.getId(), decisionInstance.getInputs()))
+        .evaluatedOutputs(mapOutputs(decisionInstance.getId(), decisionInstance.getOutputs()))
+        .historyCleanupDate(convertDate(decisionInstance.getRemovalTime()))
+        .build();
+  }
+
+  private List<DecisionInstanceDbModel.EvaluatedInput> mapInputs(String decisionInstanceId,
+                                                                 List<HistoricDecisionInputInstance> legacyInputs) {
+    return legacyInputs.stream().map(input -> new DecisionInstanceDbModel.EvaluatedInput(decisionInstanceId,
+        input.getId(),
+        input.getClauseName(),
+        String.valueOf(input.getValue())
+    )).toList();
+  }
+
+  private List<DecisionInstanceDbModel.EvaluatedOutput> mapOutputs(String decisionInstanceId,
+                                                                   List<HistoricDecisionOutputInstance> legacyOutputs) {
+    return legacyOutputs.stream().map(output -> new DecisionInstanceDbModel.EvaluatedOutput(decisionInstanceId,
+        output.getId(),
+        output.getClauseName(),
+        String.valueOf(output.getValue()),
+        output.getRuleId(),
+        output.getRuleOrder())).toList();
+  }
+}

--- a/core/src/main/java/io/camunda/migrator/converter/DecisionRequirementsDefinitionConverter.java
+++ b/core/src/main/java/io/camunda/migrator/converter/DecisionRequirementsDefinitionConverter.java
@@ -8,9 +8,9 @@
 package io.camunda.migrator.converter;
 
 import static io.camunda.migrator.impl.util.ConverterUtil.getNextKey;
+import static io.camunda.migrator.impl.util.ConverterUtil.getTenantId;
 
 import io.camunda.db.rdbms.write.domain.DecisionRequirementsDbModel;
-import org.apache.commons.lang3.StringUtils;
 import org.camunda.bpm.engine.repository.DecisionRequirementsDefinition;
 
 public class DecisionRequirementsDefinitionConverter {
@@ -23,9 +23,7 @@ public class DecisionRequirementsDefinitionConverter {
         .resourceName(legacyDecisionRequirements.getResourceName())
         .version(legacyDecisionRequirements.getVersion())
         .xml(null) // TODO not stored in C7 DecisionRequirementsDefinition
-        .tenantId(StringUtils.isEmpty(legacyDecisionRequirements.getTenantId())
-            ? "<default>"
-            : legacyDecisionRequirements.getTenantId())
+        .tenantId(getTenantId(legacyDecisionRequirements.getTenantId()))
         .build();
   }
 }

--- a/core/src/main/java/io/camunda/migrator/converter/ProcessInstanceConverter.java
+++ b/core/src/main/java/io/camunda/migrator/converter/ProcessInstanceConverter.java
@@ -8,6 +8,7 @@
 package io.camunda.migrator.converter;
 
 import static io.camunda.db.rdbms.write.domain.ProcessInstanceDbModel.ProcessInstanceDbModelBuilder;
+import static io.camunda.migrator.constants.MigratorConstants.C7_HISTORY_PARTITION_ID;
 import static io.camunda.migrator.impl.util.ConverterUtil.convertDate;
 import static io.camunda.migrator.impl.util.ConverterUtil.getNextKey;
 import static io.camunda.search.entities.ProcessInstanceEntity.ProcessInstanceState;
@@ -44,7 +45,7 @@ public class ProcessInstanceConverter {
         //        .parentElementInstanceKey(null)
         //        .treePath(null)
         .numIncidents(getIncidents(processInstance))
-        .partitionId(ConverterUtil.C7_HISTORY_PARTITION_ID)
+        .partitionId(C7_HISTORY_PARTITION_ID)
         .historyCleanupDate(convertDate(processInstance.getRemovalTime()))
         .build();
   }

--- a/core/src/main/java/io/camunda/migrator/impl/logging/HistoryMigratorLogs.java
+++ b/core/src/main/java/io/camunda/migrator/impl/logging/HistoryMigratorLogs.java
@@ -29,10 +29,13 @@ public class HistoryMigratorLogs {
 
   public static final String MIGRATING_INSTANCES = "Migrating historic {} instances";
   public static final String MIGRATING_INSTANCE = "Migrating historic {} instance with legacyId: [{}]";
-  public static final String MIGRATING_INSTANCE_COMPLETE = "Migration of historic {} instance with legacyId "
-      + "[{}] completed";
+  public static final String MIGRATING_INSTANCE_COMPLETE =
+      "Migration of historic {} instance with legacyId " + "[{}] completed";
   public static final String SKIPPING_INSTANCE_MISSING_PARENT = "Migration of historic {} instance with legacyId [{}] skipped. Parent instance not yet available.";
   public static final String SKIPPING_INSTANCE_MISSING_DEFINITION = "Migration of historic {} instance with legacyId [{}] skipped. {} definition not yet available.";
+  public static final String SKIPPING_DECISION_INSTANCE_MISSING_PROCESS_INSTANCE = "Migration of historic decision instance with legacyId [{}] skipped. Process instance not yet available.";
+  public static final String SKIPPING_DECISION_INSTANCE_MISSING_FLOW_NODE_INSTANCE = "Migration of historic decision "
+      + "instance with legacyId [{}] skipped. Flow node instance not yet available.";
 
   public static final String MIGRATING_INCIDENTS = "Migrating historic incidents";
   public static final String MIGRATING_INCIDENT = "Migrating historic incident with legacyId: [{}]";
@@ -109,6 +112,38 @@ public class HistoryMigratorLogs {
 
   public static void skippingProcessInstanceDueToMissingDefinition(String legacyProcessInstanceId) {
     LOGGER.debug(SKIPPING_INSTANCE_MISSING_DEFINITION, "process", legacyProcessInstanceId, "process");
+  }
+
+  public static void migratingDecisionInstances() {
+    LOGGER.info(MIGRATING_INSTANCES, "decision");
+  }
+
+  public static void migratingDecisionInstance(String legacyDecisionInstanceId) {
+    LOGGER.debug(MIGRATING_INSTANCE, "decision", legacyDecisionInstanceId);
+  }
+
+  public static void migratingDecisionInstanceCompleted(String legacyDecisionInstanceId) {
+    LOGGER.debug(MIGRATING_INSTANCE_COMPLETE, "decision", legacyDecisionInstanceId);
+  }
+
+  public static void skippingDecisionInstanceDueToMissingParent(String legacyDecisionInstanceId) {
+    LOGGER.debug(SKIPPING_INSTANCE_MISSING_PARENT, "decision", legacyDecisionInstanceId);
+  }
+
+  public static void skippingDecisionInstanceDueToMissingDecisionDefinition(String legacyDecisionInstanceId) {
+    LOGGER.debug(SKIPPING_INSTANCE_MISSING_DEFINITION, "decision", legacyDecisionInstanceId, "decision");
+  }
+
+  public static void skippingDecisionInstanceDueToMissingProcessDefinition(String legacyDecisionInstanceId) {
+    LOGGER.debug(SKIPPING_INSTANCE_MISSING_DEFINITION, "decision", legacyDecisionInstanceId, "process");
+  }
+
+  public static void skippingDecisionInstanceDueToMissingProcessInstance(String legacyDecisionInstanceId) {
+    LOGGER.debug(SKIPPING_DECISION_INSTANCE_MISSING_PROCESS_INSTANCE, legacyDecisionInstanceId);
+  }
+
+  public static void skippingDecisionInstanceDueToMissingFlowNodeInstanceInstance(String legacyDecisionInstanceId) {
+    LOGGER.debug(SKIPPING_DECISION_INSTANCE_MISSING_FLOW_NODE_INSTANCE, legacyDecisionInstanceId);
   }
 
   public static void migratingHistoricIncidents() {

--- a/core/src/main/java/io/camunda/migrator/impl/persistence/IdKeyMapper.java
+++ b/core/src/main/java/io/camunda/migrator/impl/persistence/IdKeyMapper.java
@@ -25,6 +25,8 @@ public interface IdKeyMapper {
     HISTORY_USER_TASK("Historic User Task"),
     HISTORY_FLOW_NODE("Historic Flow Node"),
     HISTORY_DECISION_INSTANCE("Historic Decision Instance"),
+    HISTORY_DECISION_INSTANCE_INPUT("Historic Decision Instance Input"),
+    HISTORY_DECISION_INSTANCE_OUTPUT("Historic Decision Instance Output"),
     HISTORY_DECISION_DEFINITION("Historic Decision Definition"),
     HISTORY_DECISION_REQUIREMENT("Historic Decision Requirement"),
 

--- a/core/src/main/java/io/camunda/migrator/impl/util/ConverterUtil.java
+++ b/core/src/main/java/io/camunda/migrator/impl/util/ConverterUtil.java
@@ -13,17 +13,13 @@ import java.security.SecureRandom;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.Date;
+import org.apache.commons.lang3.StringUtils;
 
+import static io.camunda.migrator.constants.MigratorConstants.C7_HISTORY_PARTITION_ID;
+import static io.camunda.migrator.constants.MigratorConstants.C8_DEFAULT_TENANT;
 import static io.camunda.zeebe.protocol.Protocol.KEY_BITS;
 
 public class ConverterUtil {
-
-  /**
-   * Partition ID used for history data migration from Camunda 7 to Camunda 8.
-   * Set to 4095 (maximum possible partition value) to ensure generated keys don't
-   * collide with actual Zeebe partition keys during migration.
-   */
-  public static int C7_HISTORY_PARTITION_ID = 4095;
 
   public static Long getNextKey() {
     SecureRandom secureRandom = new SecureRandom();
@@ -37,6 +33,10 @@ public class ConverterUtil {
   public static OffsetDateTime convertDate(Date date) {
     if (date == null) return null;
     return date.toInstant().atOffset(ZoneOffset.UTC);
+  }
+
+  public static String getTenantId(String c7TenantId) {
+    return StringUtils.isEmpty(c7TenantId) ? C8_DEFAULT_TENANT : c7TenantId;
   }
 
 }

--- a/core/src/test/java/io/camunda/migrator/history/ConverterUtilTest.java
+++ b/core/src/test/java/io/camunda/migrator/history/ConverterUtilTest.java
@@ -11,7 +11,7 @@ import io.camunda.migrator.impl.util.ConverterUtil;
 import io.camunda.zeebe.protocol.Protocol;
 import org.junit.jupiter.api.Test;
 
-import static io.camunda.migrator.impl.util.ConverterUtil.C7_HISTORY_PARTITION_ID;
+import static io.camunda.migrator.constants.MigratorConstants.C7_HISTORY_PARTITION_ID;
 import static io.camunda.migrator.impl.util.ConverterUtil.getUpperBound;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;

--- a/qa/src/test/java/io/camunda/migrator/qa/AbstractMigratorTest.java
+++ b/qa/src/test/java/io/camunda/migrator/qa/AbstractMigratorTest.java
@@ -13,6 +13,7 @@ import io.camunda.migrator.qa.util.ProcessDefinitionDeployer;
 import io.camunda.migrator.qa.util.WithMultiDb;
 import io.camunda.migrator.qa.util.WithSpringProfile;
 import org.camunda.bpm.engine.ManagementService;
+import org.camunda.bpm.engine.DecisionService;
 import org.camunda.bpm.engine.RepositoryService;
 import org.camunda.bpm.engine.RuntimeService;
 import org.camunda.bpm.engine.TaskService;
@@ -38,6 +39,9 @@ public class AbstractMigratorTest {
 
   @Autowired
   protected RuntimeService runtimeService;
+
+  @Autowired
+  protected DecisionService decisionService;
 
   @Autowired
   protected TaskService taskService;

--- a/qa/src/test/java/io/camunda/migrator/qa/history/HistoryDecisionMigrationTest.java
+++ b/qa/src/test/java/io/camunda/migrator/qa/history/HistoryDecisionMigrationTest.java
@@ -8,14 +8,32 @@
 
 package io.camunda.migrator.qa.history;
 
+import static io.camunda.search.entities.FlowNodeInstanceEntity.FlowNodeType.BUSINESS_RULE_TASK;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.camunda.bpm.engine.variable.Variables.stringValue;
+import static io.camunda.migrator.constants.MigratorConstants.C8_DEFAULT_TENANT;
 
+import io.camunda.migrator.impl.clients.C7Client;
 import io.camunda.search.entities.DecisionDefinitionEntity;
+import io.camunda.search.entities.DecisionInstanceEntity;
 import io.camunda.search.entities.DecisionRequirementsEntity;
+import io.camunda.search.entities.FlowNodeInstanceEntity;
+import io.camunda.search.entities.ProcessInstanceEntity;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.util.Date;
 import java.util.List;
+import java.util.Map;
+import org.camunda.bpm.engine.history.HistoricDecisionInstance;
+import org.camunda.bpm.engine.impl.util.ClockUtil;
+import org.camunda.bpm.engine.variable.Variables;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 
 public class HistoryDecisionMigrationTest extends HistoryMigrationAbstractTest {
+
+  @Autowired
+  private C7Client c7Client;
 
   @Test
   public void migrateSingleHistoricDecision() {
@@ -27,16 +45,15 @@ public class HistoryDecisionMigrationTest extends HistoryMigrationAbstractTest {
 
     // then
     List<DecisionDefinitionEntity> migratedDecisions = searchHistoricDecisionDefinitions("simpleDecisionId");
-    assertThat(migratedDecisions).singleElement()
-        .satisfies(decision -> {
-          assertThat(decision.decisionDefinitionId()).isEqualTo("simpleDecisionId");
-          assertThat(decision.decisionDefinitionKey()).isNotNull();
-          assertThat(decision.version()).isEqualTo(1);
-          assertThat(decision.name()).isEqualTo("simpleDecisionName");
-          assertThat(decision.tenantId()).isEqualTo("<default>");
-          assertThat(decision.decisionRequirementsKey()).isNull();
-          assertThat(decision.decisionRequirementsId()).isNull();
-        });
+    assertThat(migratedDecisions).singleElement().satisfies(decision -> {
+      assertThat(decision.decisionDefinitionId()).isEqualTo("simpleDecisionId");
+      assertThat(decision.decisionDefinitionKey()).isNotNull();
+      assertThat(decision.version()).isEqualTo(1);
+      assertThat(decision.name()).isEqualTo("simpleDecisionName");
+      assertThat(decision.tenantId()).isEqualTo(C8_DEFAULT_TENANT);
+      assertThat(decision.decisionRequirementsKey()).isNull();
+      assertThat(decision.decisionRequirementsId()).isNull();
+    });
   }
 
   @Test
@@ -51,38 +68,144 @@ public class HistoryDecisionMigrationTest extends HistoryMigrationAbstractTest {
     List<DecisionRequirementsEntity> decisionReqs = searchHistoricDecisionRequirementsDefinition("simpleDmnWithReqsId");
 
     // then
-    assertThat(decisionReqs).singleElement()
-        .satisfies(decisionRequirements -> {
-          assertThat(decisionRequirements.decisionRequirementsId()).isEqualTo("simpleDmnWithReqsId");
-          assertThat(decisionRequirements.decisionRequirementsKey()).isNotNull();
-          assertThat(decisionRequirements.version()).isEqualTo(1);
-          assertThat(decisionRequirements.name()).isEqualTo("simpleDmnWithReqsName");
-          assertThat(decisionRequirements.tenantId()).isEqualTo("<default>");
-          assertThat(decisionRequirements.xml()).isNull();
-          assertThat(decisionRequirements.resourceName()).isEqualTo("io/camunda/migrator/dmn/c7/simpleDmnWithReqs.dmn");
-        });
+    assertThat(decisionReqs).singleElement().satisfies(decisionRequirements -> {
+      assertThat(decisionRequirements.decisionRequirementsId()).isEqualTo("simpleDmnWithReqsId");
+      assertThat(decisionRequirements.decisionRequirementsKey()).isNotNull();
+      assertThat(decisionRequirements.version()).isEqualTo(1);
+      assertThat(decisionRequirements.name()).isEqualTo("simpleDmnWithReqsName");
+      assertThat(decisionRequirements.tenantId()).isEqualTo(C8_DEFAULT_TENANT);
+      assertThat(decisionRequirements.xml()).isNull();
+      assertThat(decisionRequirements.resourceName()).isEqualTo("io/camunda/migrator/dmn/c7/simpleDmnWithReqs.dmn");
+    });
     Long decisionReqsKey = decisionReqs.get(0).decisionRequirementsKey();
 
-    assertThat(firstDecision).singleElement()
-        .satisfies(decision -> {
-          assertThat(decision.decisionDefinitionId()).isEqualTo("simpleDmnWithReqs1Id");
-          assertThat(decision.decisionDefinitionKey()).isNotNull();
-          assertThat(decision.version()).isEqualTo(1);
-          assertThat(decision.name()).isEqualTo("simpleDmnWithReqs1Name");
-          assertThat(decision.tenantId()).isEqualTo("<default>");
-          assertThat(decision.decisionRequirementsKey()).isEqualTo(decisionReqsKey);
-          assertThat(decision.decisionRequirementsId()).isEqualTo("simpleDmnWithReqsId");
-        });
+    assertThat(firstDecision).singleElement().satisfies(decision -> {
+      assertThat(decision.decisionDefinitionId()).isEqualTo("simpleDmnWithReqs1Id");
+      assertThat(decision.decisionDefinitionKey()).isNotNull();
+      assertThat(decision.version()).isEqualTo(1);
+      assertThat(decision.name()).isEqualTo("simpleDmnWithReqs1Name");
+      assertThat(decision.tenantId()).isEqualTo(C8_DEFAULT_TENANT);
+      assertThat(decision.decisionRequirementsKey()).isEqualTo(decisionReqsKey);
+      assertThat(decision.decisionRequirementsId()).isEqualTo("simpleDmnWithReqsId");
+    });
 
-    assertThat(secondDecision).singleElement()
-        .satisfies(decision -> {
-          assertThat(decision.decisionDefinitionId()).isEqualTo("simpleDmnWithReqs2Id");
-          assertThat(decision.decisionDefinitionKey()).isNotNull();
-          assertThat(decision.version()).isEqualTo(1);
-          assertThat(decision.name()).isEqualTo("simpleDmnWithReqs2Name");
-          assertThat(decision.tenantId()).isEqualTo("<default>");
-          assertThat(decision.decisionRequirementsKey()).isEqualTo(decisionReqsKey);
-          assertThat(decision.decisionRequirementsId()).isEqualTo("simpleDmnWithReqsId");
-        });
+    assertThat(secondDecision).singleElement().satisfies(decision -> {
+      assertThat(decision.decisionDefinitionId()).isEqualTo("simpleDmnWithReqs2Id");
+      assertThat(decision.decisionDefinitionKey()).isNotNull();
+      assertThat(decision.version()).isEqualTo(1);
+      assertThat(decision.name()).isEqualTo("simpleDmnWithReqs2Name");
+      assertThat(decision.tenantId()).isEqualTo(C8_DEFAULT_TENANT);
+      assertThat(decision.decisionRequirementsKey()).isEqualTo(decisionReqsKey);
+      assertThat(decision.decisionRequirementsId()).isEqualTo("simpleDmnWithReqsId");
+    });
+  }
+
+  @Test
+  public void migrateHistoricDecisionInstance() {
+    // given
+    Date now = ClockUtil.now();
+    ClockUtil.setCurrentTime(now);
+    deployer.deployCamunda7Decision("simpleDmn.dmn");
+    deployer.deployCamunda7Process("businessRuleProcess.bpmn");
+    Map<String, Object> variables = Variables.createVariables().putValue("inputA", stringValue("A"));
+    runtimeService.startProcessInstanceByKey("businessRuleProcessId", variables);
+
+    // when
+    historyMigrator.migrate();
+
+    // then
+    List<ProcessInstanceEntity> migratedProcessInstances = searchHistoricProcessInstances("businessRuleProcessId");
+    assertThat(migratedProcessInstances).singleElement();
+    List<DecisionDefinitionEntity> migratedDecisions = searchHistoricDecisionDefinitions("simpleDecisionId");
+    assertThat(migratedDecisions).singleElement();
+    List<FlowNodeInstanceEntity> migratedFlowNodeInstances = searchHistoricFlowNodesForType(
+        migratedProcessInstances.getFirst().processInstanceKey(), BUSINESS_RULE_TASK);
+    assertThat(migratedFlowNodeInstances).singleElement();
+    List<DecisionInstanceEntity> migratedInstances = searchHistoricDecisionInstances("simpleDecisionId");
+    HistoricDecisionInstance legacyInstance = c7Client.getHistoricDecisionInstanceByDefinitionKey("simpleDecisionId");
+
+    assertThat(migratedInstances).singleElement().satisfies(instance -> {
+      assertThat(instance.decisionInstanceId()).isEqualTo(
+          instance.decisionInstanceKey() + "-" + legacyInstance.getId());
+      assertThat(instance.decisionInstanceKey()).isNotNull();
+      assertThat(instance.state()).isEqualTo(DecisionInstanceEntity.DecisionInstanceState.UNSPECIFIED);
+      assertThat(instance.evaluationDate()).isEqualTo(
+          OffsetDateTime.ofInstant(now.toInstant(), ZoneId.systemDefault()));
+      assertThat(instance.evaluationFailure()).isNull();
+      assertThat(instance.evaluationFailureMessage()).isNull();
+      assertThat(instance.flowNodeInstanceKey()).isEqualTo(migratedFlowNodeInstances.getFirst().flowNodeInstanceKey());
+      assertThat(instance.processInstanceKey()).isEqualTo(migratedProcessInstances.getFirst().processInstanceKey());
+      assertThat(instance.processDefinitionKey()).isEqualTo(migratedProcessInstances.getFirst().processDefinitionKey());
+      assertThat(instance.decisionDefinitionKey()).isEqualTo(migratedDecisions.getFirst().decisionDefinitionKey());
+      assertThat(instance.decisionDefinitionId()).isEqualTo("simpleDecisionId");
+      assertThat(instance.tenantId()).isEqualTo(C8_DEFAULT_TENANT);
+      assertThat(instance.decisionDefinitionType()).isEqualTo(
+          DecisionInstanceEntity.DecisionDefinitionType.UNSPECIFIED);
+
+      // TODO find out how to get a result http://github.com/camunda/camunda-bpm-platform/issues/5365
+      //      assertThat(instance.result()).isEqualTo("B");
+
+      // TODO https://github.com/camunda/camunda-bpm-platform/issues/5364
+//      assertThat(instance.evaluatedInputs()).singleElement().satisfies(input -> {
+//        assertThat(input.inputId()).isNotNull();
+//        assertThat(input.inputName()).isEqualTo("inputA");
+//        assertThat(input.inputValue()).isEqualTo("A");
+//      });
+//      assertThat(instance.evaluatedOutputs()).singleElement().satisfies(output -> {
+//        assertThat(output.outputId()).isNotNull();
+//        assertThat(output.outputName()).isEqualTo("outputB");
+//        assertThat(output.outputValue()).isEqualTo("B");
+//      });
+    });
+  }
+
+  @Test
+  public void migrateHistoricDecisionInstanceWithNonDefaultTenant() {
+    // given
+    deployer.deployCamunda7Decision("simpleDmn.dmn", "aTenantId");
+    deployer.deployCamunda7Process("businessRuleProcess.bpmn", "aTenantId");
+    Map<String, Object> variables = Variables.createVariables().putValue("inputA", stringValue("A"));
+    runtimeService.startProcessInstanceByKey("businessRuleProcessId", variables);
+
+    // when
+    historyMigrator.migrate();
+
+    // then
+    List<DecisionInstanceEntity> migratedInstances = searchHistoricDecisionInstances("simpleDecisionId");
+    assertThat(migratedInstances).flatExtracting(DecisionInstanceEntity::tenantId)
+        .singleElement()
+        .isEqualTo("aTenantId");
+  }
+
+  @Test
+  public void migrateChildDecisionInstanceWhenParentInstanceTriggeredFromBusinessTask() {
+    // given
+    deployer.deployCamunda7Decision("simpleDmnWithReqs.dmn");
+    deployer.deployCamunda7Process("businessRuleForDmnWithReqs.bpmn");
+    runtimeService.startProcessInstanceByKey("businessRuleForDmnWithReqsId",
+        Variables.createVariables().putValue("inputA", stringValue("A")));
+
+    // when
+    historyMigrator.migrate();
+
+    // then
+    List<DecisionInstanceEntity> instances1 = searchHistoricDecisionInstances("simpleDmnWithReqs1Id");
+    List<DecisionInstanceEntity> instances2 = searchHistoricDecisionInstances("simpleDmnWithReqs2Id");
+    assertThat(instances1).singleElement();
+    assertThat(instances2).singleElement();
+  }
+
+  @Test
+  public void doNotMigrateDecisionInstanceWhenNotOriginatingFromProcessDefinition() {
+    // given
+    deployer.deployCamunda7Decision("simpleDmn.dmn");
+    Map<String, Object> variables = Variables.createVariables().putValue("inputA", stringValue("A"));
+    decisionService.evaluateDecisionTableByKey("simpleDecisionId", variables);
+
+    // when
+    historyMigrator.migrate();
+
+    // then
+    assertThat(searchHistoricDecisionInstances("simpleDecisionId")).isEmpty();
   }
 }

--- a/qa/src/test/java/io/camunda/migrator/qa/history/HistoryMigrationAbstractTest.java
+++ b/qa/src/test/java/io/camunda/migrator/qa/history/HistoryMigrationAbstractTest.java
@@ -21,6 +21,7 @@ import io.camunda.migrator.qa.AbstractMigratorTest;
 import io.camunda.migrator.qa.config.TestProcessEngineConfiguration;
 import io.camunda.migrator.qa.util.WithSpringProfile;
 import io.camunda.search.entities.DecisionDefinitionEntity;
+import io.camunda.search.entities.DecisionInstanceEntity;
 import io.camunda.search.entities.DecisionRequirementsEntity;
 import io.camunda.search.entities.FlowNodeInstanceEntity;
 import io.camunda.search.entities.IncidentEntity;
@@ -29,6 +30,7 @@ import io.camunda.search.entities.ProcessInstanceEntity;
 import io.camunda.search.entities.UserTaskEntity;
 import io.camunda.search.entities.VariableEntity;
 import io.camunda.search.query.DecisionDefinitionQuery;
+import io.camunda.search.query.DecisionInstanceQuery;
 import io.camunda.search.query.DecisionRequirementsQuery;
 import io.camunda.search.query.FlowNodeInstanceQuery;
 import io.camunda.search.query.IncidentQuery;
@@ -36,6 +38,7 @@ import io.camunda.search.query.ProcessDefinitionQuery;
 import io.camunda.search.query.ProcessInstanceQuery;
 import io.camunda.search.query.UserTaskQuery;
 import io.camunda.search.query.VariableQuery;
+import io.camunda.search.result.DecisionInstanceQueryResultConfig;
 import java.util.List;
 import org.camunda.bpm.engine.HistoryService;
 import org.camunda.bpm.engine.impl.util.ClockUtil;
@@ -117,6 +120,14 @@ public abstract class HistoryMigrationAbstractTest extends AbstractMigratorTest 
         .search(ProcessInstanceQuery.of(queryBuilder ->
             queryBuilder.filter(filterBuilder ->
                 filterBuilder.processDefinitionIds(processDefinitionId))))
+        .items();
+  }
+
+  public List<DecisionInstanceEntity> searchHistoricDecisionInstances(String decisionDefinitionId) {
+    return rdbmsService.getDecisionInstanceReader()
+        .search(DecisionInstanceQuery.of(queryBuilder -> queryBuilder.filter(
+                filterBuilder -> filterBuilder.decisionDefinitionIds(decisionDefinitionId))
+            .resultConfig(DecisionInstanceQueryResultConfig.of(DecisionInstanceQueryResultConfig.Builder::includeAll))))
         .items();
   }
 

--- a/qa/src/test/java/io/camunda/migrator/qa/history/HistoryMigrationSkippingTest.java
+++ b/qa/src/test/java/io/camunda/migrator/qa/history/HistoryMigrationSkippingTest.java
@@ -8,15 +8,21 @@
 package io.camunda.migrator.qa.history;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.camunda.bpm.engine.variable.Variables.stringValue;
 
 import io.camunda.migrator.HistoryMigrator;
 import io.camunda.migrator.impl.clients.DbClient;
 import io.camunda.migrator.impl.persistence.IdKeyMapper;
 import io.camunda.search.entities.ProcessInstanceEntity;
 import io.github.netmikey.logunit.api.LogCapturer;
+import java.util.Date;
 import java.util.Map;
 import org.camunda.bpm.engine.HistoryService;
+import org.camunda.bpm.engine.ManagementService;
+import org.camunda.bpm.engine.impl.HistoricActivityInstanceQueryImpl;
+import org.camunda.bpm.engine.impl.util.ClockUtil;
 import org.camunda.bpm.engine.task.Task;
+import org.camunda.bpm.engine.variable.Variables;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -394,36 +400,111 @@ public class HistoryMigrationSkippingTest extends HistoryMigrationAbstractTest {
     assertThat(dbClient.countSkippedByType(IdKeyMapper.TYPE.HISTORY_DECISION_DEFINITION)).isEqualTo(2);
   }
 
-    @Test
-    public void shouldNotSkipTaskVariablesWhenEntityWithSameIdButDifferentTypeIsSkipped() {
-        // given state in c7
-        deployer.deployCamunda7Process("userTaskProcess.bpmn");
-        runtimeService.startProcessInstanceByKey("userTaskProcessId");
+  @Test
+  public void shouldSkipDecisionInstanceWhenDecisionDefinitionIsSkipped() {
+    // given
+    deployer.deployCamunda7Decision("simpleDmn.dmn");
+    deployer.deployCamunda7Process("businessRuleProcess.bpmn");
+    runtimeService.startProcessInstanceByKey("businessRuleProcessId",
+        Variables.createVariables().putValue("inputA", stringValue("A")));
+    String decisionDefinitionId = repositoryService.createDecisionDefinitionQuery()
+        .decisionDefinitionKey("simpleDecisionId")
+        .singleResult()
+        .getId();
+    dbClient.insert(decisionDefinitionId, null, IdKeyMapper.TYPE.HISTORY_DECISION_DEFINITION);
 
-        var taskId = taskService.createTaskQuery().singleResult().getId();
+    // when
+    historyMigrator.migrate();
 
-        // Simulate ID collision by manually inserting a record with the same ID as the task
-        // but with a different type (HISTORY_INCIDENT)
-        dbClient.insert(taskId, null, IdKeyMapper.TYPE.HISTORY_INCIDENT);
-        // Verify the collision record exists before completing the task
-        assertThat(dbClient.checkExistsByIdAndType(taskId, IdKeyMapper.TYPE.HISTORY_INCIDENT)).as("Record with task ID should exist").isTrue();
+    // then
+    assertThat(searchHistoricDecisionInstances("simpleDecisionId")).isEmpty();
+    assertThat(dbClient.countSkippedByType(IdKeyMapper.TYPE.HISTORY_DECISION_INSTANCE)).isEqualTo(1);
+  }
 
-        // when history is migrated
-        historyMigrator.migrate();
+  @Test
+  public void shouldSkipDecisionInstanceWhenProcessDefinitionIsSkipped() {
+    // given
+    deployer.deployCamunda7Decision("simpleDmn.dmn");
+    deployer.deployCamunda7Process("businessRuleProcess.bpmn");
+    runtimeService.startProcessInstanceByKey("businessRuleProcessId",
+        Variables.createVariables().putValue("inputA", stringValue("A")));
+    String processDefinitionId = repositoryService.createProcessDefinitionQuery()
+        .processDefinitionKey("businessRuleProcessId")
+        .singleResult()
+        .getId();
+    dbClient.insert(processDefinitionId, null, IdKeyMapper.TYPE.HISTORY_PROCESS_DEFINITION);
 
-        // then
-        // 1. Process instance should be migrated
-        var historicProcesses = searchHistoricProcessInstances("userTaskProcessId");
-        assertThat(historicProcesses).hasSize(1);
-        var processInstanceKey = historicProcesses.getFirst().processInstanceKey();
+    // when
+    historyMigrator.migrate();
 
-        // 2. User task should be migrated (not skipped due to ID collision with HISTORY_INCIDENT)
-        var userTasks = searchHistoricUserTasks(processInstanceKey);
-        assertThat(userTasks)
-            .as("User task should be migrated despite ID collision with HISTORY_INCIDENT")
-            .hasSize(1);
-        assertThat(userTasks.getFirst().elementId())
-            .as("User task should have correct id")
-            .isEqualTo("userTaskId");
-    }
+    // then
+    assertThat(searchHistoricDecisionInstances("simpleDecisionId")).isEmpty();
+    assertThat(dbClient.countSkippedByType(IdKeyMapper.TYPE.HISTORY_DECISION_INSTANCE)).isEqualTo(1);
+  }
+
+  @Test
+  public void shouldSkipDecisionInstanceWhenProcessInstanceIsSkipped() {
+    // given
+    deployer.deployCamunda7Decision("simpleDmn.dmn");
+    deployer.deployCamunda7Process("businessRuleProcess.bpmn");
+    var processInstance = runtimeService.startProcessInstanceByKey("businessRuleProcessId",
+        Variables.createVariables().putValue("inputA", stringValue("A")));
+    dbClient.insert(processInstance.getId(), null, IdKeyMapper.TYPE.HISTORY_PROCESS_INSTANCE);
+
+    // when
+    historyMigrator.migrate();
+
+    // then
+    assertThat(searchHistoricDecisionInstances("simpleDecisionId")).isEmpty();
+    assertThat(dbClient.countSkippedByType(IdKeyMapper.TYPE.HISTORY_DECISION_INSTANCE)).isEqualTo(1);
+  }
+
+  @Test
+  public void shouldSkipDecisionInstanceWhenFlowNodeIsSkipped() {
+    // given
+    deployer.deployCamunda7Decision("simpleDmn.dmn");
+    deployer.deployCamunda7Process("businessRuleProcess.bpmn");
+    runtimeService.startProcessInstanceByKey("businessRuleProcessId",
+        Variables.createVariables().putValue("inputA", stringValue("A")));
+    String legacyFlowNodeId =
+        historyService.createHistoricActivityInstanceQuery().activityId("businessRuleTaskId").singleResult().getId();
+    dbClient.insert(legacyFlowNodeId, null, IdKeyMapper.TYPE.HISTORY_FLOW_NODE);
+
+    // when
+    historyMigrator.migrate();
+
+    // then
+    assertThat(searchHistoricDecisionInstances("simpleDecisionId")).isEmpty();
+    assertThat(dbClient.countSkippedByType(IdKeyMapper.TYPE.HISTORY_DECISION_INSTANCE)).isEqualTo(1);
+  }
+
+  @Test
+  public void shouldNotSkipTaskVariablesWhenEntityWithSameIdButDifferentTypeIsSkipped() {
+    // given state in c7
+    deployer.deployCamunda7Process("userTaskProcess.bpmn");
+    runtimeService.startProcessInstanceByKey("userTaskProcessId");
+
+    var taskId = taskService.createTaskQuery().singleResult().getId();
+
+    // Simulate ID collision by manually inserting a record with the same ID as the task
+    // but with a different type (HISTORY_INCIDENT)
+    dbClient.insert(taskId, null, IdKeyMapper.TYPE.HISTORY_INCIDENT);
+    // Verify the collision record exists before completing the task
+    assertThat(dbClient.checkExistsByIdAndType(taskId, IdKeyMapper.TYPE.HISTORY_INCIDENT)).as(
+        "Record with task ID should exist").isTrue();
+
+    // when history is migrated
+    historyMigrator.migrate();
+
+    // then
+    // 1. Process instance should be migrated
+    var historicProcesses = searchHistoricProcessInstances("userTaskProcessId");
+    assertThat(historicProcesses).hasSize(1);
+    var processInstanceKey = historicProcesses.getFirst().processInstanceKey();
+
+    // 2. User task should be migrated (not skipped due to ID collision with HISTORY_INCIDENT)
+    var userTasks = searchHistoricUserTasks(processInstanceKey);
+    assertThat(userTasks).as("User task should be migrated despite ID collision with HISTORY_INCIDENT").hasSize(1);
+    assertThat(userTasks.getFirst().elementId()).as("User task should have correct id").isEqualTo("userTaskId");
+  }
 }

--- a/qa/src/test/java/io/camunda/migrator/qa/util/ProcessDefinitionDeployer.java
+++ b/qa/src/test/java/io/camunda/migrator/qa/util/ProcessDefinitionDeployer.java
@@ -67,7 +67,14 @@ public class ProcessDefinitionDeployer {
   }
 
   public void deployCamunda7Decision(String fileName) {
-    Deployment deployment = repositoryService.createDeployment().addClasspathResource("io/camunda/migrator/dmn/c7/" + fileName).deploy();
+    deployCamunda7Decision(fileName, null);
+  }
+
+  public void deployCamunda7Decision(String fileName, String tenantId) {
+    Deployment deployment = repositoryService.createDeployment()
+        .tenantId(tenantId)
+        .addClasspathResource("io/camunda/migrator/dmn/c7/" + fileName)
+        .deploy();
     if (deployment == null) {
       throw new IllegalStateException("Could not deploy decision");
     }

--- a/qa/src/test/resources/io/camunda/migrator/bpmn/c7/businessRuleForDmnWithReqs.bpmn
+++ b/qa/src/test/resources/io/camunda/migrator/bpmn/c7/businessRuleForDmnWithReqs.bpmn
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_0ucdxls" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.24.0" modeler:executionPlatform="Camunda Platform" modeler:executionPlatformVersion="7.21.0">
+  <bpmn:process id="businessRuleForDmnWithReqsId" name="businessRuleForDmnWithReqs" isExecutable="true" camunda:historyTimeToLive="180">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_199ggw8</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_199ggw8" sourceRef="StartEvent_1" targetRef="businessRuleTaskForDmnWithReqsId" />
+    <bpmn:businessRuleTask id="businessRuleTaskForDmnWithReqsId" name="businessRuleTaskForDmnWithReqs" camunda:resultVariable="businessRuleTaskForDmnWithReqsResultVar" camunda:decisionRef="simpleDmnWithReqs2Id" camunda:mapDecisionResult="singleEntry">
+      <bpmn:incoming>Flow_199ggw8</bpmn:incoming>
+      <bpmn:outgoing>Flow_0x7xb10</bpmn:outgoing>
+    </bpmn:businessRuleTask>
+    <bpmn:endEvent id="Event_0z4nwb0">
+      <bpmn:incoming>Flow_0x7xb10</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_0x7xb10" sourceRef="businessRuleTaskForDmnWithReqsId" targetRef="Event_0z4nwb0" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="businessRuleForDmnWithReqsId">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_01fv9qv_di" bpmnElement="businessRuleTaskForDmnWithReqsId">
+        <dc:Bounds x="270" y="77" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0z4nwb0_di" bpmnElement="Event_0z4nwb0">
+        <dc:Bounds x="432" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_199ggw8_di" bpmnElement="Flow_199ggw8">
+        <di:waypoint x="215" y="117" />
+        <di:waypoint x="270" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0x7xb10_di" bpmnElement="Flow_0x7xb10">
+        <di:waypoint x="370" y="117" />
+        <di:waypoint x="432" y="117" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/qa/src/test/resources/io/camunda/migrator/bpmn/c7/businessRuleProcess.bpmn
+++ b/qa/src/test/resources/io/camunda/migrator/bpmn/c7/businessRuleProcess.bpmn
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1x6ctet" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.24.0" modeler:executionPlatform="Camunda Platform" modeler:executionPlatformVersion="7.21.0">
+  <bpmn:process id="businessRuleProcessId" name="BusinessRuleProcess" isExecutable="true" camunda:historyTimeToLive="180">
+    <bpmn:startEvent id="startEventId" name="startEvent">
+      <bpmn:outgoing>Flow_0664xsl</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_0664xsl" sourceRef="startEventId" targetRef="businessRuleTaskId" />
+    <bpmn:endEvent id="endEventId" name="endEvent">
+      <bpmn:incoming>Flow_15e4fhj</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_15e4fhj" sourceRef="businessRuleTaskId" targetRef="endEventId" />
+    <bpmn:businessRuleTask id="businessRuleTaskId" name="businessRuleTask" camunda:resultVariable="businessRuleTaskResultVar" camunda:decisionRef="simpleDecisionId" camunda:mapDecisionResult="singleEntry">
+      <bpmn:extensionElements />
+      <bpmn:incoming>Flow_0664xsl</bpmn:incoming>
+      <bpmn:outgoing>Flow_15e4fhj</bpmn:outgoing>
+    </bpmn:businessRuleTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="businessRuleProcessId">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="startEventId">
+        <dc:Bounds x="179" y="99" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="172" y="142" width="50" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_157b19p_di" bpmnElement="endEventId">
+        <dc:Bounds x="432" y="99" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="428" y="142" width="47" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1xzxlv7_di" bpmnElement="businessRuleTaskId">
+        <dc:Bounds x="270" y="77" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0664xsl_di" bpmnElement="Flow_0664xsl">
+        <di:waypoint x="215" y="117" />
+        <di:waypoint x="270" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_15e4fhj_di" bpmnElement="Flow_15e4fhj">
+        <di:waypoint x="370" y="117" />
+        <di:waypoint x="432" y="117" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/qa/src/test/resources/io/camunda/migrator/dmn/c7/simpleDmn.dmn
+++ b/qa/src/test/resources/io/camunda/migrator/dmn/c7/simpleDmn.dmn
@@ -1,13 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:modeler="http://camunda.org/schema/modeler/1.0" xmlns:camunda="http://camunda.org/schema/1.0/dmn" id="simpleDmnId" name="simpleDmnName" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="5.24.0" modeler:executionPlatform="Camunda Platform" modeler:executionPlatformVersion="7.21.0">
   <decision id="simpleDecisionId" name="simpleDecisionName" camunda:historyTimeToLive="180">
-    <decisionTable id="DecisionTable_0mnlytf">
-      <input id="Input_1" label="InputA">
+    <decisionTable id="simpleDecisionTableId">
+      <input id="Input_1" label="inputA" camunda:inputVariable="inputA">
         <inputExpression id="InputExpression_1" typeRef="string">
           <text>inputA</text>
         </inputExpression>
+        <inputValues id="UnaryTests_11zmcor">
+          <text>"A"</text>
+        </inputValues>
       </input>
-      <output id="Output_1" label="OutputB" name="outputB" typeRef="string" />
+      <output id="Output_1" label="outputB" name="outputB" typeRef="string">
+        <outputValues id="UnaryTests_0mn8p5u">
+          <text>"B"</text>
+        </outputValues>
+      </output>
       <rule id="DecisionRule_0rh3id4">
         <inputEntry id="UnaryTests_1kbouhu">
           <text>"A"</text>

--- a/qa/src/test/resources/io/camunda/migrator/dmn/c7/simpleDmnWithReqs.dmn
+++ b/qa/src/test/resources/io/camunda/migrator/dmn/c7/simpleDmnWithReqs.dmn
@@ -2,12 +2,15 @@
 <definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:modeler="http://camunda.org/schema/modeler/1.0" xmlns:camunda="http://camunda.org/schema/1.0/dmn" xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" id="simpleDmnWithReqsId" name="simpleDmnWithReqsName" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="5.24.0" modeler:executionPlatform="Camunda Platform" modeler:executionPlatformVersion="7.21.0">
   <decision id="simpleDmnWithReqs1Id" name="simpleDmnWithReqs1Name" camunda:historyTimeToLive="180">
     <decisionTable id="decisionTable1Id">
-      <input id="Input_1">
+      <input id="Input_1" label="inputA" camunda:inputVariable="inputA">
         <inputExpression id="InputExpression_1" typeRef="string">
-          <text></text>
+          <text>inputA</text>
         </inputExpression>
+        <inputValues id="UnaryTests_0yd65ap">
+          <text>"A"</text>
+        </inputValues>
       </input>
-      <output id="Output_1" typeRef="string" />
+      <output id="Output_1" label="outputB" name="outputB" typeRef="string" />
       <rule id="DecisionRule_0ogxiwg">
         <inputEntry id="UnaryTests_0z3jjio">
           <text>"A"</text>
@@ -23,10 +26,19 @@
       <requiredDecision href="#simpleDmnWithReqs1Id" />
     </informationRequirement>
     <decisionTable id="DecisionTable_1jv5g6j">
-      <input id="InputClause_0r96y1o">
-        <inputExpression id="LiteralExpression_1g7ifox" typeRef="string" />
+      <input id="InputClause_0r96y1o" label="inputB" camunda:inputVariable="outputB">
+        <inputExpression id="LiteralExpression_1g7ifox" typeRef="string">
+          <text>inputB</text>
+        </inputExpression>
+        <inputValues id="UnaryTests_11qhq94">
+          <text>"B"</text>
+        </inputValues>
       </input>
-      <output id="OutputClause_1chdy58" typeRef="string" />
+      <output id="OutputClause_1chdy58" label="outputC" name="outputC" typeRef="string">
+        <outputValues id="UnaryTests_1mo1hrd">
+          <text>"C"</text>
+        </outputValues>
+      </output>
       <rule id="DecisionRule_1itcc5z">
         <inputEntry id="UnaryTests_0a5k9fi">
           <text>"B"</text>


### PR DESCRIPTION
related to [#5307](https://github.com/camunda/camunda-bpm-platform/issues/5307)

Some fields mapped but not yet tested:
- `collectedResult`: I was not yet able to find out what that field is for and how to trigger it to not be null. Currently assuming its equivalent of the C8 `result` field but this also needs validated. Follow up ticket [here](https://github.com/camunda/camunda-7-to-8-data-migrator/issues/345)
- `inputs` and `outputs`: currently not inserted by DecisionInstanceMapper so will not be written to C8 DB. Insertion methods [added with this ticket](https://github.com/camunda/camunda/issues/37083) and testing will be added with [this ticket](https://github.com/camunda/camunda-bpm-platform-maintenance/issues/1638)

Some fields not yet mapped properly:
- `decisionType`: we potentially need to scan the xml to find out if its a literal expression or a decision table. Worth it or leave unspecified? Check whether null, unspecified or unknown makes more sense here. Follow up [here](https://github.com/camunda/camunda-bpm-platform/issues/5370)
- `state`: unsure what this would be. Check whether null, unspecified or unknown makes more sense here. Follow up [here](https://github.com/camunda/camunda-bpm-platform/issues/5370)
- `evaluationFailure` and `evaluationFailureMessage`: not yet found how to find this in C7 or even how to trigger its creation for testing. Follow up [here](https://github.com/camunda/camunda-bpm-platform/issues/5366). 

Further Notes:
- ordering by ID is not available for decision instance queries - follow up ticket [here](https://github.com/camunda/camunda-bpm-platform/issues/5368)
- diverted from our usual if/else syntax to fail fast for the decision migration method, I find this much easier to follow

prio for working on follow ups:
1. ordering by ID > can get into next C7 alpha and include in next data migrator release also
   > note: also do variable creation date query stuff while i'm there
3. `inputs` and `outputs` > should be in next c8 release, can already use in snapshot
4. collectedResult
5. all other missing fields