### PR TITLE
chore(dmn): fetch decision instances ordered by id

### DIFF
--- a/core/src/main/java/io/camunda/migrator/impl/clients/C7Client.java
+++ b/core/src/main/java/io/camunda/migrator/impl/clients/C7Client.java
@@ -299,7 +299,9 @@ public class C7Client {
         .includeInputs()
         .includeOutputs()
         .orderByEvaluationTime()
-        .asc(); // TODO order by ID https://github.com/camunda/camunda-bpm-platform/issues/5368
+        .asc()
+        .orderByDecisionInstanceId()
+        .asc();
 
     if (evaluatedAfter != null) {
       query.evaluatedAfter(evaluatedAfter);


### PR DESCRIPTION
related to https://github.com/camunda/camunda-bpm-platform/issues/5368

CI expected to fail since C7 query implementation not merged yet
based on https://github.com/camunda/camunda-7-to-8-data-migrator/pull/205, needs rebased once that one is merged