### PR TITLE
chore(ci): remove reference to DecisionInstanceState.UNSPECIFIED and set null

### DIFF
--- a/core/src/main/java/io/camunda/migrator/converter/DecisionInstanceConverter.java
+++ b/core/src/main/java/io/camunda/migrator/converter/DecisionInstanceConverter.java
@@ -35,7 +35,7 @@ public class DecisionInstanceConverter {
         .partitionId(C7_HISTORY_PARTITION_ID)
         .decisionInstanceId(String.format("%d-%s", decisionInstanceKey, decisionInstance.getId()))
         .decisionInstanceKey(decisionInstanceKey)
-        .state(DecisionInstanceEntity.DecisionInstanceState.UNSPECIFIED) // TODO https://github.com/camunda/camunda-bpm-platform/issues/5370
+        .state(null) // TODO https://github.com/camunda/camunda-bpm-platform/issues/5370
         .evaluationDate(convertDate(decisionInstance.getEvaluationTime()))
         .evaluationFailure(null) // not stored in HistoricDecisionInstance
         .evaluationFailureMessage(null) // not stored in HistoricDecisionInstance
@@ -50,7 +50,7 @@ public class DecisionInstanceConverter {
         .decisionRequirementsKey(decisionRequirementsDefinitionKey)
         .decisionRequirementsId(decisionInstance.getDecisionRequirementsDefinitionKey())
         .rootDecisionDefinitionKey(rootDecisionDefinitionKey)
-        .decisionType(DecisionInstanceEntity.DecisionDefinitionType.UNSPECIFIED) // TODO https://github.com/camunda/camunda-bpm-platform/issues/5370
+        .decisionType(null) // TODO https://github.com/camunda/camunda-bpm-platform/issues/5370
         .tenantId(getTenantId(decisionInstance.getTenantId()))
         .evaluatedInputs(mapInputs(decisionInstance.getId(), decisionInstance.getInputs()))
         .evaluatedOutputs(mapOutputs(decisionInstance.getId(), decisionInstance.getOutputs()))

--- a/qa/src/test/java/io/camunda/migrator/qa/history/entity/HistoryDecisionMigrationTest.java
+++ b/qa/src/test/java/io/camunda/migrator/qa/history/entity/HistoryDecisionMigrationTest.java
@@ -138,7 +138,7 @@ public class HistoryDecisionMigrationTest extends HistoryMigrationAbstractTest {
       assertThat(instance.decisionInstanceId()).isEqualTo(
           instance.decisionInstanceKey() + "-" + c7Instance.getId());
       assertThat(instance.decisionInstanceKey()).isNotNull();
-      assertThat(instance.state()).isEqualTo(DecisionInstanceEntity.DecisionInstanceState.UNSPECIFIED);
+      assertThat(instance.state()).isNull();
       assertThat(instance.evaluationDate()).isEqualTo(
           OffsetDateTime.ofInstant(now.toInstant(), ZoneId.systemDefault()));
       assertThat(instance.evaluationFailure()).isNull();
@@ -149,8 +149,7 @@ public class HistoryDecisionMigrationTest extends HistoryMigrationAbstractTest {
       assertThat(instance.decisionDefinitionKey()).isEqualTo(migratedDecisions.getFirst().decisionDefinitionKey());
       assertThat(instance.decisionDefinitionId()).isEqualTo("simpleDecisionId");
       assertThat(instance.tenantId()).isEqualTo(C8_DEFAULT_TENANT);
-      assertThat(instance.decisionDefinitionType()).isEqualTo(
-          DecisionInstanceEntity.DecisionDefinitionType.UNSPECIFIED);
+      assertThat(instance.decisionDefinitionType()).isNull();
 
       // TODO find out how to get a result http://github.com/camunda/camunda-bpm-platform/issues/5365
       //      assertThat(instance.result()).isEqualTo("B");


### PR DESCRIPTION
This will be permanently fixed by https://github.com/camunda/camunda-bpm-platform/issues/5370
