### PR TITLE
test(suite): dirty spring context after test execution

### DIFF
--- a/qa/src/test/java/io/camunda/migrator/qa/AbstractMigratorTest.java
+++ b/qa/src/test/java/io/camunda/migrator/qa/AbstractMigratorTest.java
@@ -20,10 +20,12 @@ import org.camunda.bpm.engine.TaskService;
 import org.camunda.bpm.engine.runtime.Job;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
 
 @SpringBootTest
 @WithMultiDb
 @WithSpringProfile("history-level-full")
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 public class AbstractMigratorTest {
 
   @Autowired


### PR DESCRIPTION
This fixes Hikiari data source pools not consistently shutting down, leading to exceeding the max database connections.

related to camunda/camunda-bpm-platform#5413