### PR TITLE
chore(code-conversion): use unified C8 version (#560)

### DIFF
--- a/code-conversion/patterns/code-examples/camunda-8/src/main/java/io/camunda/conversion/job_worker/handling_a_bpmn_error/RetrievePaymentWorkerBPMNError.java
+++ b/code-conversion/patterns/code-examples/camunda-8/src/main/java/io/camunda/conversion/job_worker/handling_a_bpmn_error/RetrievePaymentWorkerBPMNError.java
@@ -9,8 +9,8 @@ package io.camunda.conversion.job_worker.handling_a_bpmn_error;
 
 import io.camunda.client.api.response.ActivatedJob;
 import io.camunda.client.api.worker.JobClient;
-import io.camunda.spring.client.annotation.JobWorker;
-import io.camunda.spring.client.exception.CamundaError;
+import io.camunda.client.annotation.JobWorker;
+import io.camunda.client.exception.CamundaError;
 
 import java.util.Map;
 

--- a/code-conversion/patterns/code-examples/camunda-8/src/main/java/io/camunda/conversion/job_worker/handling_a_failure/RetrievePaymentWorkerFailure.java
+++ b/code-conversion/patterns/code-examples/camunda-8/src/main/java/io/camunda/conversion/job_worker/handling_a_failure/RetrievePaymentWorkerFailure.java
@@ -9,8 +9,8 @@ package io.camunda.conversion.job_worker.handling_a_failure;
 
 import io.camunda.client.api.response.ActivatedJob;
 import io.camunda.client.api.worker.JobClient;
-import io.camunda.spring.client.annotation.JobWorker;
-import io.camunda.spring.client.exception.CamundaError;
+import io.camunda.client.annotation.JobWorker;
+import io.camunda.client.exception.CamundaError;
 
 import java.time.Duration;
 import java.util.Map;

--- a/code-conversion/patterns/code-examples/camunda-8/src/main/java/io/camunda/conversion/job_worker/handling_an_incident/RetrievePaymentWorkerIncident.java
+++ b/code-conversion/patterns/code-examples/camunda-8/src/main/java/io/camunda/conversion/job_worker/handling_an_incident/RetrievePaymentWorkerIncident.java
@@ -9,8 +9,8 @@ package io.camunda.conversion.job_worker.handling_an_incident;
 
 import io.camunda.client.api.response.ActivatedJob;
 import io.camunda.client.api.worker.JobClient;
-import io.camunda.spring.client.annotation.JobWorker;
-import io.camunda.spring.client.exception.CamundaError;
+import io.camunda.client.annotation.JobWorker;
+import io.camunda.client.exception.CamundaError;
 
 import java.time.Duration;
 import java.util.Map;

--- a/code-conversion/patterns/code-examples/camunda-8/src/main/java/io/camunda/conversion/job_worker/handling_process_variables/RetrievePaymentAdapter.java
+++ b/code-conversion/patterns/code-examples/camunda-8/src/main/java/io/camunda/conversion/job_worker/handling_process_variables/RetrievePaymentAdapter.java
@@ -6,8 +6,8 @@
  * except in compliance with the Camunda License 1.0.
  */
 package io.camunda.conversion.job_worker.handling_process_variables;
+import io.camunda.client.annotation.JobWorker;
 import io.camunda.client.api.response.ActivatedJob;
-import io.camunda.spring.client.annotation.JobWorker;
 import org.springframework.stereotype.Component;
 
 import java.util.HashMap;

--- a/code-conversion/patterns/code-examples/camunda-8/src/main/java/io/camunda/conversion/job_worker/handling_process_variables/RetrievePaymentWorkerProcessVariables.java
+++ b/code-conversion/patterns/code-examples/camunda-8/src/main/java/io/camunda/conversion/job_worker/handling_process_variables/RetrievePaymentWorkerProcessVariables.java
@@ -9,7 +9,7 @@ package io.camunda.conversion.job_worker.handling_process_variables;
 
 import io.camunda.client.api.response.ActivatedJob;
 import io.camunda.client.api.worker.JobClient;
-import io.camunda.spring.client.annotation.JobWorker;
+import io.camunda.client.annotation.JobWorker;
 import io.camunda.spring.client.annotation.Variable;
 
 import java.util.Map;

--- a/code-conversion/recipes/pom.xml
+++ b/code-conversion/recipes/pom.xml
@@ -19,10 +19,6 @@
     <version.lombok>1.18.42</version.lombok>
     <version.javax-annotation>1.3.2</version.javax-annotation>
     <version.commons-lang3>3.20.0</version.commons-lang3>
-    <!-- TODO consolidate Camunda 8 versions camunda/camunda-7-to-8-migration-tooling/issues/528 -->
-    <version.zeebe-client-java>8.8.7</version.zeebe-client-java>
-    <version.camunda8-spring-boot-sdk>8.8.0-alpha6</version.camunda8-spring-boot-sdk>
-    <version.camunda8-process-test-spring>8.8.8</version.camunda8-process-test-spring>
   </properties>
 
   <dependencyManagement>
@@ -167,7 +163,7 @@
     <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>zeebe-client-java</artifactId>
-      <version>${version.zeebe-client-java}</version>
+      <version>${version.camunda-8}</version>
       <scope>provided</scope>
     </dependency>
 
@@ -185,12 +181,12 @@
     <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>spring-boot-starter-camunda-sdk</artifactId>
-      <version>${version.camunda8-spring-boot-sdk}</version>
+      <version>${version.camunda-8}</version>
     </dependency>
     <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>camunda-process-test-spring</artifactId>
-      <version>${version.camunda8-process-test-spring}</version>
+      <version>${version.camunda-8}</version>
     </dependency>
 
 
@@ -201,6 +197,23 @@
   </dependencies>
 
   <build>
+    <resources>
+      <resource>
+        <directory>src/main/resources</directory>
+        <filtering>true</filtering>
+        <includes>
+          <include>**/*.yml</include>
+        </includes>
+      </resource>
+      <resource>
+        <directory>src/main/resources</directory>
+        <filtering>false</filtering>
+        <excludes>
+          <exclude>**/*.yml</exclude>
+        </excludes>
+      </resource>
+    </resources>
+
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/code-conversion/recipes/src/main/java/io/camunda/migration/code/recipes/client/MigrateUserTaskMethodsRecipe.java
+++ b/code-conversion/recipes/src/main/java/io/camunda/migration/code/recipes/client/MigrateUserTaskMethodsRecipe.java
@@ -223,11 +223,10 @@ public class MigrateUserTaskMethodsRecipe extends AbstractMigrationRecipe {
         new ReplacementUtils.ReturnReplacementSpec(
             new MethodMatcher("org.camunda.bpm.engine.task.Task getDueDate()"),
             RecipeUtils.createSimpleJavaTemplate(
-                "Date.from(Instant.parse((#{any()}.getDueDate()))",
-                "java.util.Date",
-                "java.time.Instant"),
+                "Date.from(#{any()}.getDueDate().toInstant())",
+                "java.util.Date"),
             Collections.emptyList(),
-            List.of("java.util.Date", "java.time.Instant")));
+            List.of("java.util.Date")));
   }
 
   @Override

