### PR TITLE
refactor(*): improve C7 and C8 naming

### DIFF
--- a/core/src/main/java/io/camunda/migrator/HistoryMigrator.java
+++ b/core/src/main/java/io/camunda/migrator/HistoryMigrator.java
@@ -206,23 +206,23 @@ public class HistoryMigrator {
     HistoryMigratorLogs.migratingProcessDefinitions();
     if (RETRY_SKIPPED.equals(mode)) {
       dbClient.fetchAndHandleSkippedForType(HISTORY_PROCESS_DEFINITION, idKeyDbModel -> {
-        ProcessDefinition historicProcessDefinition = c7Client.getProcessDefinition(idKeyDbModel.getId());
+        ProcessDefinition historicProcessDefinition = c7Client.getProcessDefinition(idKeyDbModel.getC7Id());
         migrateProcessDefinition(historicProcessDefinition);
       });
     } else {
-      c7Client.fetchAndHandleProcessDefinitions(this::migrateProcessDefinition, dbClient.findLatestStartDateByType((HISTORY_PROCESS_DEFINITION)));
+      c7Client.fetchAndHandleProcessDefinitions(this::migrateProcessDefinition, dbClient.findLatestCreateTimeByType((HISTORY_PROCESS_DEFINITION)));
     }
   }
 
