### PR TITLE
chore(workflow): enable generating release notes

### DIFF
--- a/.github/workflows/extract-issue-links.yml
+++ b/.github/workflows/extract-issue-links.yml
@@ -13,10 +13,7 @@ jobs:
     secrets: inherit
     with: 
       versions: ${{ github.event.inputs.versions }}
+      generate-release-notes: true
       support-webhook-secret: SUPPORT_CHANNEL_SLACK_WEBHOOK_URL
       sec-webhook-secret: SEC_CHANNEL_SLACK_WEBHOOK_URL
-      # TODO: improve workflow to pass the translation webhook secret only if needed
-      # See https://github.com/camunda/team-automation-platform/issues/414
-      translation-webhook-secret: TRANSLATION_CHANNEL_SLACK_WEBHOOK_URL
-      translation-notification-matcher: 7\.[0-9]+\.0
       sec-dri-secret: SEC_DRI_SLACK_ID


### PR DESCRIPTION
- Removed translation webhook secret and related matcher from workflow.
- Enable generating release notes.

related to camunda/team-automation-platform#176