--- a/code-conversion/recipes/src/main/java/io/camunda/migration/code/recipes/delegate/MigrateExecutionRecipe.java
+++ b/code-conversion/recipes/src/main/java/io/camunda/migration/code/recipes/delegate/MigrateExecutionRecipe.java
@@ -64,7 +64,7 @@ public class MigrateExecutionRecipe extends Recipe {
       // define preconditions
       TreeVisitor<?, ExecutionContext> check =
           Preconditions.and(
-              new UsesType<>("io.camunda.spring.client.annotation.JobWorker", true),
+              new UsesType<>("io.camunda.client.annotation.JobWorker", true),
               new UsesType<>("org.camunda.bpm.engine.delegate.JavaDelegate", true));
 
       return Preconditions.check(
@@ -144,7 +144,7 @@ public class MigrateExecutionRecipe extends Recipe {
     @Override
     protected TreeVisitor<?, ExecutionContext> preconditions() {
       return Preconditions.and(
-          new UsesType<>("io.camunda.spring.client.annotation.JobWorker", true),
+          new UsesType<>("io.camunda.client.annotation.JobWorker", true),
           new UsesType<>("org.camunda.bpm.engine.delegate.JavaDelegate", true));
     }
 
@@ -302,10 +302,10 @@ public class MigrateExecutionRecipe extends Recipe {
                 new MethodMatcher(
                     "org.camunda.bpm.engine.delegate.BpmnError <constructor>(java.lang.String)"),
                 RecipeUtils.createSimpleJavaTemplate(
-                    "throw #{any(io.camunda.spring.client.exception.CamundaError)}.bpmnError(#{any(java.lang.String)}, \"Add an error message here\")",
-                    "io.camunda.spring.client.exception.CamundaError"),
+                    "throw #{any(io.camunda.client.exception.CamundaError)}.bpmnError(#{any(java.lang.String)}, \"Add an error message here\")",
+                    "io.camunda.client.exception.CamundaError"),
                 RecipeUtils.createSimpleIdentifier(
-                    "CamundaError", "io.camunda.spring.client.exception.CamundaError"),
+                    "CamundaError", "io.camunda.client.exception.CamundaError"),
                 null,
                 ReplacementUtils.ReturnTypeStrategy.VOID,
                 List.of(
@@ -316,10 +316,10 @@ public class MigrateExecutionRecipe extends Recipe {
                 new MethodMatcher(
                     "org.camunda.bpm.engine.delegate.BpmnError <constructor>(java.lang.String, java.lang.String)"),
                 RecipeUtils.createSimpleJavaTemplate(
-                    "throw #{any(io.camunda.spring.client.exception.CamundaError)}.bpmnError(#{any(java.lang.String)}, #{any(java.lang.String)})",
-                    "io.camunda.spring.client.exception.CamundaError"),
+                    "throw #{any(io.camunda.client.exception.CamundaError)}.bpmnError(#{any(java.lang.String)}, #{any(java.lang.String)})",
+                    "io.camunda.client.exception.CamundaError"),
                 RecipeUtils.createSimpleIdentifier(
-                    "CamundaError", "io.camunda.spring.client.exception.CamundaError"),
+                    "CamundaError", "io.camunda.client.exception.CamundaError"),
                 null,
                 ReplacementUtils.ReturnTypeStrategy.VOID,
                 List.of(
@@ -333,11 +333,11 @@ public class MigrateExecutionRecipe extends Recipe {
                 new MethodMatcher(
                     "org.camunda.bpm.engine.delegate.BpmnError <constructor>(java.lang.String, java.lang.String, java.lang.Throwable)"),
                 RecipeUtils.createSimpleJavaTemplate(
-                    "throw #{any(io.camunda.spring.client.exception.CamundaError)}.bpmnError(#{any(java.lang.String)}, #{any(java.lang.String)}, Collections.emptyMap(), #{any(java.lang.Throwable)})",
-                    "io.camunda.spring.client.exception.CamundaError",
+                    "throw #{any(io.camunda.client.exception.CamundaError)}.bpmnError(#{any(java.lang.String)}, #{any(java.lang.String)}, Collections.emptyMap(), #{any(java.lang.Throwable)})",
+                    "io.camunda.client.exception.CamundaError",
                     "java.util.Collections"),
                 RecipeUtils.createSimpleIdentifier(
-                    "CamundaError", "io.camunda.spring.client.exception.CamundaError"),
+                    "CamundaError", "io.camunda.client.exception.CamundaError"),
                 null,
                 ReplacementUtils.ReturnTypeStrategy.VOID,
                 List.of(
@@ -351,11 +351,11 @@ public class MigrateExecutionRecipe extends Recipe {
                 new MethodMatcher(
                     "org.camunda.bpm.engine.delegate.BpmnError <constructor>(java.lang.String, java.lang.Throwable)"),
                 RecipeUtils.createSimpleJavaTemplate(
-                    "throw #{any(io.camunda.spring.client.exception.CamundaError)}.bpmnError(#{any(java.lang.String)}, \"Add an error message here\", Collections.emptyMap(), #{any(java.lang.Throwable)})",
-                    "io.camunda.spring.client.exception.CamundaError",
+                    "throw #{any(io.camunda.client.exception.CamundaError)}.bpmnError(#{any(java.lang.String)}, \"Add an error message here\", Collections.emptyMap(), #{any(java.lang.Throwable)})",
+                    "io.camunda.client.exception.CamundaError",
                     "java.util.Collections"),
                 RecipeUtils.createSimpleIdentifier(
-                    "CamundaError", "io.camunda.spring.client.exception.CamundaError"),
+                    "CamundaError", "io.camunda.client.exception.CamundaError"),
                 null,
                 ReplacementUtils.ReturnTypeStrategy.VOID,
                 List.of(
@@ -366,10 +366,10 @@ public class MigrateExecutionRecipe extends Recipe {
                 // ProcessEngineException()
                 new MethodMatcher("org.camunda.bpm.engine.ProcessEngineException <constructor>()"),
                 RecipeUtils.createSimpleJavaTemplate(
-                    "throw #{any(io.camunda.spring.client.exception.CamundaError)}.jobError(\"Add an error message here\")",
-                    "io.camunda.spring.client.exception.CamundaError"),
+                    "throw #{any(io.camunda.client.exception.CamundaError)}.jobError(\"Add an error message here\")",
+                    "io.camunda.client.exception.CamundaError"),
                 RecipeUtils.createSimpleIdentifier(
-                    "CamundaError", "io.camunda.spring.client.exception.CamundaError"),
+                    "CamundaError", "io.camunda.client.exception.CamundaError"),
                 null,
                 ReplacementUtils.ReturnTypeStrategy.VOID,
                 Collections.emptyList(),
@@ -379,10 +379,10 @@ public class MigrateExecutionRecipe extends Recipe {
                 new MethodMatcher(
                     "org.camunda.bpm.engine.ProcessEngineException <constructor>(java.lang.String)"),
                 RecipeUtils.createSimpleJavaTemplate(
-                    "throw #{any(io.camunda.spring.client.exception.CamundaError)}.jobError(#{any(java.lang.String)})",
-                    "io.camunda.spring.client.exception.CamundaError"),
+                    "throw #{any(io.camunda.client.exception.CamundaError)}.jobError(#{any(java.lang.String)})",
+                    "io.camunda.client.exception.CamundaError"),
                 RecipeUtils.createSimpleIdentifier(
-                    "CamundaError", "io.camunda.spring.client.exception.CamundaError"),
+                    "CamundaError", "io.camunda.client.exception.CamundaError"),
                 null,
                 ReplacementUtils.ReturnTypeStrategy.VOID,
                 List.of(
@@ -393,12 +393,12 @@ public class MigrateExecutionRecipe extends Recipe {
                 new MethodMatcher(
                     "org.camunda.bpm.engine.ProcessEngineException <constructor>(java.lang.String, java.lang.Throwable)"),
                 RecipeUtils.createSimpleJavaTemplate(
-                    "throw #{any(io.camunda.spring.client.exception.CamundaError)}.jobError(#{any(String)}, Collections.emptyMap(), 3, Duration.ofSeconds(30), #{any(java.lang.Throwable)})",
-                    "io.camunda.spring.client.exception.CamundaError",
+                    "throw #{any(io.camunda.client.exception.CamundaError)}.jobError(#{any(String)}, Collections.emptyMap(), 3, Duration.ofSeconds(30), #{any(java.lang.Throwable)})",
+                    "io.camunda.client.exception.CamundaError",
                     "java.util.Collections",
                     "java.time.Duration"),
                 RecipeUtils.createSimpleIdentifier(
-                    "CamundaError", "io.camunda.spring.client.exception.CamundaError"),
+                    "CamundaError", "io.camunda.client.exception.CamundaError"),
                 null,
                 ReplacementUtils.ReturnTypeStrategy.VOID,
                 List.of(
@@ -410,10 +410,10 @@ public class MigrateExecutionRecipe extends Recipe {
                 new MethodMatcher(
                     "org.camunda.bpm.engine.ProcessEngineException <constructor>(java.lang.String, int)"),
                 RecipeUtils.createSimpleJavaTemplate(
-                    "throw #{any(io.camunda.spring.client.exception.CamundaError)}.jobError(#{any(String)})",
-                    "io.camunda.spring.client.exception.CamundaError"),
+                    "throw #{any(io.camunda.client.exception.CamundaError)}.jobError(#{any(String)})",
+                    "io.camunda.client.exception.CamundaError"),
                 RecipeUtils.createSimpleIdentifier(
-                    "CamundaError", "io.camunda.spring.client.exception.CamundaError"),
+                    "CamundaError", "io.camunda.client.exception.CamundaError"),
                 null,
                 ReplacementUtils.ReturnTypeStrategy.VOID,
                 List.of(
@@ -424,12 +424,12 @@ public class MigrateExecutionRecipe extends Recipe {
                 new MethodMatcher(
                     "org.camunda.bpm.engine.ProcessEngineException <constructor>(java.lang.Throwable)"),
                 RecipeUtils.createSimpleJavaTemplate(
-                    "throw #{any(io.camunda.spring.client.exception.CamundaError)}.jobError(\"Add an error message here\", Collections.emptyMap(), 3, Duration.ofSeconds(30), #{any(java.lang.Throwable)})",
-                    "io.camunda.spring.client.exception.CamundaError",
+                    "throw #{any(io.camunda.client.exception.CamundaError)}.jobError(\"Add an error message here\", Collections.emptyMap(), 3, Duration.ofSeconds(30), #{any(java.lang.Throwable)})",
+                    "io.camunda.client.exception.CamundaError",
                     "java.util.Collections",
                     "java.time.Duration"),
                 RecipeUtils.createSimpleIdentifier(
-                    "CamundaError", "io.camunda.spring.client.exception.CamundaError"),
+                    "CamundaError", "io.camunda.client.exception.CamundaError"),
                 null,
                 ReplacementUtils.ReturnTypeStrategy.VOID,
                 List.of(
@@ -443,11 +443,11 @@ public class MigrateExecutionRecipe extends Recipe {
                 new MethodMatcher(
                     "org.camunda.bpm.engine.delegate.DelegateExecution createIncident(java.lang.String, java.lang.String)"),
                 RecipeUtils.createSimpleJavaTemplate(
-                    "throw #{any(io.camunda.spring.client.exception.CamundaError)}.jobError(\"Add an error message here\", Collections.emptyMap(), 0)",
-                    "io.camunda.spring.client.exception.CamundaError",
+                    "throw #{any(io.camunda.client.exception.CamundaError)}.jobError(\"Add an error message here\", Collections.emptyMap(), 0)",
+                    "io.camunda.client.exception.CamundaError",
                     "java.util.Collections"),
                 RecipeUtils.createSimpleIdentifier(
-                    "CamundaError", "io.camunda.spring.client.exception.CamundaError"),
+                    "CamundaError", "io.camunda.client.exception.CamundaError"),
                 null,
                 ReplacementUtils.ReturnTypeStrategy.VOID,
                 Collections.emptyList(),
@@ -461,11 +461,11 @@ public class MigrateExecutionRecipe extends Recipe {
                 new MethodMatcher(
                     "org.camunda.bpm.engine.delegate.DelegateExecution createIncident(java.lang.String, java.lang.String, java.lang.String)"),
                 RecipeUtils.createSimpleJavaTemplate(
-                    "throw #{any(io.camunda.spring.client.exception.CamundaError)}.jobError(#{any(java.lang.String)}, Collections.emptyMap(), 0)",
-                    "io.camunda.spring.client.exception.CamundaError",
+                    "throw #{any(io.camunda.client.exception.CamundaError)}.jobError(#{any(java.lang.String)}, Collections.emptyMap(), 0)",
+                    "io.camunda.client.exception.CamundaError",
                     "java.util.Collections"),
                 RecipeUtils.createSimpleIdentifier(
-                    "CamundaError", "io.camunda.spring.client.exception.CamundaError"),
+                    "CamundaError", "io.camunda.client.exception.CamundaError"),
                 null,
                 ReplacementUtils.ReturnTypeStrategy.VOID,
                 List.of(
@@ -488,7 +488,7 @@ public class MigrateExecutionRecipe extends Recipe {
       // define preconditions
       TreeVisitor<?, ExecutionContext> check =
           Preconditions.and(
-              new UsesType<>("io.camunda.spring.client.annotation.JobWorker", true),
+              new UsesType<>("io.camunda.client.annotation.JobWorker", true),
               new UsesType<>("org.camunda.bpm.engine.delegate.JavaDelegate", true));
 
       return Preconditions.check(
@@ -507,7 +507,7 @@ public class MigrateExecutionRecipe extends Recipe {
                 for (ReplacementUtils.SimpleReplacementSpec spec : errorSpecs) {
                   if (spec.matcher().matches(newClass)) {
 
-                    maybeAddImport("io.camunda.spring.client.exception.CamundaError");
+                    maybeAddImport("io.camunda.client.exception.CamundaError");
 
                     return maybeAutoFormat(
                         throwStmt,
@@ -606,7 +606,7 @@ public class MigrateExecutionRecipe extends Recipe {
                                   specs.baseIdentifier(),
                                   specs.argumentIndexes()));
 
-                  maybeAddImport("io.camunda.spring.client.exception.CamundaError");
+                  maybeAddImport("io.camunda.client.exception.CamundaError");
 
                   return maybeAutoFormat(methodInvocation, statement, ctx);
                 }

--- a/code-conversion/recipes/src/main/java/io/camunda/migration/code/recipes/delegate/PrepareJobWorkerBeneathDelegateRecipe.java
+++ b/code-conversion/recipes/src/main/java/io/camunda/migration/code/recipes/delegate/PrepareJobWorkerBeneathDelegateRecipe.java
@@ -60,7 +60,7 @@ public class PrepareJobWorkerBeneathDelegateRecipe extends Recipe {
                     Character.toLowerCase(classDeclaration.getSimpleName().charAt(0))
                         + classDeclaration.getSimpleName().substring(1);
 
-                maybeAddImport("io.camunda.spring.client.annotation.JobWorker");
+                maybeAddImport("io.camunda.client.annotation.JobWorker");
                 maybeAddImport("io.camunda.client.api.response.ActivatedJob");
                 maybeAddImport("java.util.Map");
                 maybeAddImport("java.util.HashMap");
@@ -74,7 +74,7 @@ public class PrepareJobWorkerBeneathDelegateRecipe extends Recipe {
                           return resultMap;
                       }
                       """,
-                        "io.camunda.spring.client.annotation.JobWorker",
+                        "io.camunda.client.annotation.JobWorker",
                         "io.camunda.client.api.response.ActivatedJob",
                         "java.util.Map",
                         "java.util.HashMap")

--- a/code-conversion/recipes/src/main/java/io/camunda/migration/code/recipes/external/MigrateExternalWorkerRecipe.java
+++ b/code-conversion/recipes/src/main/java/io/camunda/migration/code/recipes/external/MigrateExternalWorkerRecipe.java
@@ -64,7 +64,7 @@ public class MigrateExternalWorkerRecipe extends Recipe {
       // define preconditions
       TreeVisitor<?, ExecutionContext> check =
           Preconditions.and(
-              new UsesType<>("io.camunda.spring.client.annotation.JobWorker", true),
+              new UsesType<>("io.camunda.client.annotation.JobWorker", true),
               new UsesType<>("org.camunda.bpm.client.task.ExternalTask", true));
 
       return Preconditions.check(
@@ -139,7 +139,7 @@ public class MigrateExternalWorkerRecipe extends Recipe {
     @Override
     protected TreeVisitor<?, ExecutionContext> preconditions() {
       return Preconditions.and(
-          new UsesType<>("io.camunda.spring.client.annotation.JobWorker", true),
+          new UsesType<>("io.camunda.client.annotation.JobWorker", true),
           new UsesType<>("org.camunda.bpm.client.task.ExternalTask", true));
     }
 
@@ -257,10 +257,10 @@ public class MigrateExternalWorkerRecipe extends Recipe {
                 new MethodMatcher(
                     "org.camunda.bpm.client.task.ExternalTaskService handleBpmnError(org.camunda.bpm.client.task.ExternalTask, java.lang.String)"),
                 RecipeUtils.createSimpleJavaTemplate(
-                    "throw #{any(io.camunda.spring.client.exception.CamundaError)}.bpmnError(#{any(java.lang.String)}, \"Add an error message here\")",
-                    "io.camunda.spring.client.exception.CamundaError"),
+                    "throw #{any(io.camunda.client.exception.CamundaError)}.bpmnError(#{any(java.lang.String)}, \"Add an error message here\")",
+                    "io.camunda.client.exception.CamundaError"),
                 RecipeUtils.createSimpleIdentifier(
-                    "CamundaError", "io.camunda.spring.client.exception.CamundaError"),
+                    "CamundaError", "io.camunda.client.exception.CamundaError"),
                 null,
                 ReplacementUtils.ReturnTypeStrategy.VOID,
                 List.of(
@@ -271,10 +271,10 @@ public class MigrateExternalWorkerRecipe extends Recipe {
                 new MethodMatcher(
                     "org.camunda.bpm.client.task.ExternalTaskService handleBpmnError(org.camunda.bpm.client.task.ExternalTask, java.lang.String, java.lang.String)"),
                 RecipeUtils.createSimpleJavaTemplate(
-                    "throw #{any(io.camunda.spring.client.exception.CamundaError)}.bpmnError(#{any(java.lang.String)}, #{any(java.lang.String)})",
-                    "io.camunda.spring.client.exception.CamundaError"),
+                    "throw #{any(io.camunda.client.exception.CamundaError)}.bpmnError(#{any(java.lang.String)}, #{any(java.lang.String)})",
+                    "io.camunda.client.exception.CamundaError"),
                 RecipeUtils.createSimpleIdentifier(
-                    "CamundaError", "io.camunda.spring.client.exception.CamundaError"),
+                    "CamundaError", "io.camunda.client.exception.CamundaError"),
                 null,
                 ReplacementUtils.ReturnTypeStrategy.VOID,
                 List.of(
@@ -288,11 +288,11 @@ public class MigrateExternalWorkerRecipe extends Recipe {
                 new MethodMatcher(
                     "org.camunda.bpm.client.task.ExternalTaskService handleBpmnError(org.camunda.bpm.client.task.ExternalTask, java.lang.String, java.lang.String, java.util.Map)"),
                 RecipeUtils.createSimpleJavaTemplate(
-                    "throw #{any(io.camunda.spring.client.exception.CamundaError)}.bpmnError(#{any(java.lang.String)}, #{any(java.lang.String)}, #{any(java.util.Map)})",
-                    "io.camunda.spring.client.exception.CamundaError",
+                    "throw #{any(io.camunda.client.exception.CamundaError)}.bpmnError(#{any(java.lang.String)}, #{any(java.lang.String)}, #{any(java.util.Map)})",
+                    "io.camunda.client.exception.CamundaError",
                     "java.util.Map"),
                 RecipeUtils.createSimpleIdentifier(
-                    "CamundaError", "io.camunda.spring.client.exception.CamundaError"),
+                    "CamundaError", "io.camunda.client.exception.CamundaError"),
                 null,
                 ReplacementUtils.ReturnTypeStrategy.VOID,
                 List.of(
@@ -308,11 +308,11 @@ public class MigrateExternalWorkerRecipe extends Recipe {
                 new MethodMatcher(
                     "org.camunda.bpm.client.task.ExternalTaskService handleBpmnError(java.lang.String, java.lang.String, java.lang.String, java.util.Map)"),
                 RecipeUtils.createSimpleJavaTemplate(
-                    "throw #{any(io.camunda.spring.client.exception.CamundaError)}.bpmnError(#{any(java.lang.String)}, #{any(java.lang.String)}, #{any(java.util.Map)})",
-                    "io.camunda.spring.client.exception.CamundaError",
+                    "throw #{any(io.camunda.client.exception.CamundaError)}.bpmnError(#{any(java.lang.String)}, #{any(java.lang.String)}, #{any(java.util.Map)})",
+                    "io.camunda.client.exception.CamundaError",
                     "java.util.Map"),
                 RecipeUtils.createSimpleIdentifier(
-                    "CamundaError", "io.camunda.spring.client.exception.CamundaError"),
+                    "CamundaError", "io.camunda.client.exception.CamundaError"),
                 null,
                 ReplacementUtils.ReturnTypeStrategy.VOID,
                 List.of(
@@ -328,10 +328,10 @@ public class MigrateExternalWorkerRecipe extends Recipe {
                 new MethodMatcher(
                     "org.camunda.bpm.client.task.ExternalTaskService handleFailure(org.camunda.bpm.client.task.ExternalTask, java.lang.String, java.lang.String, int, long)"),
                 RecipeUtils.createSimpleJavaTemplate(
-                    "throw #{any(io.camunda.spring.client.exception.CamundaError)}.jobError(#{any(java.lang.String)}, Collections.emptyMap(), Integer.valueOf(#{any()}), Duration.ofMillis(#{any()}))",
-                    "io.camunda.spring.client.exception.CamundaError", "java.util.Collections", "java.time.Duration"),
+                    "throw #{any(io.camunda.client.exception.CamundaError)}.jobError(#{any(java.lang.String)}, Collections.emptyMap(), Integer.valueOf(#{any()}), Duration.ofMillis(#{any()}))",
+                    "io.camunda.client.exception.CamundaError", "java.util.Collections", "java.time.Duration"),
                 RecipeUtils.createSimpleIdentifier(
-                    "CamundaError", "io.camunda.spring.client.exception.CamundaError"),
+                    "CamundaError", "io.camunda.client.exception.CamundaError"),
                 null,
                 ReplacementUtils.ReturnTypeStrategy.VOID,
                 List.of(
@@ -346,10 +346,10 @@ public class MigrateExternalWorkerRecipe extends Recipe {
                 new MethodMatcher(
                     "org.camunda.bpm.client.task.ExternalTaskService handleFailure(java.lang.String, java.lang.String, java.lang.String, int, long)"),
                 RecipeUtils.createSimpleJavaTemplate(
-                    "throw #{any(io.camunda.spring.client.exception.CamundaError)}.jobError(#{any(java.lang.String)}, Collections.emptyMap(), Integer.valueOf(#{any()}), Duration.ofMillis(#{any()}))",
-                    "io.camunda.spring.client.exception.CamundaError", "java.util.Collections", "java.time.Duration"),
+                    "throw #{any(io.camunda.client.exception.CamundaError)}.jobError(#{any(java.lang.String)}, Collections.emptyMap(), Integer.valueOf(#{any()}), Duration.ofMillis(#{any()}))",
+                    "io.camunda.client.exception.CamundaError", "java.util.Collections", "java.time.Duration"),
                 RecipeUtils.createSimpleIdentifier(
-                    "CamundaError", "io.camunda.spring.client.exception.CamundaError"),
+                    "CamundaError", "io.camunda.client.exception.CamundaError"),
                 null,
                 ReplacementUtils.ReturnTypeStrategy.VOID,
                 List.of(
@@ -365,10 +365,10 @@ public class MigrateExternalWorkerRecipe extends Recipe {
                 new MethodMatcher(
                     "org.camunda.bpm.client.task.ExternalTaskService handleFailure(java.lang.String, java.lang.String, java.lang.String, int, long, java.util.Map, java.util.Map)"),
                 RecipeUtils.createSimpleJavaTemplate(
-                    "throw #{any(io.camunda.spring.client.exception.CamundaError)}.jobError(#{any(java.lang.String)}, #{any(java.util.Map)}, Integer.valueOf(#{any()}), Duration.ofMillis(#{any()}))",
-                    "io.camunda.spring.client.exception.CamundaError", "java.util.Map", "java.time.Duration"),
+                    "throw #{any(io.camunda.client.exception.CamundaError)}.jobError(#{any(java.lang.String)}, #{any(java.util.Map)}, Integer.valueOf(#{any()}), Duration.ofMillis(#{any()}))",
+                    "io.camunda.client.exception.CamundaError", "java.util.Map", "java.time.Duration"),
                 RecipeUtils.createSimpleIdentifier(
-                    "CamundaError", "io.camunda.spring.client.exception.CamundaError"),
+                    "CamundaError", "io.camunda.client.exception.CamundaError"),
                 null,
                 ReplacementUtils.ReturnTypeStrategy.VOID,
                 List.of(
@@ -386,10 +386,10 @@ public class MigrateExternalWorkerRecipe extends Recipe {
                 new MethodMatcher(
                     "org.camunda.bpm.client.task.ExternalTaskService handleFailure(java.lang.String, java.lang.String, java.lang.String, int, long, java.util.Map, java.util.Map)"),
                 RecipeUtils.createSimpleJavaTemplate(
-                    "throw #{any(io.camunda.spring.client.exception.CamundaError)}.jobError(#{any(java.lang.String)}, #{any(java.util.Map)}, Integer.valueOf(#{any()}), Duration.ofMillis(#{any()}))",
-                    "io.camunda.spring.client.exception.CamundaError", "java.util.Map", "java.time.Duration"),
+                    "throw #{any(io.camunda.client.exception.CamundaError)}.jobError(#{any(java.lang.String)}, #{any(java.util.Map)}, Integer.valueOf(#{any()}), Duration.ofMillis(#{any()}))",
+                    "io.camunda.client.exception.CamundaError", "java.util.Map", "java.time.Duration"),
                 RecipeUtils.createSimpleIdentifier(
-                    "CamundaError", "io.camunda.spring.client.exception.CamundaError"),
+                    "CamundaError", "io.camunda.client.exception.CamundaError"),
                 null,
                 ReplacementUtils.ReturnTypeStrategy.VOID,
                 List.of(
@@ -460,7 +460,7 @@ public class MigrateExternalWorkerRecipe extends Recipe {
       // define preconditions
       TreeVisitor<?, ExecutionContext> check =
           Preconditions.and(
-              new UsesType<>("io.camunda.spring.client.annotation.JobWorker", true),
+              new UsesType<>("io.camunda.client.annotation.JobWorker", true),
               new UsesType<>("org.camunda.bpm.client.task.ExternalTask", true));
 
       return Preconditions.check(
@@ -495,7 +495,7 @@ public class MigrateExternalWorkerRecipe extends Recipe {
 
               for (ReplacementUtils.SimpleReplacementSpec spec : errorSpecs) {
                 if (spec.matcher().matches(invocation)) {
-                  maybeAddImport("io.camunda.spring.client.exception.CamundaError");
+                  maybeAddImport("io.camunda.client.exception.CamundaError");
 
                   J.Throw throwStmt =
                       spec.template()

--- a/code-conversion/recipes/src/main/java/io/camunda/migration/code/recipes/external/PrepareJobWorkerBeneathExternalWorkerRecipe.java
+++ b/code-conversion/recipes/src/main/java/io/camunda/migration/code/recipes/external/PrepareJobWorkerBeneathExternalWorkerRecipe.java
@@ -99,7 +99,7 @@ public class PrepareJobWorkerBeneathExternalWorkerRecipe extends Recipe {
                     Character.toLowerCase(classDeclaration.getSimpleName().charAt(0))
                         + classDeclaration.getSimpleName().substring(1);
 
-                maybeAddImport("io.camunda.spring.client.annotation.JobWorker");
+                maybeAddImport("io.camunda.client.annotation.JobWorker");
                 maybeAddImport("io.camunda.client.api.response.ActivatedJob");
 
                 // Insert the new field at the bottom of the class body
@@ -111,7 +111,7 @@ public class PrepareJobWorkerBeneathExternalWorkerRecipe extends Recipe {
                           return resultMap;
                       }
                       """,
-                        "io.camunda.spring.client.annotation.JobWorker",
+                        "io.camunda.client.annotation.JobWorker",
                         "io.camunda.client.api.response.ActivatedJob",
                         "java.util.Map",
                         "java.util.HashMap")

--- a/code-conversion/recipes/src/main/resources/META-INF/rewrite/clientRecipes.yml
+++ b/code-conversion/recipes/src/main/resources/META-INF/rewrite/clientRecipes.yml
@@ -6,7 +6,7 @@ recipeList:
   - org.openrewrite.java.dependencies.AddDependency:
       groupId: io.camunda
       artifactId: spring-boot-starter-camunda-sdk
-      version: 8.8.0-alpha4.1
+      version: ${version.camunda-8}
   - io.camunda.migration.code.recipes.client.PrepareCamundaClientDependencyRecipe
   - io.camunda.migration.code.recipes.sharedRecipes.ReplaceTypedValueAPIRecipe
 ---

--- a/code-conversion/recipes/src/main/resources/META-INF/rewrite/delegateRecipes.yml
+++ b/code-conversion/recipes/src/main/resources/META-INF/rewrite/delegateRecipes.yml
@@ -6,7 +6,7 @@ recipeList:
   - org.openrewrite.java.dependencies.AddDependency:
       groupId: io.camunda
       artifactId: spring-boot-starter-camunda-sdk
-      version: 8.8.0-alpha4.1
+      version: ${version.camunda-8}
   - io.camunda.migration.code.recipes.sharedRecipes.ReplaceTypedValueAPIRecipe
   - io.camunda.migration.code.recipes.delegate.PrepareJobWorkerBeneathDelegateRecipe
 ---

--- a/code-conversion/recipes/src/main/resources/META-INF/rewrite/externalWorkerRecipes.yml
+++ b/code-conversion/recipes/src/main/resources/META-INF/rewrite/externalWorkerRecipes.yml
@@ -6,7 +6,7 @@ recipeList:
   - org.openrewrite.java.dependencies.AddDependency:
       groupId: io.camunda
       artifactId: spring-boot-starter-camunda-sdk
-      version: 8.8.0-alpha4.1
+      version: ${version.camunda-8}
   - io.camunda.migration.code.recipes.sharedRecipes.ReplaceTypedValueAPIRecipe
   - io.camunda.migration.code.recipes.external.PrepareJobWorkerBeneathExternalWorkerRecipe
 ---

--- a/code-conversion/recipes/src/test/java/io/camunda/migration/code/recipes/client/migrate/ReplaceUserTaskMethodsTest.java
+++ b/code-conversion/recipes/src/test/java/io/camunda/migration/code/recipes/client/migrate/ReplaceUserTaskMethodsTest.java
@@ -68,7 +68,6 @@ import io.camunda.client.CamundaClient;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
-import java.time.Instant;
 import java.util.Date;
 import java.util.Map;
 import java.util.List;
@@ -96,7 +95,7 @@ public class HandleUserTasksTestClass {
         String tenantId = firstTask.getTenantId();
         String taskId = String.valueOf(firstTask.getUserTaskKey());
         String assignee = firstTask.getAssignee();
-        Date dueDate = Date.from(Instant.parse((firstTask.getDueDate())));
+        Date dueDate = Date.from(firstTask.getDueDate().toInstant());
     }
 }
 """));

--- a/code-conversion/recipes/src/test/java/io/camunda/migration/code/recipes/delegate/JavaDelegateSpringToJobWorkerSpringTest.java
+++ b/code-conversion/recipes/src/test/java/io/camunda/migration/code/recipes/delegate/JavaDelegateSpringToJobWorkerSpringTest.java
@@ -46,8 +46,8 @@ public class RetrievePaymentAdapter implements JavaDelegate {
 """
 package org.camunda.community.migration.example;
 
+import io.camunda.client.annotation.JobWorker;
 import io.camunda.client.api.response.ActivatedJob;
-import io.camunda.spring.client.annotation.JobWorker;
 import org.springframework.stereotype.Component;
 
 import java.util.HashMap;
@@ -92,8 +92,8 @@ public class RetrievePaymentAdapter {
             """
         package org.camunda.community.migration.example;
 
+        import io.camunda.client.annotation.JobWorker;
         import io.camunda.client.api.response.ActivatedJob;
-        import io.camunda.spring.client.annotation.JobWorker;
         import org.springframework.stereotype.Component;
 
         import java.util.HashMap;
@@ -144,8 +144,8 @@ public class RetrievePaymentAdapter implements JavaDelegate {
 """
 package org.camunda.community.migration.example;
 
+import io.camunda.client.annotation.JobWorker;
 import io.camunda.client.api.response.ActivatedJob;
-import io.camunda.spring.client.annotation.JobWorker;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestTemplate;
@@ -236,8 +236,8 @@ public class TestDelegate implements JavaDelegate {
 """
 package org.camunda.community.migration.example;
 
+import io.camunda.client.annotation.JobWorker;
 import io.camunda.client.api.response.ActivatedJob;
-import io.camunda.spring.client.annotation.JobWorker;
 import org.springframework.stereotype.Component;
 
 import java.util.HashMap;

--- a/code-conversion/recipes/src/test/java/io/camunda/migration/code/recipes/delegate/cleanup/RemoveDelegateTest.java
+++ b/code-conversion/recipes/src/test/java/io/camunda/migration/code/recipes/delegate/cleanup/RemoveDelegateTest.java
@@ -23,8 +23,8 @@ class RemoveDelegateTest implements RewriteTest {
 """
 package org.camunda.conversion.java_delegates.handling_process_variables;
 
+import io.camunda.client.annotation.JobWorker;
 import io.camunda.client.api.response.ActivatedJob;
-import io.camunda.spring.client.annotation.JobWorker;
 import org.camunda.bpm.engine.delegate.DelegateExecution;
 import org.camunda.bpm.engine.delegate.JavaDelegate;
 import org.camunda.bpm.engine.variable.Variables;
@@ -57,8 +57,8 @@ public class RetrievePaymentAdapter implements JavaDelegate {
 """
 package org.camunda.conversion.java_delegates.handling_process_variables;
 
+import io.camunda.client.annotation.JobWorker;
 import io.camunda.client.api.response.ActivatedJob;
-import io.camunda.spring.client.annotation.JobWorker;
 import org.camunda.bpm.engine.variable.Variables;
 import org.camunda.bpm.engine.variable.value.IntegerValue;
 import org.camunda.bpm.engine.variable.value.StringValue;

--- a/code-conversion/recipes/src/test/java/io/camunda/migration/code/recipes/delegate/migrate/ReplaceExecutionTest.java
+++ b/code-conversion/recipes/src/test/java/io/camunda/migration/code/recipes/delegate/migrate/ReplaceExecutionTest.java
@@ -30,8 +30,8 @@ class ReplaceExecutionTest implements RewriteTest {
 """
 package org.camunda.conversion.java_delegates.handling_process_variables;
 
+import io.camunda.client.annotation.JobWorker;
 import io.camunda.client.api.response.ActivatedJob;
-import io.camunda.spring.client.annotation.JobWorker;
 import org.camunda.bpm.engine.delegate.DelegateExecution;
 import org.camunda.bpm.engine.delegate.JavaDelegate;
 import org.springframework.stereotype.Component;
@@ -61,8 +61,8 @@ public class RetrievePaymentAdapter implements JavaDelegate {
 """
 package org.camunda.conversion.java_delegates.handling_process_variables;
 
+import io.camunda.client.annotation.JobWorker;
 import io.camunda.client.api.response.ActivatedJob;
-import io.camunda.spring.client.annotation.JobWorker;
 import org.camunda.bpm.engine.delegate.DelegateExecution;
 import org.camunda.bpm.engine.delegate.JavaDelegate;
 import org.springframework.stereotype.Component;
@@ -104,7 +104,7 @@ public class RetrievePaymentAdapter implements JavaDelegate {
                     package org.camunda.conversion.java_delegates.handling_process_variables;
 
                     import io.camunda.client.api.response.ActivatedJob;
-                    import io.camunda.spring.client.annotation.JobWorker;
+                    import io.camunda.client.annotation.JobWorker;
                     import org.camunda.bpm.engine.delegate.DelegateExecution;
                     import org.camunda.bpm.engine.delegate.JavaDelegate;
                     import org.camunda.bpm.engine.delegate.BpmnError;
@@ -157,8 +157,8 @@ public class RetrievePaymentAdapter implements JavaDelegate {
                     package org.camunda.conversion.java_delegates.handling_process_variables;
 
                     import io.camunda.client.api.response.ActivatedJob;
-                    import io.camunda.spring.client.annotation.JobWorker;
-                    import io.camunda.spring.client.exception.CamundaError;
+                    import io.camunda.client.exception.CamundaError;
+                    import io.camunda.client.annotation.JobWorker;
                     import org.camunda.bpm.engine.delegate.DelegateExecution;
                     import org.camunda.bpm.engine.delegate.JavaDelegate;
                     import org.camunda.bpm.engine.delegate.BpmnError;

--- a/code-conversion/recipes/src/test/java/io/camunda/migration/code/recipes/delegate/prepare/InsertJobWorkerTest.java
+++ b/code-conversion/recipes/src/test/java/io/camunda/migration/code/recipes/delegate/prepare/InsertJobWorkerTest.java
@@ -53,8 +53,8 @@ public class RetrievePaymentAdapter implements JavaDelegate {
 """
 package org.camunda.conversion.java_delegates.handling_process_variables;
 
+import io.camunda.client.annotation.JobWorker;
 import io.camunda.client.api.response.ActivatedJob;
-import io.camunda.spring.client.annotation.JobWorker;
 import org.camunda.bpm.engine.delegate.DelegateExecution;
 import org.camunda.bpm.engine.delegate.JavaDelegate;
 import org.camunda.bpm.engine.variable.Variables;

--- a/code-conversion/recipes/src/test/java/io/camunda/migration/code/recipes/external/ExternalWorkerToJobWorkerSpringTest.java
+++ b/code-conversion/recipes/src/test/java/io/camunda/migration/code/recipes/external/ExternalWorkerToJobWorkerSpringTest.java
@@ -58,8 +58,8 @@ public class RetrievePaymentAdapter implements ExternalTaskHandler {
 """
 package org.camunda.community.migration.example;
 
+import io.camunda.client.annotation.JobWorker;
 import io.camunda.client.api.response.ActivatedJob;
-import io.camunda.spring.client.annotation.JobWorker;
 import org.springframework.stereotype.Component;
 
 import java.util.HashMap;

--- a/code-conversion/recipes/src/test/java/io/camunda/migration/code/recipes/external/cleanup/RemoveExternalWorkerTest.java
+++ b/code-conversion/recipes/src/test/java/io/camunda/migration/code/recipes/external/cleanup/RemoveExternalWorkerTest.java
@@ -23,8 +23,8 @@ class RemoveExternalWorkerTest implements RewriteTest {
 """
 package org.camunda.community.migration.example;
 
+import io.camunda.client.annotation.JobWorker;
 import io.camunda.client.api.response.ActivatedJob;
-import io.camunda.spring.client.annotation.JobWorker;
 import org.camunda.bpm.client.spring.annotation.ExternalTaskSubscription;
 import org.camunda.bpm.client.task.ExternalTask;
 import org.camunda.bpm.client.task.ExternalTaskHandler;
@@ -58,8 +58,8 @@ public class RetrievePaymentAdapter implements ExternalTaskHandler {
 """
 package org.camunda.community.migration.example;
 
+import io.camunda.client.annotation.JobWorker;
 import io.camunda.client.api.response.ActivatedJob;
-import io.camunda.spring.client.annotation.JobWorker;
 import org.springframework.stereotype.Component;
 
 import java.util.HashMap;

--- a/code-conversion/recipes/src/test/java/io/camunda/migration/code/recipes/external/migrate/ReplaceWorkerClientTest.java
+++ b/code-conversion/recipes/src/test/java/io/camunda/migration/code/recipes/external/migrate/ReplaceWorkerClientTest.java
@@ -30,8 +30,8 @@ class ReplaceWorkerClientTest implements RewriteTest {
 """
 package org.camunda.community.migration.example;
 
+import io.camunda.client.annotation.JobWorker;
 import io.camunda.client.api.response.ActivatedJob;
-import io.camunda.spring.client.annotation.JobWorker;
 import org.camunda.bpm.client.spring.annotation.ExternalTaskSubscription;
 import org.camunda.bpm.client.task.ExternalTask;
 import org.camunda.bpm.client.task.ExternalTaskHandler;
@@ -66,8 +66,8 @@ public class RetrievePaymentAdapter implements ExternalTaskHandler {
 """
 package org.camunda.community.migration.example;
 
+import io.camunda.client.annotation.JobWorker;
 import io.camunda.client.api.response.ActivatedJob;
-import io.camunda.spring.client.annotation.JobWorker;
 import org.camunda.bpm.client.spring.annotation.ExternalTaskSubscription;
 import org.camunda.bpm.client.task.ExternalTask;
 import org.camunda.bpm.client.task.ExternalTaskHandler;
@@ -115,8 +115,8 @@ public class RetrievePaymentAdapter implements ExternalTaskHandler {
             """
                     package org.camunda.community.migration.example;
 
+                    import io.camunda.client.annotation.JobWorker;
                     import io.camunda.client.api.response.ActivatedJob;
-                    import io.camunda.spring.client.annotation.JobWorker;
                     import org.camunda.bpm.client.spring.annotation.ExternalTaskSubscription;
                     import org.camunda.bpm.client.task.ExternalTask;
                     import org.camunda.bpm.client.task.ExternalTaskHandler;
@@ -163,9 +163,9 @@ public class RetrievePaymentAdapter implements ExternalTaskHandler {
             """
                     package org.camunda.community.migration.example;
 
+                    import io.camunda.client.annotation.JobWorker;
                     import io.camunda.client.api.response.ActivatedJob;
-                    import io.camunda.spring.client.annotation.JobWorker;
-                    import io.camunda.spring.client.exception.CamundaError;
+                    import io.camunda.client.exception.CamundaError;
                     import org.camunda.bpm.client.spring.annotation.ExternalTaskSubscription;
                     import org.camunda.bpm.client.task.ExternalTask;
                     import org.camunda.bpm.client.task.ExternalTaskHandler;

--- a/code-conversion/recipes/src/test/java/io/camunda/migration/code/recipes/external/prepare/InsertJobWorkerTest.java
+++ b/code-conversion/recipes/src/test/java/io/camunda/migration/code/recipes/external/prepare/InsertJobWorkerTest.java
@@ -59,8 +59,8 @@ public class RetrievePaymentAdapter implements ExternalTaskHandler {
 """
 package org.camunda.community.migration.example;
 
+import io.camunda.client.annotation.JobWorker;
 import io.camunda.client.api.response.ActivatedJob;
-import io.camunda.spring.client.annotation.JobWorker;
 import org.camunda.bpm.client.spring.annotation.ExternalTaskSubscription;
 import org.camunda.bpm.client.task.ExternalTask;
 import org.camunda.bpm.client.task.ExternalTaskHandler;


### PR DESCRIPTION
related to: #528
Back porting changer from PR https://github.com/camunda/camunda-7-to-8-migration-tooling/pull/560
Cherry-picked f04e4f7d0fcc8770bc9546622e207b0a1c676bf4
# Pull Request Template

## Description
<!-- Describe your changes in detail -->

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Test-only changes (no production code changes)

## Testing Checklist

### Black-Box Testing Requirements
- [ ] Tests follow **black-box testing approach**: verify behavior through observable outputs (logs, C8 API queries, real-world skip scenarios)
- [ ] Tests **DO NOT** access implementation details (`DbClient`, `IdKeyMapper`, `..impl..` packages except logging constants)
- [ ] Architecture tests pass (`ArchitectureTest` validates these rules)

### Test Coverage
- [ ] Added tests for new functionality
- [ ] Updated tests for modified functionality
- [ ] All tests pass locally

## Architecture Compliance

Run architecture tests to ensure compliance:
```bash
mvn test -Dtest=ArchitectureTest
```

If architecture tests fail, refactor your tests to use:
- `LogCapturer` for log assertions
- `camundaClient.new*SearchRequest()` for C8 queries
- Real-World skip scenarios (e.g., migrate children without parents)

## Documentation
- [ ] Updated TESTING_GUIDELINES.md if adding new test patterns
- [ ] Added Javadoc comments for public APIs
- [ ] Updated README if user-facing changes

## Checklist
- [ ] Code follows project style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments for complex logic
- [ ] No new compiler warnings
- [ ] Dependent changes have been merged

## Related Issues
<!-- Link to related issues: Fixes #123, Related to #456 -->

