### PR TITLE
chore(README): remove redundant content

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,6 @@ Please see the official documentation for more details: [Camunda 7 to 8 Migratio
 
 ## Table of Contents
 
-- [Overview](#overview)
-- [Migration Modes](#migration-modes)
 - [Key Features](#key-features)
 - [Prerequisites](#prerequisites)
 - [Installation & Setup](#installation--setup)


### PR DESCRIPTION
Documentation content has been moved to `docs.camunda.io`: 
https://docs.camunda.io/docs/next/guides/migrating-from-camunda-7/data-migrator/

See camunda/camunda-docs#6552

related to camunda/camunda-bpm-platform#4992