### PR TITLE
fix(core): adopt latest rdmbs and client changes

### DIFF
--- a/core/src/main/java/io/camunda/migrator/config/mybatis/C8Configuration.java
+++ b/core/src/main/java/io/camunda/migrator/config/mybatis/C8Configuration.java
@@ -7,11 +7,13 @@
  */
 package io.camunda.migrator.config.mybatis;
 
+import io.camunda.client.metrics.MetricsRecorder;
 import io.camunda.db.rdbms.RdbmsService;
 import io.camunda.db.rdbms.config.VendorDatabaseProperties;
 import io.camunda.db.rdbms.read.service.AuthorizationDbReader;
 import io.camunda.db.rdbms.read.service.BatchOperationDbReader;
 import io.camunda.db.rdbms.read.service.BatchOperationItemDbReader;
+import io.camunda.db.rdbms.read.service.CorrelatedMessageDbReader;
 import io.camunda.db.rdbms.read.service.DecisionDefinitionDbReader;
 import io.camunda.db.rdbms.read.service.DecisionInstanceDbReader;
 import io.camunda.db.rdbms.read.service.DecisionRequirementsDbReader;
@@ -34,6 +36,7 @@ import io.camunda.db.rdbms.read.service.UserTaskDbReader;
 import io.camunda.db.rdbms.read.service.VariableDbReader;
 import io.camunda.db.rdbms.sql.AuthorizationMapper;
 import io.camunda.db.rdbms.sql.BatchOperationMapper;
+import io.camunda.db.rdbms.sql.CorrelatedMessageMapper;
 import io.camunda.db.rdbms.sql.DecisionDefinitionMapper;
 import io.camunda.db.rdbms.sql.DecisionInstanceMapper;
 import io.camunda.db.rdbms.sql.DecisionRequirementsMapper;
@@ -58,10 +61,8 @@ import io.camunda.db.rdbms.sql.UserTaskMapper;
 import io.camunda.db.rdbms.sql.VariableMapper;
 import io.camunda.db.rdbms.write.RdbmsWriterFactory;
 import io.camunda.db.rdbms.write.RdbmsWriterMetrics;
-import io.camunda.db.rdbms.sql.CorrelatedMessageMapper;
 import io.camunda.migrator.config.C8DataSourceConfigured;
 import io.camunda.migrator.config.property.MigratorProperties;
-import io.camunda.spring.client.metrics.MetricsRecorder;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.util.Properties;
@@ -376,6 +377,11 @@ public class C8Configuration extends AbstractConfiguration {
   }
 
   @Bean
+  public CorrelatedMessageDbReader correlatedMessageReader(CorrelatedMessageMapper correlatedMessageMapper) {
+    return new CorrelatedMessageDbReader(correlatedMessageMapper);
+  }
+
+  @Bean
   public RdbmsWriterFactory rdbmsWriterFactory(
       @Qualifier("c8SqlSessionFactory") SqlSessionFactory c8SqlSessionFactory,
       ExporterPositionMapper exporterPositionMapper,
@@ -443,7 +449,8 @@ public class C8Configuration extends AbstractConfiguration {
       JobDbReader jobReader,
       UsageMetricsDbReader usageMetricsReader,
       UsageMetricTUDbReader usageMetricTUDbReader,
-      MessageSubscriptionDbReader messageSubscriptionDbReader) {
+      MessageSubscriptionDbReader messageSubscriptionDbReader,
+      CorrelatedMessageDbReader correlatedMessageDbReader) {
     return new RdbmsService(
         rdbmsWriterFactory,
         authorizationReader,
@@ -468,7 +475,8 @@ public class C8Configuration extends AbstractConfiguration {
         jobReader,
         usageMetricsReader,
         usageMetricTUDbReader,
-        messageSubscriptionDbReader);
+        messageSubscriptionDbReader,
+        correlatedMessageDbReader);
   }
 
 }


### PR DESCRIPTION
addresses compilation errors against 8.8-Snapshot

<details><summary>Details</summary>

