### PR TITLE
chore(logs): improve c8 process definition validation logs

### DIFF
--- a/core/src/main/java/io/camunda/migrator/impl/RuntimeValidator.java
+++ b/core/src/main/java/io/camunda/migrator/impl/RuntimeValidator.java
@@ -18,7 +18,6 @@ import static io.camunda.migrator.impl.logging.RuntimeValidatorLogs.MULTI_INSTAN
 import static io.camunda.migrator.impl.logging.RuntimeValidatorLogs.NO_C8_DEPLOYMENT_ERROR;
 import static io.camunda.migrator.impl.logging.RuntimeValidatorLogs.NO_EXECUTION_LISTENER_OF_TYPE_ERROR;
 import static io.camunda.migrator.impl.logging.RuntimeValidatorLogs.NO_NONE_START_EVENT_ERROR;
-import static io.camunda.migrator.impl.util.C7Utils.getActiveActivityIdsById;
 import static io.camunda.migrator.impl.util.ExceptionUtils.callApi;
 import static io.camunda.migrator.impl.logging.RuntimeValidatorLogs.CALL_ACTIVITY_LEGACY_ID_ERROR;
 
@@ -29,7 +28,6 @@ import io.camunda.client.api.search.response.ProcessDefinition;
 import io.camunda.migrator.config.property.MigratorProperties;
 import io.camunda.migrator.impl.clients.C7Client;
 import io.camunda.migrator.impl.clients.C8Client;
-import io.camunda.migrator.impl.logging.RuntimeValidatorLogs;
 import io.camunda.migrator.impl.model.FlowNode;
 import io.camunda.zeebe.model.bpmn.impl.instance.ProcessImpl;
 import io.camunda.zeebe.model.bpmn.impl.instance.zeebe.ZeebeExecutionListenersImpl;
@@ -78,7 +76,7 @@ public class RuntimeValidator {
   /**
    * Validates C8 process structure and execution listeners.
    */
-  public void validateC8Process(String xmlString, long processDefinitionKey) {
+  public void validateC8Process(String xmlString, ProcessDefinition procDef) {
     var bpmnModelInstance = parseBpmnModel(xmlString);
 
     var processInstanceStartEvents = bpmnModelInstance.getDefinitions()
@@ -91,7 +89,7 @@ public class RuntimeValidator {
     boolean hasNoneStartEvent = processInstanceStartEvents.stream()
         .anyMatch(startEvent -> startEvent.getEventDefinitions().isEmpty());
     if (!hasNoneStartEvent) {
-      throw new IllegalStateException(String.format(NO_NONE_START_EVENT_ERROR, processDefinitionKey));
+      throw new IllegalStateException(String.format(NO_NONE_START_EVENT_ERROR, procDef.getProcessDefinitionId(), procDef.getVersion()));
     }
 
     // Skip job type validation if disabled
@@ -110,7 +108,7 @@ public class RuntimeValidator {
       if (!hasMigratorListener) {
         throw new IllegalStateException(
             String.format(NO_EXECUTION_LISTENER_OF_TYPE_ERROR, validationJobType, startEvent.getId(),
-                processDefinitionKey, validationJobType));
+                procDef.getProcessDefinitionId(), procDef.getVersion(), validationJobType));
       }
     });
   }