-  private void migrateProcessDefinition(ProcessDefinition legacyProcessDefinition) {
-    String legacyId = legacyProcessDefinition.getId();
-    if (shouldMigrate(legacyId, HISTORY_PROCESS_DEFINITION)) {
-      HistoryMigratorLogs.migratingProcessDefinition(legacyId);
-      ProcessDefinitionDbModel dbModel = processDefinitionConverter.apply(legacyProcessDefinition);
+  private void migrateProcessDefinition(ProcessDefinition c7ProcessDefinition) {
+    String c7Id = c7ProcessDefinition.getId();
+    if (shouldMigrate(c7Id, HISTORY_PROCESS_DEFINITION)) {
+      HistoryMigratorLogs.migratingProcessDefinition(c7Id);
+      ProcessDefinitionDbModel dbModel = processDefinitionConverter.apply(c7ProcessDefinition);
       processDefinitionMapper.insert(dbModel);
-      Date deploymentTime = c7Client.getDefinitionDeploymentTime(legacyProcessDefinition.getDeploymentId());
-      saveRecord(legacyId, deploymentTime, dbModel.processDefinitionKey(), HISTORY_PROCESS_DEFINITION);
-      HistoryMigratorLogs.migratingProcessDefinitionCompleted(legacyId);
+      Date deploymentTime = c7Client.getDefinitionDeploymentTime(c7ProcessDefinition.getDeploymentId());
+      saveRecord(c7Id, deploymentTime, dbModel.processDefinitionKey(), HISTORY_PROCESS_DEFINITION);
+      HistoryMigratorLogs.migratingProcessDefinitionCompleted(c7Id);
     }
   }
 
@@ -230,42 +230,42 @@ public class HistoryMigrator {
     HistoryMigratorLogs.migratingProcessInstances();
     if (RETRY_SKIPPED.equals(mode)) {
       dbClient.fetchAndHandleSkippedForType(HISTORY_PROCESS_INSTANCE, idKeyDbModel -> {
-        HistoricProcessInstance historicProcessInstance = c7Client.getHistoricProcessInstance(idKeyDbModel.getId());
+        HistoricProcessInstance historicProcessInstance = c7Client.getHistoricProcessInstance(idKeyDbModel.getC7Id());
         migrateProcessInstance(historicProcessInstance);
       });
     } else {
-      c7Client.fetchAndHandleHistoricProcessInstances(this::migrateProcessInstance, dbClient.findLatestStartDateByType((HISTORY_PROCESS_INSTANCE)));
+      c7Client.fetchAndHandleHistoricProcessInstances(this::migrateProcessInstance, dbClient.findLatestCreateTimeByType((HISTORY_PROCESS_INSTANCE)));
     }
   }
 
-  private void migrateProcessInstance(HistoricProcessInstance legacyProcessInstance) {
-    String legacyProcessInstanceId = legacyProcessInstance.getId();
-    if (shouldMigrate(legacyProcessInstanceId, HISTORY_PROCESS_INSTANCE)) {
-      HistoryMigratorLogs.migratingProcessInstance(legacyProcessInstanceId);
-      Long processDefinitionKey = findProcessDefinitionKey(legacyProcessInstance.getProcessDefinitionId());
-      String processDefinitionId = legacyProcessInstance.getProcessDefinitionId();
+  private void migrateProcessInstance(HistoricProcessInstance c7ProcessInstance) {
+    String c7ProcessInstanceId = c7ProcessInstance.getId();
+    if (shouldMigrate(c7ProcessInstanceId, HISTORY_PROCESS_INSTANCE)) {
+      HistoryMigratorLogs.migratingProcessInstance(c7ProcessInstanceId);
+      Long processDefinitionKey = findProcessDefinitionKey(c7ProcessInstance.getProcessDefinitionId());
+      String processDefinitionId = c7ProcessInstance.getProcessDefinitionId();
 
       if (isMigrated(processDefinitionId, HISTORY_PROCESS_DEFINITION)) {
-        String legacySuperProcessInstanceId = legacyProcessInstance.getSuperProcessInstanceId();
+        String c7SuperProcessInstanceId = c7ProcessInstance.getSuperProcessInstanceId();
         Long parentProcessInstanceKey = null;
-        if (legacySuperProcessInstanceId != null) {
-          ProcessInstanceEntity parentInstance = findProcessInstanceByLegacyId(legacySuperProcessInstanceId);
+        if (c7SuperProcessInstanceId != null) {
+          ProcessInstanceEntity parentInstance = findProcessInstanceByC7Id(c7SuperProcessInstanceId);
           if (parentInstance != null) {
             parentProcessInstanceKey = parentInstance.processInstanceKey();
           }
         }
-        if (parentProcessInstanceKey != null || legacySuperProcessInstanceId == null) {
-          ProcessInstanceDbModel dbModel = processInstanceConverter.apply(legacyProcessInstance, processDefinitionKey, parentProcessInstanceKey);
+        if (parentProcessInstanceKey != null || c7SuperProcessInstanceId == null) {
+          ProcessInstanceDbModel dbModel = processInstanceConverter.apply(c7ProcessInstance, processDefinitionKey, parentProcessInstanceKey);
           processInstanceMapper.insert(dbModel);
-          saveRecord(legacyProcessInstanceId, legacyProcessInstance.getStartTime(), dbModel.processInstanceKey(), HISTORY_PROCESS_INSTANCE);
-          HistoryMigratorLogs.migratingProcessInstanceCompleted(legacyProcessInstanceId);
+          saveRecord(c7ProcessInstanceId, c7ProcessInstance.getStartTime(), dbModel.processInstanceKey(), HISTORY_PROCESS_INSTANCE);
+          HistoryMigratorLogs.migratingProcessInstanceCompleted(c7ProcessInstanceId);
         } else {
-          saveRecord(legacyProcessInstanceId, null, HISTORY_PROCESS_INSTANCE, SKIP_REASON_MISSING_PARENT_PROCESS_INSTANCE);
-          HistoryMigratorLogs.skippingProcessInstanceDueToMissingParent(legacyProcessInstanceId);
+          saveRecord(c7ProcessInstanceId, null, HISTORY_PROCESS_INSTANCE, SKIP_REASON_MISSING_PARENT_PROCESS_INSTANCE);
+          HistoryMigratorLogs.skippingProcessInstanceDueToMissingParent(c7ProcessInstanceId);
         }
       } else {
-        saveRecord(legacyProcessInstanceId, null, HISTORY_PROCESS_INSTANCE, SKIP_REASON_MISSING_PROCESS_DEFINITION);
-        HistoryMigratorLogs.skippingProcessInstanceDueToMissingDefinition(legacyProcessInstanceId);
+        saveRecord(c7ProcessInstanceId, null, HISTORY_PROCESS_INSTANCE, SKIP_REASON_MISSING_PROCESS_DEFINITION);
+        HistoryMigratorLogs.skippingProcessInstanceDueToMissingDefinition(c7ProcessInstanceId);
       }
     }
   }
@@ -275,23 +275,23 @@ public class HistoryMigrator {
 
     if (RETRY_SKIPPED.equals(mode)) {
       dbClient.fetchAndHandleSkippedForType(HISTORY_DECISION_REQUIREMENT, idKeyDbModel -> {
-        DecisionRequirementsDefinition legacyDecisionRequirement = c7Client.getDecisionRequirementsDefinition(
-            idKeyDbModel.getId());
-        migrateDecisionRequirementsDefinition(legacyDecisionRequirement);
+        DecisionRequirementsDefinition c7DecisionRequirement = c7Client.getDecisionRequirementsDefinition(
+            idKeyDbModel.getC7Id());
+        migrateDecisionRequirementsDefinition(c7DecisionRequirement);
       });
     } else {
       c7Client.fetchAndHandleDecisionRequirementsDefinitions(this::migrateDecisionRequirementsDefinition);
     }
   }
 
-  private void migrateDecisionRequirementsDefinition(DecisionRequirementsDefinition legacyDecisionRequirements) {
-    String legacyId = legacyDecisionRequirements.getId();
-    if (shouldMigrate(legacyId, HISTORY_DECISION_REQUIREMENT)) {
-      HistoryMigratorLogs.migratingDecisionRequirements(legacyId);
-      DecisionRequirementsDbModel dbModel = decisionRequirementsConverter.apply(legacyDecisionRequirements);
+  private void migrateDecisionRequirementsDefinition(DecisionRequirementsDefinition c7DecisionRequirements) {
+    String c7Id = c7DecisionRequirements.getId();
+    if (shouldMigrate(c7Id, HISTORY_DECISION_REQUIREMENT)) {
+      HistoryMigratorLogs.migratingDecisionRequirements(c7Id);
+      DecisionRequirementsDbModel dbModel = decisionRequirementsConverter.apply(c7DecisionRequirements);
       decisionRequirementsMapper.insert(dbModel);
-      saveRecord(legacyId, dbModel.decisionRequirementsKey(), HISTORY_DECISION_REQUIREMENT);
-      HistoryMigratorLogs.migratingDecisionRequirementsCompleted(legacyId);
+      saveRecord(c7Id, dbModel.decisionRequirementsKey(), HISTORY_DECISION_REQUIREMENT);
+      HistoryMigratorLogs.migratingDecisionRequirementsCompleted(c7Id);
     }
   }
 
@@ -300,38 +300,38 @@ public class HistoryMigrator {
 
     if (RETRY_SKIPPED.equals(mode)) {
       dbClient.fetchAndHandleSkippedForType(HISTORY_DECISION_DEFINITION, idKeyDbModel -> {
-        DecisionDefinition legacyDecisionDefinition = c7Client.getDecisionDefinition(idKeyDbModel.getId());
-        migrateDecisionDefinition(legacyDecisionDefinition);
+        DecisionDefinition c7DecisionDefinition = c7Client.getDecisionDefinition(idKeyDbModel.getC7Id());
+        migrateDecisionDefinition(c7DecisionDefinition);
       });
     } else {
       c7Client.fetchAndHandleDecisionDefinitions(this::migrateDecisionDefinition,
-          dbClient.findLatestStartDateByType((HISTORY_DECISION_DEFINITION)));
+          dbClient.findLatestCreateTimeByType((HISTORY_DECISION_DEFINITION)));
     }
   }
 
-  private void migrateDecisionDefinition(DecisionDefinition legacyDecisionDefinition) {
-    String legacyId = legacyDecisionDefinition.getId();
-    if (shouldMigrate(legacyId, HISTORY_DECISION_DEFINITION)) {
-      HistoryMigratorLogs.migratingDecisionDefinition(legacyId);
+  private void migrateDecisionDefinition(DecisionDefinition c7DecisionDefinition) {
+    String c7Id = c7DecisionDefinition.getId();
+    if (shouldMigrate(c7Id, HISTORY_DECISION_DEFINITION)) {
+      HistoryMigratorLogs.migratingDecisionDefinition(c7Id);
       Long decisionRequirementsKey = null;
 
-      if (legacyDecisionDefinition.getDecisionRequirementsDefinitionId() != null) {
-        decisionRequirementsKey = dbClient.findKeyByIdAndType(legacyDecisionDefinition.getDecisionRequirementsDefinitionId(),
+      if (c7DecisionDefinition.getDecisionRequirementsDefinitionId() != null) {
+        decisionRequirementsKey = dbClient.findC8KeyByC7IdAndType(c7DecisionDefinition.getDecisionRequirementsDefinitionId(),
             HISTORY_DECISION_REQUIREMENT);
 
         if (decisionRequirementsKey == null) {
-          saveRecord(legacyId, null, HISTORY_DECISION_DEFINITION, SKIP_REASON_MISSING_DECISION_REQUIREMENTS);
-          HistoryMigratorLogs.skippingDecisionDefinition(legacyId);
+          saveRecord(c7Id, null, HISTORY_DECISION_DEFINITION, SKIP_REASON_MISSING_DECISION_REQUIREMENTS);
+          HistoryMigratorLogs.skippingDecisionDefinition(c7Id);
           return;
         }
       }
 
-      DecisionDefinitionDbModel dbModel = decisionDefinitionConverter.apply(legacyDecisionDefinition,
+      DecisionDefinitionDbModel dbModel = decisionDefinitionConverter.apply(c7DecisionDefinition,
           decisionRequirementsKey);
       decisionDefinitionMapper.insert(dbModel);
-      Date deploymentTime = c7Client.getDefinitionDeploymentTime(legacyDecisionDefinition.getDeploymentId());
-      saveRecord(legacyId, deploymentTime, dbModel.decisionDefinitionKey(), HISTORY_DECISION_DEFINITION);
-      HistoryMigratorLogs.migratingDecisionDefinitionCompleted(legacyId);
+      Date deploymentTime = c7Client.getDefinitionDeploymentTime(c7DecisionDefinition.getDeploymentId());
+      saveRecord(c7Id, deploymentTime, dbModel.decisionDefinitionKey(), HISTORY_DECISION_DEFINITION);
+      HistoryMigratorLogs.migratingDecisionDefinitionCompleted(c7Id);
     }
   }
 
@@ -339,76 +339,76 @@ public class HistoryMigrator {
     HistoryMigratorLogs.migratingDecisionInstances();
     if (RETRY_SKIPPED.equals(mode)) {
       dbClient.fetchAndHandleSkippedForType(HISTORY_DECISION_INSTANCE, idKeyDbModel -> {
-        HistoricDecisionInstance historicDecisionInstance = c7Client.getHistoricDecisionInstance(idKeyDbModel.getId());
+        HistoricDecisionInstance historicDecisionInstance = c7Client.getHistoricDecisionInstance(idKeyDbModel.getC7Id());
         migrateDecisionInstance(historicDecisionInstance);
       });
     } else {
       c7Client.fetchAndHandleHistoricDecisionInstances(this::migrateDecisionInstance,
-          dbClient.findLatestStartDateByType((HISTORY_DECISION_INSTANCE)));
+          dbClient.findLatestCreateTimeByType((HISTORY_DECISION_INSTANCE)));
     }
   }
 
-  private void migrateDecisionInstance(HistoricDecisionInstance legacyDecisionInstance) {
-    if (legacyDecisionInstance.getProcessDefinitionKey() == null) {
+  private void migrateDecisionInstance(HistoricDecisionInstance c7DecisionInstance) {
+    if (c7DecisionInstance.getProcessDefinitionKey() == null) {
       // only migrate decision instances that were triggered by process definitions
-      HistoryMigratorLogs.notMigratingDecisionInstancesNotOriginatingFromBusinessRuleTasks(legacyDecisionInstance.getId());
+      HistoryMigratorLogs.notMigratingDecisionInstancesNotOriginatingFromBusinessRuleTasks(c7DecisionInstance.getId());
       return;
     }
 
-    String legacyDecisionInstanceId = legacyDecisionInstance.getId();
-    if (shouldMigrate(legacyDecisionInstanceId, IdKeyMapper.TYPE.HISTORY_DECISION_INSTANCE)) {
-      HistoryMigratorLogs.migratingDecisionInstance(legacyDecisionInstanceId);
+    String c7DecisionInstanceId = c7DecisionInstance.getId();
+    if (shouldMigrate(c7DecisionInstanceId, IdKeyMapper.TYPE.HISTORY_DECISION_INSTANCE)) {
+      HistoryMigratorLogs.migratingDecisionInstance(c7DecisionInstanceId);
 
-      if (!isMigrated(legacyDecisionInstance.getDecisionDefinitionId(), HISTORY_DECISION_DEFINITION)) {
-        saveRecord(legacyDecisionInstanceId, null, IdKeyMapper.TYPE.HISTORY_DECISION_INSTANCE, SKIP_REASON_MISSING_DECISION_DEFINITION);
-        HistoryMigratorLogs.skippingDecisionInstanceDueToMissingDecisionDefinition(legacyDecisionInstanceId);
+      if (!isMigrated(c7DecisionInstance.getDecisionDefinitionId(), HISTORY_DECISION_DEFINITION)) {
+        saveRecord(c7DecisionInstanceId, null, IdKeyMapper.TYPE.HISTORY_DECISION_INSTANCE, SKIP_REASON_MISSING_DECISION_DEFINITION);
+        HistoryMigratorLogs.skippingDecisionInstanceDueToMissingDecisionDefinition(c7DecisionInstanceId);
         return;
       }
 
-      if (!isMigrated(legacyDecisionInstance.getProcessDefinitionId(), HISTORY_PROCESS_DEFINITION)) {
-        saveRecord(legacyDecisionInstanceId, null, IdKeyMapper.TYPE.HISTORY_DECISION_INSTANCE, SKIP_REASON_MISSING_PROCESS_DEFINITION);
-        HistoryMigratorLogs.skippingDecisionInstanceDueToMissingProcessDefinition(legacyDecisionInstanceId);
+      if (!isMigrated(c7DecisionInstance.getProcessDefinitionId(), HISTORY_PROCESS_DEFINITION)) {
+        saveRecord(c7DecisionInstanceId, null, IdKeyMapper.TYPE.HISTORY_DECISION_INSTANCE, SKIP_REASON_MISSING_PROCESS_DEFINITION);
+        HistoryMigratorLogs.skippingDecisionInstanceDueToMissingProcessDefinition(c7DecisionInstanceId);
         return;
       }
 
-      if (!isMigrated(legacyDecisionInstance.getProcessInstanceId(), HISTORY_PROCESS_INSTANCE)) {
-        saveRecord(legacyDecisionInstanceId, null, IdKeyMapper.TYPE.HISTORY_DECISION_INSTANCE, SKIP_REASON_MISSING_PROCESS_INSTANCE);
-        HistoryMigratorLogs.skippingDecisionInstanceDueToMissingProcessInstance(legacyDecisionInstanceId);
+      if (!isMigrated(c7DecisionInstance.getProcessInstanceId(), HISTORY_PROCESS_INSTANCE)) {
+        saveRecord(c7DecisionInstanceId, null, IdKeyMapper.TYPE.HISTORY_DECISION_INSTANCE, SKIP_REASON_MISSING_PROCESS_INSTANCE);
+        HistoryMigratorLogs.skippingDecisionInstanceDueToMissingProcessInstance(c7DecisionInstanceId);
         return;
       }
 
-      String legacyRootDecisionInstanceId = legacyDecisionInstance.getRootDecisionInstanceId();
+      String c7RootDecisionInstanceId = c7DecisionInstance.getRootDecisionInstanceId();
       Long parentDecisionDefinitionKey = null;
-      if (legacyRootDecisionInstanceId != null) {
-        if (!isMigrated(legacyRootDecisionInstanceId, HISTORY_DECISION_INSTANCE)) {
-          saveRecord(legacyDecisionInstanceId, null, IdKeyMapper.TYPE.HISTORY_DECISION_INSTANCE, SKIP_REASON_MISSING_PARENT_DECISION_INSTANCE);
-          HistoryMigratorLogs.skippingDecisionInstanceDueToMissingParent(legacyDecisionInstanceId);
+      if (c7RootDecisionInstanceId != null) {
+        if (!isMigrated(c7RootDecisionInstanceId, HISTORY_DECISION_INSTANCE)) {
+          saveRecord(c7DecisionInstanceId, null, IdKeyMapper.TYPE.HISTORY_DECISION_INSTANCE, SKIP_REASON_MISSING_PARENT_DECISION_INSTANCE);
+          HistoryMigratorLogs.skippingDecisionInstanceDueToMissingParent(c7DecisionInstanceId);
           return;
         }
-        parentDecisionDefinitionKey = findDecisionInstance(legacyRootDecisionInstanceId).decisionDefinitionKey();
+        parentDecisionDefinitionKey = findDecisionInstance(c7RootDecisionInstanceId).decisionDefinitionKey();
       }
 
-      if (!isMigrated(legacyDecisionInstance.getActivityInstanceId(), HISTORY_FLOW_NODE)) {
-        saveRecord(legacyDecisionInstanceId, null, IdKeyMapper.TYPE.HISTORY_DECISION_INSTANCE, SKIP_REASON_MISSING_FLOW_NODE);
-        HistoryMigratorLogs.skippingDecisionInstanceDueToMissingFlowNodeInstanceInstance(legacyDecisionInstanceId);
+      if (!isMigrated(c7DecisionInstance.getActivityInstanceId(), HISTORY_FLOW_NODE)) {
+        saveRecord(c7DecisionInstanceId, null, IdKeyMapper.TYPE.HISTORY_DECISION_INSTANCE, SKIP_REASON_MISSING_FLOW_NODE);
+        HistoryMigratorLogs.skippingDecisionInstanceDueToMissingFlowNodeInstanceInstance(c7DecisionInstanceId);
         return;
       }
 
       DecisionDefinitionEntity decisionDefinition = findDecisionDefinition(
-          legacyDecisionInstance.getDecisionDefinitionId());
-      Long processDefinitionKey = findProcessDefinitionKey(legacyDecisionInstance.getProcessDefinitionId());
-      Long processInstanceKey = findProcessInstanceByLegacyId(
-          legacyDecisionInstance.getProcessInstanceId()).processInstanceKey();
-      FlowNodeInstanceDbModel flowNode = findFlowNodeInstance(legacyDecisionInstance.getActivityInstanceId());
+          c7DecisionInstance.getDecisionDefinitionId());
+      Long processDefinitionKey = findProcessDefinitionKey(c7DecisionInstance.getProcessDefinitionId());
+      Long processInstanceKey = findProcessInstanceByC7Id(
+          c7DecisionInstance.getProcessInstanceId()).processInstanceKey();
+      FlowNodeInstanceDbModel flowNode = findFlowNodeInstance(c7DecisionInstance.getActivityInstanceId());
 
-      DecisionInstanceDbModel dbModel = decisionInstanceConverter.apply(legacyDecisionInstance,
+      DecisionInstanceDbModel dbModel = decisionInstanceConverter.apply(c7DecisionInstance,
           decisionDefinition.decisionDefinitionKey(), processDefinitionKey,
           decisionDefinition.decisionRequirementsKey(), processInstanceKey, parentDecisionDefinitionKey,
           flowNode.flowNodeInstanceKey(), flowNode.flowNodeId());
       decisionInstanceMapper.insert(dbModel);
-      saveRecord(legacyDecisionInstanceId, legacyDecisionInstance.getEvaluationTime(), dbModel.decisionInstanceKey(),
+      saveRecord(c7DecisionInstanceId, c7DecisionInstance.getEvaluationTime(), dbModel.decisionInstanceKey(),
           HISTORY_DECISION_INSTANCE);
-      HistoryMigratorLogs.migratingDecisionInstanceCompleted(legacyDecisionInstanceId);
+      HistoryMigratorLogs.migratingDecisionInstanceCompleted(c7DecisionInstanceId);
     }
   }
 
@@ -416,36 +416,36 @@ public class HistoryMigrator {
     HistoryMigratorLogs.migratingHistoricIncidents();
     if (RETRY_SKIPPED.equals(mode)) {
       dbClient.fetchAndHandleSkippedForType(HISTORY_INCIDENT, idKeyDbModel -> {
-        HistoricIncident historicIncident = c7Client.getHistoricIncident(idKeyDbModel.getId());
+        HistoricIncident historicIncident = c7Client.getHistoricIncident(idKeyDbModel.getC7Id());
         migrateIncident(historicIncident);
       });
     } else {
-      c7Client.fetchAndHandleHistoricIncidents(this::migrateIncident, dbClient.findLatestStartDateByType((HISTORY_INCIDENT)));
+      c7Client.fetchAndHandleHistoricIncidents(this::migrateIncident, dbClient.findLatestCreateTimeByType((HISTORY_INCIDENT)));
     }
   }
 
-  private void migrateIncident(HistoricIncident legacyIncident) {
-    String legacyIncidentId = legacyIncident.getId();
-    if (shouldMigrate(legacyIncidentId, HISTORY_INCIDENT)) {
-      HistoryMigratorLogs.migratingHistoricIncident(legacyIncidentId);
-      ProcessInstanceEntity legacyProcessInstance = findProcessInstanceByLegacyId(legacyIncident.getProcessInstanceId());
-      if (legacyProcessInstance != null) {
-        Long processInstanceKey = legacyProcessInstance.processInstanceKey();
+  private void migrateIncident(HistoricIncident c7Incident) {
+    String c7IncidentId = c7Incident.getId();
+    if (shouldMigrate(c7IncidentId, HISTORY_INCIDENT)) {
+      HistoryMigratorLogs.migratingHistoricIncident(c7IncidentId);
+      ProcessInstanceEntity c7ProcessInstance = findProcessInstanceByC7Id(c7Incident.getProcessInstanceId());
+      if (c7ProcessInstance != null) {
+        Long processInstanceKey = c7ProcessInstance.processInstanceKey();
         if (processInstanceKey != null) {
-          Long flowNodeInstanceKey = findFlowNodeInstanceKey(legacyIncident.getActivityId(), legacyIncident.getProcessInstanceId());
-          Long processDefinitionKey = findProcessDefinitionKey(legacyIncident.getProcessDefinitionId());
+          Long flowNodeInstanceKey = findFlowNodeInstanceKey(c7Incident.getActivityId(), c7Incident.getProcessInstanceId());
+          Long processDefinitionKey = findProcessDefinitionKey(c7Incident.getProcessDefinitionId());
           Long jobDefinitionKey = null; // TODO Job table doesn't exist yet.
-          IncidentDbModel dbModel = incidentConverter.apply(legacyIncident, processDefinitionKey, processInstanceKey, jobDefinitionKey, flowNodeInstanceKey);
+          IncidentDbModel dbModel = incidentConverter.apply(c7Incident, processDefinitionKey, processInstanceKey, jobDefinitionKey, flowNodeInstanceKey);
           incidentMapper.insert(dbModel);
-          saveRecord(legacyIncidentId, legacyIncident.getCreateTime(), dbModel.incidentKey(), HISTORY_INCIDENT);
-          HistoryMigratorLogs.migratingHistoricIncidentCompleted(legacyIncidentId);
+          saveRecord(c7IncidentId, c7Incident.getCreateTime(), dbModel.incidentKey(), HISTORY_INCIDENT);
+          HistoryMigratorLogs.migratingHistoricIncidentCompleted(c7IncidentId);
         } else {
-          saveRecord(legacyIncidentId, null, HISTORY_INCIDENT, SKIP_REASON_MISSING_PROCESS_INSTANCE_KEY);
-          HistoryMigratorLogs.skippingHistoricIncident(legacyIncidentId);
+          saveRecord(c7IncidentId, null, HISTORY_INCIDENT, SKIP_REASON_MISSING_PROCESS_INSTANCE_KEY);
+          HistoryMigratorLogs.skippingHistoricIncident(c7IncidentId);
         }
       } else {
-        saveRecord(legacyIncidentId, null, HISTORY_INCIDENT, SKIP_REASON_MISSING_PROCESS_INSTANCE);
-        HistoryMigratorLogs.skippingHistoricIncident(legacyIncidentId);
+        saveRecord(c7IncidentId, null, HISTORY_INCIDENT, SKIP_REASON_MISSING_PROCESS_INSTANCE);
+        HistoryMigratorLogs.skippingHistoricIncident(c7IncidentId);
       }
     }
   }
@@ -455,50 +455,50 @@ public class HistoryMigrator {
 
     if (RETRY_SKIPPED.equals(mode)) {
       dbClient.fetchAndHandleSkippedForType(HISTORY_VARIABLE, idKeyDbModel -> {
-        HistoricVariableInstance historicVariableInstance = c7Client.getHistoricVariableInstance(idKeyDbModel.getId());
+        HistoricVariableInstance historicVariableInstance = c7Client.getHistoricVariableInstance(idKeyDbModel.getC7Id());
         migrateVariable(historicVariableInstance);
       });
     } else {
-      c7Client.fetchAndHandleHistoricVariables(this::migrateVariable, dbClient.findLatestStartDateByType(HISTORY_VARIABLE));
+      c7Client.fetchAndHandleHistoricVariables(this::migrateVariable, dbClient.findLatestCreateTimeByType(HISTORY_VARIABLE));
     }
   }
 
-  private void migrateVariable(HistoricVariableInstance legacyVariable) {
-    String legacyVariableId = legacyVariable.getId();
-    if (shouldMigrate(legacyVariableId, HISTORY_VARIABLE)) {
-      HistoryMigratorLogs.migratingHistoricVariable(legacyVariableId);
+  private void migrateVariable(HistoricVariableInstance c7Variable) {
+    String c7VariableId = c7Variable.getId();
+    if (shouldMigrate(c7VariableId, HISTORY_VARIABLE)) {
+      HistoryMigratorLogs.migratingHistoricVariable(c7VariableId);
 
-      String taskId = legacyVariable.getTaskId();
+      String taskId = c7Variable.getTaskId();
       if (taskId != null && !isMigrated(taskId, HISTORY_USER_TASK)) {
         // Skip variable if it belongs to a skipped task
-        saveRecord(legacyVariableId, null, IdKeyMapper.TYPE.HISTORY_VARIABLE, SKIP_REASON_BELONGS_TO_SKIPPED_TASK);
-        HistoryMigratorLogs.skippingHistoricVariableDueToMissingTask(legacyVariableId, taskId);
+        saveRecord(c7VariableId, null, IdKeyMapper.TYPE.HISTORY_VARIABLE, SKIP_REASON_BELONGS_TO_SKIPPED_TASK);
+        HistoryMigratorLogs.skippingHistoricVariableDueToMissingTask(c7VariableId, taskId);
         return;
       }
 
-      String legacyProcessInstanceId = legacyVariable.getProcessInstanceId();
-      if (isMigrated(legacyProcessInstanceId, HISTORY_PROCESS_INSTANCE)) {
-        if (isMigrated(legacyVariable.getActivityInstanceId(), HISTORY_FLOW_NODE) ||
-            isMigrated(legacyVariable.getActivityInstanceId(), HISTORY_PROCESS_INSTANCE)) {
-          ProcessInstanceEntity processInstance = findProcessInstanceByLegacyId(legacyProcessInstanceId);
+      String c7ProcessInstanceId = c7Variable.getProcessInstanceId();
+      if (isMigrated(c7ProcessInstanceId, HISTORY_PROCESS_INSTANCE)) {
+        if (isMigrated(c7Variable.getActivityInstanceId(), HISTORY_FLOW_NODE) ||
+            isMigrated(c7Variable.getActivityInstanceId(), HISTORY_PROCESS_INSTANCE)) {
+          ProcessInstanceEntity processInstance = findProcessInstanceByC7Id(c7ProcessInstanceId);
           Long processInstanceKey = processInstance.processInstanceKey();
-          Long scopeKey = findScopeKey(legacyVariable.getActivityInstanceId());
+          Long scopeKey = findScopeKey(c7Variable.getActivityInstanceId());
           if (scopeKey != null) {
-            VariableDbModel dbModel = variableConverter.apply(legacyVariable, processInstanceKey, scopeKey);
+            VariableDbModel dbModel = variableConverter.apply(c7Variable, processInstanceKey, scopeKey);
             variableMapper.insert(dbModel);
-            saveRecord(legacyVariableId, legacyVariable.getCreateTime(), dbModel.variableKey(), HISTORY_VARIABLE);
-            HistoryMigratorLogs.migratingHistoricVariableCompleted(legacyVariableId);
+            saveRecord(c7VariableId, c7Variable.getCreateTime(), dbModel.variableKey(), HISTORY_VARIABLE);
+            HistoryMigratorLogs.migratingHistoricVariableCompleted(c7VariableId);
           } else {
-            saveRecord(legacyVariableId, null, IdKeyMapper.TYPE.HISTORY_VARIABLE, SKIP_REASON_MISSING_SCOPE_KEY);
-            HistoryMigratorLogs.skippingHistoricVariableDueToMissingScopeKey(legacyVariableId);
+            saveRecord(c7VariableId, null, IdKeyMapper.TYPE.HISTORY_VARIABLE, SKIP_REASON_MISSING_SCOPE_KEY);
+            HistoryMigratorLogs.skippingHistoricVariableDueToMissingScopeKey(c7VariableId);
           }
         } else {
-          saveRecord(legacyVariableId, null, IdKeyMapper.TYPE.HISTORY_VARIABLE, SKIP_REASON_MISSING_FLOW_NODE);
-          HistoryMigratorLogs.skippingHistoricVariableDueToMissingFlowNode(legacyVariableId);
+          saveRecord(c7VariableId, null, IdKeyMapper.TYPE.HISTORY_VARIABLE, SKIP_REASON_MISSING_FLOW_NODE);
+          HistoryMigratorLogs.skippingHistoricVariableDueToMissingFlowNode(c7VariableId);
         }
       } else {
-        saveRecord(legacyVariableId, null, IdKeyMapper.TYPE.HISTORY_VARIABLE, SKIP_REASON_MISSING_PROCESS_INSTANCE);
-        HistoryMigratorLogs.skippingHistoricVariableDueToMissingProcessInstance(legacyVariableId);
+        saveRecord(c7VariableId, null, IdKeyMapper.TYPE.HISTORY_VARIABLE, SKIP_REASON_MISSING_PROCESS_INSTANCE);
+        HistoryMigratorLogs.skippingHistoricVariableDueToMissingProcessInstance(c7VariableId);
       }
     }
   }
@@ -508,34 +508,34 @@ public class HistoryMigrator {
 
     if (RETRY_SKIPPED.equals(mode)) {
       dbClient.fetchAndHandleSkippedForType(HISTORY_USER_TASK, idKeyDbModel -> {
-        HistoricTaskInstance historicTaskInstance = c7Client.getHistoricTaskInstance(idKeyDbModel.getId());
+        HistoricTaskInstance historicTaskInstance = c7Client.getHistoricTaskInstance(idKeyDbModel.getC7Id());
         migrateUserTask(historicTaskInstance);
       });
     } else {
-      c7Client.fetchAndHandleHistoricUserTasks(this::migrateUserTask, dbClient.findLatestStartDateByType((HISTORY_USER_TASK)));
+      c7Client.fetchAndHandleHistoricUserTasks(this::migrateUserTask, dbClient.findLatestCreateTimeByType((HISTORY_USER_TASK)));
     }
   }
 
-  private void migrateUserTask(HistoricTaskInstance legacyUserTask) {
-    String legacyUserTaskId = legacyUserTask.getId();
-    if (shouldMigrate(legacyUserTaskId, HISTORY_USER_TASK)) {
-      HistoryMigratorLogs.migratingHistoricUserTask(legacyUserTaskId);
-      if (isMigrated(legacyUserTask.getProcessInstanceId(), HISTORY_PROCESS_INSTANCE)) {
-        ProcessInstanceEntity processInstance = findProcessInstanceByLegacyId(legacyUserTask.getProcessInstanceId());
-        if (isMigrated(legacyUserTask.getActivityInstanceId(), HISTORY_FLOW_NODE)) {
-          Long elementInstanceKey = findFlowNodeInstanceKey(legacyUserTask.getActivityInstanceId());
-          Long processDefinitionKey = findProcessDefinitionKey(legacyUserTask.getProcessDefinitionId());
-          UserTaskDbModel dbModel = userTaskConverter.apply(legacyUserTask, processDefinitionKey, processInstance, elementInstanceKey);
+  private void migrateUserTask(HistoricTaskInstance c7UserTask) {
+    String c7UserTaskId = c7UserTask.getId();
+    if (shouldMigrate(c7UserTaskId, HISTORY_USER_TASK)) {
+      HistoryMigratorLogs.migratingHistoricUserTask(c7UserTaskId);
+      if (isMigrated(c7UserTask.getProcessInstanceId(), HISTORY_PROCESS_INSTANCE)) {
+        ProcessInstanceEntity processInstance = findProcessInstanceByC7Id(c7UserTask.getProcessInstanceId());
+        if (isMigrated(c7UserTask.getActivityInstanceId(), HISTORY_FLOW_NODE)) {
+          Long elementInstanceKey = findFlowNodeInstanceKey(c7UserTask.getActivityInstanceId());
+          Long processDefinitionKey = findProcessDefinitionKey(c7UserTask.getProcessDefinitionId());
+          UserTaskDbModel dbModel = userTaskConverter.apply(c7UserTask, processDefinitionKey, processInstance, elementInstanceKey);
           userTaskMapper.insert(dbModel);
-          saveRecord(legacyUserTaskId, legacyUserTask.getStartTime(), dbModel.userTaskKey(), HISTORY_USER_TASK);
-          HistoryMigratorLogs.migratingHistoricUserTaskCompleted(legacyUserTaskId);
+          saveRecord(c7UserTaskId, c7UserTask.getStartTime(), dbModel.userTaskKey(), HISTORY_USER_TASK);
+          HistoryMigratorLogs.migratingHistoricUserTaskCompleted(c7UserTaskId);
         } else {
-          saveRecord(legacyUserTaskId, null, IdKeyMapper.TYPE.HISTORY_USER_TASK, SKIP_REASON_MISSING_FLOW_NODE);
-          HistoryMigratorLogs.skippingHistoricUserTaskDueToMissingFlowNode(legacyUserTaskId);
+          saveRecord(c7UserTaskId, null, IdKeyMapper.TYPE.HISTORY_USER_TASK, SKIP_REASON_MISSING_FLOW_NODE);
+          HistoryMigratorLogs.skippingHistoricUserTaskDueToMissingFlowNode(c7UserTaskId);
         }
       } else {
-        saveRecord(legacyUserTaskId, null, IdKeyMapper.TYPE.HISTORY_USER_TASK, SKIP_REASON_MISSING_PROCESS_INSTANCE);
-        HistoryMigratorLogs.skippingHistoricUserTaskDueToMissingProcessInstance(legacyUserTaskId);
+        saveRecord(c7UserTaskId, null, IdKeyMapper.TYPE.HISTORY_USER_TASK, SKIP_REASON_MISSING_PROCESS_INSTANCE);
+        HistoryMigratorLogs.skippingHistoricUserTaskDueToMissingProcessInstance(c7UserTaskId);
       }
     }
   }
@@ -545,50 +545,50 @@ public class HistoryMigrator {
 
     if (RETRY_SKIPPED.equals(mode)) {
       dbClient.fetchAndHandleSkippedForType(HISTORY_FLOW_NODE, idKeyDbModel -> {
-        HistoricActivityInstance historicActivityInstance = c7Client.getHistoricActivityInstance(idKeyDbModel.getId());
+        HistoricActivityInstance historicActivityInstance = c7Client.getHistoricActivityInstance(idKeyDbModel.getC7Id());
         migrateFlowNode(historicActivityInstance);
       });
     } else {
-      c7Client.fetchAndHandleHistoricFlowNodes(this::migrateFlowNode, dbClient.findLatestStartDateByType((HISTORY_FLOW_NODE)));
+      c7Client.fetchAndHandleHistoricFlowNodes(this::migrateFlowNode, dbClient.findLatestCreateTimeByType((HISTORY_FLOW_NODE)));
     }
   }
 
-  private void migrateFlowNode(HistoricActivityInstance legacyFlowNode) {
-    String legacyFlowNodeId = legacyFlowNode.getId();
-    if (shouldMigrate(legacyFlowNodeId, HISTORY_FLOW_NODE)) {
-      HistoryMigratorLogs.migratingHistoricFlowNode(legacyFlowNodeId);
-      ProcessInstanceEntity processInstance = findProcessInstanceByLegacyId(legacyFlowNode.getProcessInstanceId());
+  private void migrateFlowNode(HistoricActivityInstance c7FlowNode) {
+    String c7FlowNodeId = c7FlowNode.getId();
+    if (shouldMigrate(c7FlowNodeId, HISTORY_FLOW_NODE)) {
+      HistoryMigratorLogs.migratingHistoricFlowNode(c7FlowNodeId);
+      ProcessInstanceEntity processInstance = findProcessInstanceByC7Id(c7FlowNode.getProcessInstanceId());
       if (processInstance != null) {
         Long processInstanceKey = processInstance.processInstanceKey();
-        Long processDefinitionKey = findProcessDefinitionKey(legacyFlowNode.getProcessDefinitionId());
-        FlowNodeInstanceDbModel dbModel = flowNodeConverter.apply(legacyFlowNode, processDefinitionKey, processInstanceKey);
+        Long processDefinitionKey = findProcessDefinitionKey(c7FlowNode.getProcessDefinitionId());
+        FlowNodeInstanceDbModel dbModel = flowNodeConverter.apply(c7FlowNode, processDefinitionKey, processInstanceKey);
         flowNodeMapper.insert(dbModel);
-        saveRecord(legacyFlowNodeId, legacyFlowNode.getStartTime(), dbModel.flowNodeInstanceKey(), HISTORY_FLOW_NODE);
-        HistoryMigratorLogs.migratingHistoricFlowNodeCompleted(legacyFlowNodeId);
+        saveRecord(c7FlowNodeId, c7FlowNode.getStartTime(), dbModel.flowNodeInstanceKey(), HISTORY_FLOW_NODE);
+        HistoryMigratorLogs.migratingHistoricFlowNodeCompleted(c7FlowNodeId);
       } else {
-        saveRecord(legacyFlowNodeId, null, HISTORY_FLOW_NODE, SKIP_REASON_MISSING_PROCESS_INSTANCE);
-        HistoryMigratorLogs.skippingHistoricFlowNode(legacyFlowNodeId);
+        saveRecord(c7FlowNodeId, null, HISTORY_FLOW_NODE, SKIP_REASON_MISSING_PROCESS_INSTANCE);
+        HistoryMigratorLogs.skippingHistoricFlowNode(c7FlowNodeId);
       }
     }
   }
 
-  protected ProcessInstanceEntity findProcessInstanceByLegacyId(String processInstanceId) {
+  protected ProcessInstanceEntity findProcessInstanceByC7Id(String processInstanceId) {
     if (processInstanceId == null)
       return null;
 
-    Long key = dbClient.findKeyByIdAndType(processInstanceId, HISTORY_PROCESS_INSTANCE);
-    if (key == null) {
+    Long c8Key = dbClient.findC8KeyByC7IdAndType(processInstanceId, HISTORY_PROCESS_INSTANCE);
+    if (c8Key == null) {
       return null;
     }
 
-    return processInstanceMapper.findOne(key);
+    return processInstanceMapper.findOne(c8Key);
   }
 
   protected DecisionInstanceEntity findDecisionInstance(String decisionInstanceId) {
     if (decisionInstanceId == null)
       return null;
 
-    Long key = dbClient.findKeyByIdAndType(decisionInstanceId, HISTORY_DECISION_INSTANCE);
+    Long key = dbClient.findC8KeyByC7IdAndType(decisionInstanceId, HISTORY_DECISION_INSTANCE);
     if (key == null) {
       return null;
     }
@@ -601,7 +601,7 @@ public class HistoryMigrator {
   }
 
   protected DecisionDefinitionEntity findDecisionDefinition(String decisionDefinitionId) {
-    Long key = dbClient.findKeyByIdAndType(decisionDefinitionId, HISTORY_DECISION_DEFINITION);
+    Long key = dbClient.findC8KeyByC7IdAndType(decisionDefinitionId, HISTORY_DECISION_DEFINITION);
     if (key == null) {
       return null;
     }
@@ -614,7 +614,7 @@ public class HistoryMigrator {
   }
 
   private Long findProcessDefinitionKey(String processDefinitionId) {
-    Long key = dbClient.findKeyByIdAndType(processDefinitionId, HISTORY_PROCESS_DEFINITION);
+    Long key = dbClient.findC8KeyByC7IdAndType(processDefinitionId, HISTORY_PROCESS_DEFINITION);
     if (key == null) {
       return null;
     }
@@ -630,7 +630,7 @@ public class HistoryMigrator {
   }
 
   private Long findFlowNodeInstanceKey(String activityId, String processInstanceId) {
-    Long key = dbClient.findKeyByIdAndType(processInstanceId, HISTORY_PROCESS_INSTANCE);
+    Long key = dbClient.findC8KeyByC7IdAndType(processInstanceId, HISTORY_PROCESS_INSTANCE);
     if (key == null) {
       return null;
     }
@@ -652,7 +652,7 @@ public class HistoryMigrator {
   }
 
   protected FlowNodeInstanceDbModel findFlowNodeInstance(String activityInstanceId) {
-    Long key = dbClient.findKeyByIdAndType(activityInstanceId, HISTORY_FLOW_NODE);
+    Long key = dbClient.findC8KeyByC7IdAndType(activityInstanceId, HISTORY_FLOW_NODE);
     if (key == null) {
       return null;
     }
@@ -669,7 +669,7 @@ public class HistoryMigrator {
       return key;
     }
 
-    Long processInstanceKey = dbClient.findKeyByIdAndType(instanceId, HISTORY_PROCESS_INSTANCE);
+    Long processInstanceKey = dbClient.findC8KeyByC7IdAndType(instanceId, HISTORY_PROCESS_INSTANCE);
     if (processInstanceKey == null) {
       return null;
     }
@@ -680,19 +680,19 @@ public class HistoryMigrator {
   }
 
   private boolean isMigrated(String id, IdKeyMapper.TYPE type) {
-    return dbClient.checkHasKeyByIdAndType(id, type);
+    return dbClient.checkHasC8KeyByC7IdAndType(id, type);
   }
 
   private boolean shouldMigrate(String id, IdKeyMapper.TYPE type) {
     if (mode == RETRY_SKIPPED) {
-      return !dbClient.checkHasKeyByIdAndType(id, type);
+      return !dbClient.checkHasC8KeyByC7IdAndType(id, type);
     }
-    return !dbClient.checkExistsByIdAndType(id, type);
+    return !dbClient.checkExistsByC7IdAndType(id, type);
   }
 
   protected void saveRecord(String entityId, Long entityKey, IdKeyMapper.TYPE type) {
     if (RETRY_SKIPPED.equals(mode)) {
-      dbClient.updateKeyByIdAndType(entityId, entityKey, type);
+      dbClient.updateC8KeyByC7IdAndType(entityId, entityKey, type);
     } else if (MIGRATE.equals(mode)) {
       dbClient.insert(entityId, entityKey, type);
     }
@@ -700,7 +700,7 @@ public class HistoryMigrator {
 
   protected void saveRecord(String entityId, Date date, Long entityKey, IdKeyMapper.TYPE type) {
     if (RETRY_SKIPPED.equals(mode)) {
-      dbClient.updateKeyByIdAndType(entityId, entityKey, type);
+      dbClient.updateC8KeyByC7IdAndType(entityId, entityKey, type);
     } else if (MIGRATE.equals(mode)) {
       dbClient.insert(entityId, date, entityKey, type);
     }
@@ -708,7 +708,7 @@ public class HistoryMigrator {
 
   protected void saveRecord(String entityId, Long entityKey, IdKeyMapper.TYPE type, String skipReason) {
     if (RETRY_SKIPPED.equals(mode)) {
-      dbClient.updateKeyByIdAndType(entityId, entityKey, type);
+      dbClient.updateC8KeyByC7IdAndType(entityId, entityKey, type);
     } else if (MIGRATE.equals(mode)) {
       dbClient.insert(entityId, null, type, skipReason);
 

--- a/core/src/main/java/io/camunda/migrator/RuntimeMigrator.java
+++ b/core/src/main/java/io/camunda/migrator/RuntimeMigrator.java
@@ -76,68 +76,68 @@ public class RuntimeMigrator {
   }
 
   protected void migrate() {
-    fetchProcessInstancesToMigrate(legacyProcessInstance -> {
-      String legacyProcessInstanceId = legacyProcessInstance.getId();
-      Date startDate = legacyProcessInstance.getStartDate();
+    fetchProcessInstancesToMigrate(c7ProcessInstance -> {
+      String c7ProcessInstanceId = c7ProcessInstance.getC7Id();
+      Date createTime = c7ProcessInstance.getCreateTime();
 
-      String skipReason = getSkipReason(legacyProcessInstanceId);
-      if (skipReason == null && shouldStartProcessInstance(legacyProcessInstanceId)) {
-        startProcessInstance(legacyProcessInstanceId, startDate);
-      } else if (isUnknown(legacyProcessInstanceId)) {
-        dbClient.insert(legacyProcessInstanceId, startDate, TYPE.RUNTIME_PROCESS_INSTANCE, skipReason);
+      String skipReason = getSkipReason(c7ProcessInstanceId);
+      if (skipReason == null && shouldStartProcessInstance(c7ProcessInstanceId)) {
+        startProcessInstance(c7ProcessInstanceId, createTime);
+      } else if (isUnknown(c7ProcessInstanceId)) {
+        dbClient.insert(c7ProcessInstanceId, createTime, TYPE.RUNTIME_PROCESS_INSTANCE, skipReason);
       }
     });
 
     activateMigratorJobs();
   }
 
-  protected String getSkipReason(String legacyProcessInstanceId) {
+  protected String getSkipReason(String c7ProcessInstanceId) {
     try {
-      runtimeValidator.validateProcessInstanceState(legacyProcessInstanceId);
+      runtimeValidator.validateProcessInstanceState(c7ProcessInstanceId);
       return null;
     } catch (IllegalStateException e) {
-      RuntimeMigratorLogs.skippingProcessInstanceValidationError(legacyProcessInstanceId, e.getMessage());
+      RuntimeMigratorLogs.skippingProcessInstanceValidationError(c7ProcessInstanceId, e.getMessage());
       return e.getMessage();
     }
   }
 
-  protected boolean shouldStartProcessInstance(String legacyProcessInstanceId) {
-    return RETRY_SKIPPED.equals(mode) || isUnknown(legacyProcessInstanceId);
+  protected boolean shouldStartProcessInstance(String c7ProcessInstanceId) {
+    return RETRY_SKIPPED.equals(mode) || isUnknown(c7ProcessInstanceId);
   }
 
-  protected boolean isUnknown(String legacyProcessInstanceId) {
-    return MIGRATE.equals(mode) && !dbClient.checkExistsByIdAndType(legacyProcessInstanceId, RUNTIME_PROCESS_INSTANCE);
+  protected boolean isUnknown(String c7ProcessInstanceId) {
+    return MIGRATE.equals(mode) && !dbClient.checkExistsByC7IdAndType(c7ProcessInstanceId, RUNTIME_PROCESS_INSTANCE);
   }
 
-  protected void startProcessInstance(String legacyProcessInstanceId, Date startDate) {
-    RuntimeMigratorLogs.startingNewC8ProcessInstance(legacyProcessInstanceId);
+  protected void startProcessInstance(String c7ProcessInstanceId, Date createTime) {
+    RuntimeMigratorLogs.startingNewC8ProcessInstance(c7ProcessInstanceId);
 
     try {
-      Long processInstanceKey = startNewProcessInstance(legacyProcessInstanceId);
+      Long processInstanceKey = startNewProcessInstance(c7ProcessInstanceId);
       RuntimeMigratorLogs.startedC8ProcessInstance(processInstanceKey);
 
       if (processInstanceKey != null) {
-        saveRecord(legacyProcessInstanceId, startDate, processInstanceKey);
+        saveRecord(c7ProcessInstanceId, createTime, processInstanceKey);
       }
     } catch (VariableInterceptorException e) {
-      handleVariableInterceptorException(e, legacyProcessInstanceId, startDate);
+      handleVariableInterceptorException(e, c7ProcessInstanceId, createTime);
     }
   }
 
-  protected void handleVariableInterceptorException(VariableInterceptorException e, String legacyProcessInstanceId, Date startDate) {
-    RuntimeMigratorLogs.skippingProcessInstanceVariableError(legacyProcessInstanceId, e.getMessage());
+  protected void handleVariableInterceptorException(VariableInterceptorException e, String c7ProcessInstanceId, Date createTime) {
+    RuntimeMigratorLogs.skippingProcessInstanceVariableError(c7ProcessInstanceId, e.getMessage());
     RuntimeMigratorLogs.stacktrace(e);
 
     if (MIGRATE.equals(mode)) {
-      dbClient.insert(legacyProcessInstanceId, startDate, TYPE.RUNTIME_PROCESS_INSTANCE, e.getMessage());
+      dbClient.insert(c7ProcessInstanceId, createTime, TYPE.RUNTIME_PROCESS_INSTANCE, e.getMessage());
     }
   }
 
-  protected void saveRecord(String legacyProcessInstanceId, Date startDate, Long processInstanceKey) {
+  protected void saveRecord(String c7ProcessInstanceId, Date createTime, Long processInstanceKey) {
     if (RETRY_SKIPPED.equals(mode)) {
-      dbClient.updateKeyByIdAndType(legacyProcessInstanceId, processInstanceKey, TYPE.RUNTIME_PROCESS_INSTANCE);
+      dbClient.updateC8KeyByC7IdAndType(c7ProcessInstanceId, processInstanceKey, TYPE.RUNTIME_PROCESS_INSTANCE);
     } else if (MIGRATE.equals(mode)) {
-      dbClient.insert(legacyProcessInstanceId, startDate, processInstanceKey, TYPE.RUNTIME_PROCESS_INSTANCE);
+      dbClient.insert(c7ProcessInstanceId, createTime, processInstanceKey, TYPE.RUNTIME_PROCESS_INSTANCE);
     }
   }
 
@@ -147,26 +147,26 @@ public class RuntimeMigrator {
     if (RETRY_SKIPPED.equals(mode)) {
       dbClient.fetchAndHandleSkippedForType(TYPE.RUNTIME_PROCESS_INSTANCE, storeMappingConsumer);
     } else {
-      RuntimeMigratorLogs.fetchingLatestStartDate();
-      Date latestStartDate = dbClient.findLatestStartDateByType(TYPE.RUNTIME_PROCESS_INSTANCE);
-      RuntimeMigratorLogs.latestStartDate(latestStartDate);
+      RuntimeMigratorLogs.fetchingLatestCreateTime();
+      Date latestCreateTime = dbClient.findLatestCreateTimeByType(TYPE.RUNTIME_PROCESS_INSTANCE);
+      RuntimeMigratorLogs.latestCreateTime(latestCreateTime);
 
-      c7Client.fetchAndHandleHistoricRootProcessInstances(storeMappingConsumer, latestStartDate);
+      c7Client.fetchAndHandleHistoricRootProcessInstances(storeMappingConsumer, latestCreateTime);
     }
   }
 
-  protected Long startNewProcessInstance(String legacyProcessInstanceId) throws VariableInterceptorException {
-    var processInstance = c7Client.getProcessInstance(legacyProcessInstanceId);
+  protected Long startNewProcessInstance(String c7ProcessInstanceId) throws VariableInterceptorException {
+    var processInstance = c7Client.getProcessInstance(c7ProcessInstanceId);
     if (processInstance != null) {
       String bpmnProcessId = processInstance.getProcessDefinitionKey();
 
       // Ensure all variables are fetched and can be transformed before starting the new instance
-      Map<String, Object> globalVariables = variableService.getGlobalVariables(legacyProcessInstanceId);
+      Map<String, Object> globalVariables = variableService.getGlobalVariables(c7ProcessInstanceId);
 
       return c8Client.createProcessInstance(bpmnProcessId, processInstance.getTenantId(), globalVariables)
           .getProcessInstanceKey();
     } else {
-      RuntimeMigratorLogs.processInstanceNotExists(legacyProcessInstanceId);
+      RuntimeMigratorLogs.processInstanceNotExists(c7ProcessInstanceId);
       return null;
     }
   }
@@ -182,8 +182,8 @@ public class RuntimeMigrator {
       migratorJobs.forEach(job -> {
         boolean externallyStarted = variableService.isExternallyStartedJob(job);
         if (!externallyStarted) {
-          String legacyId = variableService.getLegacyIdFromJob(job);
-          var activityInstanceTree = c7Client.getActivityInstance(legacyId);
+          String c7Id = variableService.getC7IdFromJob(job);
+          var activityInstanceTree = c7Client.getActivityInstance(c7Id);
 
           RuntimeMigratorLogs.collectingActiveDescendantActivities(activityInstanceTree.getActivityId());
           Map<String, FlowNode> activityInstanceMap = C7Utils.getActiveActivityIdsById(activityInstanceTree, new HashMap<>());

--- a/core/src/main/java/io/camunda/migrator/converter/DecisionDefinitionConverter.java
+++ b/core/src/main/java/io/camunda/migrator/converter/DecisionDefinitionConverter.java
@@ -15,14 +15,14 @@ import org.camunda.bpm.engine.repository.DecisionDefinition;
 
 public class DecisionDefinitionConverter {
 
-  public DecisionDefinitionDbModel apply(DecisionDefinition legacyDecisionDefinition, Long decisionRequirementsKey) {
+  public DecisionDefinitionDbModel apply(DecisionDefinition c7DecisionDefinition, Long decisionRequirementsKey) {
 
     return new DecisionDefinitionDbModel.DecisionDefinitionDbModelBuilder().decisionDefinitionKey(getNextKey())
-        .name(legacyDecisionDefinition.getName())
-        .decisionDefinitionId(legacyDecisionDefinition.getKey())
-        .tenantId(getTenantId(legacyDecisionDefinition.getTenantId()))
-        .version(legacyDecisionDefinition.getVersion())
-        .decisionRequirementsId(legacyDecisionDefinition.getDecisionRequirementsDefinitionKey())
+        .name(c7DecisionDefinition.getName())
+        .decisionDefinitionId(c7DecisionDefinition.getKey())
+        .tenantId(getTenantId(c7DecisionDefinition.getTenantId()))
+        .version(c7DecisionDefinition.getVersion())
+        .decisionRequirementsId(c7DecisionDefinition.getDecisionRequirementsDefinitionKey())
         .decisionRequirementsKey(decisionRequirementsKey)
         .build();
   }

--- a/core/src/main/java/io/camunda/migrator/converter/DecisionInstanceConverter.java
+++ b/core/src/main/java/io/camunda/migrator/converter/DecisionInstanceConverter.java
@@ -59,8 +59,8 @@ public class DecisionInstanceConverter {
   }
 
   private List<DecisionInstanceDbModel.EvaluatedInput> mapInputs(String decisionInstanceId,
-                                                                 List<HistoricDecisionInputInstance> legacyInputs) {
-    return legacyInputs.stream().map(input -> new DecisionInstanceDbModel.EvaluatedInput(decisionInstanceId,
+                                                                 List<HistoricDecisionInputInstance> c7Inputs) {
+    return c7Inputs.stream().map(input -> new DecisionInstanceDbModel.EvaluatedInput(decisionInstanceId,
         input.getId(),
         input.getClauseName(),
         String.valueOf(input.getValue())
@@ -68,8 +68,8 @@ public class DecisionInstanceConverter {
   }
 
   private List<DecisionInstanceDbModel.EvaluatedOutput> mapOutputs(String decisionInstanceId,
-                                                                   List<HistoricDecisionOutputInstance> legacyOutputs) {
-    return legacyOutputs.stream().map(output -> new DecisionInstanceDbModel.EvaluatedOutput(decisionInstanceId,
+                                                                   List<HistoricDecisionOutputInstance> c7Outputs) {
+    return c7Outputs.stream().map(output -> new DecisionInstanceDbModel.EvaluatedOutput(decisionInstanceId,
         output.getId(),
         output.getClauseName(),
         String.valueOf(output.getValue()),

--- a/core/src/main/java/io/camunda/migrator/converter/DecisionRequirementsDefinitionConverter.java
+++ b/core/src/main/java/io/camunda/migrator/converter/DecisionRequirementsDefinitionConverter.java
@@ -15,15 +15,15 @@ import org.camunda.bpm.engine.repository.DecisionRequirementsDefinition;
 
 public class DecisionRequirementsDefinitionConverter {
 
-  public DecisionRequirementsDbModel apply(DecisionRequirementsDefinition legacyDecisionRequirements) {
+  public DecisionRequirementsDbModel apply(DecisionRequirementsDefinition c7DecisionRequirements) {
     return new DecisionRequirementsDbModel.Builder()
         .decisionRequirementsKey(getNextKey())
-        .decisionRequirementsId(legacyDecisionRequirements.getKey())
-        .name(legacyDecisionRequirements.getName())
-        .resourceName(legacyDecisionRequirements.getResourceName())
-        .version(legacyDecisionRequirements.getVersion())
+        .decisionRequirementsId(c7DecisionRequirements.getKey())
+        .name(c7DecisionRequirements.getName())
+        .resourceName(c7DecisionRequirements.getResourceName())
+        .version(c7DecisionRequirements.getVersion())
         .xml(null) // TODO not stored in C7 DecisionRequirementsDefinition
-        .tenantId(getTenantId(legacyDecisionRequirements.getTenantId()))
+        .tenantId(getTenantId(c7DecisionRequirements.getTenantId()))
         .build();
   }
 }

--- a/core/src/main/java/io/camunda/migrator/converter/ProcessDefinitionConverter.java
+++ b/core/src/main/java/io/camunda/migrator/converter/ProcessDefinitionConverter.java
@@ -25,16 +25,16 @@ public class ProcessDefinitionConverter {
   @Autowired
   private C7Client c7Client;
 
-  public ProcessDefinitionDbModel apply(ProcessDefinition legacyProcessDefinition) {
-    String bpmnXml = getBpmnXmlAsString(legacyProcessDefinition);
+  public ProcessDefinitionDbModel apply(ProcessDefinition c7ProcessDefinition) {
+    String bpmnXml = getBpmnXmlAsString(c7ProcessDefinition);
 
     return new ProcessDefinitionDbModel.ProcessDefinitionDbModelBuilder().processDefinitionKey(getNextKey())
-        .processDefinitionId(legacyProcessDefinition.getKey())
-        .resourceName(legacyProcessDefinition.getResourceName())
-        .name(legacyProcessDefinition.getName())
-        .tenantId(legacyProcessDefinition.getTenantId())
-        .versionTag(legacyProcessDefinition.getVersionTag())
-        .version(legacyProcessDefinition.getVersion())
+        .processDefinitionId(c7ProcessDefinition.getKey())
+        .resourceName(c7ProcessDefinition.getResourceName())
+        .name(c7ProcessDefinition.getName())
+        .tenantId(c7ProcessDefinition.getTenantId())
+        .versionTag(c7ProcessDefinition.getVersionTag())
+        .version(c7ProcessDefinition.getVersion())
         .bpmnXml(bpmnXml)
         .formId(null) // TODO https://github.com/camunda/camunda-bpm-platform/issues/5347
         .build();

--- a/core/src/main/java/io/camunda/migrator/impl/RuntimeValidator.java
+++ b/core/src/main/java/io/camunda/migrator/impl/RuntimeValidator.java
@@ -156,9 +156,9 @@ public class RuntimeValidator {
    */
   public void validateC8DefinitionExists(List<ProcessDefinition> c8Definitions,
                                          String c8DefinitionId,
-                                         String legacyProcessInstanceId) {
+                                         String c7ProcessInstanceId) {
     if (c8Definitions.isEmpty()) {
-      throw new IllegalStateException(String.format(NO_C8_DEPLOYMENT_ERROR, c8DefinitionId, legacyProcessInstanceId));
+      throw new IllegalStateException(String.format(NO_C8_DEPLOYMENT_ERROR, c8DefinitionId, c7ProcessInstanceId));
     }
   }
 
@@ -187,10 +187,10 @@ public class RuntimeValidator {
    * This method iterates over all the activity instances of the root process instance and its
    * children until it either finds an activityInstance that cannot be migrated or the iteration ends.
    *
-   * @param legacyProcessInstanceId the legacy id of the root process instance.
+   * @param c7ProcessInstanceId the C7 id of the root process instance.
    */
-  public void validateProcessInstanceState(String legacyProcessInstanceId) {
-    RuntimeValidatorLogs.validateLegacyProcessInstance(legacyProcessInstanceId);
+  public void validateProcessInstanceState(String c7ProcessInstanceId) {
+    RuntimeValidatorLogs.validateC7ProcessInstance(c7ProcessInstanceId);
     c7Client.fetchAndHandleProcessInstances(processInstance -> {
       String processInstanceId = processInstance.getId();
       String c7DefinitionId = processInstance.getProcessDefinitionId();
@@ -216,7 +216,7 @@ public class RuntimeValidator {
         validateC7FlowNodes(c7DefinitionId, flowNode.activityId());
         validateC8FlowNodes(c8XmlString, flowNode.activityId());
       }
-    }, legacyProcessInstanceId);
+    }, c7ProcessInstanceId);
   }
 
   protected void validateMultiTenancy(String tenantId) {

--- a/core/src/main/java/io/camunda/migrator/impl/clients/C7Client.java
+++ b/core/src/main/java/io/camunda/migrator/impl/clients/C7Client.java
@@ -83,35 +83,35 @@ public class C7Client {
   /**
    * Gets a single process definition by ID.
    */
-  public ProcessDefinition getProcessDefinition(String legacyId) {
-    var query = repositoryService.createProcessDefinitionQuery().processDefinitionId(legacyId);
-    return callApi(query::singleResult, format(FAILED_TO_FETCH_HISTORIC_ELEMENT, "ProcessDefinition", legacyId));
+  public ProcessDefinition getProcessDefinition(String c7Id) {
+    var query = repositoryService.createProcessDefinitionQuery().processDefinitionId(c7Id);
+    return callApi(query::singleResult, format(FAILED_TO_FETCH_HISTORIC_ELEMENT, "ProcessDefinition", c7Id));
   }
 
   /**
    * Gets a single decision requirements definition by ID.
    */
-  public DecisionRequirementsDefinition getDecisionRequirementsDefinition(String legacyId) {
+  public DecisionRequirementsDefinition getDecisionRequirementsDefinition(String c7Id) {
     var query = repositoryService.createDecisionRequirementsDefinitionQuery()
-        .decisionRequirementsDefinitionId(legacyId);
+        .decisionRequirementsDefinitionId(c7Id);
     return callApi(query::singleResult,
-        format(FAILED_TO_FETCH_HISTORIC_ELEMENT, "DecisionRequirementsDefinition", legacyId));
+        format(FAILED_TO_FETCH_HISTORIC_ELEMENT, "DecisionRequirementsDefinition", c7Id));
   }
 
   /**
    * Gets a single decision definition by ID.
    */
-  public DecisionDefinition getDecisionDefinition(String legacyId) {
-    var query = repositoryService.createDecisionDefinitionQuery().decisionDefinitionId(legacyId);
-    return callApi(query::singleResult, format(FAILED_TO_FETCH_HISTORIC_ELEMENT, "DecisionDefinition", legacyId));
+  public DecisionDefinition getDecisionDefinition(String c7Id) {
+    var query = repositoryService.createDecisionDefinitionQuery().decisionDefinitionId(c7Id);
+    return callApi(query::singleResult, format(FAILED_TO_FETCH_HISTORIC_ELEMENT, "DecisionDefinition", c7Id));
   }
 
   /**
    * Gets a single historic decision instance by ID.
    */
-  public HistoricDecisionInstance getHistoricDecisionInstance(String legacyId) {
-    var query = historyService.createHistoricDecisionInstanceQuery().decisionInstanceId(legacyId);
-    return callApi(query::singleResult, format(FAILED_TO_FETCH_HISTORIC_ELEMENT, "HistoricDecisionInstance", legacyId));
+  public HistoricDecisionInstance getHistoricDecisionInstance(String c7Id) {
+    var query = historyService.createHistoricDecisionInstanceQuery().decisionInstanceId(c7Id);
+    return callApi(query::singleResult, format(FAILED_TO_FETCH_HISTORIC_ELEMENT, "HistoricDecisionInstance", c7Id));
   }
 
   /**
@@ -125,41 +125,41 @@ public class C7Client {
   /**
    * Gets a single historic process instance by ID.
    */
-  public HistoricProcessInstance getHistoricProcessInstance(String legacyId) {
-    var query = historyService.createHistoricProcessInstanceQuery().processInstanceId(legacyId);
-    return callApi(query::singleResult, format(FAILED_TO_FETCH_HISTORIC_ELEMENT, "HistoricProcessInstance", legacyId));
+  public HistoricProcessInstance getHistoricProcessInstance(String c7Id) {
+    var query = historyService.createHistoricProcessInstanceQuery().processInstanceId(c7Id);
+    return callApi(query::singleResult, format(FAILED_TO_FETCH_HISTORIC_ELEMENT, "HistoricProcessInstance", c7Id));
   }
 
   /**
    * Gets a single historic activity instance by ID.
    */
-  public HistoricActivityInstance getHistoricActivityInstance(String legacyId) {
-    var query = historyService.createHistoricActivityInstanceQuery().activityInstanceId(legacyId);
-    return callApi(query::singleResult, format(FAILED_TO_FETCH_HISTORIC_ELEMENT, "HistoricActivityInstance", legacyId));
+  public HistoricActivityInstance getHistoricActivityInstance(String c7Id) {
+    var query = historyService.createHistoricActivityInstanceQuery().activityInstanceId(c7Id);
+    return callApi(query::singleResult, format(FAILED_TO_FETCH_HISTORIC_ELEMENT, "HistoricActivityInstance", c7Id));
   }
 
   /**
    * Gets a single historic task instance by ID.
    */
-  public HistoricTaskInstance getHistoricTaskInstance(String legacyId) {
-    var query = historyService.createHistoricTaskInstanceQuery().taskId(legacyId);
-    return callApi(query::singleResult, format(FAILED_TO_FETCH_HISTORIC_ELEMENT, "HistoricTaskInstance", legacyId));
+  public HistoricTaskInstance getHistoricTaskInstance(String c7Id) {
+    var query = historyService.createHistoricTaskInstanceQuery().taskId(c7Id);
+    return callApi(query::singleResult, format(FAILED_TO_FETCH_HISTORIC_ELEMENT, "HistoricTaskInstance", c7Id));
   }
 
   /**
    * Gets a single historic variable instance by ID.
    */
-  public HistoricVariableInstance getHistoricVariableInstance(String legacyId) {
-    var query = historyService.createHistoricVariableInstanceQuery().variableId(legacyId);
-    return callApi(query::singleResult, format(FAILED_TO_FETCH_HISTORIC_ELEMENT, "HistoricVariableInstance", legacyId));
+  public HistoricVariableInstance getHistoricVariableInstance(String c7Id) {
+    var query = historyService.createHistoricVariableInstanceQuery().variableId(c7Id);
+    return callApi(query::singleResult, format(FAILED_TO_FETCH_HISTORIC_ELEMENT, "HistoricVariableInstance", c7Id));
   }
 
   /**
    * Gets a single historic incident by ID.
    */
-  public HistoricIncident getHistoricIncident(String legacyId) {
-    var query = historyService.createHistoricIncidentQuery().incidentId(legacyId);
-    return callApi(query::singleResult, format(FAILED_TO_FETCH_HISTORIC_ELEMENT, "HistoricIncident", legacyId));
+  public HistoricIncident getHistoricIncident(String c7Id) {
+    var query = historyService.createHistoricIncidentQuery().incidentId(c7Id);
+    return callApi(query::singleResult, format(FAILED_TO_FETCH_HISTORIC_ELEMENT, "HistoricIncident", c7Id));
   }
 
   /**
@@ -173,10 +173,10 @@ public class C7Client {
   /**
    * Gets all variables for a process instance with pagination and variable transformation.
    */
-  public List<VariableInstance> getAllVariables(String legacyProcessInstanceId) {
+  public List<VariableInstance> getAllVariables(String c7ProcessInstanceId) {
     VariableInstanceQuery variableQuery = runtimeService.createVariableInstanceQuery()
         .disableCustomObjectDeserialization()
-        .processInstanceIdIn(legacyProcessInstanceId);
+        .processInstanceIdIn(c7ProcessInstanceId);
 
     return new Pagination<VariableInstance>()
         .pageSize(properties.getPageSize())

--- a/core/src/main/java/io/camunda/migrator/impl/clients/DbClient.java
+++ b/core/src/main/java/io/camunda/migrator/impl/clients/DbClient.java
@@ -13,7 +13,7 @@ import static io.camunda.migrator.impl.logging.DbClientLogs.FAILED_TO_DELETE;
 import static io.camunda.migrator.impl.logging.DbClientLogs.FAILED_TO_FIND_ALL;
 import static io.camunda.migrator.impl.logging.DbClientLogs.FAILED_TO_FIND_ALL_SKIPPED;
 import static io.camunda.migrator.impl.logging.DbClientLogs.FAILED_TO_FIND_KEY_BY_ID;
-import static io.camunda.migrator.impl.logging.DbClientLogs.FAILED_TO_FIND_LATEST_START_DATE;
+import static io.camunda.migrator.impl.logging.DbClientLogs.FAILED_TO_FIND_LATEST_CREATE_TIME;
 import static io.camunda.migrator.impl.logging.DbClientLogs.FAILED_TO_FIND_SKIPPED_COUNT;
 import static io.camunda.migrator.impl.logging.DbClientLogs.FAILED_TO_INSERT_RECORD;
 import static io.camunda.migrator.impl.logging.DbClientLogs.FAILED_TO_UPDATE_KEY;
@@ -49,76 +49,76 @@ public class DbClient {
   /**
    * Checks if an entity exists in the mapping table by type and id.
    */
-  public boolean checkExistsByIdAndType(String legacyId, TYPE type) {
-    return callApi(() -> idKeyMapper.checkExistsByIdAndType(type, legacyId), FAILED_TO_CHECK_EXISTENCE + legacyId);
+  public boolean checkExistsByC7IdAndType(String c7Id, TYPE type) {
+    return callApi(() -> idKeyMapper.checkExistsByC7IdAndType(type, c7Id), FAILED_TO_CHECK_EXISTENCE + c7Id);
   }
 
   /**
    * Checks if an entity exists in the mapping table by type and id.
    */
-  public boolean checkHasKeyByIdAndType(String legacyId, TYPE type) {
-    return callApi(() -> idKeyMapper.checkHasKeyByIdAndType(type, legacyId), FAILED_TO_CHECK_KEY + legacyId);
+  public boolean checkHasC8KeyByC7IdAndType(String c7Id, TYPE type) {
+    return callApi(() -> idKeyMapper.checkHasC8KeyByC7IdAndType(type, c7Id), FAILED_TO_CHECK_KEY + c7Id);
   }
 
   /**
-   * Finds the latest start date by type.
+   * Finds the latest create time by type.
    */
-  public Date findLatestStartDateByType(TYPE type) {
-    Date latestStartDate = callApi(() -> idKeyMapper.findLatestStartDateByType(type),
-        FAILED_TO_FIND_LATEST_START_DATE + type);
-    DbClientLogs.foundLatestStartDate(latestStartDate, type);
-    return latestStartDate;
+  public Date findLatestCreateTimeByType(TYPE type) {
+    Date latestCreateTime = callApi(() -> idKeyMapper.findLatestCreateTimeByType(type),
+        FAILED_TO_FIND_LATEST_CREATE_TIME + type);
+    DbClientLogs.foundLatestCreateTime(latestCreateTime, type);
+    return latestCreateTime;
   }
 
   /**
-   * Finds the key by legacy ID and type.
+   * Finds the key by C7 ID and type.
    */
-  public Long findKeyByIdAndType(String legacyId, TYPE type) {
-    return callApi(() -> idKeyMapper.findKeysByIdAndType(legacyId, type), FAILED_TO_FIND_KEY_BY_ID + legacyId);
+  public Long findC8KeyByC7IdAndType(String c7Id, TYPE type) {
+    return callApi(() -> idKeyMapper.findC8KeyByC7IdAndType(c7Id, type), FAILED_TO_FIND_KEY_BY_ID + c7Id);
   }
 
   /**
-   * Finds all legacy IDs.
+   * Finds all C7 IDs.
    */
-  public List<String> findAllIds() {
-    return callApi(() -> idKeyMapper.findAllIds(), FAILED_TO_FIND_ALL);
+  public List<String> findAllC7Ids() {
+    return callApi(() -> idKeyMapper.findAllC7Ids(), FAILED_TO_FIND_ALL);
   }
 
   /**
    * Updates a record by setting the key for an existing ID and type.
    */
-  public void updateKeyByIdAndType(String legacyId, Long entityKey, TYPE type) {
-    DbClientLogs.updatingKeyForLegacyId(legacyId, entityKey);
-    var model = createIdKeyDbModel(legacyId, null, entityKey, type);
-    callApi(() -> idKeyMapper.updateKeyByIdAndType(model), FAILED_TO_UPDATE_KEY + entityKey);
+  public void updateC8KeyByC7IdAndType(String c7Id, Long c8Key, TYPE type) {
+    DbClientLogs.updatingC8KeyForC7Id(c7Id, c8Key);
+    var model = createIdKeyDbModel(c7Id, null, c8Key, type);
+    callApi(() -> idKeyMapper.updateC8KeyByC7IdAndType(model), FAILED_TO_UPDATE_KEY + c8Key);
   }
 
   /**
    * Inserts a new process instance record into the mapping table.
    */
-  public void insert(String legacyId, Date startDate, Long entityKey, TYPE type) {
-    DbClientLogs.insertingRecord(legacyId, startDate, entityKey, null);
-    var model = createIdKeyDbModel(legacyId, startDate, entityKey, type);
-    callApi(() -> idKeyMapper.insert(model), FAILED_TO_INSERT_RECORD + legacyId);
+  public void insert(String c7Id, Date createTime, Long c8Key, TYPE type) {
+    DbClientLogs.insertingRecord(c7Id, createTime, c8Key, null);
+    var model = createIdKeyDbModel(c7Id, createTime, c8Key, type);
+    callApi(() -> idKeyMapper.insert(model), FAILED_TO_INSERT_RECORD + c7Id);
   }
 
   /**
    * Inserts a new record into the mapping table.
    */
-  public void insert(String legacyId, Long key, TYPE type) {
-    DbClientLogs.insertingRecord(legacyId, null, key, null);
-    var model = createIdKeyDbModel(legacyId, null, key, type);
-    callApi(() -> idKeyMapper.insert(model), FAILED_TO_INSERT_RECORD + legacyId);
+  public void insert(String c7Id, Long c8Key, TYPE type) {
+    DbClientLogs.insertingRecord(c7Id, null, c8Key, null);
+    var model = createIdKeyDbModel(c7Id, null, c8Key, type);
+    callApi(() -> idKeyMapper.insert(model), FAILED_TO_INSERT_RECORD + c7Id);
   }
 
   /**
    * Inserts a new process instance record into the mapping table.
    */
-  public void insert(String legacyId, Date startDate, TYPE type, String skipReason) {
+  public void insert(String c7Id, Date createTime, TYPE type, String skipReason) {
     String finalSkipReason = properties.getSaveSkipReason() ? skipReason : null;
-    DbClientLogs.insertingRecord(legacyId, startDate, null, finalSkipReason);
-    var model = createIdKeyDbModel(legacyId, startDate, null, type, finalSkipReason);
-    callApi(() -> idKeyMapper.insert(model), FAILED_TO_INSERT_RECORD + legacyId);
+    DbClientLogs.insertingRecord(c7Id, createTime, null, finalSkipReason);
+    var model = createIdKeyDbModel(c7Id, createTime, null, type, finalSkipReason);
+    callApi(() -> idKeyMapper.insert(model), FAILED_TO_INSERT_RECORD + c7Id);
   }
 
   /**
@@ -129,7 +129,7 @@ public class DbClient {
         .maxCount(() -> idKeyMapper.countSkippedByType(type))
         .page(offset -> idKeyMapper.findSkippedByType(type, offset, properties.getPageSize())
             .stream()
-            .map(IdKeyDbModel::getId)
+            .map(IdKeyDbModel::getC7Id)
             .collect(Collectors.toList()))
         .callback(PrintUtils::print);
   }
@@ -171,24 +171,24 @@ public class DbClient {
    * Deletes all mappings from the database.
    */
   public void deleteAllMappings() {
-    findAllIds().forEach(this::delete);
+    findAllC7Ids().forEach(this::deleteByC7Id);
   }
 
   /**
-   * Deletes a mapping by legacy ID.
+   * Deletes a mapping by C7 ID.
    */
-  protected void delete(String legacyId) {
-    callApi(() -> idKeyMapper.delete(legacyId), FAILED_TO_DELETE + legacyId);
+  protected void deleteByC7Id(String c7Id) {
+    callApi(() -> idKeyMapper.deleteByC7Id(c7Id), FAILED_TO_DELETE + c7Id);
   }
 
   /**
    * Creates a new IdKeyDbModel instance with the provided parameters including skip reason.
    */
-  protected IdKeyDbModel createIdKeyDbModel(String id, Date startDate, Long key, TYPE type, String skipReason) {
+  protected IdKeyDbModel createIdKeyDbModel(String c7Id, Date createTime, Long c8Key, TYPE type, String skipReason) {
     var keyIdDbModel = new IdKeyDbModel();
-    keyIdDbModel.setId(id);
-    keyIdDbModel.setStartDate(startDate);
-    keyIdDbModel.setInstanceKey(key);
+    keyIdDbModel.setC7Id(c7Id);
+    keyIdDbModel.setCreateTime(createTime);
+    keyIdDbModel.setC8Key(c8Key);
     keyIdDbModel.setType(type);
     keyIdDbModel.setSkipReason(skipReason);
     return keyIdDbModel;
@@ -197,8 +197,8 @@ public class DbClient {
   /**
    * Creates a new IdKeyDbModel instance with the provided parameters.
    */
-  protected IdKeyDbModel createIdKeyDbModel(String id, Date startDate, Long key, TYPE type) {
-    return createIdKeyDbModel(id, startDate, key, type, null);
+  protected IdKeyDbModel createIdKeyDbModel(String c7Id, Date createTime, Long c8Key, TYPE type) {
+    return createIdKeyDbModel(c7Id, createTime, c8Key, type, null);
   }
 
 }

--- a/core/src/main/java/io/camunda/migrator/impl/logging/C7ClientLogs.java
+++ b/core/src/main/java/io/camunda/migrator/impl/logging/C7ClientLogs.java
@@ -16,8 +16,8 @@ public class C7ClientLogs {
 
   // C7 Client Error Messages
   public static final String FAILED_TO_FETCH_ACTIVITY_INSTANCE = "Failed to fetch activity instance for processInstanceId: ";
-  public static final String FAILED_TO_FETCH_DEPLOYMENT_TIME = "Failed to fetch deployment time for definition with legacyId: ";
+  public static final String FAILED_TO_FETCH_DEPLOYMENT_TIME = "Failed to fetch deployment time for definition with C7 ID: ";
   public static final String FAILED_TO_FETCH_BPMN_XML = "Failed to fetch BPMN model instance for process definition Id: ";
-  public static final String FAILED_TO_FETCH_PROCESS_INSTANCE = "Process instance fetching failed for legacyId: ";
-  public static final String FAILED_TO_FETCH_HISTORIC_ELEMENT = "Failed to fetch %s for legacyId: %s";
+  public static final String FAILED_TO_FETCH_PROCESS_INSTANCE = "Process instance fetching failed for C7 ID: ";
+  public static final String FAILED_TO_FETCH_HISTORIC_ELEMENT = "Failed to fetch %s for C7 ID: %s";
 }

--- a/core/src/main/java/io/camunda/migrator/impl/logging/DbClientLogs.java
+++ b/core/src/main/java/io/camunda/migrator/impl/logging/DbClientLogs.java
@@ -8,7 +8,7 @@
 package io.camunda.migrator.impl.logging;
 
 import io.camunda.migrator.impl.clients.DbClient;
-import io.camunda.migrator.impl.persistence.IdKeyMapper;
+import io.camunda.migrator.impl.persistence.IdKeyMapper.TYPE;
 import java.util.Date;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -21,36 +21,32 @@ public class DbClientLogs {
   protected static final Logger LOGGER = LoggerFactory.getLogger(DbClient.class);
 
   // DbClient Messages
-  public static final String UPDATING_KEY_FOR_LEGACY_ID = "Updating key for legacyId [{}] with value [{}]";
-  public static final String INSERTING_RECORD = "Inserting record [{}], [{}], [{}]";
-  public static final String FOUND_START_DATE_FOR_TYPE = "Latest start date for {}: {}";
+  public static final String UPDATING_KEY_FOR_C7_ID = "Updating key for C7 ID [{}] with value [{}]";
+  public static final String INSERTING_RECORD = "Inserting record [{}], [{}], [{}], [{}]";
+  public static final String FOUND_CREATE_TIME_FOR_TYPE = "Latest create time for {}: {}";
 
   // DbClient Error Messages
-  public static final String FAILED_TO_CHECK_EXISTENCE = "Failed to check existence for legacyId: ";
-  public static final String FAILED_TO_CHECK_KEY = "Failed to check key for legacyId: ";
-  public static final String FAILED_TO_FIND_ALL = "Failed to find all ids";
-  public static final String FAILED_TO_FIND_LATEST_START_DATE = "Failed to find latest start date for type: ";
-  public static final String FAILED_TO_FIND_KEY_BY_ID = "Failed to find key by legacyId: ";
-  public static final String FAILED_TO_UPDATE_KEY = "Failed to update key for legacyId: ";
-  public static final String FAILED_TO_INSERT_RECORD = "Failed to insert record for legacyId: ";
+  public static final String FAILED_TO_CHECK_EXISTENCE = "Failed to check existence for C7 ID: ";
+  public static final String FAILED_TO_CHECK_KEY = "Failed to check key for C7 ID: ";
+  public static final String FAILED_TO_FIND_ALL = "Failed to find all C7 IDs";
+  public static final String FAILED_TO_FIND_LATEST_CREATE_TIME = "Failed to find latest create time for type: ";
+  public static final String FAILED_TO_FIND_KEY_BY_ID = "Failed to find key by C7 ID: ";
+  public static final String FAILED_TO_UPDATE_KEY = "Failed to update key for C7 ID: ";
+  public static final String FAILED_TO_INSERT_RECORD = "Failed to insert record for C7 ID: ";
   public static final String FAILED_TO_FIND_SKIPPED_COUNT = "Failed to find skipped count";
-  public static final String FAILED_TO_FIND_ALL_SKIPPED = "Failed to find skipped entity Ids";
-  public static final String FAILED_TO_DELETE = "Failed to delete mapping for legacyId: ";
+  public static final String FAILED_TO_FIND_ALL_SKIPPED = "Failed to find skipped C7 IDs";
+  public static final String FAILED_TO_DELETE = "Failed to delete mapping for C7 ID: ";
   public static final String FAILED_TO_DROP_MIGRATION_TABLE = "Failed to drop migration mapping table";
 
-  public static void updatingKeyForLegacyId(String legacyProcessInstanceId, Long processInstanceKey) {
-    LOGGER.debug(UPDATING_KEY_FOR_LEGACY_ID, legacyProcessInstanceId, processInstanceKey);
+  public static void updatingC8KeyForC7Id(String c7Id, Long c8Key) {
+    LOGGER.debug(UPDATING_KEY_FOR_C7_ID, c7Id, c8Key);
   }
 
-  public static void insertingRecord(String legacyProcessInstanceId, Object startDate, Long processInstanceKey) {
-    LOGGER.debug(INSERTING_RECORD, legacyProcessInstanceId, startDate, processInstanceKey);
+  public static void insertingRecord(String c7Id, Object startDate, Long c8Key, String skipReason) {
+    LOGGER.debug(INSERTING_RECORD, c7Id, startDate, c8Key, skipReason);
   }
 
-  public static void insertingRecord(String legacyProcessInstanceId, Object startDate, Long processInstanceKey, String skipReason) {
-    LOGGER.debug(INSERTING_RECORD, legacyProcessInstanceId, startDate, processInstanceKey, skipReason);
-  }
-
-  public static void foundLatestStartDate(Date latestStartDate, IdKeyMapper.TYPE type) {
-    LOGGER.debug(FOUND_START_DATE_FOR_TYPE, type, latestStartDate);
+  public static void foundLatestCreateTime(Date latestCreateTime, TYPE type) {
+    LOGGER.debug(FOUND_CREATE_TIME_FOR_TYPE, type, latestCreateTime);
   }
 }

--- a/core/src/main/java/io/camunda/migrator/impl/logging/HistoryMigratorLogs.java
+++ b/core/src/main/java/io/camunda/migrator/impl/logging/HistoryMigratorLogs.java
@@ -34,225 +34,225 @@ public class HistoryMigratorLogs {
 
   // HistoryMigrator Messages
   public static final String MIGRATING_DEFINITIONS = "Migrating {} definitions";
-  public static final String MIGRATING_DEFINITION = "Migrating {} definition with legacyId: [{}]";
-  public static final String MIGRATING_DEFINITION_COMPLETE = "Migration of {} definition with legacyId [{}] completed";
+  public static final String MIGRATING_DEFINITION = "Migrating {} definition with C7 ID: [{}]";
+  public static final String MIGRATING_DEFINITION_COMPLETE = "Migration of {} definition with C7 ID [{}] completed";
 
-  public static final String SKIPPING_DECISION_DEFINITION = "Migration of historic decision definition with legacyId [{}] skipped. Decision requirements definition not yet available.";
+  public static final String SKIPPING_DECISION_DEFINITION = "Migration of historic decision definition with C7 ID [{}] skipped. Decision requirements definition not yet available.";
 
   public static final String MIGRATING_INSTANCES = "Migrating historic {} instances";
-  public static final String MIGRATING_INSTANCE = "Migrating historic {} instance with legacyId: [{}]";
+  public static final String MIGRATING_INSTANCE = "Migrating historic {} instance with C7 ID: [{}]";
   public static final String MIGRATING_INSTANCE_COMPLETE =
-      "Migration of historic {} instance with legacyId " + "[{}] completed";
-  public static final String SKIPPING_INSTANCE_MISSING_PARENT = "Migration of historic {} instance with legacyId [{}] skipped. Parent instance not yet available.";
-  public static final String SKIPPING_INSTANCE_MISSING_DEFINITION = "Migration of historic {} instance with legacyId [{}] skipped. {} definition not yet available.";
-  public static final String SKIPPING_DECISION_INSTANCE_MISSING_PROCESS_INSTANCE = "Migration of historic decision instance with legacyId [{}] skipped. Process instance not yet available.";
+      "Migration of historic {} instance with C7 ID " + "[{}] completed";
+  public static final String SKIPPING_INSTANCE_MISSING_PARENT = "Migration of historic {} instance with C7 ID [{}] skipped. Parent instance not yet available.";
+  public static final String SKIPPING_INSTANCE_MISSING_DEFINITION = "Migration of historic {} instance with C7 ID [{}] skipped. {} definition not yet available.";
+  public static final String SKIPPING_DECISION_INSTANCE_MISSING_PROCESS_INSTANCE = "Migration of historic decision instance with C7 ID [{}] skipped. Process instance not yet available.";
   public static final String SKIPPING_DECISION_INSTANCE_MISSING_FLOW_NODE_INSTANCE = "Migration of historic decision "
-      + "instance with legacyId [{}] skipped. Flow node instance not yet available.";
+      + "instance with C7 ID [{}] skipped. Flow node instance not yet available.";
   public static final String NOT_MIGRATING_DECISION_INSTANCE = "Not migrating historic decision instance with "
-      + "legacyId: [{}] because it does not originate from a business rule task.";
+      + "C7 ID: [{}] because it does not originate from a business rule task.";
 
   public static final String MIGRATING_INCIDENTS = "Migrating historic incidents";
-  public static final String MIGRATING_INCIDENT = "Migrating historic incident with legacyId: [{}]";
-  public static final String MIGRATING_INCIDENT_COMPLETED = "Migration of historic incident with legacyId [{}] completed.";
-  public static final String SKIPPING_INCIDENT = "Migration of historic incident with legacyId [{}] skipped. Process "
+  public static final String MIGRATING_INCIDENT = "Migrating historic incident with C7 ID: [{}]";
+  public static final String MIGRATING_INCIDENT_COMPLETED = "Migration of historic incident with C7 ID [{}] completed.";
+  public static final String SKIPPING_INCIDENT = "Migration of historic incident with C7 ID [{}] skipped. Process "
       + "instance not yet available.";
 
   public static final String MIGRATING_VARIABLES = "Migrating historic variables";
-  public static final String MIGRATING_VARIABLE = "Migrating historic variables with legacyId: [{}]";
-  public static final String MIGRATING_VARIABLE_COMPLETED = "Migration of historic variable with legacyId [{}] completed.";
-  public static final String SKIPPING_VARIABLE_MISSING_FLOW_NODE = "Migration of historic variable with legacyId [{}] skipped. Flow node instance not yet available.";
-  public static final String SKIPPING_VARIABLE_MISSING_PROCESS = "Migration of historic variable with legacyId [{}] skipped. Process instance not yet available.";
-  public static final String SKIPPING_VARIABLE_MISSING_TASK = "Migration of historic variable with legacyId [{}] skipped. Associated task [{}] was skipped.";
-  public static final String SKIPPING_VARIABLE_MISSING_SCOPE = "Migration of historic variable with legacyId [{}] skipped. Scope key is not yet available.";
+  public static final String MIGRATING_VARIABLE = "Migrating historic variables with C7 ID: [{}]";
+  public static final String MIGRATING_VARIABLE_COMPLETED = "Migration of historic variable with C7 ID [{}] completed.";
+  public static final String SKIPPING_VARIABLE_MISSING_FLOW_NODE = "Migration of historic variable with C7 ID [{}] skipped. Flow node instance not yet available.";
+  public static final String SKIPPING_VARIABLE_MISSING_PROCESS = "Migration of historic variable with C7 ID [{}] skipped. Process instance not yet available.";
+  public static final String SKIPPING_VARIABLE_MISSING_TASK = "Migration of historic variable with C7 ID [{}] skipped. Associated task [{}] was skipped.";
+  public static final String SKIPPING_VARIABLE_MISSING_SCOPE = "Migration of historic variable with C7 ID [{}] skipped. Scope key is not yet available.";
 
   public static final String MIGRATING_USER_TASKS = "Migrating historic user tasks";
-  public static final String MIGRATING_USER_TASK = "Migrating historic user task with legacyId: [{}]";
-  public static final String MIGRATING_USER_TASK_COMPLETED = "Migration of historic user task with legacyId [{}] completed.";
-  public static final String SKIPPING_MIGRATING_USER_TASK_MISSING_FLOW_NODE = "Migration of historic user task with legacyId [{}] skipped. Flow node instance yet not available.";
-  public static final String SKIPPING_USER_TASK_MISSING_PROCESS = "Migration of historic user task with legacyId [{}] skipped. Process instance yet not available.";
+  public static final String MIGRATING_USER_TASK = "Migrating historic user task with C7 ID: [{}]";
+  public static final String MIGRATING_USER_TASK_COMPLETED = "Migration of historic user task with C7 ID [{}] completed.";
+  public static final String SKIPPING_MIGRATING_USER_TASK_MISSING_FLOW_NODE = "Migration of historic user task with C7 ID [{}] skipped. Flow node instance yet not available.";
+  public static final String SKIPPING_USER_TASK_MISSING_PROCESS = "Migration of historic user task with C7 ID [{}] skipped. Process instance yet not available.";
 
   public static final String MIGRATING_FLOW_NODES = "Migrating historic flow nodes";
-  public static final String MIGRATING_FLOW_NODE = "Migrating historic flow nodes with legacyId: [{}]";
-  public static final String MIGRATING_FLOW_NODE_COMPLETED = "Migration of historic flow nodes with legacyId [{}] completed.";
-  public static final String SKIPPING_FLOW_NODE = "Migration of historic flow nodes with legacyId [{}] skipped. Process instance yet not available.";
+  public static final String MIGRATING_FLOW_NODE = "Migrating historic flow nodes with C7 ID: [{}]";
+  public static final String MIGRATING_FLOW_NODE_COMPLETED = "Migration of historic flow nodes with C7 ID [{}] completed.";
+  public static final String SKIPPING_FLOW_NODE = "Migration of historic flow nodes with C7 ID [{}] skipped. Process instance yet not available.";
 
   public static final String MIGRATING_DECISION_REQUIREMENTS = "Migrating decision requirements";
-  public static final String MIGRATING_DECISION_REQUIREMENT = "Migrating decision requirements with legacyId: [{}]";
-  public static final String MIGRATING_DECISION_REQUIREMENT_COMPLETED = "Migration of decision requirements with legacyId [{}] completed.";
+  public static final String MIGRATING_DECISION_REQUIREMENT = "Migrating decision requirements with C7 ID: [{}]";
+  public static final String MIGRATING_DECISION_REQUIREMENT_COMPLETED = "Migration of decision requirements with C7 ID [{}] completed.";
 
   public static void migratingDecisionDefinitions() {
     LOGGER.info(MIGRATING_DEFINITIONS, "decision");
   }
 
-  public static void migratingDecisionDefinition(String legacyDecisionDefinitionId) {
-    LOGGER.debug(MIGRATING_DEFINITION, "decision", legacyDecisionDefinitionId);
+  public static void migratingDecisionDefinition(String c7DecisionDefinitionId) {
+    LOGGER.debug(MIGRATING_DEFINITION, "decision", c7DecisionDefinitionId);
   }
 
-  public static void migratingDecisionDefinitionCompleted(String legacyDecisionDefinitionId) {
-    LOGGER.debug(MIGRATING_DEFINITION_COMPLETE, "decision", legacyDecisionDefinitionId);
+  public static void migratingDecisionDefinitionCompleted(String c7DecisionDefinitionId) {
+    LOGGER.debug(MIGRATING_DEFINITION_COMPLETE, "decision", c7DecisionDefinitionId);
   }
 
-  public static void skippingDecisionDefinition(String legacyDecisionDefinitionId) {
-    LOGGER.debug(SKIPPING_DECISION_DEFINITION, legacyDecisionDefinitionId);
+  public static void skippingDecisionDefinition(String c7DecisionDefinitionId) {
+    LOGGER.debug(SKIPPING_DECISION_DEFINITION, c7DecisionDefinitionId);
   }
 
   public static void migratingProcessDefinitions() {
     LOGGER.info(MIGRATING_DEFINITIONS, "process");
   }
 
-  public static void migratingProcessDefinition(String legacyProcessDefinitionId) {
-    LOGGER.debug(MIGRATING_DEFINITION, "process", legacyProcessDefinitionId);
+  public static void migratingProcessDefinition(String c7ProcessDefinitionId) {
+    LOGGER.debug(MIGRATING_DEFINITION, "process", c7ProcessDefinitionId);
   }
 
-  public static void migratingProcessDefinitionCompleted(String legacyProcessDefinitionId) {
-    LOGGER.debug(MIGRATING_DEFINITION_COMPLETE, "process", legacyProcessDefinitionId);
+  public static void migratingProcessDefinitionCompleted(String c7ProcessDefinitionId) {
+    LOGGER.debug(MIGRATING_DEFINITION_COMPLETE, "process", c7ProcessDefinitionId);
   }
 
   public static void migratingProcessInstances() {
     LOGGER.info(MIGRATING_INSTANCES, "process");
   }
 
-  public static void migratingProcessInstance(String legacyProcessInstanceId) {
-    LOGGER.debug(MIGRATING_INSTANCE, "process", legacyProcessInstanceId);
+  public static void migratingProcessInstance(String c7ProcessInstanceId) {
+    LOGGER.debug(MIGRATING_INSTANCE, "process", c7ProcessInstanceId);
   }
 
-  public static void migratingProcessInstanceCompleted(String legacyProcessInstanceId) {
-    LOGGER.debug(MIGRATING_INSTANCE_COMPLETE, "process", legacyProcessInstanceId);
+  public static void migratingProcessInstanceCompleted(String c7ProcessInstanceId) {
+    LOGGER.debug(MIGRATING_INSTANCE_COMPLETE, "process", c7ProcessInstanceId);
   }
 
-  public static void skippingProcessInstanceDueToMissingParent(String legacyProcessInstanceId) {
-    LOGGER.debug(SKIPPING_INSTANCE_MISSING_PARENT, "process", legacyProcessInstanceId);
+  public static void skippingProcessInstanceDueToMissingParent(String c7ProcessInstanceId) {
+    LOGGER.debug(SKIPPING_INSTANCE_MISSING_PARENT, "process", c7ProcessInstanceId);
   }
 
-  public static void skippingProcessInstanceDueToMissingDefinition(String legacyProcessInstanceId) {
-    LOGGER.debug(SKIPPING_INSTANCE_MISSING_DEFINITION, "process", legacyProcessInstanceId, "process");
+  public static void skippingProcessInstanceDueToMissingDefinition(String c7ProcessInstanceId) {
+    LOGGER.debug(SKIPPING_INSTANCE_MISSING_DEFINITION, "process", c7ProcessInstanceId, "process");
   }
 
   public static void migratingDecisionInstances() {
     LOGGER.info(MIGRATING_INSTANCES, "decision");
   }
 
-  public static void notMigratingDecisionInstancesNotOriginatingFromBusinessRuleTasks(String legacyDecisionInstanceId) {
-    LOGGER.debug(NOT_MIGRATING_DECISION_INSTANCE, legacyDecisionInstanceId);
+  public static void notMigratingDecisionInstancesNotOriginatingFromBusinessRuleTasks(String c7DecisionInstanceId) {
+    LOGGER.debug(NOT_MIGRATING_DECISION_INSTANCE, c7DecisionInstanceId);
   }
 
-  public static void migratingDecisionInstance(String legacyDecisionInstanceId) {
-    LOGGER.debug(MIGRATING_INSTANCE, "decision", legacyDecisionInstanceId);
+  public static void migratingDecisionInstance(String c7DecisionInstanceId) {
+    LOGGER.debug(MIGRATING_INSTANCE, "decision", c7DecisionInstanceId);
   }
 
-  public static void migratingDecisionInstanceCompleted(String legacyDecisionInstanceId) {
-    LOGGER.debug(MIGRATING_INSTANCE_COMPLETE, "decision", legacyDecisionInstanceId);
+  public static void migratingDecisionInstanceCompleted(String c7DecisionInstanceId) {
+    LOGGER.debug(MIGRATING_INSTANCE_COMPLETE, "decision", c7DecisionInstanceId);
   }
 
-  public static void skippingDecisionInstanceDueToMissingParent(String legacyDecisionInstanceId) {
-    LOGGER.debug(SKIPPING_INSTANCE_MISSING_PARENT, "decision", legacyDecisionInstanceId);
+  public static void skippingDecisionInstanceDueToMissingParent(String c7DecisionInstanceId) {
+    LOGGER.debug(SKIPPING_INSTANCE_MISSING_PARENT, "decision", c7DecisionInstanceId);
   }
 
-  public static void skippingDecisionInstanceDueToMissingDecisionDefinition(String legacyDecisionInstanceId) {
-    LOGGER.debug(SKIPPING_INSTANCE_MISSING_DEFINITION, "decision", legacyDecisionInstanceId, "decision");
+  public static void skippingDecisionInstanceDueToMissingDecisionDefinition(String c7DecisionInstanceId) {
+    LOGGER.debug(SKIPPING_INSTANCE_MISSING_DEFINITION, "decision", c7DecisionInstanceId, "decision");
   }
 
-  public static void skippingDecisionInstanceDueToMissingProcessDefinition(String legacyDecisionInstanceId) {
-    LOGGER.debug(SKIPPING_INSTANCE_MISSING_DEFINITION, "decision", legacyDecisionInstanceId, "process");
+  public static void skippingDecisionInstanceDueToMissingProcessDefinition(String c7DecisionInstanceId) {
+    LOGGER.debug(SKIPPING_INSTANCE_MISSING_DEFINITION, "decision", c7DecisionInstanceId, "process");
   }
 
-  public static void skippingDecisionInstanceDueToMissingProcessInstance(String legacyDecisionInstanceId) {
-    LOGGER.debug(SKIPPING_DECISION_INSTANCE_MISSING_PROCESS_INSTANCE, legacyDecisionInstanceId);
+  public static void skippingDecisionInstanceDueToMissingProcessInstance(String c7DecisionInstanceId) {
+    LOGGER.debug(SKIPPING_DECISION_INSTANCE_MISSING_PROCESS_INSTANCE, c7DecisionInstanceId);
   }
 
-  public static void skippingDecisionInstanceDueToMissingFlowNodeInstanceInstance(String legacyDecisionInstanceId) {
-    LOGGER.debug(SKIPPING_DECISION_INSTANCE_MISSING_FLOW_NODE_INSTANCE, legacyDecisionInstanceId);
+  public static void skippingDecisionInstanceDueToMissingFlowNodeInstanceInstance(String c7DecisionInstanceId) {
+    LOGGER.debug(SKIPPING_DECISION_INSTANCE_MISSING_FLOW_NODE_INSTANCE, c7DecisionInstanceId);
   }
 
   public static void migratingHistoricIncidents() {
     LOGGER.info(MIGRATING_INCIDENTS);
   }
 
-  public static void migratingHistoricIncident(String legacyIncidentId) {
-    LOGGER.debug(MIGRATING_INCIDENT, legacyIncidentId);
+  public static void migratingHistoricIncident(String c7IncidentId) {
+    LOGGER.debug(MIGRATING_INCIDENT, c7IncidentId);
   }
 
-  public static void migratingHistoricIncidentCompleted(String legacyIncidentId) {
-    LOGGER.debug(MIGRATING_INCIDENT_COMPLETED, legacyIncidentId);
+  public static void migratingHistoricIncidentCompleted(String c7IncidentId) {
+    LOGGER.debug(MIGRATING_INCIDENT_COMPLETED, c7IncidentId);
   }
 
-  public static void skippingHistoricIncident(String legacyIncidentId) {
-    LOGGER.debug(SKIPPING_INCIDENT, legacyIncidentId);
+  public static void skippingHistoricIncident(String c7IncidentId) {
+    LOGGER.debug(SKIPPING_INCIDENT, c7IncidentId);
   }
 
   public static void migratingHistoricVariables() {
     LOGGER.info(MIGRATING_VARIABLES);
   }
 
-  public static void migratingHistoricVariable(String legacyVariableId) {
-    LOGGER.debug(MIGRATING_VARIABLE, legacyVariableId);
+  public static void migratingHistoricVariable(String c7VariableId) {
+    LOGGER.debug(MIGRATING_VARIABLE, c7VariableId);
   }
 
-  public static void migratingHistoricVariableCompleted(String legacyVariableId) {
-    LOGGER.debug(MIGRATING_VARIABLE_COMPLETED, legacyVariableId);
+  public static void migratingHistoricVariableCompleted(String c7VariableId) {
+    LOGGER.debug(MIGRATING_VARIABLE_COMPLETED, c7VariableId);
   }
 
-  public static void skippingHistoricVariableDueToMissingFlowNode(String legacyVariableId) {
-    LOGGER.debug(SKIPPING_VARIABLE_MISSING_FLOW_NODE, legacyVariableId);
+  public static void skippingHistoricVariableDueToMissingFlowNode(String c7VariableId) {
+    LOGGER.debug(SKIPPING_VARIABLE_MISSING_FLOW_NODE, c7VariableId);
   }
 
-  public static void skippingHistoricVariableDueToMissingProcessInstance(String legacyVariableId) {
-    LOGGER.debug(SKIPPING_VARIABLE_MISSING_PROCESS, legacyVariableId);
+  public static void skippingHistoricVariableDueToMissingProcessInstance(String c7VariableId) {
+    LOGGER.debug(SKIPPING_VARIABLE_MISSING_PROCESS, c7VariableId);
   }
 
-  public static void skippingHistoricVariableDueToMissingTask(String legacyVariableId, String taskId) {
-    LOGGER.debug(SKIPPING_VARIABLE_MISSING_TASK, legacyVariableId, taskId);
+  public static void skippingHistoricVariableDueToMissingTask(String c7VariableId, String taskId) {
+    LOGGER.debug(SKIPPING_VARIABLE_MISSING_TASK, c7VariableId, taskId);
   }
 
-  public static void skippingHistoricVariableDueToMissingScopeKey(String legacyVariableId) {
-    LOGGER.debug(SKIPPING_VARIABLE_MISSING_SCOPE, legacyVariableId);
+  public static void skippingHistoricVariableDueToMissingScopeKey(String c7VariableId) {
+    LOGGER.debug(SKIPPING_VARIABLE_MISSING_SCOPE, c7VariableId);
   }
 
   public static void migratingHistoricUserTasks() {
     LOGGER.info(MIGRATING_USER_TASKS);
   }
 
-  public static void migratingHistoricUserTask(String legacyUserTaskId) {
-    LOGGER.debug(MIGRATING_USER_TASK, legacyUserTaskId);
+  public static void migratingHistoricUserTask(String c7UserTaskId) {
+    LOGGER.debug(MIGRATING_USER_TASK, c7UserTaskId);
   }
 
-  public static void migratingHistoricUserTaskCompleted(String legacyUserTaskId) {
-    LOGGER.debug(MIGRATING_USER_TASK_COMPLETED, legacyUserTaskId);
+  public static void migratingHistoricUserTaskCompleted(String c7UserTaskId) {
+    LOGGER.debug(MIGRATING_USER_TASK_COMPLETED, c7UserTaskId);
   }
 
-  public static void skippingHistoricUserTaskDueToMissingFlowNode(String legacyUserTaskId) {
-    LOGGER.debug(SKIPPING_MIGRATING_USER_TASK_MISSING_FLOW_NODE, legacyUserTaskId);
+  public static void skippingHistoricUserTaskDueToMissingFlowNode(String c7UserTaskId) {
+    LOGGER.debug(SKIPPING_MIGRATING_USER_TASK_MISSING_FLOW_NODE, c7UserTaskId);
   }
 
-  public static void skippingHistoricUserTaskDueToMissingProcessInstance(String legacyUserTaskId) {
-    LOGGER.debug(SKIPPING_USER_TASK_MISSING_PROCESS, legacyUserTaskId);
+  public static void skippingHistoricUserTaskDueToMissingProcessInstance(String c7UserTaskId) {
+    LOGGER.debug(SKIPPING_USER_TASK_MISSING_PROCESS, c7UserTaskId);
   }
 
   public static void migratingHistoricFlowNodes() {
     LOGGER.info(MIGRATING_FLOW_NODES);
   }
 
-  public static void migratingHistoricFlowNode(String legacyFlowNodeId) {
-    LOGGER.debug(MIGRATING_FLOW_NODE, legacyFlowNodeId);
+  public static void migratingHistoricFlowNode(String c7FlowNodeId) {
+    LOGGER.debug(MIGRATING_FLOW_NODE, c7FlowNodeId);
   }
 
-  public static void migratingHistoricFlowNodeCompleted(String legacyFlowNodeId) {
-    LOGGER.debug(MIGRATING_FLOW_NODE_COMPLETED, legacyFlowNodeId);
+  public static void migratingHistoricFlowNodeCompleted(String c7FlowNodeId) {
+    LOGGER.debug(MIGRATING_FLOW_NODE_COMPLETED, c7FlowNodeId);
   }
 
-  public static void skippingHistoricFlowNode(String legacyFlowNodeId) {
-    LOGGER.debug(SKIPPING_FLOW_NODE, legacyFlowNodeId);
+  public static void skippingHistoricFlowNode(String c7FlowNodeId) {
+    LOGGER.debug(SKIPPING_FLOW_NODE, c7FlowNodeId);
   }
 
   public static void migratingDecisionRequirements() {
     LOGGER.info(MIGRATING_DECISION_REQUIREMENTS);
   }
 
-  public static void migratingDecisionRequirements(String legacyDecisionRequirementsId) {
-    LOGGER.debug(MIGRATING_DECISION_REQUIREMENT, legacyDecisionRequirementsId);
+  public static void migratingDecisionRequirements(String c7DecisionRequirementsId) {
+    LOGGER.debug(MIGRATING_DECISION_REQUIREMENT, c7DecisionRequirementsId);
   }
 
-  public static void migratingDecisionRequirementsCompleted(String legacyDecisionRequirementsId) {
-    LOGGER.debug(MIGRATING_DECISION_REQUIREMENT_COMPLETED, legacyDecisionRequirementsId);
+  public static void migratingDecisionRequirementsCompleted(String c7DecisionRequirementsId) {
+    LOGGER.debug(MIGRATING_DECISION_REQUIREMENT_COMPLETED, c7DecisionRequirementsId);
   }
 }

--- a/core/src/main/java/io/camunda/migrator/impl/logging/ProcessDefinitionConverterLogs.java
+++ b/core/src/main/java/io/camunda/migrator/impl/logging/ProcessDefinitionConverterLogs.java
@@ -21,9 +21,9 @@ public class ProcessDefinitionConverterLogs {
   protected static final Logger LOGGER = LoggerFactory.getLogger(ProcessDefinitionConverter.class);
 
   // ProcessDefinitionConverter Error Messages
-  public static final String FAILED_FETCHING_RESOURCE_STREAM = "Error while fetching resource stream for process definition with legacyId [{}] due to: {}";
+  public static final String FAILED_FETCHING_RESOURCE_STREAM = "Error while fetching resource stream for process definition with C7 ID [{}] due to: {}";
 
-  public static void failedFetchingResourceStream(String legacyId, String errorMessage) {
-    LOGGER.error(FAILED_FETCHING_RESOURCE_STREAM, legacyId, errorMessage);
+  public static void failedFetchingResourceStream(String c7Id, String errorMessage) {
+    LOGGER.error(FAILED_FETCHING_RESOURCE_STREAM, c7Id, errorMessage);
   }
 }

--- a/core/src/main/java/io/camunda/migrator/impl/logging/RuntimeMigratorLogs.java
+++ b/core/src/main/java/io/camunda/migrator/impl/logging/RuntimeMigratorLogs.java
@@ -8,6 +8,7 @@
 package io.camunda.migrator.impl.logging;
 
 import io.camunda.migrator.RuntimeMigrator;
+import java.util.Date;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -19,55 +20,55 @@ public class RuntimeMigratorLogs {
   protected static final Logger LOGGER = LoggerFactory.getLogger(RuntimeMigrator.class);
 
   // RuntimeMigrator Messages
-  public static final String STARTING_NEW_C8_PROCESS_INSTANCE = "Starting new C8 process instance with legacyId: [{}]";
+  public static final String STARTING_NEW_C8_PROCESS_INSTANCE = "Starting new C8 process instance with C7 ID: [{}]";
   public static final String STARTED_C8_PROCESS_INSTANCE = "Started C8 process instance with processInstanceKey: [{}]";
-  public static final String SKIPPING_PROCESS_INSTANCE_VARIABLE_ERROR = "Skipping process instance with legacyId: {}; due to: {} Enable DEBUG level to print the stacktrace.";
+  public static final String SKIPPING_PROCESS_INSTANCE_VARIABLE_ERROR = "Skipping process instance with C7 ID: {}; due to: {} Enable DEBUG level to print the stacktrace.";
   public static final String STACKTRACE = "Stacktrace:";
-  public static final String SKIPPING_PROCESS_INSTANCE_VALIDATION_ERROR = "Skipping process instance with legacyId [{}]: {}";
+  public static final String SKIPPING_PROCESS_INSTANCE_VALIDATION_ERROR = "Skipping process instance with C7 ID [{}]: {}";
   public static final String FETCHING_PROCESS_INSTANCES = "Fetching process instances to migrate";
-  public static final String FETCHING_LATEST_START_DATE = "Fetching latest start date of process instances";
-  public static final String LATEST_START_DATE = "Latest start date: {}";
-  public static final String PROCESS_INSTANCE_NOT_EXISTS = "Process instance with legacyId {} doesn't exist anymore. Has it been completed or cancelled in the meantime?";
+  public static final String FETCHING_LATEST_CREATE_TIME = "Fetching latest create time of process instances";
+  public static final String LATEST_CREATE_TIME = "Latest create time: {}";
+  public static final String PROCESS_INSTANCE_NOT_EXISTS = "Process instance with C7 ID {} doesn't exist anymore. Has it been completed or cancelled in the meantime?";
   public static final String ACTIVATING_MIGRATOR_JOBS = "Activating migrator jobs";
   public static final String MIGRATOR_JOBS_FOUND = "Migrator jobs found: {}";
   public static final String COLLECTING_ACTIVE_DESCENDANT_ACTIVITIES = "Collecting active descendant activity instances for activityId [{}]";
   public static final String FOUND_ACTIVE_ACTIVITIES_TO_ACTIVATE = "Found {} active activity instances to activate";
   public static final String EXTERNALLY_STARTED_PROCESS_INSTANCE = "Process instance with key [{}] was externally started, skipping migrator job activation.";
 
-  public static void startingNewC8ProcessInstance(String legacyProcessInstanceId) {
-    LOGGER.debug(STARTING_NEW_C8_PROCESS_INSTANCE, legacyProcessInstanceId);
+  public static void startingNewC8ProcessInstance(String c7ProcessInstanceId) {
+    LOGGER.debug(STARTING_NEW_C8_PROCESS_INSTANCE, c7ProcessInstanceId);
   }
 
   public static void startedC8ProcessInstance(Long processInstanceKey) {
     LOGGER.debug(STARTED_C8_PROCESS_INSTANCE, processInstanceKey);
   }
 
-  public static void skippingProcessInstanceVariableError(String legacyProcessInstanceId, String message) {
-    LOGGER.info(SKIPPING_PROCESS_INSTANCE_VARIABLE_ERROR, legacyProcessInstanceId, message);
+  public static void skippingProcessInstanceVariableError(String c7ProcessInstanceId, String message) {
+    LOGGER.info(SKIPPING_PROCESS_INSTANCE_VARIABLE_ERROR, c7ProcessInstanceId, message);
   }
 
   public static void stacktrace(Exception e) {
     LOGGER.debug(STACKTRACE, e);
   }
 
-  public static void skippingProcessInstanceValidationError(String legacyProcessInstanceId, String message) {
-    LOGGER.warn(SKIPPING_PROCESS_INSTANCE_VALIDATION_ERROR, legacyProcessInstanceId, message);
+  public static void skippingProcessInstanceValidationError(String c7ProcessInstanceId, String message) {
+    LOGGER.warn(SKIPPING_PROCESS_INSTANCE_VALIDATION_ERROR, c7ProcessInstanceId, message);
   }
 
   public static void fetchingProcessInstances() {
     LOGGER.info(FETCHING_PROCESS_INSTANCES);
   }
 
-  public static void fetchingLatestStartDate() {
-    LOGGER.debug(FETCHING_LATEST_START_DATE);
+  public static void fetchingLatestCreateTime() {
+    LOGGER.debug(FETCHING_LATEST_CREATE_TIME);
   }
 
-  public static void latestStartDate(Object startDate) {
-    LOGGER.debug(LATEST_START_DATE, startDate);
+  public static void latestCreateTime(Date createTime) {
+    LOGGER.debug(LATEST_CREATE_TIME, createTime);
   }
 
-  public static void processInstanceNotExists(String legacyProcessInstanceId) {
-    LOGGER.warn(PROCESS_INSTANCE_NOT_EXISTS, legacyProcessInstanceId);
+  public static void processInstanceNotExists(String c7ProcessInstanceId) {
+    LOGGER.warn(PROCESS_INSTANCE_NOT_EXISTS, c7ProcessInstanceId);
   }
 
   public static void activatingMigratorJobs() {

--- a/core/src/main/java/io/camunda/migrator/impl/logging/RuntimeValidatorLogs.java
+++ b/core/src/main/java/io/camunda/migrator/impl/logging/RuntimeValidatorLogs.java
@@ -20,8 +20,8 @@ public class RuntimeValidatorLogs {
   protected static final Logger LOGGER = LoggerFactory.getLogger(RuntimeValidator.class);
 
   // RuntimeValidator Messages
-  public static final String VALIDATE_LEGACY_PROCESS_INSTANCE = "Validate legacy process instance by ID: {}";
-  public static final String COLLECTING_ACTIVE_DESCENDANT_ACTIVITIES_VALIDATION = "Collecting active descendant activity instances for legacyId [{}]";
+  public static final String VALIDATE_C7_PROCESS_INSTANCE = "Validate C7 process instance by ID: {}";
+  public static final String COLLECTING_ACTIVE_DESCENDANT_ACTIVITIES_VALIDATION = "Collecting active descendant activity instances for C7 ID [{}]";
   public static final String FOUND_ACTIVE_ACTIVITIES_TO_VALIDATE = "Found {} active activity instances to validate";
   public static final String JOB_TYPE_VALIDATION_DISABLED = "Job type validation is disabled, skipping execution listener validation";
 
@@ -30,13 +30,13 @@ public class RuntimeValidatorLogs {
   public static final String NO_NONE_START_EVENT_ERROR = "C8 process definition [id: %s, version: %d] should have a None Start Event.";
   public static final String NO_EXECUTION_LISTENER_OF_TYPE_ERROR = "No execution listener of type '%s' found on start event [%s] for C8 process definition [id: %s, version: %d]. At least one '%s' listener is required.";
   public static final String FLOW_NODE_NOT_EXISTS_ERROR = "Flow node with id [%s] doesn't exist in the equivalent deployed C8 model.";
-  public static final String NO_C8_DEPLOYMENT_ERROR = "No C8 deployment found for process ID [%s] required for instance with legacyID [%s].";
+  public static final String NO_C8_DEPLOYMENT_ERROR = "No C8 deployment found for process ID [%s] required for instance with C7 ID [%s].";
   public static final String FAILED_TO_PARSE_BPMN_MODEL = "Failed to parse BPMN model from XML";
-  public static final String CALL_ACTIVITY_LEGACY_ID_ERROR = "Found call activity with propagateAllParentVariables=false for flow node with id [%s] in C8 process. This is not supported by the migrator unless there is an explicit mapping for the legacyId variable, as it would lead to orphaned sub-process instances.";
+  public static final String CALL_ACTIVITY_LEGACY_ID_ERROR = "Found call activity with propagateAllParentVariables=false for flow node with id [%s] in C8 process. This is not supported by the migrator unless there is an explicit mapping for the C7 ID variable, as it would lead to orphaned sub-process instances.";
   public static final String TENANT_ID_ERROR = "Found a process instance with tenant id [%s] that is not configured for migration.";
 
-  public static void validateLegacyProcessInstance(String legacyProcessInstanceId) {
-    LOGGER.debug(VALIDATE_LEGACY_PROCESS_INSTANCE, legacyProcessInstanceId);
+  public static void validateC7ProcessInstance(String c7ProcessInstanceId) {
+    LOGGER.debug(VALIDATE_C7_PROCESS_INSTANCE, c7ProcessInstanceId);
   }
 
   public static void collectingActiveDescendantActivitiesValidation(String processInstanceId) {

--- a/core/src/main/java/io/camunda/migrator/impl/logging/VariableConverterLogs.java
+++ b/core/src/main/java/io/camunda/migrator/impl/logging/VariableConverterLogs.java
@@ -21,18 +21,18 @@ public class VariableConverterLogs {
   private static final Logger LOGGER = LoggerFactory.getLogger(VariableConverter.class);
 
   // VariableConverter Messages
-  public static final String CONVERTING_OF_TYPE = "Converting variable with legacyId [{}] of type: {}";
+  public static final String CONVERTING_OF_TYPE = "Converting variable with C7 ID [{}] of type: {}";
 
   // VariableConverter Error Messages
   public static final String WARN_NO_HANDLING_AVAILABLE = "No existing handling for variable with id= {}, type: {}, returning null.";
   public static final String ERROR_CONVERTING_JSON = "Error converting typed value to json: {}, exception: {}. Mapped to null";
 
-  public static void convertingOfType(String legacyId, String type) {
-    LOGGER.info(CONVERTING_OF_TYPE, legacyId, type);
+  public static void convertingOfType(String c7Id, String type) {
+    LOGGER.info(CONVERTING_OF_TYPE, c7Id, type);
   }
 
-  public static void warnNoHandlingAvailable(String legacyId, String type) {
-    LOGGER.warn(WARN_NO_HANDLING_AVAILABLE, legacyId, type);
+  public static void warnNoHandlingAvailable(String c7Id, String type) {
+    LOGGER.warn(WARN_NO_HANDLING_AVAILABLE, c7Id, type);
   }
 
   public static void failedConvertingJson(ObjectValueImpl typedValue, String message) {

--- a/core/src/main/java/io/camunda/migrator/impl/logging/VariableServiceLogs.java
+++ b/core/src/main/java/io/camunda/migrator/impl/logging/VariableServiceLogs.java
@@ -19,9 +19,6 @@ public class VariableServiceLogs {
 
   static final Logger LOGGER = LoggerFactory.getLogger(VariableService.class);
 
-  // Constants
-  public static final String LEGACY_ID_VARIABLE = "legacyId";
-
   // Date format constants
   public static final String DATE_FORMAT_PATTERN = "yyyy-MM-dd'T'HH:mm:ss.SSSZ";
 

--- a/core/src/main/java/io/camunda/migrator/impl/persistence/IdKeyDbModel.java
+++ b/core/src/main/java/io/camunda/migrator/impl/persistence/IdKeyDbModel.java
@@ -13,54 +13,54 @@ import java.util.Objects;
 
 public class IdKeyDbModel {
 
-  protected Long instanceKey;
-  protected String id;
+  protected String c7Id;
+  protected Long c8Key;
   protected TYPE type;
-  protected Date startDate;
+  protected Date createTime;
   protected String skipReason;
 
   public IdKeyDbModel() {
   }
 
-  public IdKeyDbModel(String id, Date startDate) {
-    this.id = id;
-    this.startDate = startDate;
+  public IdKeyDbModel(String c7Id, Date createTime) {
+    this.c7Id = c7Id;
+    this.createTime = createTime;
   }
 
-  public Long getInstanceKey() {
-    return instanceKey;
+  public Long getC8Key() {
+    return c8Key;
   }
 
-  public String getId() {
-    return id;
+  public String getC7Id() {
+    return c7Id;
   }
 
   public TYPE getType() {
     return type;
   }
 
-  public Date getStartDate() {
-    return startDate;
+  public Date getCreateTime() {
+    return createTime;
   }
 
   public String getSkipReason() {
     return skipReason;
   }
 
-  public void setInstanceKey(Long instanceKey) {
-    this.instanceKey = instanceKey;
+  public void setC8Key(Long c8Key) {
+    this.c8Key = c8Key;
   }
 
-  public void setId(String id) {
-    this.id = id;
+  public void setC7Id(String c7Id) {
+    this.c7Id = c7Id;
   }
 
   public void setType(TYPE type) {
     this.type = type;
   }
 
-  public void setStartDate(Date startDate) {
-    this.startDate = startDate;
+  public void setCreateTime(Date createTime) {
+    this.createTime = createTime;
   }
 
   public void setSkipReason(String skipReason) {
@@ -74,17 +74,17 @@ public class IdKeyDbModel {
     if (obj == null || obj.getClass() != this.getClass())
       return false;
     var that = (IdKeyDbModel) obj;
-    return Objects.equals(this.instanceKey, that.instanceKey) && Objects.equals(this.id, that.id) && Objects.equals(this.type, that.type);
+    return Objects.equals(this.c8Key, that.c8Key) && Objects.equals(this.c7Id, that.c7Id) && Objects.equals(this.type, that.type);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(instanceKey, id, type);
+    return Objects.hash(c8Key, c7Id, type);
   }
 
   @Override
   public String toString() {
-    return "IdKey[" + "instanceKey=" + instanceKey + ", " + "id=" + id + ", " + "type=" + type + ']';
+    return "IdKey[" + "c8Key=" + c8Key + ", " + "c7Id=" + c7Id + ", " + "type=" + type + ']';
   }
 
 }

--- a/core/src/main/java/io/camunda/migrator/impl/persistence/IdKeyMapper.java
+++ b/core/src/main/java/io/camunda/migrator/impl/persistence/IdKeyMapper.java
@@ -61,13 +61,13 @@ public interface IdKeyMapper {
     return HISTORY_TYPES;
   }
 
-  boolean checkExistsByIdAndType(@Param("type") TYPE type, @Param("id") String id);
+  boolean checkExistsByC7IdAndType(@Param("type") TYPE type, @Param("c7Id") String c7Id);
 
-  boolean checkHasKeyByIdAndType(@Param("type") TYPE type, @Param("id") String id);
+  boolean checkHasC8KeyByC7IdAndType(@Param("type") TYPE type, @Param("c7Id") String c7Id);
 
-  Date findLatestStartDateByType(TYPE type);
+  Date findLatestCreateTimeByType(TYPE type);
 
-  Long findKeysByIdAndType(@Param("id") String id, @Param("type") TYPE type);
+  Long findC8KeyByC7IdAndType(@Param("c7Id") String id, @Param("type") TYPE type);
 
   void insert(IdKeyDbModel idKeyDbModel);
 
@@ -79,9 +79,9 @@ public interface IdKeyMapper {
 
   long countSkipped();
 
-  List<String> findAllIds();
+  List<String> findAllC7Ids();
 
-  void updateKeyByIdAndType(IdKeyDbModel idKeyDbModel);
+  void updateC8KeyByC7IdAndType(IdKeyDbModel idKeyDbModel);
 
-  void delete(String id);
+  void deleteByC7Id(String c7Id);
 }

--- a/core/src/main/resources/db/changelog/migrator/db.0.1.0.xml
+++ b/core/src/main/resources/db/changelog/migrator/db.0.1.0.xml
@@ -18,23 +18,23 @@
 
   <changeSet id="create_migration_mapping_table" author="Camunda">
     <createTable tableName="${prefix}MIGRATION_MAPPING">
-      <column name="ID" type="VARCHAR(64)">
+      <column name="C7_ID" type="VARCHAR(64)">
         <constraints nullable="false"/>
       </column>
-      <column name="INSTANCE_KEY" type="BIGINT" />
+      <column name="C8_KEY" type="BIGINT" />
       <column name="TYPE" type="VARCHAR(255)">
         <constraints nullable="false"/>
       </column>
-      <column name="START_DATE" type="TIMESTAMP WITH TIME ZONE(3)" />
+      <column name="CREATE_TIME" type="TIMESTAMP WITH TIME ZONE(3)" />
       <column name="SKIP_REASON" type="VARCHAR(1024)" />
     </createTable>
 
     <addPrimaryKey tableName="${prefix}MIGRATION_MAPPING"
-                  columnNames="ID, TYPE"
+                  columnNames="C7_ID, TYPE"
                   constraintName="${prefix}PK_MIGRATION_MAPPING"/>
 
-    <createIndex tableName="${prefix}MIGRATION_MAPPING" indexName="${prefix}IDX_MIGRATION_MAPPING_INSTANCE_KEY">
-      <column name="INSTANCE_KEY" />
+    <createIndex tableName="${prefix}MIGRATION_MAPPING" indexName="${prefix}IDX_MIGRATION_MAPPING_C8_KEY">
+      <column name="C8_KEY" />
     </createIndex>
   </changeSet>
 

--- a/core/src/main/resources/mapper/IdKey.xml
+++ b/core/src/main/resources/mapper/IdKey.xml
@@ -10,21 +10,21 @@
 <mapper namespace="io.camunda.migrator.impl.persistence.IdKeyMapper">
 
   <resultMap id="idKeyResultMap" type="io.camunda.migrator.impl.persistence.IdKeyDbModel">
-    <id property="id" column="ID" jdbcType="VARCHAR"/>
-    <result property="instanceKey" column="INSTANCE_KEY" jdbcType="BIGINT"/>
-    <result property="startDate" column="START_DATE" jdbcType="TIMESTAMP"/>
+    <id property="c7Id" column="C7_ID" jdbcType="VARCHAR"/>
+    <result property="c8Key" column="C8_KEY" jdbcType="BIGINT"/>
+    <result property="createTime" column="CREATE_TIME" jdbcType="TIMESTAMP"/>
     <result property="type" column="TYPE" jdbcType="VARCHAR"/>
     <result property="skipReason" column="SKIP_REASON" jdbcType="VARCHAR"/>
   </resultMap>
 
   <select id="countSkipped" resultType="long">
-    SELECT COUNT(ID) FROM ${prefix}MIGRATION_MAPPING
-    WHERE INSTANCE_KEY IS NULL
+    SELECT COUNT(C7_ID) FROM ${prefix}MIGRATION_MAPPING
+    WHERE C8_KEY IS NULL
   </select>
 
   <select id="countSkippedByType" resultType="long">
-    SELECT COUNT(ID) FROM ${prefix}MIGRATION_MAPPING
-    WHERE TYPE = #{type} AND INSTANCE_KEY IS NULL
+    SELECT COUNT(C7_ID) FROM ${prefix}MIGRATION_MAPPING
+    WHERE TYPE = #{type} AND C8_KEY IS NULL
   </select>
 
   <!-- countMigratedByType is used for testing and by the migrator cockpit plugin -->
@@ -34,58 +34,58 @@
 
   <!-- countMigratedByType is used by the migrator cockpit plugin -->
   <select id="countMigratedByType" resultType="long">
-    SELECT COUNT(ID) FROM ${prefix}MIGRATION_MAPPING
-    WHERE TYPE = #{type} AND INSTANCE_KEY IS NOT NULL
+    SELECT COUNT(C7_ID) FROM ${prefix}MIGRATION_MAPPING
+    WHERE TYPE = #{type} AND C8_KEY IS NOT NULL
   </select>
 
   <!-- findMigratedByType is used for testing and by the migrator cockpit plugin -->
   <select id="findMigratedByType" resultMap="idKeyResultMap">
-    SELECT ID, INSTANCE_KEY, START_DATE, TYPE, SKIP_REASON FROM ${prefix}MIGRATION_MAPPING
-    WHERE TYPE = #{type} AND INSTANCE_KEY IS NOT NULL
+    SELECT C7_ID, C8_KEY, CREATE_TIME, TYPE, SKIP_REASON FROM ${prefix}MIGRATION_MAPPING
+    WHERE TYPE = #{type} AND C8_KEY IS NOT NULL
     <include refid="io.camunda.migrator.Commons.pageSql"/>
   </select>
 
   <sql id="findSkippedByQueryCriteriaSql">
-    SELECT ID, INSTANCE_KEY, START_DATE, TYPE, SKIP_REASON FROM ${prefix}MIGRATION_MAPPING
-    WHERE TYPE = #{type} AND INSTANCE_KEY IS NULL
+    SELECT C7_ID, C8_KEY, CREATE_TIME, TYPE, SKIP_REASON FROM ${prefix}MIGRATION_MAPPING
+    WHERE TYPE = #{type} AND C8_KEY IS NULL
     <include refid="io.camunda.migrator.Commons.pageSql"/>
   </sql>
 
-  <select id="findAllIds">
-    SELECT ID
+  <select id="findAllC7Ids">
+    SELECT C7_ID
     FROM ${prefix}MIGRATION_MAPPING
   </select>
 
-  <update id="updateKeyByIdAndType" parameterType="io.camunda.migrator.impl.persistence.IdKeyDbModel">
+  <update id="updateC8KeyByC7IdAndType" parameterType="io.camunda.migrator.impl.persistence.IdKeyDbModel">
     UPDATE ${prefix}MIGRATION_MAPPING
-    SET INSTANCE_KEY = #{instanceKey, jdbcType=BIGINT}
-    WHERE ID = #{id, jdbcType=VARCHAR} AND TYPE = #{type, jdbcType=VARCHAR}
+    SET C8_KEY = #{c8Key, jdbcType=BIGINT}
+    WHERE C7_ID = #{c7Id, jdbcType=VARCHAR} AND TYPE = #{type, jdbcType=VARCHAR}
   </update>
 
-  <select id="checkHasKeyByIdAndType" resultType="boolean">
+  <select id="checkHasC8KeyByC7IdAndType" resultType="boolean">
     SELECT CASE WHEN COUNT(*) > 0 THEN TRUE ELSE FALSE END
     FROM ${prefix}MIGRATION_MAPPING
-    WHERE ID = #{id, jdbcType=VARCHAR}
+    WHERE C7_ID = #{c7Id, jdbcType=VARCHAR}
     AND TYPE = #{type, jdbcType=VARCHAR}
-    AND INSTANCE_KEY IS NOT NULL
+    AND C8_KEY IS NOT NULL
   </select>
 
-  <select id="checkExistsByIdAndType" resultType="boolean">
+  <select id="checkExistsByC7IdAndType" resultType="boolean">
     SELECT CASE WHEN COUNT(*) > 0 THEN TRUE ELSE FALSE END
     FROM ${prefix}MIGRATION_MAPPING
-    WHERE ID = #{id, jdbcType=VARCHAR}
+    WHERE C7_ID = #{c7Id, jdbcType=VARCHAR}
     AND TYPE = #{type, jdbcType=VARCHAR}
   </select>
 
-  <select id="findLatestStartDateByType" parameterType="java.lang.String">
-    <!-- No need to order with two criteria since we limit result to return exactly one start date -->
-    SELECT START_DATE FROM ${prefix}MIGRATION_MAPPING WHERE TYPE = '${type}' ORDER BY START_DATE DESC
+  <select id="findLatestCreateTimeByType" parameterType="java.lang.String">
+    <!-- No need to order with two criteria since we limit result to return exactly one create time -->
+    SELECT CREATE_TIME FROM ${prefix}MIGRATION_MAPPING WHERE TYPE = '${type}' ORDER BY CREATE_TIME DESC
     <include refid="io.camunda.migrator.Commons.singleResultSql"/>
   </select>
 
-  <select id="findKeysByIdAndType" resultType="java.lang.Long">
-    SELECT INSTANCE_KEY FROM ${prefix}MIGRATION_MAPPING
-    WHERE ID = #{id, jdbcType=VARCHAR} AND TYPE = #{type, jdbcType=VARCHAR}
+  <select id="findC8KeyByC7IdAndType" resultType="java.lang.Long">
+    SELECT C8_KEY FROM ${prefix}MIGRATION_MAPPING
+    WHERE C7_ID = #{c7Id, jdbcType=VARCHAR} AND TYPE = #{type, jdbcType=VARCHAR}
     <include refid="io.camunda.migrator.Commons.singleResultSql"/>
   </select>
 
@@ -93,13 +93,13 @@
     id="insert"
     parameterType="io.camunda.migrator.impl.persistence.IdKeyDbModel"
     flushCache="true">
-    INSERT INTO ${prefix}MIGRATION_MAPPING (ID, INSTANCE_KEY, START_DATE, TYPE, SKIP_REASON)
-    VALUES (#{id, jdbcType=VARCHAR}, #{instanceKey, jdbcType=BIGINT}, #{startDate, jdbcType=TIMESTAMP}, #{type, jdbcType=VARCHAR}, #{skipReason, jdbcType=VARCHAR})
+    INSERT INTO ${prefix}MIGRATION_MAPPING (C7_ID, C8_KEY, CREATE_TIME, TYPE, SKIP_REASON)
+    VALUES (#{c7Id, jdbcType=VARCHAR}, #{c8Key, jdbcType=BIGINT}, #{createTime, jdbcType=TIMESTAMP}, #{type, jdbcType=VARCHAR}, #{skipReason, jdbcType=VARCHAR})
   </insert>
 
-  <delete id="delete">
+  <delete id="deleteByC7Id">
     DELETE FROM ${prefix}MIGRATION_MAPPING
-    WHERE ID = #{id}
+    WHERE C7_ID = #{c7Id}
   </delete>
 
 </mapper>

--- a/plugins/cockpit/frontend/src/SkippedEntities.js
+++ b/plugins/cockpit/frontend/src/SkippedEntities.js
@@ -29,11 +29,11 @@ function SkippedEntities({camundaAPI}) {
 
   const getEntityLink = (entity) => {
     if (entity.type === ENTITY_TYPES.RUNTIME_PROCESS_INSTANCE) {
-      return <a href={`#/process-instance/${entity.id}/runtime`}>{entity.id}</a>;
+      return <a href={`#/process-instance/${entity.c7Id}/runtime`}>{entity.c7Id}</a>;
     } else if (entity.type === ENTITY_TYPES.HISTORY_PROCESS_INSTANCE) {
-      return <a href={`#/process-instance/${entity.id}/history`}>{entity.id}</a>;
+      return <a href={`#/process-instance/${entity.c7Id}/history`}>{entity.c7Id}</a>;
     } else {
-      return entity.id;
+      return entity.c7Id;
     }
   }
 
@@ -77,8 +77,8 @@ function SkippedEntities({camundaAPI}) {
 
       // Create link to history process instance view with activity highlighting
       const processInstanceId = entity.type === ENTITY_TYPES.HISTORY_VARIABLE
-        ? processInstanceIds[entity.id]
-        : entity.id;
+        ? processInstanceIds[entity.c7Id]
+        : entity.c7Id;
 
       if (processInstanceId) {
         parts.push("flow node with id ");
@@ -110,14 +110,14 @@ function SkippedEntities({camundaAPI}) {
   const columns = useMemo(
     () => {
       let baseColumns = [
-        columnHelper.accessor('id', {
+        columnHelper.accessor('c7Id', {
           header: getColumnHeader(),
           cell: info => getEntityLink(info.row.original),
           size: 370
         })];
 
       if (!showSkipped) {
-        baseColumns.push(columnHelper.accessor('instanceKey', {
+        baseColumns.push(columnHelper.accessor('c8Key', {
           header: 'C8 Key',
           cell: info =>
             <a href={`http://localhost:8080/operate/processes/${info.getValue()}`} target={"_blank"}>{info.getValue()}</a>,
@@ -137,7 +137,7 @@ function SkippedEntities({camundaAPI}) {
       // Add process instance column for HISTORY_VARIABLE type
       if (selectedType === ENTITY_TYPES.HISTORY_VARIABLE) {
         baseColumns.splice(1, 0,
-          columnHelper.accessor('id', {
+          columnHelper.accessor('c7Id', {
             id: 'processInstanceId',
             header: 'Process Instance ID',
             cell: info => {
@@ -152,14 +152,14 @@ function SkippedEntities({camundaAPI}) {
           columnHelper.accessor('name', {
             header: 'Variable Name',
             cell: info => {
-              const variableId = info.row.original.id;
+              const variableId = info.row.original.c7Id;
               return variableMetadata[variableId]?.name || <span>Loading...</span>;
             },
           }),
           columnHelper.accessor('type', {
             header: 'Variable Type',
             cell: info => {
-              const variableId = info.row.original.id;
+              const variableId = info.row.original.c7Id;
               return variableMetadata[variableId]?.type || <span>Loading...</span>;
             },
           })
@@ -169,7 +169,7 @@ function SkippedEntities({camundaAPI}) {
       // Add process definition key column for RUNTIME_PROCESS_INSTANCE type
       if (selectedType === ENTITY_TYPES.RUNTIME_PROCESS_INSTANCE) {
         baseColumns.splice(1, 0,
-          columnHelper.accessor('id', {
+          columnHelper.accessor('c7Id', {
             id: 'processDefinitionKey',
             header: 'Process Definition Key',
             cell: info => {
@@ -185,7 +185,7 @@ function SkippedEntities({camundaAPI}) {
       // Add process definition key column for HISTORY_PROCESS_INSTANCE type
       if (selectedType === ENTITY_TYPES.HISTORY_PROCESS_INSTANCE) {
         baseColumns.splice(1, 0,
-          columnHelper.accessor('id', {
+          columnHelper.accessor('c7Id', {
             id: 'historyProcessDefinitionKey',
             header: 'Process Definition Key',
             cell: info => {
@@ -302,11 +302,11 @@ function SkippedEntities({camundaAPI}) {
 
     const fetchPromises = entities.map(async (entity) => {
       // Skip if we already have the process instance ID
-      if (newProcessInstanceIds[entity.id]) return;
+      if (newProcessInstanceIds[entity.c7Id]) return;
 
       try {
         const response = await fetch(
-          `${restApi}/history/variable-instance/${entity.id}`,
+          `${restApi}/history/variable-instance/${entity.c7Id}`,
           {
             headers: {
               'Accept': 'application/json'
@@ -316,7 +316,7 @@ function SkippedEntities({camundaAPI}) {
         const data = await response.json();
 
         if (data && data.processInstanceId) {
-          newProcessInstanceIds[entity.id] = data.processInstanceId;
+          newProcessInstanceIds[entity.c7Id] = data.processInstanceId;
           hasChanges = true;
         }
 
@@ -328,11 +328,11 @@ function SkippedEntities({camundaAPI}) {
           // Store variable metadata separately
           setVariableMetadata(prevMetadata => ({
             ...prevMetadata,
-            [entity.id]: {name: data.name, type: data.type}
+            [entity.c7Id]: {name: data.name, type: data.type}
           }));
         }
       } catch (err) {
-        console.error(`Failed to fetch process instance ID for variable ${entity.id}:`, err);
+        console.error(`Failed to fetch process instance ID for variable ${entity.c7Id}:`, err);
       }
     });
 
@@ -351,7 +351,7 @@ function SkippedEntities({camundaAPI}) {
 
     const fetchPromises = entities.map(async (entity) => {
       // Skip if we already have the process definition key
-      if (newProcessDefinitionKeys[entity.id]) return;
+      if (newProcessDefinitionKeys[entity.c7Id]) return;
 
       try {
         let response;
@@ -359,7 +359,7 @@ function SkippedEntities({camundaAPI}) {
         // Use different endpoints for runtime vs history
         if (selectedType === ENTITY_TYPES.RUNTIME_PROCESS_INSTANCE) {
           response = await fetch(
-            `${restApi}/process-instance/${entity.id}`,
+            `${restApi}/process-instance/${entity.c7Id}`,
             {
               headers: {
                 'Accept': 'application/json'
@@ -368,7 +368,7 @@ function SkippedEntities({camundaAPI}) {
           );
         } else if (selectedType === ENTITY_TYPES.HISTORY_PROCESS_INSTANCE) {
           response = await fetch(
-            `${restApi}/history/process-instance/${entity.id}`,
+            `${restApi}/history/process-instance/${entity.c7Id}`,
             {
               headers: {
                 'Accept': 'application/json'
@@ -378,8 +378,8 @@ function SkippedEntities({camundaAPI}) {
         }
 
         if (!response.ok) {
-          console.error(`Failed to fetch process instance ${entity.id}:`, response.status, response.statusText);
-          newProcessDefinitionKeys[entity.id] = 'Error';
+          console.error(`Failed to fetch process instance ${entity.c7Id}:`, response.status, response.statusText);
+          newProcessDefinitionKeys[entity.c7Id] = 'Error';
           hasChanges = true;
           return;
         }
@@ -387,16 +387,16 @@ function SkippedEntities({camundaAPI}) {
         const data = await response.json();
 
         if (data && (data.processDefinitionKey || data.definitionKey)) {
-          newProcessDefinitionKeys[entity.id] = data.processDefinitionKey || data.definitionKey;
+          newProcessDefinitionKeys[entity.c7Id] = data.processDefinitionKey || data.definitionKey;
           hasChanges = true;
         } else {
-          console.warn('No processDefinitionKey found for process instance:', entity.id, 'Available fields:', Object.keys(data || {}));
-          newProcessDefinitionKeys[entity.id] = 'Unknown';
+          console.warn('No processDefinitionKey found for process instance:', entity.c7Id, 'Available fields:', Object.keys(data || {}));
+          newProcessDefinitionKeys[entity.c7Id] = 'Unknown';
           hasChanges = true;
         }
       } catch (err) {
-        console.error(`Failed to fetch process definition key for process instance ${entity.id}:`, err);
-        newProcessDefinitionKeys[entity.id] = 'Error';
+        console.error(`Failed to fetch process definition key for process instance ${entity.c7Id}:`, err);
+        newProcessDefinitionKeys[entity.c7Id] = 'Error';
         hasChanges = true;
       }
     });

--- a/plugins/cockpit/src/test/java/io/camunda/migrator/plugin/cockpit/resources/MigratorResourceTest.java
+++ b/plugins/cockpit/src/test/java/io/camunda/migrator/plugin/cockpit/resources/MigratorResourceTest.java
@@ -43,8 +43,8 @@ public class MigratorResourceTest extends AbstractCockpitPluginTest {
   @Test
   public void testMigratedRecords() {
     // given - insert multiple migrated records
-    IdKeyDbModel expectedMigrated1 = createExpectedMigratedModel("migratedLegacyId1");
-    IdKeyDbModel expectedMigrated2 = createExpectedMigratedModel("migratedLegacyId2");
+    IdKeyDbModel expectedMigrated1 = createExpectedMigratedModel("migratedC7Id1");
+    IdKeyDbModel expectedMigrated2 = createExpectedMigratedModel("migratedC7Id2");
     insertTestData(expectedMigrated1);
     insertTestData(expectedMigrated2);
     String processInstanceType = String.valueOf(IdKeyMapper.TYPE.RUNTIME_PROCESS_INSTANCE);
@@ -62,8 +62,8 @@ public class MigratorResourceTest extends AbstractCockpitPluginTest {
   @Test
   public void testSkippedRecords() {
     // given - insert multiple skipped records
-    IdKeyDbModel expectedSkipped1 = createExpectedSkippedModel("skippedLegacyId1", "Test skip reason 1");
-    IdKeyDbModel expectedSkipped2 = createExpectedSkippedModel("skippedLegacyId2", "Test skip reason 2");
+    IdKeyDbModel expectedSkipped1 = createExpectedSkippedModel("skippedC7Id1", "Test skip reason 1");
+    IdKeyDbModel expectedSkipped2 = createExpectedSkippedModel("skippedC7Id2", "Test skip reason 2");
     insertTestData(expectedSkipped1);
     insertTestData(expectedSkipped2);
     String processInstanceType = String.valueOf(IdKeyMapper.TYPE.RUNTIME_PROCESS_INSTANCE);
@@ -139,10 +139,10 @@ public class MigratorResourceTest extends AbstractCockpitPluginTest {
 
     // Sort both lists by ID for comparison
     List<IdKeyDbModel> sortedExpected = expected.stream()
-        .sorted(Comparator.comparing(IdKeyDbModel::getId))
+        .sorted(Comparator.comparing(IdKeyDbModel::getC7Id))
         .toList();
     List<IdKeyDbModel> sortedActual = actual.stream()
-        .sorted(Comparator.comparing(IdKeyDbModel::getId))
+        .sorted(Comparator.comparing(IdKeyDbModel::getC7Id))
         .toList();
 
     // Compare each element
@@ -150,41 +150,41 @@ public class MigratorResourceTest extends AbstractCockpitPluginTest {
       IdKeyDbModel expectedModel = sortedExpected.get(i);
       IdKeyDbModel actualModel = sortedActual.get(i);
 
-      assertThat(actualModel.getId()).isEqualTo(expectedModel.getId());
-      assertThat(actualModel.getInstanceKey()).isEqualTo(expectedModel.getInstanceKey());
+      assertThat(actualModel.getC7Id()).isEqualTo(expectedModel.getC7Id());
+      assertThat(actualModel.getC8Key()).isEqualTo(expectedModel.getC8Key());
       assertThat(actualModel.getType()).isEqualTo(expectedModel.getType());
       assertThat(actualModel.getSkipReason()).isEqualTo(expectedModel.getSkipReason());
     }
   }
 
-  private IdKeyDbModel createExpectedMigratedModel(String legacyId) {
+  private IdKeyDbModel createExpectedMigratedModel(String c7Id) {
     IdKeyDbModel model = new IdKeyDbModel();
-    model.setId(legacyId);
-    model.setInstanceKey(getNextKey());
+    model.setC7Id(c7Id);
+    model.setC8Key(getNextKey());
     model.setType(IdKeyMapper.TYPE.RUNTIME_PROCESS_INSTANCE);
     return model;
   }
 
-  private IdKeyDbModel createExpectedSkippedModel(String legacyId, String skipReason) {
-    IdKeyDbModel model = createExpectedMigratedModel(legacyId);
+  private IdKeyDbModel createExpectedSkippedModel(String c7Id, String skipReason) {
+    IdKeyDbModel model = createExpectedMigratedModel(c7Id);
     model.setSkipReason(skipReason);
-    model.setInstanceKey(null);
+    model.setC8Key(null);
     return model;
   }
 
   private static void insertTestData(IdKeyDbModel idKeyDbModel) {
     try (Connection conn = DriverManager.getConnection(
         "jdbc:h2:mem:default-process-engine;DB_CLOSE_DELAY=-1", "sa", "")) {
-      String insertSql = "INSERT INTO MIGRATION_MAPPING (ID, INSTANCE_KEY, START_DATE, TYPE, SKIP_REASON) VALUES (?, ?, ?, ?, ?)";
+      String insertSql = "INSERT INTO MIGRATION_MAPPING (C7_ID, C8_KEY, CREATE_TIME, TYPE, SKIP_REASON) VALUES (?, ?, ?, ?, ?)";
       try (var stmt = conn.prepareStatement(insertSql)) {
-        stmt.setString(1, idKeyDbModel.getId());
+        stmt.setString(1, idKeyDbModel.getC7Id());
         stmt.setTimestamp(3, null);
         stmt.setString(4, String.valueOf(idKeyDbModel.getType()));
         stmt.setString(5, idKeyDbModel.getSkipReason());
-        if (idKeyDbModel.getInstanceKey() == null) {
+        if (idKeyDbModel.getC8Key() == null) {
           stmt.setNull(2, java.sql.Types.BIGINT);
         } else {
-          stmt.setLong(2, idKeyDbModel.getInstanceKey());
+          stmt.setLong(2, idKeyDbModel.getC8Key());
         }
         stmt.executeUpdate();
       }

--- a/qa/src/test/java/io/camunda/migrator/qa/history/HistoryMigrationOrderedByCreateTimeTest.java
+++ b/qa/src/test/java/io/camunda/migrator/qa/history/HistoryMigrationOrderedByCreateTimeTest.java
@@ -25,7 +25,7 @@ import org.camunda.bpm.engine.variable.VariableMap;
 import org.camunda.bpm.engine.variable.Variables;
 import org.junit.jupiter.api.Test;
 
-public class HistoryMigrationOrderedByStartDateTest extends HistoryMigrationAbstractTest {
+public class HistoryMigrationOrderedByCreateTimeTest extends HistoryMigrationAbstractTest {
 
   @Test
   public void shouldMigrateProcessDefinitionsDeployedBetweenRuns() {
@@ -129,7 +129,7 @@ public class HistoryMigrationOrderedByStartDateTest extends HistoryMigrationAbst
   }
 
   @Test
-  public void shouldMigrateProcessInstancesWithSameStartDate() {
+  public void shouldMigrateProcessInstancesWithSameCreateTime() {
     // given
     deployer.deployCamunda7Process("simpleStartEndProcess.bpmn");
     runtimeService.startProcessInstanceByKey("simpleStartEndProcessId");
@@ -162,7 +162,7 @@ public class HistoryMigrationOrderedByStartDateTest extends HistoryMigrationAbst
     // then
     assertThat(instanceSupplier.get()).singleElement()
         .extracting(ProcessInstanceEntity::processInstanceKey)
-        .satisfies(instanceKey -> assertThat(searchHistoricUserTasks(instanceKey)).singleElement());
+        .satisfies(c8Key -> assertThat(searchHistoricUserTasks(c8Key)).singleElement());
 
     // given
     runtimeService.startProcessInstanceByKey("userTaskProcessId");
@@ -174,11 +174,11 @@ public class HistoryMigrationOrderedByStartDateTest extends HistoryMigrationAbst
     // then
     assertThat(instanceSupplier.get()).hasSize(2)
         .extracting(ProcessInstanceEntity::processInstanceKey)
-        .allSatisfy(instanceKey -> assertThat(searchHistoricUserTasks(instanceKey)).singleElement());
+        .allSatisfy(c8Key -> assertThat(searchHistoricUserTasks(c8Key)).singleElement());
   }
 
   @Test
-  public void shouldMigrateUserTasksWithSameStartDate() {
+  public void shouldMigrateUserTasksWithSameCreateTime() {
     // given
     deployer.deployCamunda7Process("userTaskProcess.bpmn");
     runtimeService.startProcessInstanceByKey("userTaskProcessId");
@@ -197,7 +197,7 @@ public class HistoryMigrationOrderedByStartDateTest extends HistoryMigrationAbst
     // then
     assertThat(searchHistoricProcessInstances("userTaskProcessId")).hasSize(3)
         .extracting(ProcessInstanceEntity::processInstanceKey)
-        .allSatisfy(instanceKey -> assertThat(searchHistoricUserTasks(instanceKey)).singleElement());
+        .allSatisfy(c8Key -> assertThat(searchHistoricUserTasks(c8Key)).singleElement());
   }
 
   @Test
@@ -235,7 +235,7 @@ public class HistoryMigrationOrderedByStartDateTest extends HistoryMigrationAbst
   }
 
   @Test
-  public void shouldMigrateFlowNodesWithSameStartDate() {
+  public void shouldMigrateFlowNodesWithSameCreateTime() {
     // given
     deployer.deployCamunda7Process("multipleSignalProcess.bpmn");
     runtimeService.startProcessInstanceByKey("multipleSignalProcessId");

--- a/qa/src/test/java/io/camunda/migrator/qa/history/HistoryMigrationRetryTest.java
+++ b/qa/src/test/java/io/camunda/migrator/qa/history/HistoryMigrationRetryTest.java
@@ -27,8 +27,8 @@ public class HistoryMigrationRetryTest extends HistoryMigrationAbstractTest {
   public void shouldMigratePreviouslySkippedProcessDefinition() {
     // given state in c7
     deployer.deployCamunda7Process("userTaskProcess.bpmn");
-    String legacyId = repositoryService.createProcessDefinitionQuery().singleResult().getId();
-    markEntityAsSkipped(legacyId, HISTORY_PROCESS_DEFINITION);
+    String c7Id = repositoryService.createProcessDefinitionQuery().singleResult().getId();
+    markEntityAsSkipped(c7Id, HISTORY_PROCESS_DEFINITION);
     // when history migration is retried
     historyMigrator.setMode(MigratorMode.RETRY_SKIPPED);
     historyMigrator.migrate();
@@ -42,8 +42,8 @@ public class HistoryMigrationRetryTest extends HistoryMigrationAbstractTest {
   public void shouldMigratePreviouslySkippedDecisionDefinition() {
     // given
     deployer.deployCamunda7Decision("simpleDmn.dmn");
-    String legacyId = repositoryService.createDecisionDefinitionQuery().singleResult().getId();
-    markEntityAsSkipped(legacyId, IdKeyMapper.TYPE.HISTORY_DECISION_DEFINITION);
+    String c7Id = repositoryService.createDecisionDefinitionQuery().singleResult().getId();
+    markEntityAsSkipped(c7Id, IdKeyMapper.TYPE.HISTORY_DECISION_DEFINITION);
 
     // when 
     historyMigrator.setMode(MigratorMode.RETRY_SKIPPED);
@@ -58,8 +58,8 @@ public class HistoryMigrationRetryTest extends HistoryMigrationAbstractTest {
   public void shouldMigratePreviouslySkippedDecisionRequirementsDefinition() {
     // given
     deployer.deployCamunda7Decision("simpleDmnWithReqs.dmn");
-    String legacyId = repositoryService.createDecisionRequirementsDefinitionQuery().singleResult().getId();
-    markEntityAsSkipped(legacyId, IdKeyMapper.TYPE.HISTORY_DECISION_REQUIREMENT);
+    String c7Id = repositoryService.createDecisionRequirementsDefinitionQuery().singleResult().getId();
+    markEntityAsSkipped(c7Id, IdKeyMapper.TYPE.HISTORY_DECISION_REQUIREMENT);
 
     // when 
     historyMigrator.setMode(MigratorMode.RETRY_SKIPPED);
@@ -122,12 +122,12 @@ public class HistoryMigrationRetryTest extends HistoryMigrationAbstractTest {
     assertThat(searchHistoricVariables("userTaskVar").size()).isEqualTo(1);
 
     // and nothing marked as skipped
-    assertThat(dbClient.checkHasKeyByIdAndType(procDefId, HISTORY_PROCESS_DEFINITION)).isTrue();
-    assertThat(dbClient.checkHasKeyByIdAndType(procInstId, HISTORY_PROCESS_INSTANCE)).isTrue();
-    assertThat(dbClient.checkHasKeyByIdAndType(actInstId, HISTORY_FLOW_NODE)).isTrue();
-    assertThat(dbClient.checkHasKeyByIdAndType(taskId, HISTORY_USER_TASK)).isTrue();
-    assertThat(dbClient.checkHasKeyByIdAndType(incidentId, HISTORY_INCIDENT)).isTrue();
-    assertThat(dbClient.checkHasKeyByIdAndType(varId, HISTORY_VARIABLE)).isTrue();
+    assertThat(dbClient.checkHasC8KeyByC7IdAndType(procDefId, HISTORY_PROCESS_DEFINITION)).isTrue();
+    assertThat(dbClient.checkHasC8KeyByC7IdAndType(procInstId, HISTORY_PROCESS_INSTANCE)).isTrue();
+    assertThat(dbClient.checkHasC8KeyByC7IdAndType(actInstId, HISTORY_FLOW_NODE)).isTrue();
+    assertThat(dbClient.checkHasC8KeyByC7IdAndType(taskId, HISTORY_USER_TASK)).isTrue();
+    assertThat(dbClient.checkHasC8KeyByC7IdAndType(incidentId, HISTORY_INCIDENT)).isTrue();
+    assertThat(dbClient.checkHasC8KeyByC7IdAndType(varId, HISTORY_VARIABLE)).isTrue();
   }
 
   @Test
@@ -166,12 +166,12 @@ public class HistoryMigrationRetryTest extends HistoryMigrationAbstractTest {
     assertThat(processInstances.size()).isEqualTo(4);
 
     // and skipped entities are still skipped
-    assertThat(dbClient.checkHasKeyByIdAndType(procInstId, HISTORY_PROCESS_INSTANCE)).isFalse();
-    assertThat(dbClient.checkHasKeyByIdAndType(actInstId, HISTORY_FLOW_NODE)).isFalse();
-    assertThat(dbClient.checkHasKeyByIdAndType(taskId, HISTORY_USER_TASK)).isFalse();
+    assertThat(dbClient.checkHasC8KeyByC7IdAndType(procInstId, HISTORY_PROCESS_INSTANCE)).isFalse();
+    assertThat(dbClient.checkHasC8KeyByC7IdAndType(actInstId, HISTORY_FLOW_NODE)).isFalse();
+    assertThat(dbClient.checkHasC8KeyByC7IdAndType(taskId, HISTORY_USER_TASK)).isFalse();
   }
 
-  private void markEntityAsSkipped(String legacyId, IdKeyMapper.TYPE type) {
-    dbClient.insert(legacyId, null, type);
+  private void markEntityAsSkipped(String c7Id, IdKeyMapper.TYPE type) {
+    dbClient.insert(c7Id, null, type);
   }
 }

--- a/qa/src/test/java/io/camunda/migrator/qa/history/IdKeyCreateTimeMappingTest.java
+++ b/qa/src/test/java/io/camunda/migrator/qa/history/IdKeyCreateTimeMappingTest.java
@@ -16,16 +16,16 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 /**
- * Test to verify that IdKeyDbModel startDate is mapped correctly across different database types
+ * Test to verify that IdKeyDbModel createTime is mapped correctly across different database types
  * when running actual migration queries defined in IdKey.xml.
  */
-public class IdKeyStartDateMappingTest extends HistoryMigrationAbstractTest {
+public class IdKeyCreateTimeMappingTest extends HistoryMigrationAbstractTest {
 
   @Autowired
   private IdKeyMapper idKeyMapper;
 
   @Test
-  public void shouldCorrectlyMapStartDateDuringActualMigration() {
+  public void shouldCorrectlyMapCreateTimeDuringActualMigration() {
 
     // Given
     deployer.deployCamunda7Process("simpleProcess.bpmn");
@@ -40,8 +40,8 @@ public class IdKeyStartDateMappingTest extends HistoryMigrationAbstractTest {
     IdKeyDbModel migratedInstance = idKeyMapper.findMigratedByType(
         IdKeyMapper.TYPE.HISTORY_PROCESS_INSTANCE, 0, Integer.MAX_VALUE).stream().toList().getFirst();
 
-    assertThat(migratedInstance.getId()).isEqualTo(processInstanceId);
-    assertThat(migratedInstance.getStartDate()).isNotNull().isBefore(beforeMigration); // Should be before we started the test
-    assertThat(migratedInstance.getInstanceKey()).isNotNull().isPositive();
+    assertThat(migratedInstance.getC7Id()).isEqualTo(processInstanceId);
+    assertThat(migratedInstance.getCreateTime()).isNotNull().isBefore(beforeMigration); // Should be before we started the test
+    assertThat(migratedInstance.getC8Key()).isNotNull().isPositive();
   }
 }

--- a/qa/src/test/java/io/camunda/migrator/qa/history/entity/HistoryDecisionMigrationTest.java
+++ b/qa/src/test/java/io/camunda/migrator/qa/history/entity/HistoryDecisionMigrationTest.java
@@ -132,11 +132,11 @@ public class HistoryDecisionMigrationTest extends HistoryMigrationAbstractTest {
         migratedProcessInstances.getFirst().processInstanceKey(), BUSINESS_RULE_TASK);
     assertThat(migratedFlowNodeInstances).singleElement();
     List<DecisionInstanceEntity> migratedInstances = searchHistoricDecisionInstances("simpleDecisionId");
-    HistoricDecisionInstance legacyInstance = c7Client.getHistoricDecisionInstanceByDefinitionKey("simpleDecisionId");
+    HistoricDecisionInstance c7Instance = c7Client.getHistoricDecisionInstanceByDefinitionKey("simpleDecisionId");
 
     assertThat(migratedInstances).singleElement().satisfies(instance -> {
       assertThat(instance.decisionInstanceId()).isEqualTo(
-          instance.decisionInstanceKey() + "-" + legacyInstance.getId());
+          instance.decisionInstanceKey() + "-" + c7Instance.getId());
       assertThat(instance.decisionInstanceKey()).isNotNull();
       assertThat(instance.state()).isEqualTo(DecisionInstanceEntity.DecisionInstanceState.UNSPECIFIED);
       assertThat(instance.evaluationDate()).isEqualTo(

--- a/qa/src/test/java/io/camunda/migrator/qa/history/entity/HistoryProcessInstanceTest.java
+++ b/qa/src/test/java/io/camunda/migrator/qa/history/entity/HistoryProcessInstanceTest.java
@@ -157,9 +157,9 @@ public class HistoryProcessInstanceTest extends HistoryMigrationAbstractTest {
     assertThat(processInstance.processDefinitionId()).isEqualTo(processDefinitionId);
     assertThat(processInstance.state()).isEqualTo(processInstanceState);
     assertThat(processInstance.processInstanceKey()).isEqualTo(
-        dbClient.findKeyByIdAndType(historicProcessInstance.getId(), IdKeyMapper.TYPE.HISTORY_PROCESS_INSTANCE));
+        dbClient.findC8KeyByC7IdAndType(historicProcessInstance.getId(), IdKeyMapper.TYPE.HISTORY_PROCESS_INSTANCE));
     assertThat(processInstance.processDefinitionKey()).isEqualTo(
-        dbClient.findKeyByIdAndType(historicProcessInstance.getProcessDefinitionId(),
+        dbClient.findC8KeyByC7IdAndType(historicProcessInstance.getProcessDefinitionId(),
             IdKeyMapper.TYPE.HISTORY_PROCESS_DEFINITION));
     assertThat(processInstance.tenantId()).isEqualTo(tenantId);
     assertThat(processInstance.startDate()).isEqualTo(
@@ -170,7 +170,7 @@ public class HistoryProcessInstanceTest extends HistoryMigrationAbstractTest {
 
     if (hasParent) {
       assertThat(processInstance.parentProcessInstanceKey()).isEqualTo(
-          dbClient.findKeyByIdAndType(historicProcessInstance.getSuperProcessInstanceId(),
+          dbClient.findC8KeyByC7IdAndType(historicProcessInstance.getSuperProcessInstanceId(),
               IdKeyMapper.TYPE.HISTORY_PROCESS_INSTANCE));
       assertThat(processInstance.parentFlowNodeInstanceKey()).isNull();
     } else {

--- a/qa/src/test/java/io/camunda/migrator/qa/history/entity/HistoryUserTaskTest.java
+++ b/qa/src/test/java/io/camunda/migrator/qa/history/entity/HistoryUserTaskTest.java
@@ -17,14 +17,11 @@ import io.camunda.search.entities.UserTaskEntity;
 import java.util.Date;
 import java.util.List;
 import org.apache.commons.lang3.StringUtils;
-import org.camunda.bpm.engine.HistoryService;
 import org.camunda.bpm.engine.history.HistoricTaskInstance;
 import org.camunda.bpm.engine.runtime.ProcessInstance;
 import org.camunda.bpm.engine.task.Task;
 import org.camunda.bpm.model.bpmn.BpmnModelInstance;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.system.CapturedOutput;
 
 public class HistoryUserTaskTest extends HistoryMigrationAbstractTest {
 
@@ -343,13 +340,13 @@ public class HistoryUserTaskTest extends HistoryMigrationAbstractTest {
                                       String expectedElementId) {
     // Basic identifiers
     assertThat(userTask.userTaskKey()).isEqualTo(
-        dbClient.findKeyByIdAndType(c7Task.getId(), IdKeyMapper.TYPE.HISTORY_USER_TASK));
+        dbClient.findC8KeyByC7IdAndType(c7Task.getId(), IdKeyMapper.TYPE.HISTORY_USER_TASK));
     assertThat(userTask.elementId()).isEqualTo(expectedElementId);
     assertThat(userTask.processDefinitionId()).isEqualTo(c7Task.getProcessDefinitionKey());
     assertThat(userTask.processDefinitionKey()).isEqualTo(
-        dbClient.findKeyByIdAndType(c7Task.getProcessDefinitionId(), IdKeyMapper.TYPE.HISTORY_PROCESS_DEFINITION));
+        dbClient.findC8KeyByC7IdAndType(c7Task.getProcessDefinitionId(), IdKeyMapper.TYPE.HISTORY_PROCESS_DEFINITION));
     assertThat(userTask.elementInstanceKey()).isEqualTo(
-        dbClient.findKeyByIdAndType(c7Task.getActivityInstanceId(), IdKeyMapper.TYPE.HISTORY_FLOW_NODE));
+        dbClient.findC8KeyByC7IdAndType(c7Task.getActivityInstanceId(), IdKeyMapper.TYPE.HISTORY_FLOW_NODE));
 
     // Dates
     assertThat(userTask.creationDate()).isNotNull();

--- a/qa/src/test/java/io/camunda/migrator/qa/history/entity/HistoryVariableTest.java
+++ b/qa/src/test/java/io/camunda/migrator/qa/history/entity/HistoryVariableTest.java
@@ -384,7 +384,7 @@ public class HistoryVariableTest extends HistoryMigrationAbstractTest {
         .create();
 
     VariableMap fileVar = Variables.createVariables().putValueTyped("fileVar", fileValue);
-    String legacyId = runtimeService.startProcessInstanceByKey("simpleProcess", fileVar).getId();
+    runtimeService.startProcessInstanceByKey("simpleProcess", fileVar);
 
     // when
     historyMigrator.migrate();
@@ -399,8 +399,8 @@ public class HistoryVariableTest extends HistoryMigrationAbstractTest {
     // deploy processes
     deployer.deployCamunda7Process("simpleProcess.bpmn");
 
-    String legacyId = runtimeService.startProcessInstanceByKey("simpleProcess",
-        Collections.singletonMap("bytesVar", "foo".getBytes())).getId();
+    runtimeService.startProcessInstanceByKey("simpleProcess",
+        Collections.singletonMap("bytesVar", "foo".getBytes()));
 
     // when
     historyMigrator.migrate();

--- a/qa/src/test/java/io/camunda/migrator/qa/persistence/DropSchemaTest.java
+++ b/qa/src/test/java/io/camunda/migrator/qa/persistence/DropSchemaTest.java
@@ -76,7 +76,7 @@ public class DropSchemaTest {
     ensureTrue("Migration mapping table does not exist", tableExists(durableDataSource, MIGRATION_MAPPING_TABLE));
     DbClient dbClient = context.getBean("dbClient", DbClient.class);
     // and some entities are marked as skipped
-    dbClient.insert("legacyId", null, IdKeyMapper.TYPE.RUNTIME_PROCESS_INSTANCE);
+    dbClient.insert("c7Id", null, IdKeyMapper.TYPE.RUNTIME_PROCESS_INSTANCE);
 
     // when application is shut down
     context.close();
@@ -97,7 +97,7 @@ public class DropSchemaTest {
     ensureTrue("Migration mapping table does not exist", tableExists(durableDataSource, prefix + MIGRATION_MAPPING_TABLE));
     DbClient dbClient = context.getBean("dbClient", DbClient.class);
     // and some entities are marked as skipped
-    dbClient.insert("legacyId", null, IdKeyMapper.TYPE.RUNTIME_PROCESS_INSTANCE);
+    dbClient.insert("c7Id", null, IdKeyMapper.TYPE.RUNTIME_PROCESS_INSTANCE);
 
     // when application is shut down
     context.close();

--- a/qa/src/test/java/io/camunda/migrator/qa/persistence/SaveSkipReasonTest.java
+++ b/qa/src/test/java/io/camunda/migrator/qa/persistence/SaveSkipReasonTest.java
@@ -53,7 +53,7 @@ public class SaveSkipReasonTest extends RuntimeMigrationAbstractTest {
     assertThat(skippedInstances).hasSize(1);
 
     IdKeyDbModel savedInstance = skippedInstances.getFirst();
-    assertThat(savedInstance.getInstanceKey()).isNull();
+    assertThat(savedInstance.getC8Key()).isNull();
     assertThat(savedInstance.getSkipReason()).isEqualTo(String.format(MULTI_INSTANCE_LOOP_CHARACTERISTICS_ERROR, "multiUserTask"));
   }
 
@@ -77,6 +77,6 @@ public class SaveSkipReasonTest extends RuntimeMigrationAbstractTest {
 
     IdKeyDbModel savedInstance = skippedInstances.getFirst();
     assertThat(savedInstance.getSkipReason()).isNull();
-    assertThat(savedInstance.getInstanceKey()).isNull();
+    assertThat(savedInstance.getC8Key()).isNull();
   }
 }

--- a/qa/src/test/java/io/camunda/migrator/qa/runtime/MigrationOrderedByStartDateTest.java
+++ b/qa/src/test/java/io/camunda/migrator/qa/runtime/MigrationOrderedByStartDateTest.java
@@ -15,7 +15,7 @@ import java.util.function.Supplier;
 import org.camunda.bpm.engine.impl.util.ClockUtil;
 import org.junit.jupiter.api.Test;
 
-class MigrationOrderedByStartDateTest extends RuntimeMigrationAbstractTest {
+class MigrationOrderedByCreateTimeTest extends RuntimeMigrationAbstractTest {
 
   @Test
   public void shouldMigrateStartedBetweenRuns() {
@@ -44,7 +44,7 @@ class MigrationOrderedByStartDateTest extends RuntimeMigrationAbstractTest {
   }
 
   @Test
-  public void shouldMigrateWithSameStartDate() {
+  public void shouldMigrateWithSameCreateTime() {
     // given
     deployer.deployProcessInC7AndC8("simpleProcess.bpmn");
 
@@ -68,7 +68,7 @@ class MigrationOrderedByStartDateTest extends RuntimeMigrationAbstractTest {
   }
 
   @Test
-  public void shouldRerunWithDifferentStartDateProcessInstancesMigratedAndValidationFailure() {
+  public void shouldRerunWithDifferentCreateTimeProcessInstancesMigratedAndValidationFailure() {
     // given
     deployer.deployProcessInC7AndC8("simpleProcess.bpmn");
 
@@ -94,7 +94,7 @@ class MigrationOrderedByStartDateTest extends RuntimeMigrationAbstractTest {
   }
 
   @Test
-  public void shouldRerunWithDifferentStartDateWithProcessInstancesSkippedAndValidationFailure() {
+  public void shouldRerunWithDifferentCreateTimeWithProcessInstancesSkippedAndValidationFailure() {
     // given
     deployer.deployCamunda7Process("simpleProcess.bpmn");
     deployer.deployCamunda8Process("simpleProcessWithoutListener.bpmn");
@@ -121,7 +121,7 @@ class MigrationOrderedByStartDateTest extends RuntimeMigrationAbstractTest {
   }
 
   @Test
-  public void shouldRerunSameStartDateWithProcessInstancesMigratedAndValidationFailure() {
+  public void shouldRerunSameCreateTimeWithProcessInstancesMigratedAndValidationFailure() {
     // given
     deployer.deployProcessInC7AndC8("simpleProcess.bpmn");
 
@@ -146,7 +146,7 @@ class MigrationOrderedByStartDateTest extends RuntimeMigrationAbstractTest {
   }
 
   @Test
-  public void shouldRerunWithSameStartDateWithProcessInstancesSkippedAndValidationFailure() {
+  public void shouldRerunWithSameCreateTimeWithProcessInstancesSkippedAndValidationFailure() {
     // given
     deployer.deployCamunda7Process("simpleProcess.bpmn");
     deployer.deployCamunda8Process("simpleProcessWithoutListener.bpmn");

--- a/qa/src/test/java/io/camunda/migrator/qa/runtime/ProcessDefinitionNotFoundTest.java
+++ b/qa/src/test/java/io/camunda/migrator/qa/runtime/ProcessDefinitionNotFoundTest.java
@@ -40,7 +40,7 @@ class ProcessDefinitionNotFoundTest extends RuntimeMigrationAbstractTest {
     assertThatProcessInstanceCountIsEqualTo(0);
     List<IdKeyDbModel> skippedProcessInstanceIds = dbClient.findSkippedProcessInstances();
     assertThat(skippedProcessInstanceIds.size()).isEqualTo(1);
-    assertThat(skippedProcessInstanceIds.getFirst().getId()).isEqualTo(c7Instance.getId());
+    assertThat(skippedProcessInstanceIds.getFirst().getC7Id()).isEqualTo(c7Instance.getId());
   }
 
   @Test

--- a/qa/src/test/java/io/camunda/migrator/qa/runtime/ProcessElementNotFoundTest.java
+++ b/qa/src/test/java/io/camunda/migrator/qa/runtime/ProcessElementNotFoundTest.java
@@ -40,7 +40,7 @@ public class ProcessElementNotFoundTest  extends RuntimeMigrationAbstractTest {
     assertThatProcessInstanceCountIsEqualTo(0);
     List<IdKeyDbModel> skippedProcessInstanceIds = dbClient.findSkippedProcessInstances();
     assertThat(skippedProcessInstanceIds.size()).isEqualTo(1);
-    assertThat(skippedProcessInstanceIds.getFirst().getId()).isEqualTo(c7Instance.getId());
+    assertThat(skippedProcessInstanceIds.getFirst().getC7Id()).isEqualTo(c7Instance.getId());
   }
 
 }

--- a/qa/src/test/java/io/camunda/migrator/qa/runtime/SkipAndRetryProcessInstancesTest.java
+++ b/qa/src/test/java/io/camunda/migrator/qa/runtime/SkipAndRetryProcessInstancesTest.java
@@ -69,7 +69,7 @@ class SkipAndRetryProcessInstancesTest extends RuntimeMigrationAbstractTest {
 
     List<IdKeyDbModel> skippedProcessInstanceIds = findSkippedRuntimeProcessInstances().stream().toList();
     assertThat(skippedProcessInstanceIds.size()).isEqualTo(1);
-    assertThat(skippedProcessInstanceIds.getFirst().getId()).isEqualTo(process.getId());
+    assertThat(skippedProcessInstanceIds.getFirst().getC7Id()).isEqualTo(process.getId());
 
     logs.assertContains(String.format(SKIPPING_PROCESS_INSTANCE_VALIDATION_ERROR.replace("{}", "%s"), process.getId(),
         String.format(MULTI_INSTANCE_LOOP_CHARACTERISTICS_ERROR, "multiUserTask")));
@@ -90,7 +90,7 @@ class SkipAndRetryProcessInstancesTest extends RuntimeMigrationAbstractTest {
 
     List<IdKeyDbModel> skippedProcessInstanceIds = dbClient.findSkippedProcessInstances().stream().toList();
     assertThat(skippedProcessInstanceIds.size()).isEqualTo(1);
-    assertThat(skippedProcessInstanceIds.getFirst().getId()).isEqualTo(process.getId());
+    assertThat(skippedProcessInstanceIds.getFirst().getC7Id()).isEqualTo(process.getId());
 
     // Logs should contains the activityId without the multi-instance body suffix
     String activityIdWithoutMultiInstanceBody = "ServiceTask_1";
@@ -115,7 +115,7 @@ class SkipAndRetryProcessInstancesTest extends RuntimeMigrationAbstractTest {
     assertThatProcessInstanceCountIsEqualTo(0);
     List<IdKeyDbModel> skippedProcessInstanceIds = findSkippedRuntimeProcessInstances().stream().toList();
     assertThat(skippedProcessInstanceIds.size()).isEqualTo(1);
-    assertThat(skippedProcessInstanceIds.getFirst().getId()).isEqualTo(process.getId());
+    assertThat(skippedProcessInstanceIds.getFirst().getC7Id()).isEqualTo(process.getId());
 
     logs.assertContains(String.format(SKIPPING_PROCESS_INSTANCE_VALIDATION_ERROR.replace("{}", "%s"), process.getId(),
         String.format(MULTI_INSTANCE_LOOP_CHARACTERISTICS_ERROR, "multiUserTask")));
@@ -138,7 +138,7 @@ class SkipAndRetryProcessInstancesTest extends RuntimeMigrationAbstractTest {
     assertThatProcessInstanceCountIsEqualTo(0);
     List<IdKeyDbModel> skippedProcessInstanceIds = findSkippedRuntimeProcessInstances().stream().toList();
     assertThat(skippedProcessInstanceIds.size()).isEqualTo(1);
-    assertThat(skippedProcessInstanceIds.getFirst().getId()).isEqualTo(process.getId());
+    assertThat(skippedProcessInstanceIds.getFirst().getC7Id()).isEqualTo(process.getId());
 
     var events = logs.getEvents();
     Assertions.assertThat(events.stream()
@@ -179,7 +179,7 @@ class SkipAndRetryProcessInstancesTest extends RuntimeMigrationAbstractTest {
     assertThat(processInstance.getProcessDefinitionId()).isEqualTo(process.getProcessDefinitionKey());
 
     // and the key updated
-    assertThat(dbClient.findKeyByIdAndType(process.getId(), IdKeyMapper.TYPE.RUNTIME_PROCESS_INSTANCE)).isNotNull();
+    assertThat(dbClient.findC8KeyByC7IdAndType(process.getId(), IdKeyMapper.TYPE.RUNTIME_PROCESS_INSTANCE)).isNotNull();
 
     // and no additional skipping logs (still 1, not 2 matches)
     Assertions.assertThat(events.stream()
@@ -251,7 +251,7 @@ class SkipAndRetryProcessInstancesTest extends RuntimeMigrationAbstractTest {
     assertThat(output.getOut().trim()).endsWith(expectedMessage);
 
     // and no migration was done
-    assertThat(dbClient.findAllIds().size()).isEqualTo(0);
+    assertThat(dbClient.findAllC7Ids().size()).isEqualTo(0);
   }
 
   @Test
@@ -265,15 +265,15 @@ class SkipAndRetryProcessInstancesTest extends RuntimeMigrationAbstractTest {
     historyMigrator.start();
 
     // then verify history process instance was migrated
-    assertThat(dbClient.checkHasKeyByIdAndType(processInstanceId, IdKeyMapper.TYPE.HISTORY_PROCESS_INSTANCE)).isTrue();
+    assertThat(dbClient.checkHasC8KeyByC7IdAndType(processInstanceId, IdKeyMapper.TYPE.HISTORY_PROCESS_INSTANCE)).isTrue();
     // then verify runtime process instance was not yet migrated
-    assertThat(dbClient.checkHasKeyByIdAndType(processInstanceId, IdKeyMapper.TYPE.RUNTIME_PROCESS_INSTANCE)).isFalse();
+    assertThat(dbClient.checkHasC8KeyByC7IdAndType(processInstanceId, IdKeyMapper.TYPE.RUNTIME_PROCESS_INSTANCE)).isFalse();
 
     // when running runtime migration afterwards
     runtimeMigrator.start();
 
     // then verify runtime process instance was also migrated successfully
-    assertThat(dbClient.checkHasKeyByIdAndType(processInstanceId, IdKeyMapper.TYPE.RUNTIME_PROCESS_INSTANCE)).isTrue();
+    assertThat(dbClient.checkHasC8KeyByC7IdAndType(processInstanceId, IdKeyMapper.TYPE.RUNTIME_PROCESS_INSTANCE)).isTrue();
 
     // Verify C8 process instance was created
     List<ProcessInstance> c8ProcessInstances = camundaClient.newProcessInstanceSearchRequest().execute().items();

--- a/qa/src/test/java/io/camunda/migrator/qa/runtime/element/SubprocessMigrationTest.java
+++ b/qa/src/test/java/io/camunda/migrator/qa/runtime/element/SubprocessMigrationTest.java
@@ -75,7 +75,7 @@ public class SubprocessMigrationTest extends RuntimeMigrationAbstractTest {
     assertThatProcessInstanceCountIsEqualTo(0);
 
     // verify the correct error message was logged
-    logs.assertContains(String.format("Skipping process instance with legacyId [%s]: " + CALL_ACTIVITY_LEGACY_ID_ERROR,
+    logs.assertContains(String.format("Skipping process instance with C7 ID [%s]: " + CALL_ACTIVITY_LEGACY_ID_ERROR,
                 parentInstance.getId(), "callActivityId"));
   }
 

--- a/qa/src/test/java/io/camunda/migrator/qa/runtime/variables/VariablesTest.java
+++ b/qa/src/test/java/io/camunda/migrator/qa/runtime/variables/VariablesTest.java
@@ -130,7 +130,7 @@ public class VariablesTest extends RuntimeMigrationAbstractTest {
     // deploy processes
     deployer.deployProcessInC7AndC8("simpleProcess.bpmn");
 
-    String legacyId = runtimeService.startProcessInstanceByKey("simpleProcess", Collections.singletonMap("bytesVar", "foo".getBytes())).getId();
+    String c7Id = runtimeService.startProcessInstanceByKey("simpleProcess", Collections.singletonMap("bytesVar", "foo".getBytes())).getId();
 
     // when running runtime migration
     runtimeMigrator.start();
@@ -138,7 +138,7 @@ public class VariablesTest extends RuntimeMigrationAbstractTest {
     // then
     assertThatProcessInstanceCountIsEqualTo(0);
     LOGS.assertContains(
-        String.format(SKIPPING_PROCESS_INSTANCE_VARIABLE_ERROR.replace("{}", "%s"), legacyId,
+        String.format(SKIPPING_PROCESS_INSTANCE_VARIABLE_ERROR.replace("{}", "%s"), c7Id,
             BYTE_ARRAY_UNSUPPORTED_ERROR));
   }
 
@@ -244,7 +244,7 @@ public class VariablesTest extends RuntimeMigrationAbstractTest {
     deployer.deployProcessInC7AndC8("simpleProcess.bpmn");
 
     // given process state in c7
-    String legacyId = runtimeService.startProcessInstanceByKey("simpleProcess").getId();
+    String c7Id = runtimeService.startProcessInstanceByKey("simpleProcess").getId();
 
     String json = "{ broken syntax!";
     ObjectValue objectValue = Variables.serializedObjectValue(json)
@@ -252,14 +252,14 @@ public class VariablesTest extends RuntimeMigrationAbstractTest {
         .objectTypeName("io.camunda.migrator.qa.runtime.variables.JsonSerializable")
         .create();
 
-    runtimeService.setVariable(legacyId, "var", objectValue);
+    runtimeService.setVariable(c7Id, "var", objectValue);
 
     // when running runtime migration
     runtimeMigrator.start();
 
     // then
     assertThatProcessInstanceCountIsEqualTo(0);
-    LOGS.assertContains(String.format(SKIPPING_PROCESS_INSTANCE_VARIABLE_ERROR.replace("{}", "%s"), legacyId,
+    LOGS.assertContains(String.format(SKIPPING_PROCESS_INSTANCE_VARIABLE_ERROR.replace("{}", "%s"), c7Id,
         "Error while deserializing JSON into Map type."));
   }
 
@@ -304,7 +304,7 @@ public class VariablesTest extends RuntimeMigrationAbstractTest {
         .create();
 
     VariableMap fileVar = Variables.createVariables().putValueTyped("fileVar", fileValue);
-    String legacyId = runtimeService.startProcessInstanceByKey("simpleProcess", fileVar).getId();
+    String c7Id = runtimeService.startProcessInstanceByKey("simpleProcess", fileVar).getId();
 
     // when running runtime migration
     runtimeMigrator.start();
@@ -312,7 +312,7 @@ public class VariablesTest extends RuntimeMigrationAbstractTest {
     // then
     assertThatProcessInstanceCountIsEqualTo(0);
     LOGS.assertContains(
-        String.format(SKIPPING_PROCESS_INSTANCE_VARIABLE_ERROR.replace("{}", "%s"), legacyId,
+        String.format(SKIPPING_PROCESS_INSTANCE_VARIABLE_ERROR.replace("{}", "%s"), c7Id,
             FILE_TYPE_UNSUPPORTED_ERROR));
   }
 


### PR DESCRIPTION
- No change of user-facing variable name `legacyId` in C8
- Update database schema: ID → C7_ID, INSTANCE_KEY → C8_KEY, START_DATE → CREATE_TIME
- Rename variables in implementation from `legacyId` to `c7Id`, etc.
- Rename method parameters and local variables throughout the codebase
- Update mapper methods: `findKeysByIdAndType` → `findC8KeyByC7IdAndType`, etc.
- Adjust log messages and error text to use C7 naming
- Update Cockpit plugin frontend code
- Rename test files and methods

This change improves code readability by using explicit "C7" (Camunda 7) and "C8" (Camunda 8) terminology instead of generic "legacy" references.

related to camunda/camunda-bpm-platform#5429