```
Error:  Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.14.0:compile (default-compile) on project camunda-7-to-8-data-migrator-core: Compilation failure: Compilation failure: 
Error:  /home/runner/work/camunda-7-to-8-data-migrator/camunda-7-to-8-data-migrator/core/src/main/java/io/camunda/migrator/config/mybatis/C8Configuration.java:[64,40] package io.camunda.spring.client.metrics does not exist
Error:  /home/runner/work/camunda-7-to-8-data-migrator/camunda-7-to-8-data-migrator/core/src/main/java/io/camunda/migrator/config/mybatis/C8Configuration.java:[221,28] cannot find symbol
Error:    symbol:   class MetricsRecorder
Error:    location: class io.camunda.migrator.config.mybatis.C8Configuration
Error:  /home/runner/work/camunda-7-to-8-data-migrator/camunda-7-to-8-data-migrator/core/src/main/java/io/camunda/migrator/config/mybatis/C8Configuration.java:[222,57] cannot find symbol
Error:    symbol:   class MetricsRecorder
Error:    location: class io.camunda.migrator.config.mybatis.C8Configuration
Error:  /home/runner/work/camunda-7-to-8-data-migrator/camunda-7-to-8-data-migrator/core/src/main/java/io/camunda/migrator/config/mybatis/C8Configuration.java:[447,12] constructor RdbmsService in class io.camunda.db.rdbms.RdbmsService cannot be applied to given types;
Error:    required: io.camunda.db.rdbms.write.RdbmsWriterFactory,io.camunda.db.rdbms.read.service.AuthorizationDbReader,io.camunda.db.rdbms.read.service.DecisionDefinitionDbReader,io.camunda.db.rdbms.read.service.DecisionInstanceDbReader,io.camunda.db.rdbms.read.service.DecisionRequirementsDbReader,io.camunda.db.rdbms.read.service.FlowNodeInstanceDbReader,io.camunda.db.rdbms.read.service.GroupDbReader,io.camunda.db.rdbms.read.service.IncidentDbReader,io.camunda.db.rdbms.read.service.ProcessDefinitionDbReader,io.camunda.db.rdbms.read.service.ProcessInstanceDbReader,io.camunda.db.rdbms.read.service.VariableDbReader,io.camunda.db.rdbms.read.service.RoleDbReader,io.camunda.db.rdbms.read.service.TenantDbReader,io.camunda.db.rdbms.read.service.UserDbReader,io.camunda.db.rdbms.read.service.UserTaskDbReader,io.camunda.db.rdbms.read.service.FormDbReader,io.camunda.db.rdbms.read.service.MappingRuleDbReader,io.camunda.db.rdbms.read.service.BatchOperationDbReader,io.camunda.db.rdbms.read.service.SequenceFlowDbReader,io.camunda.db.rdbms.read.service.BatchOperationItemDbReader,io.camunda.db.rdbms.read.service.JobDbReader,io.camunda.db.rdbms.read.service.UsageMetricsDbReader,io.camunda.db.rdbms.read.service.UsageMetricTUDbReader,io.camunda.db.rdbms.read.service.MessageSubscriptionDbReader,io.camunda.db.rdbms.read.service.CorrelatedMessageDbReader
Error:    found:    io.camunda.db.rdbms.write.RdbmsWriterFactory,io.camunda.db.rdbms.read.service.AuthorizationDbReader,io.camunda.db.rdbms.read.service.DecisionDefinitionDbReader,io.camunda.db.rdbms.read.service.DecisionInstanceDbReader,io.camunda.db.rdbms.read.service.DecisionRequirementsDbReader,io.camunda.db.rdbms.read.service.FlowNodeInstanceDbReader,io.camunda.db.rdbms.read.service.GroupDbReader,io.camunda.db.rdbms.read.service.IncidentDbReader,io.camunda.db.rdbms.read.service.ProcessDefinitionDbReader,io.camunda.db.rdbms.read.service.ProcessInstanceDbReader,io.camunda.db.rdbms.read.service.VariableDbReader,io.camunda.db.rdbms.read.service.RoleDbReader,io.camunda.db.rdbms.read.service.TenantDbReader,io.camunda.db.rdbms.read.service.UserDbReader,io.camunda.db.rdbms.read.service.UserTaskDbReader,io.camunda.db.rdbms.read.service.FormDbReader,io.camunda.db.rdbms.read.service.MappingRuleDbReader,io.camunda.db.rdbms.read.service.BatchOperationDbReader,io.camunda.db.rdbms.read.service.SequenceFlowDbReader,io.camunda.db.rdbms.read.service.BatchOperationItemDbReader,io.camunda.db.rdbms.read.service.JobDbReader,io.camunda.db.rdbms.read.service.UsageMetricsDbReader,io.camunda.db.rdbms.read.service.UsageMetricTUDbReader,io.camunda.db.rdbms.read.service.MessageSubscriptionDbReader
Error:    reason: actual and formal argument lists differ in length
Error:  -> [Help 1]
```
</details> 