@@ -209,10 +207,10 @@ public class RuntimeValidator {
 
       var activityInstanceTree = c7Client.getActivityInstance(processInstanceId);
 
-      long processDefinitionKey = c8Definitions.items().getFirst().getProcessDefinitionKey();
-      String c8XmlString = c8Client.getProcessDefinitionXml(processDefinitionKey);
+      ProcessDefinition c8ProcessDefinition = c8Definitions.items().getFirst();
+      String c8XmlString = c8Client.getProcessDefinitionXml(c8ProcessDefinition.getProcessDefinitionKey());
 
-      validateC8Process(c8XmlString, processDefinitionKey);
+      validateC8Process(c8XmlString, c8ProcessDefinition);
 
       RuntimeValidatorLogs.collectingActiveDescendantActivitiesValidation(processInstanceId);
       Map<String, FlowNode> activityInstanceMap = getActiveActivityIdsById(activityInstanceTree, new HashMap<>());

--- a/core/src/main/java/io/camunda/migrator/impl/logging/RuntimeValidatorLogs.java
+++ b/core/src/main/java/io/camunda/migrator/impl/logging/RuntimeValidatorLogs.java
@@ -8,6 +8,7 @@
 package io.camunda.migrator.impl.logging;
 
 import io.camunda.migrator.impl.RuntimeValidator;
+import org.camunda.bpm.engine.runtime.ProcessInstance;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -26,8 +27,8 @@ public class RuntimeValidatorLogs {
 
   // RuntimeValidator Error Messages
   public static final String MULTI_INSTANCE_LOOP_CHARACTERISTICS_ERROR = "Found multi-instance loop characteristics for flow node with id [%s] in C7 process instance.";
-  public static final String NO_NONE_START_EVENT_ERROR = "Couldn't find process None Start Event in C8 process with key [%s].";
-  public static final String NO_EXECUTION_LISTENER_OF_TYPE_ERROR = "No execution listener of type '%s' found on start event [%s] in C8 process with id [%s]. At least one '%s' listener is required.";
+  public static final String NO_NONE_START_EVENT_ERROR = "C8 process definition [id: %s, version: %d] should have a None Start Event.";
+  public static final String NO_EXECUTION_LISTENER_OF_TYPE_ERROR = "No execution listener of type '%s' found on start event [%s] for C8 process definition [id: %s, version: %d]. At least one '%s' listener is required.";
   public static final String FLOW_NODE_NOT_EXISTS_ERROR = "Flow node with id [%s] doesn't exist in the equivalent deployed C8 model.";
   public static final String NO_C8_DEPLOYMENT_ERROR = "No C8 deployment found for process ID [%s] required for instance with legacyID [%s].";
   public static final String FAILED_TO_PARSE_BPMN_MODEL = "Failed to parse BPMN model from XML";

--- a/qa/src/test/java/io/camunda/migrator/qa/runtime/MigratorListenerNotFoundTest.java
+++ b/qa/src/test/java/io/camunda/migrator/qa/runtime/MigratorListenerNotFoundTest.java
@@ -44,8 +44,8 @@ public class MigratorListenerNotFoundTest extends RuntimeMigrationAbstractTest {
             .matches(String.format(".*" + String.format(
                 SKIPPING_PROCESS_INSTANCE_VALIDATION_ERROR.replace("[{}]", "\\[%s\\]").replace("{}", "%s"), id,
                 String.format(
-                    NO_EXECUTION_LISTENER_OF_TYPE_ERROR.replace(".", "\\.").replace("[%s]", "\\[%s\\]"),
-                    "migrator", "Event_1px2j50", "(\\d+)", "migrator")))))).hasSize(1);
+                    NO_EXECUTION_LISTENER_OF_TYPE_ERROR.replace(".", "\\.").replace("[", "\\[").replace("]", "\\]"),
+                    "migrator", "Event_1px2j50", "noMigratorListener", 1, "migrator")))))).hasSize(1);
   }
 
   @Test
@@ -70,8 +70,8 @@ public class MigratorListenerNotFoundTest extends RuntimeMigrationAbstractTest {
             .matches(String.format(".*" + String.format(
                 SKIPPING_PROCESS_INSTANCE_VALIDATION_ERROR.replace("[{}]", "\\[%s\\]").replace("{}", "%s"), id,
                 String.format(
-                    NO_EXECUTION_LISTENER_OF_TYPE_ERROR.replace(".", "\\.").replace("[%s]", "\\[%s\\]"),
-                    "migrator", "Event_1px2j50", "(\\d+)", "migrator")))))).hasSize(1);
+                    NO_EXECUTION_LISTENER_OF_TYPE_ERROR.replace(".", "\\.").replace("[", "\\[").replace("]", "\\]"),
+                    "migrator", "Event_1px2j50", "migratorListenerCustomType", 1, "migrator")))))).hasSize(1);
   }
 
   @Test

--- a/qa/src/test/java/io/camunda/migrator/qa/runtime/element/NoneStartEventNotFoundTest.java
+++ b/qa/src/test/java/io/camunda/migrator/qa/runtime/element/NoneStartEventNotFoundTest.java
@@ -54,7 +54,7 @@ public class NoneStartEventNotFoundTest extends RuntimeMigrationAbstractTest {
 
     var events = logs.getEvents();
     assertThat(events.stream().filter(event -> event.getMessage()
-        .matches(".*Couldn't find process None Start Event in C8 process with key.*")))
+        .matches(".*C8 process definition \\[id: .+, version: .+\\] should have a None Start Event.*")))
         .hasSize(1);
   }
 
@@ -95,7 +95,7 @@ public class NoneStartEventNotFoundTest extends RuntimeMigrationAbstractTest {
 
     var events = logs.getEvents();
     assertThat(events.stream().filter(event -> event.getMessage()
-        .matches(".*Couldn't find process None Start Event in C8 process with key.*")))
+        .matches(".*C8 process definition \\[id: .+, version: .+\\] should have a None Start Event.*")))
         .hasSize(1);
   }
 }

--- a/qa/src/test/java/io/camunda/migrator/qa/runtime/element/UnsupportedStartEventMigrationTest.java
+++ b/qa/src/test/java/io/camunda/migrator/qa/runtime/element/UnsupportedStartEventMigrationTest.java
@@ -35,7 +35,7 @@ public class UnsupportedStartEventMigrationTest extends RuntimeMigrationAbstract
 
     var events = logs.getEvents();
     assertThat(events.stream().filter(event -> event.getMessage()
-        .matches(".*Couldn't find process None Start Event in C8 process with key.*")))
+        .matches(".*C8 process definition \\[id: .+, version: .+\\] should have a None Start Event.*")))
         .hasSize(1);
   }
 }

--- a/qa/src/test/java/io/camunda/migrator/qa/runtime/jobtype/ConfigureAnotherJobTypeValidationTest.java
+++ b/qa/src/test/java/io/camunda/migrator/qa/runtime/jobtype/ConfigureAnotherJobTypeValidationTest.java
@@ -52,9 +52,9 @@ public class ConfigureAnotherJobTypeValidationTest extends RuntimeMigrationAbstr
                     .replace("{}", "%s"), id,
                 String.format(NO_EXECUTION_LISTENER_OF_TYPE_ERROR
                         .replace(".", "\\.")
-                        .replace("{}", "%s")
-                        .replace("[%s]", "\\[%s\\]"),
-                    "my\\-job\\-type", "Event_1px2j50", "(\\d+)", "my\\-job\\-type"))))))
+                        .replace("[", "\\[")
+                        .replace("]", "\\]"),
+                    "my\\-job\\-type", "Event_1px2j50", "noMigratorListener", 1, "my\\-job\\-type"))))))
         .hasSize(1);
   }
 
@@ -83,9 +83,9 @@ public class ConfigureAnotherJobTypeValidationTest extends RuntimeMigrationAbstr
                     .replace("{}", "%s"), id,
                 String.format(NO_EXECUTION_LISTENER_OF_TYPE_ERROR
                         .replace(".", "\\.")
-                        .replace("{}", "%s")
-                        .replace("[%s]", "\\[%s\\]"),
-                    "my\\-job\\-type", "Event_1px2j50", "(\\d+)", "my\\-job\\-type"))))))
+                        .replace("[", "\\[")
+                        .replace("]", "\\]"),
+                    "my\\-job\\-type", "Event_1px2j50", "migratorListenerCustomType", 1, "my\\-job\\-type"))))))
         .hasSize(1);
   }
 }

--- a/qa/src/test/java/io/camunda/migrator/qa/runtime/jobtype/SeparateJobTypesValidationTest.java
+++ b/qa/src/test/java/io/camunda/migrator/qa/runtime/jobtype/SeparateJobTypesValidationTest.java
@@ -54,8 +54,9 @@ public class SeparateJobTypesValidationTest extends RuntimeMigrationAbstractTest
                     .replace("{}", "%s"), id,
                 String.format(NO_EXECUTION_LISTENER_OF_TYPE_ERROR
                         .replace(".", "\\.")
-                        .replace("[%s]", "\\[%s\\]"),
-                    VALIDATION_JOB_TYPE, "Event_1px2j50", "(\\d+)", VALIDATION_JOB_TYPE))))))
+                        .replace("[", "\\[")
+                        .replace("]", "\\]"),
+                    VALIDATION_JOB_TYPE, "Event_1px2j50", "noMigratorListener", 1, VALIDATION_JOB_TYPE))))))
         .hasSize(1);
   }
 
@@ -83,8 +84,9 @@ public class SeparateJobTypesValidationTest extends RuntimeMigrationAbstractTest
                     .replace("{}", "%s"), id,
                 String.format(NO_EXECUTION_LISTENER_OF_TYPE_ERROR
                         .replace(".", "\\.")
-                        .replace("[%s]", "\\[%s\\]"),
-                    VALIDATION_JOB_TYPE, "Event_1px2j50", "(\\d+)", VALIDATION_JOB_TYPE))))))
+                        .replace("[", "\\[")
+                        .replace("]", "\\]"),
+                    VALIDATION_JOB_TYPE, "Event_1px2j50", "migratorListenerCustomType", 1, VALIDATION_JOB_TYPE))))))
         .hasSize(1);
   }
 

--- a/qa/src/test/java/io/camunda/migrator/qa/runtime/jobtype/ValidationJobTypeOnlyTest.java
+++ b/qa/src/test/java/io/camunda/migrator/qa/runtime/jobtype/ValidationJobTypeOnlyTest.java
@@ -51,8 +51,8 @@ public class ValidationJobTypeOnlyTest extends RuntimeMigrationAbstractTest {
             .matches(String.format(".*" + String.format(
                 SKIPPING_PROCESS_INSTANCE_VALIDATION_ERROR.replace("[{}]", "\\[%s\\]").replace("{}", "%s"), id,
                 String.format(
-                    NO_EXECUTION_LISTENER_OF_TYPE_ERROR.replace(".", "\\.").replace("[%s]", "\\[%s\\]"),
-                    VALIDATION_JOB_TYPE, "Event_1px2j50", "(\\d+)", VALIDATION_JOB_TYPE)))))).hasSize(1);
+                    NO_EXECUTION_LISTENER_OF_TYPE_ERROR.replace(".", "\\.").replace("[", "\\[").replace("]", "\\]"),
+                    VALIDATION_JOB_TYPE, "Event_1px2j50", "noMigratorListener", 1, VALIDATION_JOB_TYPE)))))).hasSize(1);
   }
 
   @Test
@@ -77,8 +77,8 @@ public class ValidationJobTypeOnlyTest extends RuntimeMigrationAbstractTest {
             .matches(String.format(".*" + String.format(
                 SKIPPING_PROCESS_INSTANCE_VALIDATION_ERROR.replace("[{}]", "\\[%s\\]").replace("{}", "%s"), id,
                 String.format(
-                    NO_EXECUTION_LISTENER_OF_TYPE_ERROR.replace(".", "\\.").replace("[%s]", "\\[%s\\]"),
-                    VALIDATION_JOB_TYPE, "Event_1px2j50", "(\\d+)", VALIDATION_JOB_TYPE)))))).hasSize(1);
+                    NO_EXECUTION_LISTENER_OF_TYPE_ERROR.replace(".", "\\.").replace("[", "\\[").replace("]", "\\]"),
+                    VALIDATION_JOB_TYPE, "Event_1px2j50", "migratorListenerCustomType", 1, VALIDATION_JOB_TYPE)))))).hasSize(1);
   }
 
   @Test


### PR DESCRIPTION
Related to https://github.com/camunda/camunda-bpm-platform/issues/5301

### Notes

- Now the log message says:

```
[WARN] Skipping process instance with legacyId [5]: C8 process definition [id: MessageStartEventProcessId, version: 1] should have a None Start Event.
```

- Also updated the log message for missing execution listener.