### PR TITLE
fix(data-migrator): cancel active history process instances

### DIFF
--- a/data-migrator/assembly/resources/application.yml
+++ b/data-migrator/assembly/resources/application.yml
@@ -65,6 +65,19 @@ camunda:
     ## Find more information about the Cockpit plugin here: https://docs.camunda.io/docs/next/guides/migrating-from-camunda-7/data-migrator/cockpit-plugin/
     #save-skip-reason: false
 
+    ## History migration configuration
+    history:
+      # ACTIVE or SUSPENDED C7 instances will be automatically canceled in C8 with end date set to migration date
+      auto-cancel:
+        cleanup:
+          # Whether to populate cleanup dates for auto-canceled entities (default: true)
+          # When false, history cleanup dates will be set to null for all auto-canceled instances
+          enabled: true
+          # Time-to-live for auto-canceled active history records (default: P6M = 6 months)
+          # When cleanup is enabled, cleanup date is calculated as end date + ttl
+          # Accepts ISO-8601 duration format (e.g., P6M for 6 months, P1Y for 1 year, P90D for 90 days)
+          ttl: P6M
+
     ## Camunda 7 configuration
     c7:
       data-source:

--- a/data-migrator/core/src/main/java/io/camunda/migration/data/HistoryMigrator.java
+++ b/data-migrator/core/src/main/java/io/camunda/migration/data/HistoryMigrator.java
@@ -10,6 +10,7 @@ package io.camunda.migration.data;
 import static io.camunda.migration.data.MigratorMode.LIST_SKIPPED;
 import static io.camunda.migration.data.MigratorMode.MIGRATE;
 import static io.camunda.migration.data.MigratorMode.RETRY_SKIPPED;
+import static io.camunda.migration.data.config.property.history.CleanupProperties.DEFAULT_TTL;
 import static io.camunda.migration.data.impl.logging.HistoryMigratorLogs.SKIP_REASON_BELONGS_TO_SKIPPED_TASK;
 import static io.camunda.migration.data.impl.logging.HistoryMigratorLogs.SKIP_REASON_MISSING_DECISION_DEFINITION;
 import static io.camunda.migration.data.impl.logging.HistoryMigratorLogs.SKIP_REASON_MISSING_DECISION_REQUIREMENTS;
@@ -52,6 +53,7 @@ import io.camunda.db.rdbms.write.domain.ProcessInstanceDbModel;
 import io.camunda.db.rdbms.write.domain.UserTaskDbModel;
 import io.camunda.db.rdbms.write.domain.VariableDbModel;
 import io.camunda.migration.data.config.C8DataSourceConfigured;
+import io.camunda.migration.data.config.property.MigratorProperties;
 import io.camunda.migration.data.exception.EntityInterceptorException;
 import io.camunda.migration.data.exception.MigratorException;
 import io.camunda.migration.data.exception.VariableInterceptorException;
@@ -63,11 +65,17 @@ import io.camunda.migration.data.impl.logging.HistoryMigratorLogs;
 import io.camunda.migration.data.impl.util.ExceptionUtils;
 import io.camunda.migration.data.impl.util.PrintUtils;
 import io.camunda.migration.data.interceptor.property.EntityConversionContext;
+
+import static io.camunda.migration.data.impl.util.ConverterUtil.convertDate;
+
 import io.camunda.search.entities.DecisionDefinitionEntity;
 import io.camunda.search.entities.DecisionInstanceEntity;
 import io.camunda.search.entities.ProcessDefinitionEntity;
 import io.camunda.search.entities.ProcessInstanceEntity;
 import io.camunda.search.filter.FlowNodeInstanceFilter;
+import java.time.Duration;
+import java.time.OffsetDateTime;
+import java.time.Period;
 import java.util.Date;
 import java.util.List;
 import java.util.Optional;
@@ -78,6 +86,7 @@ import org.camunda.bpm.engine.history.HistoricIncident;
 import org.camunda.bpm.engine.history.HistoricProcessInstance;
 import org.camunda.bpm.engine.history.HistoricTaskInstance;
 import org.camunda.bpm.engine.history.HistoricVariableInstance;
+import org.camunda.bpm.engine.impl.util.ClockUtil;
 import org.camunda.bpm.engine.repository.DecisionDefinition;
 import org.camunda.bpm.engine.repository.DecisionRequirementsDefinition;
 import org.camunda.bpm.engine.repository.ProcessDefinition;
@@ -102,6 +111,13 @@ public class HistoryMigrator {
 
   @Autowired
   protected C8Client c8Client;
+
+  // Properties
+
+  @Autowired
+  protected MigratorProperties migratorProperties;
+
+  // Converters
 
   @Autowired
   protected EntityConversionService entityConversionService;
@@ -159,7 +175,7 @@ public class HistoryMigrator {
         migrateProcessDefinition(historicProcessDefinition);
       });
     } else {
-      c7Client.fetchAndHandleProcessDefinitions(this::migrateProcessDefinition, dbClient.findLatestCreateTimeByType((HISTORY_PROCESS_DEFINITION)));
+      c7Client.fetchAndHandleProcessDefinitions(this::migrateProcessDefinition, dbClient.findLatestCreateTimeByType(HISTORY_PROCESS_DEFINITION));
     }
   }
 
@@ -204,7 +220,7 @@ public class HistoryMigrator {
         migrateProcessInstance(historicProcessInstance);
       });
     } else {
-      c7Client.fetchAndHandleHistoricProcessInstances(this::migrateProcessInstance, dbClient.findLatestCreateTimeByType((HISTORY_PROCESS_INSTANCE)));
+      c7Client.fetchAndHandleHistoricProcessInstances(this::migrateProcessInstance, dbClient.findLatestCreateTimeByType(HISTORY_PROCESS_INSTANCE));
     }
   }
 
@@ -261,6 +277,17 @@ public class HistoryMigrator {
             parentProcessInstanceKey = parentInstance.processInstanceKey();
           }
         }
+        OffsetDateTime historyCleanupDate = calculateHistoryCleanupDate(
+            c7ProcessInstance.getState(),
+            c7ProcessInstance.getEndTime(),
+            c7ProcessInstance.getRemovalTime());
+        OffsetDateTime endDate = calculateEndDate(
+            c7ProcessInstance.getState(),
+            c7ProcessInstance.getEndTime());
+
+        processInstanceDbModelBuilder
+            .historyCleanupDate(historyCleanupDate)
+            .endDate(endDate);
         if (parentProcessInstanceKey != null || c7SuperProcessInstanceId == null) {
           processInstanceDbModelBuilder.parentProcessInstanceKey(parentProcessInstanceKey);
           dbModel = convertProcessInstance(context);
@@ -373,7 +400,7 @@ public class HistoryMigrator {
       });
     } else {
       c7Client.fetchAndHandleDecisionDefinitions(this::migrateDecisionDefinition,
-          dbClient.findLatestCreateTimeByType((HISTORY_DECISION_DEFINITION)));
+          dbClient.findLatestCreateTimeByType(HISTORY_DECISION_DEFINITION));
     }
   }
 
@@ -406,7 +433,6 @@ public class HistoryMigrator {
             new DecisionDefinitionDbModel.DecisionDefinitionDbModelBuilder();
         EntityConversionContext<?, ?> context = createEntityConversionContext(c7DecisionDefinition,
             DecisionDefinition.class, decisionDefinitionDbModelBuilder);
-        decisionDefinitionDbModelBuilder.decisionRequirementsId(c7DecisionDefinition.getDecisionRequirementsDefinitionKey());
 
         if (c7DecisionDefinition.getDecisionRequirementsDefinitionId() != null) {
           decisionRequirementsKey = dbClient.findC8KeyByC7IdAndType(c7DecisionDefinition.getDecisionRequirementsDefinitionId(),
@@ -589,6 +615,9 @@ public class HistoryMigrator {
               decisionInstanceDbModelBuilder.flowNodeId(flowNode.flowNodeId());
             }
           }
+
+          decisionInstanceDbModelBuilder
+              .historyCleanupDate(calculateHistoryCleanupDateForChild(processInstance.endDate(), c7DecisionInstance.getRemovalTime()));
         }
 
         // Generate decision instance key and finalize model
@@ -640,7 +669,8 @@ public class HistoryMigrator {
               .rootDecisionDefinitionKey(parentDecisionDefinitionKey)
               .flowNodeInstanceKey(c8ParentDecisionInstanceModel.flowNodeInstanceKey())
               .flowNodeId(c8ParentDecisionInstanceModel.flowNodeId())
-              .decisionType(determineDecisionType(dmnModelInstance, childDecisionInstance.getDecisionDefinitionKey()));
+              .decisionType(determineDecisionType(dmnModelInstance, childDecisionInstance.getDecisionDefinitionKey()))
+              .historyCleanupDate(c8ParentDecisionInstanceModel.historyCleanupDate());
           DecisionInstanceDbModel childDbModel = convertDecisionInstance(context);
           c8Client.insertDecisionInstance(childDbModel);
         } catch (EntityInterceptorException e) {
@@ -709,7 +739,7 @@ public class HistoryMigrator {
         migrateIncident(historicIncident);
       });
     } else {
-      c7Client.fetchAndHandleHistoricIncidents(this::migrateIncident, dbClient.findLatestCreateTimeByType((HISTORY_INCIDENT)));
+      c7Client.fetchAndHandleHistoricIncidents(this::migrateIncident, dbClient.findLatestCreateTimeByType(HISTORY_INCIDENT));
     }
   }
 
@@ -752,11 +782,11 @@ public class HistoryMigrator {
             Long processDefinitionKey = findProcessDefinitionKey(c7Incident.getProcessDefinitionId());
             Long jobDefinitionKey = null; // TODO Job table doesn't exist yet.
 
-
             incidentDbModelBuilder
                 .processDefinitionKey(processDefinitionKey)
                 .jobKey(jobDefinitionKey)
-                .flowNodeInstanceKey(flowNodeInstanceKey);
+                .flowNodeInstanceKey(flowNodeInstanceKey)
+                .historyCleanupDate(calculateHistoryCleanupDateForChild(c7ProcessInstance.endDate(), c7Incident.getRemovalTime()));
 
             IncidentDbModel dbModel = convertIncident(context);
             insertIncident(c7Incident, dbModel, c7IncidentId);
@@ -850,8 +880,7 @@ public class HistoryMigrator {
 
       try {
         VariableDbModel.VariableDbModelBuilder variableDbModelBuilder = new VariableDbModel.VariableDbModelBuilder();
-        EntityConversionContext<?, ?> context = createEntityConversionContext(c7Variable, HistoricVariableInstance.class,
-            variableDbModelBuilder);
+        EntityConversionContext<?, ?> context = createEntityConversionContext(c7Variable, HistoricVariableInstance.class, variableDbModelBuilder);
 
         // Handle task-scoped variables
         String taskId = c7Variable.getTaskId();
@@ -881,7 +910,8 @@ public class HistoryMigrator {
             variableDbModelBuilder.scopeKey(scopeKey);
           }
         }
-
+        OffsetDateTime historyCleanupDate = calculateHistoryCleanupDateForChild(processInstance.endDate(), c7Variable.getRemovalTime());
+        variableDbModelBuilder.historyCleanupDate(historyCleanupDate);
         processVariableConversion(c7Variable, context, c7VariableId);
       } catch (EntityInterceptorException | VariableInterceptorException e) {
         handleInterceptorException(c7VariableId, HISTORY_VARIABLE, c7Variable.getCreateTime(), e);
@@ -935,7 +965,7 @@ public class HistoryMigrator {
         migrateUserTask(historicTaskInstance);
       });
     } else {
-      c7Client.fetchAndHandleHistoricUserTasks(this::migrateUserTask, dbClient.findLatestCreateTimeByType((HISTORY_USER_TASK)));
+      c7Client.fetchAndHandleHistoricUserTasks(this::migrateUserTask, dbClient.findLatestCreateTimeByType(HISTORY_USER_TASK));
     }
   }
 
@@ -979,8 +1009,14 @@ public class HistoryMigrator {
             userTaskDbModelBuilder.processDefinitionKey(processDefinitionKey)
                 .elementInstanceKey(elementInstanceKey);
 
+            OffsetDateTime historyCleanupDate = calculateHistoryCleanupDateForChild(processInstance.endDate(), c7UserTask.getRemovalTime());
+            OffsetDateTime completionDate = calculateCompletionDateForChild(processInstance.endDate(), c7UserTask.getEndTime());
+            userTaskDbModelBuilder
+                .historyCleanupDate(historyCleanupDate)
+                .completionDate(completionDate);
             UserTaskDbModel dbModel = convertUserTask(context);
             insertUserTask(c7UserTask, dbModel, c7UserTaskId);
+            HistoryMigratorLogs.migratingHistoricUserTaskCompleted(c7UserTaskId);
           } else {
             UserTaskDbModel dbModel = convertUserTask(context);
             if (dbModel.elementInstanceKey() == null) {
@@ -1030,7 +1066,7 @@ public class HistoryMigrator {
         migrateFlowNode(historicActivityInstance);
       });
     } else {
-      c7Client.fetchAndHandleHistoricFlowNodes(this::migrateFlowNode, dbClient.findLatestCreateTimeByType((HISTORY_FLOW_NODE)));
+      c7Client.fetchAndHandleHistoricFlowNodes(this::migrateFlowNode, dbClient.findLatestCreateTimeByType(HISTORY_FLOW_NODE));
     }
   }
 
@@ -1077,7 +1113,9 @@ public class HistoryMigrator {
 
           flowNodeDbModelBuilder.processInstanceKey(processInstanceKey)
               .treePath(generateTreePath(processInstanceKey, flowNodeInstanceKey))
-              .processDefinitionKey(processDefinitionKey);
+              .processDefinitionKey(processDefinitionKey)
+              .historyCleanupDate(calculateHistoryCleanupDateForChild(processInstance.endDate(), c7FlowNode.getRemovalTime()))
+              .endDate(calculateCompletionDateForChild(processInstance.endDate(), c7FlowNode.getEndTime()));
 
           Long flowNodeScopeKey = resolveFlowNodeScopeKey(c7FlowNode, c7FlowNode.getProcessInstanceId(), processInstanceKey);
           if (flowNodeScopeKey == null) {
@@ -1364,5 +1402,121 @@ public class HistoryMigrator {
       return DecisionInstanceEntity.DecisionDefinitionType.DECISION_TABLE;
     }
   }
+
+  /**
+   * Calculates the history cleanup date for an entity based on its state and endDate.
+   * Only calculates a new cleanup date when C7 removalTime is null.
+   * For entities with existing removalTime, uses that value directly.
+   *
+   * @param c7State the C7 state of the entity
+   * @param c7EndDate the C7 end date (null if still active)
+   * @param c7RemovalTime the C7 removal time
+   * @return the calculated history cleanup date
+   */
+  protected OffsetDateTime calculateHistoryCleanupDate(String c7State, Date c7EndDate, Date c7RemovalTime) {
+    // If C7 already has a removalTime, use it directly
+    if (c7RemovalTime != null) {
+      return convertDate(c7RemovalTime);
+    }
+
+    // Only calculate cleanup date when removalTime is null
+    // For active entities in C7, calculate cleanup date based on now + TTL
+    if (c7EndDate == null) {
+      Period ttl = getAutoCancelTtl();
+      // If TTL is null or zero, auto-cancel is disabled - return null for cleanup date
+      if (ttl == null || ttl.isZero()) {
+        return null;
+      }
+      OffsetDateTime now = convertDate(ClockUtil.now());
+      return now.plus(ttl);
+    }
+
+    // No removalTime and not active - return null
+    return null;
+  }
+
+  /**
+   * Calculates the history cleanup date for child entities (flow nodes, variables, etc.)
+   * based on the parent ProcessInstance's endDate.
+   * Only calculates when the parent ProcessInstance has no removalTime.
+   *
+   * @param processInstanceEndDate the endDate from the parent ProcessInstanceEntity
+   * @param c7RemovalTime the C7 removal time of the child entity
+   * @return the calculated history cleanup date, or null if auto-cancel TTL is disabled
+   */
+  protected OffsetDateTime calculateHistoryCleanupDateForChild(OffsetDateTime processInstanceEndDate, Date c7RemovalTime) {
+    // If C7 already has a removalTime, use it directly
+    if (c7RemovalTime != null) {
+      return convertDate(c7RemovalTime);
+    }
+
+    Period ttl = getAutoCancelTtl();
+    // If TTL is null or zero, auto-cancel is disabled - return null for cleanup date
+    if (ttl == null || ttl.isZero()) {
+      return null;
+    }
+    return processInstanceEndDate.plus(ttl);
+  }
+
+  /**
+   * Calculates the completion/end date for child entities.
+   * For entities that don't have an end date, inherit the parent process instance's end date.
+   *
+   * @param processInstanceEndDate the parent process instance's end date
+   * @param c7EndDate the C7 entity's end date
+   * @return the completion date to use (processInstanceEndDate if null, original if set)
+   */
+  protected OffsetDateTime calculateCompletionDateForChild(OffsetDateTime processInstanceEndDate, Date c7EndDate) {
+    if (c7EndDate == null) {
+      // Inherit the parent process instance's end date
+      return processInstanceEndDate;
+    }
+    return convertDate(c7EndDate);
+  }
+
+  /**
+   * Determines if the entity should have endDate set to now when converting to C8.
+   *
+   * @param c7State the C7 state
+   * @param c7EndDate the C7 end date
+   * @return the endDate to use (now if active, original if completed)
+   */
+  protected OffsetDateTime calculateEndDate(String c7State, Date c7EndDate) {
+    if (c7EndDate == null) {
+      return convertDate(ClockUtil.now());
+    }
+    return convertDate(c7EndDate);
+  }
+
+  /**
+   * Gets the configured auto-cancel TTL period.
+   *
+   * @return the configured TTL, or null if cleanup is disabled
+   */
+  protected Period getAutoCancelTtl() {// 6 months default
+    // If history configuration doesn't exist, use default
+    if (migratorProperties.getHistory() == null) {
+      return DEFAULT_TTL;
+    }
+
+    // If auto-cancel configuration doesn't exist, use default
+    if (migratorProperties.getHistory().getAutoCancel() == null) {
+      return DEFAULT_TTL;
+    }
+
+    // If cleanup configuration doesn't exist, use default
+    if (migratorProperties.getHistory().getAutoCancel().getCleanup() == null) {
+      return DEFAULT_TTL;
+    }
+
+    // Check if cleanup is explicitly disabled
+    if (!migratorProperties.getHistory().getAutoCancel().getCleanup().isEnabled()) {
+      return null;
+    }
+
+    // Return configured TTL (will have default of 180 days if not set)
+    return migratorProperties.getHistory().getAutoCancel().getCleanup().getTtl();
+  }
+
 
 }

--- a/data-migrator/core/src/main/java/io/camunda/migration/data/config/property/MigratorProperties.java
+++ b/data-migrator/core/src/main/java/io/camunda/migration/data/config/property/MigratorProperties.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.migration.data.config.property;
 
+import io.camunda.migration.data.config.property.history.HistoryProperties;
 import java.util.List;
 import java.util.Set;
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -37,6 +38,7 @@ public class MigratorProperties {
 
   protected C7Properties c7;
   protected C8Properties c8;
+  protected HistoryProperties history;
 
   protected List<InterceptorConfig> interceptors;
 
@@ -152,4 +154,13 @@ public class MigratorProperties {
   public void setInterceptors(List<InterceptorConfig> interceptors) {
     this.interceptors = interceptors;
   }
+
+  public HistoryProperties getHistory() {
+    return history;
+  }
+
+  public void setHistory(HistoryProperties history) {
+    this.history = history;
+  }
+
 }

--- a/data-migrator/core/src/main/java/io/camunda/migration/data/config/property/history/AutoCancelProperties.java
+++ b/data-migrator/core/src/main/java/io/camunda/migration/data/config/property/history/AutoCancelProperties.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.migration.data.config.property.history;
+
+/**
+ * Configuration properties for auto-cancel behavior.
+ */
+public class AutoCancelProperties {
+
+  protected CleanupProperties cleanup;
+
+  public CleanupProperties getCleanup() {
+    return cleanup;
+  }
+
+  public void setCleanup(CleanupProperties cleanup) {
+    this.cleanup = cleanup;
+  }
+}

--- a/data-migrator/core/src/main/java/io/camunda/migration/data/config/property/history/CleanupProperties.java
+++ b/data-migrator/core/src/main/java/io/camunda/migration/data/config/property/history/CleanupProperties.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.migration.data.config.property.history;
+
+import java.time.Duration;
+import java.time.Period;
+
+/**
+ * Configuration properties for auto-cancel cleanup behavior.
+ */
+public class CleanupProperties {
+
+  public static Period DEFAULT_TTL = Period.ofDays(180); // 6 months default
+
+  /**
+   * Whether to populate cleanup dates for auto-canceled entities.
+   * When false, history cleanup dates will be set to null for auto-canceled instances.
+   * Default is true.
+   */
+  protected boolean enabled = true;
+
+  /**
+   * Time-to-live duration for auto-canceled active history records.
+   * Default is 6 months (P180D).
+   * This value is only used when cleanup is enabled.
+   */
+  protected Period ttl = DEFAULT_TTL;
+
+  public boolean isEnabled() {
+    return enabled;
+  }
+
+  public void setEnabled(boolean enabled) {
+    this.enabled = enabled;
+  }
+
+  public Period getTtl() {
+    return ttl;
+  }
+
+  public void setTtl(Period ttl) {
+    this.ttl = ttl;
+  }
+}

--- a/data-migrator/core/src/main/java/io/camunda/migration/data/config/property/history/HistoryProperties.java
+++ b/data-migrator/core/src/main/java/io/camunda/migration/data/config/property/history/HistoryProperties.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.migration.data.config.property.history;
+
+/**
+ * Configuration properties for history migration.
+ */
+public class HistoryProperties {
+
+  protected AutoCancelProperties autoCancel;
+
+  public AutoCancelProperties getAutoCancel() {
+    return autoCancel;
+  }
+
+  public void setAutoCancel(AutoCancelProperties autoCancel) {
+    this.autoCancel = autoCancel;
+  }
+
+}

--- a/data-migrator/core/src/main/java/io/camunda/migration/data/impl/interceptor/history/entity/DecisionRequirementsDefinitionTransformer.java
+++ b/data-migrator/core/src/main/java/io/camunda/migration/data/impl/interceptor/history/entity/DecisionRequirementsDefinitionTransformer.java
@@ -17,9 +17,9 @@ import io.camunda.migration.data.exception.EntityInterceptorException;
 import io.camunda.migration.data.impl.clients.C7Client;
 import io.camunda.migration.data.interceptor.EntityInterceptor;
 import io.camunda.migration.data.interceptor.property.EntityConversionContext;
-import java.util.Set;
 import java.io.InputStream;
 import java.nio.charset.Charset;
+import java.util.Set;
 import org.camunda.bpm.engine.repository.DecisionRequirementsDefinition;
 import org.camunda.bpm.model.dmn.Dmn;
 import org.camunda.bpm.model.dmn.DmnModelInstance;
@@ -28,7 +28,6 @@ import org.camunda.bpm.model.xml.instance.DomElement;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import java.io.ByteArrayOutputStream;
-import java.util.Set;
 import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
 

--- a/data-migrator/core/src/main/java/io/camunda/migration/data/impl/interceptor/history/entity/FlowNodeTransformer.java
+++ b/data-migrator/core/src/main/java/io/camunda/migration/data/impl/interceptor/history/entity/FlowNodeTransformer.java
@@ -46,7 +46,6 @@ public class FlowNodeTransformer implements EntityInterceptor {
         .flowNodeId(flowNode.getActivityId())
         .processDefinitionId(prefixDefinitionId(flowNode.getProcessDefinitionKey()))
         .startDate(convertDate(flowNode.getStartTime()))
-        .endDate(convertDate(flowNode.getEndTime()))
         .type(convertType(flowNode.getActivityType()))
         .tenantId(flowNode.getTenantId())
         .state(determineState(flowNode))
@@ -58,7 +57,7 @@ public class FlowNodeTransformer implements EntityInterceptor {
 
   protected FlowNodeInstanceEntity.FlowNodeState determineState(HistoricActivityInstance flowNode) {
     if (flowNode.getEndTime() == null) {
-      return null;
+      return FlowNodeInstanceEntity.FlowNodeState.TERMINATED; // Active nodes are auto-cancelled in C8
     }
     return flowNode.isCanceled() ?
         FlowNodeInstanceEntity.FlowNodeState.TERMINATED :

--- a/data-migrator/core/src/main/java/io/camunda/migration/data/impl/interceptor/history/entity/IncidentTransformer.java
+++ b/data-migrator/core/src/main/java/io/camunda/migration/data/impl/interceptor/history/entity/IncidentTransformer.java
@@ -7,20 +7,20 @@
  */
 package io.camunda.migration.data.impl.interceptor.history.entity;
 
+import static io.camunda.migration.data.impl.util.ConverterUtil.convertDate;
+import static io.camunda.migration.data.impl.util.ConverterUtil.getNextKey;
+import static io.camunda.migration.data.impl.util.ConverterUtil.prefixDefinitionId;
+import static io.camunda.search.entities.IncidentEntity.IncidentState.RESOLVED;
+
 import io.camunda.db.rdbms.write.domain.IncidentDbModel;
 import io.camunda.migration.data.exception.EntityInterceptorException;
 import io.camunda.migration.data.interceptor.EntityInterceptor;
 import io.camunda.migration.data.interceptor.property.EntityConversionContext;
-import io.camunda.search.entities.IncidentEntity;
 import org.camunda.bpm.engine.history.HistoricIncident;
 
 import java.util.Set;
 import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
-
-import static io.camunda.migration.data.impl.util.ConverterUtil.convertDate;
-import static io.camunda.migration.data.impl.util.ConverterUtil.getNextKey;
-import static io.camunda.migration.data.impl.util.ConverterUtil.prefixDefinitionId;
 
 @Order(7)
 @Component
@@ -46,19 +46,10 @@ public class IncidentTransformer implements EntityInterceptor {
         .errorType(null) // TODO: does error type exist in C7?
         .errorMessage(historicIncident.getIncidentMessage())
         .creationDate(convertDate(historicIncident.getCreateTime()))
-        .state(convertState(0)) //TODO: make HistoricIncidentEventEntity#getIncidentState() accessible
+        .state(RESOLVED) // Mark incident always as resolved
         .treePath(null) //TODO ?
         .tenantId(historicIncident.getTenantId());
     // Note: processDefinitionKey, processInstanceKey, jobKey, and flowNodeInstanceKey are set externally
-  }
-
-  protected IncidentEntity.IncidentState convertState(Integer state) {
-    return switch (state) {
-      case 0 -> IncidentEntity.IncidentState.ACTIVE; // open
-      case 1, 2 -> IncidentEntity.IncidentState.RESOLVED; // resolved/deleted
-
-      default -> throw new IllegalArgumentException("Unknown state: " + state);
-    };
   }
 
 }

--- a/data-migrator/core/src/main/java/io/camunda/migration/data/impl/interceptor/history/entity/ProcessInstanceTransformer.java
+++ b/data-migrator/core/src/main/java/io/camunda/migration/data/impl/interceptor/history/entity/ProcessInstanceTransformer.java
@@ -10,13 +10,12 @@ package io.camunda.migration.data.impl.interceptor.history.entity;
 import static io.camunda.migration.data.constants.MigratorConstants.C7_HISTORY_PARTITION_ID;
 import static io.camunda.migration.data.impl.util.ConverterUtil.convertDate;
 import static io.camunda.migration.data.impl.util.ConverterUtil.getNextKey;
+import static io.camunda.migration.data.impl.util.ConverterUtil.getTenantId;
 import static io.camunda.migration.data.impl.util.ConverterUtil.prefixDefinitionId;
 import static io.camunda.search.entities.ProcessInstanceEntity.ProcessInstanceState;
 
 import io.camunda.db.rdbms.write.domain.ProcessInstanceDbModel;
-import io.camunda.migration.data.constants.MigratorConstants;
 import io.camunda.migration.data.exception.EntityInterceptorException;
-import io.camunda.migration.data.impl.util.ConverterUtil;
 import io.camunda.migration.data.interceptor.EntityInterceptor;
 import io.camunda.migration.data.interceptor.property.EntityConversionContext;
 import java.util.Set;
@@ -47,9 +46,8 @@ public class ProcessInstanceTransformer implements EntityInterceptor {
         // Get key from runtime instance/model migration
         .processDefinitionId(prefixDefinitionId(processInstance.getProcessDefinitionKey()))
         .startDate(convertDate(processInstance.getStartTime()))
-        .endDate(convertDate(processInstance.getEndTime()))
         .state(convertState(processInstance.getState()))
-        .tenantId(getTenantId(processInstance))
+        .tenantId(getTenantId(processInstance.getTenantId()))
         .version(processInstance.getProcessDefinitionVersion())
         // parent and super process instance are used synonym (process instance that contained the call activity)
         // TODO: Call activity instance id that created the process in C8. No yet migrated from C7.
@@ -58,24 +56,17 @@ public class ProcessInstanceTransformer implements EntityInterceptor {
         //        .treePath(null)
         // TODO https://github.com/camunda/camunda-bpm-platform/issues/5400
 //        .numIncidents()
-        .partitionId(C7_HISTORY_PARTITION_ID)
-        .historyCleanupDate(convertDate(processInstance.getRemovalTime()));
+        .partitionId(C7_HISTORY_PARTITION_ID);
   }
 
   protected ProcessInstanceState convertState(String state) {
     return switch (state) {
-      case "ACTIVE", "SUSPENDED" -> ProcessInstanceState.ACTIVE;
+      case "ACTIVE", "SUSPENDED", "EXTERNALLY_TERMINATED", "INTERNALLY_TERMINATED" -> ProcessInstanceState.CANCELED; // Active/suspended instances are auto-canceled in C8
       case "COMPLETED" -> ProcessInstanceState.COMPLETED;
-      case "EXTERNALLY_TERMINATED", "INTERNALLY_TERMINATED" -> ProcessInstanceState.CANCELED;
 
       default -> throw new IllegalArgumentException("Unknown state: " + state);
     };
   }
 
-  protected String getTenantId(HistoricProcessInstance processInstance) {
-    return processInstance != null
-        ? ConverterUtil.getTenantId(processInstance.getTenantId())
-        : MigratorConstants.C8_DEFAULT_TENANT;
-  }
 
 }

--- a/data-migrator/core/src/main/java/io/camunda/migration/data/impl/interceptor/history/entity/UserTaskTransformer.java
+++ b/data-migrator/core/src/main/java/io/camunda/migration/data/impl/interceptor/history/entity/UserTaskTransformer.java
@@ -45,7 +45,6 @@ public class UserTaskTransformer implements EntityInterceptor {
         .elementId(historicTask.getTaskDefinitionKey())
         .processDefinitionId(prefixDefinitionId(historicTask.getProcessDefinitionKey()))
         .creationDate(convertDate(historicTask.getStartTime()))
-        .completionDate(convertDate(historicTask.getEndTime()))
         .assignee(historicTask.getAssignee())
         .state(convertState(historicTask.getTaskState()))
         .tenantId(getTenantId(historicTask.getTenantId()))
@@ -57,7 +56,6 @@ public class UserTaskTransformer implements EntityInterceptor {
         .candidateUsers(null) //TODO ?
         .externalFormReference(null) //TODO ?
         .customHeaders(null) //TODO ?
-        .historyCleanupDate(convertDate(historicTask.getRemovalTime()))
         .partitionId(C7_HISTORY_PARTITION_ID)
         .name(historicTask.getName());
     // Note: processDefinitionKey, processInstanceKey, elementInstanceKey, and processDefinitionVersion are set externally
@@ -66,10 +64,8 @@ public class UserTaskTransformer implements EntityInterceptor {
   // See TaskEntity.TaskState
   protected UserTaskDbModel.UserTaskState convertState(String state) {
     return switch (state) {
-      case "Init", "Created" -> UserTaskDbModel.UserTaskState.CREATED;
+      case "Init", "Created", "Updated", "Deleted"  -> UserTaskDbModel.UserTaskState.CANCELED;
       case "Completed" -> UserTaskDbModel.UserTaskState.COMPLETED;
-      case "Deleted" -> UserTaskDbModel.UserTaskState.CANCELED;
-      case "Updated" -> UserTaskDbModel.UserTaskState.CREATED;
 
       default -> throw new IllegalArgumentException("Unknown state: " + state);
     };

--- a/data-migrator/core/src/main/java/io/camunda/migration/data/impl/interceptor/history/entity/VariableTransformer.java
+++ b/data-migrator/core/src/main/java/io/camunda/migration/data/impl/interceptor/history/entity/VariableTransformer.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.migration.data.impl.interceptor.history.entity;
 
-import static io.camunda.migration.data.impl.util.ConverterUtil.convertDate;
 import static io.camunda.migration.data.impl.util.ConverterUtil.getNextKey;
 import static io.camunda.migration.data.impl.util.ConverterUtil.getTenantId;
 import static io.camunda.migration.data.impl.util.ConverterUtil.prefixDefinitionId;
@@ -52,8 +51,7 @@ public class VariableTransformer implements EntityInterceptor {
         .value(variableService.convertValue(historicVariable))
         .processDefinitionId(prefixDefinitionId(historicVariable.getProcessDefinitionKey()))
         .tenantId(getTenantId(historicVariable.getTenantId()))
-        .partitionId(MigratorConstants.C7_HISTORY_PARTITION_ID)
-        .historyCleanupDate(convertDate(historicVariable.getRemovalTime()));
+        .partitionId(MigratorConstants.C7_HISTORY_PARTITION_ID);
     // Note: processInstanceKey and scopeKey are set externally
   }
 

--- a/data-migrator/core/src/main/java/io/camunda/migration/data/impl/util/ConverterUtil.java
+++ b/data-migrator/core/src/main/java/io/camunda/migration/data/impl/util/ConverterUtil.java
@@ -10,7 +10,9 @@ package io.camunda.migration.data.impl.util;
 import io.camunda.zeebe.protocol.Protocol;
 
 import java.security.SecureRandom;
+import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
+import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.util.Date;
 import org.apache.commons.lang3.StringUtils;
@@ -31,9 +33,21 @@ public class ConverterUtil {
     return (1L << KEY_BITS) - 1;
   }
 
+  /**
+   *
+   * C7 stores timestamps WITHOUT timezone (wall-clock time only).
+   * When JDBC reads these timestamps, it incorrectly interprets them as being in the JVM's timezone
+   * and converts them to UTC. We need to undo this interpretation to preserve the original wall-clock time.
+   * Example: C7 has "2024-01-15 10:30:00" (no timezone)
+   * - JDBC in Europe/Berlin (UTC+1) reads this as "2024-01-15 10:30:00+01:00"
+   * - Converts to Date representing instant "2024-01-15 09:30:00Z"
+   * - We need to get back to "2024-01-15 10:30:00" and store it as UTC in C8
+   * Solution: Extract the wall-clock time in JVM timezone, then treat it as UTC.
+   */
   public static OffsetDateTime convertDate(Date date) {
     if (date == null) return null;
-    return date.toInstant().atOffset(ZoneOffset.UTC);
+    LocalDateTime localDateTime = LocalDateTime.ofInstant(date.toInstant(), ZoneId.systemDefault());
+    return localDateTime.atOffset(ZoneOffset.UTC);
   }
 
   public static String getTenantId(String c7TenantId) {

--- a/data-migrator/core/src/test/java/io/camunda/migration/data/config/property/history/CleanupPropertiesTest.java
+++ b/data-migrator/core/src/test/java/io/camunda/migration/data/config/property/history/CleanupPropertiesTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.migration.data.config.property.history;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+import java.time.Period;
+import org.junit.jupiter.api.Test;
+
+class CleanupPropertiesTest {
+
+  @Test
+  void shouldHaveDefaultEnabledTrue() {
+    // given
+    CleanupProperties properties = new CleanupProperties();
+
+    // then
+    assertThat(properties.isEnabled()).isTrue();
+  }
+
+  @Test
+  void shouldHaveDefaultTtl() {
+    // given
+    CleanupProperties properties = new CleanupProperties();
+
+    // then
+    assertThat(properties.getTtl()).isEqualTo(Period.ofDays(180));
+  }
+
+  @Test
+  void shouldSetEnabled() {
+    // given
+    CleanupProperties properties = new CleanupProperties();
+
+    // when
+    properties.setEnabled(false);
+
+    // then
+    assertThat(properties.isEnabled()).isFalse();
+  }
+
+  @Test
+  void shouldSetTtl() {
+    // given
+    CleanupProperties properties = new CleanupProperties();
+    Period customTtl = Period.ofDays(365);
+
+    // when
+    properties.setTtl(customTtl);
+
+    // then
+    assertThat(properties.getTtl()).isEqualTo(customTtl);
+  }
+
+  @Test
+  void shouldAllowNullTtl() {
+    // given
+    CleanupProperties properties = new CleanupProperties();
+
+    // when
+    properties.setTtl(null);
+
+    // then
+    assertThat(properties.getTtl()).isNull();
+  }
+}
+

--- a/data-migrator/qa/e2e-tests/tests/operate-decisions.spec.ts
+++ b/data-migrator/qa/e2e-tests/tests/operate-decisions.spec.ts
@@ -9,34 +9,6 @@
 import { test, expect } from '@playwright/test';
 
 /**
- * Helper function to navigate to the first decision instance details page
- */
-async function navigateToFirstDecisionInstance(page: any) {
-  // Navigate to decisions page
-  const decisionsLink = page.locator('nav a:has-text("Decisions"), a[href*="/decisions"], a[title*="Decisions"]').first();
-  await decisionsLink.waitFor({ state: 'visible', timeout: 10000 });
-  await decisionsLink.click();
-
-  // Wait for the decisions page to load
-  await page.waitForURL('**/decisions**', { timeout: 10000 });
-  await page.waitForTimeout(3000);
-
-  // Find the first decision instance and click on its key/ID to open details
-  const firstDecisionLink = page.locator(
-    '[data-testid="decision-instance-link"], ' +
-    'a[href*="/decisions/"], ' +
-    '[data-testid="data-list"] a, ' +
-    'table tbody tr td:first-child a'
-  ).first();
-  await firstDecisionLink.waitFor({ state: 'visible', timeout: 10000 });
-  await firstDecisionLink.click();
-
-  // Wait for the decision instance detail page to load
-  await page.waitForURL('**/decisions/**', { timeout: 10000 });
-  await page.waitForTimeout(3000);
-}
-
-/**
  * Helper function to navigate to a specific decision instance by decision name
  */
 async function navigateToDecisionByName(page: any, decisionName: string) {
@@ -243,8 +215,8 @@ test.describe('Operate - Decision Instances', () => {
   });
 
   test('should display decision inputs table with entries', async ({ page }) => {
-    // Navigate to first decision instance details
-    await navigateToFirstDecisionInstance(page);
+    // Navigate to the "Assign Approver Group" decision instance specifically
+    await navigateToDecisionByName(page, 'Assign Approver Group');
 
     // Verify inputs section is visible
     const inputsSection = page.locator('section[aria-label="input variables"]');
@@ -273,8 +245,8 @@ test.describe('Operate - Decision Instances', () => {
   });
 
   test('should display decision outputs table with entries', async ({ page }) => {
-    // Navigate to first decision instance details
-    await navigateToFirstDecisionInstance(page);
+    // Navigate to the "Assign Approver Group" decision instance specifically
+    await navigateToDecisionByName(page, 'Assign Approver Group');
 
     // Verify outputs section is visible
     const outputsSection = page.locator('section[aria-label="output variables"]');
@@ -313,8 +285,8 @@ test.describe('Operate - Decision Instances', () => {
   });
 
   test('should display DRD diagram with execution badges', async ({ page }) => {
-    // Navigate to first decision instance details
-    await navigateToFirstDecisionInstance(page);
+    // Navigate to the "Assign Approver Group" decision instance specifically
+    await navigateToDecisionByName(page, 'Assign Approver Group');
 
     // Verify the DRD panel is visible
     const drdPanel = page.locator('[data-testid="drd-panel"]');
@@ -354,8 +326,8 @@ test.describe('Operate - Decision Instances', () => {
   });
 
   test('should navigate to different decision when clicking DRD nodes', async ({ page }) => {
-    // Navigate to first decision instance details
-    await navigateToFirstDecisionInstance(page);
+    // Navigate to the "Assign Approver Group" decision instance specifically
+    await navigateToDecisionByName(page, 'Assign Approver Group');
 
     // Get the current decision name from the header
     const currentDecisionName = await page.locator('[data-testid="instance-header"] td[title*="Assign Approver Group"]').textContent();

--- a/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/ArchitectureTest.java
+++ b/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/ArchitectureTest.java
@@ -46,7 +46,7 @@ class ArchitectureTest {
         .because("Tests should not access internal implementation details from io.camunda.migration.data.impl package. " +
             "Use log assertions and C8 API queries instead. " +
             "Exceptions: (1) Constants (static final fields) and enums from impl classes are allowed, including their methods (e.g., enum.getDisplayName()), " +
-            "(2) ConverterUtil.prefixDefinitionId is allowed for ID conversion in tests, " +
+            "(2) ConverterUtil.prefixDefinitionId and ConverterUtil.convertDate are allowed for data conversion in tests, " +
             "(3) Methods annotated with @BeforeEach or @AfterEach can access impl classes for test setup/cleanup, " +
             "(4) Classes or methods annotated with @WhiteBox are allowed to access impl classes for white-box testing.")
         .check(CLASSES);
@@ -229,11 +229,11 @@ class ArchitectureTest {
               }
             }
 
-            // Allow ConverterUtil.prefixDefinitionId - it's a utility method for ID conversion
+            // Allow ConverterUtil.prefixDefinitionId and convertDate - utility methods for data conversion in tests
             if (access instanceof com.tngtech.archunit.core.domain.JavaMethodCall methodCall) {
               if (targetClassName.equals("io.camunda.migration.data.impl.util.ConverterUtil") &&
-                  methodCall.getName().equals("prefixDefinitionId")) {
-                return; // ConverterUtil.prefixDefinitionId is allowed
+                  (methodCall.getName().equals("prefixDefinitionId") || methodCall.getName().equals("convertDate"))) {
+                return; // ConverterUtil.prefixDefinitionId and convertDate are allowed
               }
             }
 

--- a/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/extension/CleanupExtension.java
+++ b/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/extension/CleanupExtension.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.migration.data.qa.extension;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.time.OffsetDateTime;
+import java.util.List;
+import org.junit.jupiter.api.extension.Extension;
+
+/**
+ * JUnit extension for querying history cleanup dates from C8 database tables.
+ *
+ * <p>This extension provides helper methods to verify HISTORY_CLEANUP_DATE column values
+ * in C8 tables during whitebox testing. Since cleanup dates are not exposed via public API,
+ * direct SQL queries are needed to verify correct cleanup date calculation (endDate + TTL).</p>
+ *
+ * <p>Usage in tests:</p>
+ * <pre>
+ * {@literal @}RegisterExtension
+ * RdbmsQueryExtension rdbmsQuery = new RdbmsQueryExtension();
+ *
+ * {@literal @}RegisterExtension
+ * CleanupExtension cleanup = new CleanupExtension(rdbmsQuery);
+ *
+ * // Query cleanup date for a process instance
+ * OffsetDateTime cleanupDate = cleanup.getProcessInstanceCleanupDate(processInstanceKey);
+ * assertThat(cleanupDate).isEqualTo(endDate.plus(Duration.ofDays(30)));
+ * </pre>
+ */
+public class CleanupExtension implements Extension {
+
+  protected final RdbmsQueryExtension rdbmsQuery;
+
+  /**
+   * Creates a CleanupExtension with the specified RdbmsQueryExtension.
+   *
+   * @param rdbmsQuery the RdbmsQueryExtension to use for database queries
+   */
+  public CleanupExtension(RdbmsQueryExtension rdbmsQuery) {
+    this.rdbmsQuery = rdbmsQuery;
+  }
+
+  protected static OffsetDateTime mapRow(ResultSet rs, int rowNum) throws SQLException {
+    return rs.getObject("HISTORY_CLEANUP_DATE", OffsetDateTime.class);
+  }
+
+  protected String getSql(String tableName, String keyColumn) {
+    return String.format("SELECT HISTORY_CLEANUP_DATE FROM %s WHERE %s = ?", tableName, keyColumn);
+  }
+
+  /**
+   * Generic method to query cleanup date information from any C8 table.
+   *
+   * @param tableName the name of the C8 table
+   * @param keyColumn the key column name
+   * @param keyValue the key value to search for
+   * @return the history cleanup date, or null if not set
+   */
+  public OffsetDateTime queryCleanupDate(String tableName, String keyColumn, Long keyValue) {
+    return rdbmsQuery.queryForObject(getSql(tableName, keyColumn), CleanupExtension::mapRow, keyValue);
+  }
+
+  /**
+   * Generic method to query multiple cleanup date records from any C8 table.
+   *
+   * @param tableName the name of the C8 table
+   * @param filterColumn the filter column name
+   * @param filterValue the filter value
+   * @return list of history cleanup dates
+   */
+  public List<OffsetDateTime> queryCleanupDates(String tableName, String filterColumn, Long filterValue) {
+    return rdbmsQuery.query(getSql(tableName, filterColumn), CleanupExtension::mapRow, filterValue);
+  }
+
+  /**
+   * Query cleanup date for a process instance.
+   *
+   * @param processInstanceKey the process instance key
+   * @return the history cleanup date, or null if not set
+   */
+  public OffsetDateTime getProcessInstanceCleanupDate(Long processInstanceKey) {
+    return queryCleanupDate("PROCESS_INSTANCE", "PROCESS_INSTANCE_KEY", processInstanceKey);
+  }
+
+  /**
+   * Query cleanup date for a flow node instance.
+   *
+   * @param flowNodeInstanceKey the flow node instance key
+   * @return the history cleanup date, or null if not set
+   */
+  public OffsetDateTime getFlowNodeCleanupDate(Long flowNodeInstanceKey) {
+    return queryCleanupDate("FLOW_NODE_INSTANCE", "FLOW_NODE_INSTANCE_KEY", flowNodeInstanceKey);
+  }
+
+  /**
+   * Query cleanup date for a user task.
+   * Note: For user tasks, endDate represents COMPLETION_DATE.
+   *
+   * @param userTaskKey the user task key
+   * @return the history cleanup date, or null if not set
+   */
+  public OffsetDateTime getUserTaskCleanupDate(Long userTaskKey) {
+    return queryCleanupDate("USER_TASK", "USER_TASK_KEY", userTaskKey);
+  }
+
+  /**
+   * Query cleanup date for a decision instance.
+   * Note: For decision instances, endDate represents EVALUATION_DATE.
+   *
+   * @param decisionInstanceKey the decision instance key
+   * @return the history cleanup date, or null if not set
+   */
+  public OffsetDateTime getDecisionInstanceCleanupDate(Long decisionInstanceKey) {
+    return queryCleanupDate("DECISION_INSTANCE", "DECISION_INSTANCE_KEY", decisionInstanceKey);
+  }
+
+  /**
+   * Query cleanup dates for all variables of a process instance.
+   * Variables don't have an end date, only cleanup date.
+   *
+   * @param processInstanceKey the process instance key
+   * @return list of history cleanup dates for all variables
+   */
+  public List<OffsetDateTime> getVariableCleanupDates(Long processInstanceKey) {
+    return queryCleanupDates("VARIABLE", "PROCESS_INSTANCE_KEY", processInstanceKey);
+  }
+}
+

--- a/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/extension/HistoryMigrationExtension.java
+++ b/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/extension/HistoryMigrationExtension.java
@@ -34,7 +34,10 @@ import io.camunda.search.query.ProcessInstanceQuery;
 import io.camunda.search.query.UserTaskQuery;
 import io.camunda.search.query.VariableQuery;
 import io.camunda.search.result.DecisionInstanceQueryResultConfig;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import org.camunda.bpm.engine.HistoryService;
 import org.camunda.bpm.engine.RepositoryService;
@@ -233,11 +236,10 @@ public class HistoryMigrationExtension implements AfterEachCallback, Application
     if (rdbmsService == null) {
       throw new IllegalStateException("RdbmsService is not available in the Spring context");
     }
-    return rdbmsService.getFlowNodeInstanceReader()
-        .search(FlowNodeInstanceQuery.of(queryBuilder ->
-            queryBuilder.filter(filterBuilder ->
-                filterBuilder.processInstanceKeys(processInstanceKey).types(type))))
-        .items();
+    return new ArrayList<>(rdbmsService.getFlowNodeInstanceReader()
+        .search(FlowNodeInstanceQuery.of(queryBuilder -> queryBuilder.filter(
+            filterBuilder -> filterBuilder.processInstanceKeys(processInstanceKey).types(type))))
+        .items());
   }
 
   public List<FlowNodeInstanceEntity> searchHistoricFlowNodesById(String... flowNodeIds) {

--- a/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/extension/RdbmsQueryExtension.java
+++ b/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/extension/RdbmsQueryExtension.java
@@ -1,0 +1,215 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.migration.data.qa.extension;
+
+import java.util.List;
+import java.util.Map;
+import javax.sql.DataSource;
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.springframework.beans.BeansException;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.stereotype.Component;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+/**
+ * Generic JUnit 5 extension for executing SQL queries against RDBMS databases in tests.
+ * Provides convenient methods for querying database tables and verifying data.
+ *
+ * <p>Usage in tests:</p>
+ * <pre>
+ * {@literal @}RegisterExtension
+ * {@literal @}Autowired
+ * RdbmsQueryExtension rdbmsQuery;
+ *
+ * // Query single row
+ * Map&lt;String, Object&gt; result = rdbmsQuery.queryForMap(
+ *     "SELECT * FROM MY_TABLE WHERE KEY = ?", key);
+ *
+ * // Query multiple rows
+ * List&lt;Map&lt;String, Object&gt;&gt; results = rdbmsQuery.queryForList(
+ *     "SELECT * FROM MY_TABLE WHERE PARENT_KEY = ?", parentKey);
+ *
+ * // Query with custom mapper
+ * MyEntity entity = rdbmsQuery.queryForObject(
+ *     "SELECT * FROM MY_TABLE WHERE KEY = ?",
+ *     (rs, rowNum) -&gt; new MyEntity(...),
+ *     key);
+ * </pre>
+ */
+@Component
+public class RdbmsQueryExtension implements BeforeEachCallback, AfterEachCallback, ApplicationContextAware {
+
+  private static ApplicationContext applicationContext;
+  private JdbcTemplate jdbcTemplate;
+  private final String dataSourceBeanName;
+
+  /**
+   * Creates extension using the default C8 data source.
+   */
+  public RdbmsQueryExtension() {
+    this("c8DataSource");
+  }
+
+  /**
+   * Creates extension using a specific data source bean name.
+   *
+   * @param dataSourceBeanName the name of the DataSource bean to use
+   */
+  public RdbmsQueryExtension(String dataSourceBeanName) {
+    this.dataSourceBeanName = dataSourceBeanName;
+  }
+
+  @Override
+  public void setApplicationContext(ApplicationContext context) throws BeansException {
+    RdbmsQueryExtension.applicationContext = context;
+  }
+
+  @Override
+  public void beforeEach(ExtensionContext context) {
+    if (applicationContext == null) {
+      applicationContext = SpringExtension.getApplicationContext(context);
+    }
+
+    if (jdbcTemplate == null && applicationContext != null) {
+      DataSource dataSource = applicationContext.getBean(dataSourceBeanName, DataSource.class);
+      jdbcTemplate = new JdbcTemplate(dataSource);
+    }
+  }
+
+  @Override
+  public void afterEach(ExtensionContext context) {
+    // Cleanup if needed - currently no cleanup required
+  }
+
+  /**
+   * Gets the underlying JdbcTemplate for advanced usage.
+   *
+   * @return the JdbcTemplate instance
+   */
+  public JdbcTemplate getJdbcTemplate() {
+    if (jdbcTemplate == null) {
+      throw new IllegalStateException("JdbcTemplate not initialized. Make sure the extension is properly registered.");
+    }
+    return jdbcTemplate;
+  }
+
+  /**
+   * Query for a single row, returning the result as a Map.
+   *
+   * @param sql the SQL query
+   * @param args the query parameters
+   * @return a map with column names as keys
+   */
+  public Map<String, Object> queryForMap(String sql, Object... args) {
+    return getJdbcTemplate().queryForMap(sql, args);
+  }
+
+  /**
+   * Query for multiple rows, returning each row as a Map.
+   *
+   * @param sql the SQL query
+   * @param args the query parameters
+   * @return list of maps with column names as keys
+   */
+  public List<Map<String, Object>> queryForList(String sql, Object... args) {
+    return getJdbcTemplate().queryForList(sql, args);
+  }
+
+  /**
+   * Query for a single object using a custom RowMapper.
+   *
+   * @param <T> the result type
+   * @param sql the SQL query
+   * @param rowMapper the mapper to convert ResultSet to object
+   * @param args the query parameters
+   * @return the mapped object
+   */
+  public <T> T queryForObject(String sql, RowMapper<T> rowMapper, Object... args) {
+    return getJdbcTemplate().queryForObject(sql, rowMapper, args);
+  }
+
+  /**
+   * Query for multiple objects using a custom RowMapper.
+   *
+   * @param <T> the result type
+   * @param sql the SQL query
+   * @param rowMapper the mapper to convert ResultSet to objects
+   * @param args the query parameters
+   * @return list of mapped objects
+   */
+  public <T> List<T> query(String sql, RowMapper<T> rowMapper, Object... args) {
+    return getJdbcTemplate().query(sql, rowMapper, args);
+  }
+
+  /**
+   * Query for a single value.
+   *
+   * @param <T> the result type
+   * @param sql the SQL query
+   * @param requiredType the required type of the result
+   * @param args the query parameters
+   * @return the single value
+   */
+  public <T> T queryForObject(String sql, Class<T> requiredType, Object... args) {
+    return getJdbcTemplate().queryForObject(sql, requiredType, args);
+  }
+
+  /**
+   * Execute an update/insert/delete statement.
+   *
+   * @param sql the SQL statement
+   * @param args the statement parameters
+   * @return the number of rows affected
+   */
+  public int update(String sql, Object... args) {
+    return getJdbcTemplate().update(sql, args);
+  }
+
+  /**
+   * Execute a SQL statement (for DDL or statements without parameters).
+   *
+   * @param sql the SQL statement
+   */
+  public void execute(String sql) {
+    getJdbcTemplate().execute(sql);
+  }
+
+  /**
+   * Check if a record exists in a table.
+   *
+   * @param tableName the table name
+   * @param keyColumn the key column name
+   * @param keyValue the key value
+   * @return true if record exists
+   */
+  public boolean exists(String tableName, String keyColumn, Object keyValue) {
+    String sql = String.format("SELECT COUNT(*) FROM %s WHERE %s = ?", tableName, keyColumn);
+    Integer count = queryForObject(sql, Integer.class, keyValue);
+    return count != null && count > 0;
+  }
+
+  /**
+   * Count rows in a table matching a condition.
+   *
+   * @param tableName the table name
+   * @param whereClause the WHERE clause (without "WHERE" keyword)
+   * @param args the query parameters
+   * @return the row count
+   */
+  public int count(String tableName, String whereClause, Object... args) {
+    String sql = String.format("SELECT COUNT(*) FROM %s WHERE %s", tableName, whereClause);
+    Integer count = queryForObject(sql, Integer.class, args);
+    return count != null ? count : 0;
+  }
+}
+

--- a/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/history/HistoryAutoCancelMigrationTest.java
+++ b/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/history/HistoryAutoCancelMigrationTest.java
@@ -1,0 +1,497 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.migration.data.qa.history;
+
+import static io.camunda.migration.data.impl.util.ConverterUtil.convertDate;
+import static io.camunda.search.entities.FlowNodeInstanceEntity.FlowNodeType.END_EVENT;
+import static io.camunda.search.entities.FlowNodeInstanceEntity.FlowNodeType.START_EVENT;
+import static io.camunda.search.entities.FlowNodeInstanceEntity.FlowNodeType.USER_TASK;
+import static io.camunda.search.entities.UserTaskEntity.UserTaskState.CANCELED;
+import static io.camunda.search.entities.UserTaskEntity.UserTaskState.COMPLETED;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+
+import io.camunda.migration.data.qa.AbstractMigratorTest;
+import io.camunda.migration.data.qa.extension.HistoryMigrationExtension;
+import io.camunda.migration.data.qa.util.ProcessDefinitionDeployer;
+import io.camunda.search.entities.FlowNodeInstanceEntity;
+import io.camunda.search.entities.ProcessInstanceEntity;
+import io.camunda.search.entities.UserTaskEntity;
+import java.time.OffsetDateTime;
+import java.util.Date;
+import java.util.List;
+import org.camunda.bpm.engine.RuntimeService;
+import org.camunda.bpm.engine.TaskService;
+import org.camunda.bpm.engine.impl.util.ClockUtil;
+import org.camunda.bpm.engine.task.Task;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+/**
+ * Integration tests for auto-cancellation of active process instances during history migration.
+ *
+ * <p>When migrating history, active process instances are automatically canceled to ensure
+ * consistency in C8. This test class verifies that:</p>
+ * <ul>
+ *   <li>Active process instances are auto-canceled with state CANCELED</li>
+ *   <li>End dates are set appropriately during auto-cancellation</li>
+ *   <li>Completed process instances retain their original state and end dates</li>
+ *   <li>Child entities (flow nodes, user tasks) are terminated/canceled consistently</li>
+ *   <li>End dates cascade correctly to terminated child entities</li>
+ * </ul>
+ */
+@SpringBootTest
+public class HistoryAutoCancelMigrationTest extends AbstractMigratorTest {
+
+  @RegisterExtension
+  HistoryMigrationExtension historyMigration = new HistoryMigrationExtension();
+
+  @Autowired
+  protected ProcessDefinitionDeployer deployer;
+
+  @Autowired
+  protected RuntimeService runtimeService;
+
+  @Autowired
+  protected TaskService taskService;
+
+  @Test
+  public void shouldAutoCancelActiveProcessInstance() {
+    // given - deploy and start a process instance that remains active
+    deployer.deployCamunda7Process("userTaskProcess.bpmn");
+    runtimeService.startProcessInstanceByKey("userTaskProcessId");
+
+    Date migrationTime = new Date();
+    ClockUtil.setCurrentTime(migrationTime);
+
+    // when - migrate history
+    historyMigration.getMigrator().migrate();
+
+    // then - process instance should be auto-canceled with endDate set to "now"
+    List<ProcessInstanceEntity> processInstances = historyMigration.searchHistoricProcessInstances("userTaskProcessId");
+    assertThat(processInstances).hasSize(1);
+
+    ProcessInstanceEntity migratedInstance = processInstances.getFirst();
+    // Verify state conversion: ACTIVE -> CANCELED
+    assertThat(migratedInstance.state()).isEqualTo(ProcessInstanceEntity.ProcessInstanceState.CANCELED);
+    // Verify endDate was set to "migrationTime" during migration
+    assertThat(migratedInstance.endDate())
+        .isNotNull()
+        .isEqualTo(convertDate(migrationTime));
+  }
+
+  @Test
+  public void shouldNotCancelCompletedProcessInstance() {
+    // given - deploy and complete a process instance
+    deployer.deployCamunda7Process("userTaskProcess.bpmn");
+    runtimeService.startProcessInstanceByKey("userTaskProcessId");
+
+    // Complete the user task at a later time
+    Date completionTime = new Date();
+    ClockUtil.setCurrentTime(completionTime);
+    Task task = taskService.createTaskQuery().singleResult();
+    taskService.complete(task.getId());
+
+    // when - migrate history
+    historyMigration.getMigrator().migrate();
+
+    // then - completed process instance should keep its original state and end date
+    List<ProcessInstanceEntity> processInstances = historyMigration.searchHistoricProcessInstances("userTaskProcessId");
+    assertThat(processInstances).hasSize(1);
+
+    ProcessInstanceEntity migratedInstance = processInstances.getFirst();
+    // Verify state remains COMPLETED
+    assertThat(migratedInstance.state()).isEqualTo(ProcessInstanceEntity.ProcessInstanceState.COMPLETED);
+    // Verify endDate exists and matches the completion time (from C7)
+    assertThat(migratedInstance.endDate())
+        .isNotNull()
+        .isEqualTo(convertDate(completionTime));
+  }
+
+  @Test
+  public void shouldTerminateActiveFlowNodesWhenAutoCanceling() {
+    // given - deploy and start a process instance
+    deployer.deployCamunda7Process("userTaskProcess.bpmn");
+    runtimeService.startProcessInstanceByKey("userTaskProcessId");
+
+    // when - migrate history
+    historyMigration.getMigrator().migrate();
+
+    // then - active flow nodes should be terminated
+    List<ProcessInstanceEntity> processInstances = historyMigration.searchHistoricProcessInstances("userTaskProcessId");
+    assertThat(processInstances).hasSize(1);
+
+    ProcessInstanceEntity migratedInstance = processInstances.getFirst();
+    Long processInstanceKey = migratedInstance.processInstanceKey();
+
+    // Check start event - should be COMPLETED with its own end date
+    var startEvents = historyMigration.searchHistoricFlowNodesForType(processInstanceKey, START_EVENT);
+    assertThat(startEvents).hasSize(1);
+    FlowNodeInstanceEntity startEvent = startEvents.getFirst();
+    assertThat(startEvent.state()).isEqualTo(FlowNodeInstanceEntity.FlowNodeState.COMPLETED);
+    assertThat(startEvent.endDate()).isNotEqualTo(migratedInstance.endDate());
+
+    // Check user task flow node - should be TERMINATED
+    var userTaskFlowNodes = historyMigration.searchHistoricFlowNodesForType(processInstanceKey, USER_TASK);
+    assertThat(userTaskFlowNodes).hasSize(1);
+    FlowNodeInstanceEntity userTaskFlowNode = userTaskFlowNodes.getFirst();
+    assertThat(userTaskFlowNode.state()).isEqualTo(FlowNodeInstanceEntity.FlowNodeState.TERMINATED);
+    assertThat(userTaskFlowNode.endDate()).isEqualTo(migratedInstance.endDate());
+  }
+
+  @Test
+  public void shouldCascadeEndDateToTerminatedFlowNodes() {
+    // given - deploy and start a process instance
+    deployer.deployCamunda7Process("userTaskProcess.bpmn");
+    runtimeService.startProcessInstanceByKey("userTaskProcessId");
+
+    // when - migrate history
+    historyMigration.getMigrator().migrate();
+
+    // then - terminated flow nodes should inherit the process instance's end date
+    List<ProcessInstanceEntity> processInstances = historyMigration.searchHistoricProcessInstances("userTaskProcessId");
+    assertThat(processInstances).hasSize(1);
+
+    ProcessInstanceEntity migratedInstance = processInstances.getFirst();
+    Long processInstanceKey = migratedInstance.processInstanceKey();
+    OffsetDateTime processInstanceEndDate = migratedInstance.endDate();
+
+    assertThat(processInstanceEndDate).isNotNull();
+
+    // Check start event - should NOT have cascaded end date (it's COMPLETED)
+    var startEvents = historyMigration.searchHistoricFlowNodesForType(processInstanceKey, START_EVENT);
+    assertThat(startEvents).hasSize(1);
+    FlowNodeInstanceEntity startEvent = startEvents.getFirst();
+    assertThat(startEvent.state()).isEqualTo(FlowNodeInstanceEntity.FlowNodeState.COMPLETED);
+    assertThat(startEvent.endDate())
+        .as("Start event should have its own completion endDate, not cascaded from process instance")
+        .isNotEqualTo(processInstanceEndDate);
+
+    // Check user task flow node - should have cascaded end date (it's TERMINATED)
+    var userTaskFlowNodes = historyMigration.searchHistoricFlowNodesForType(processInstanceKey, USER_TASK);
+    assertThat(userTaskFlowNodes).hasSize(1);
+    FlowNodeInstanceEntity userTaskFlowNode = userTaskFlowNodes.getFirst();
+    assertThat(userTaskFlowNode.state()).isEqualTo(FlowNodeInstanceEntity.FlowNodeState.TERMINATED);
+    assertThat(userTaskFlowNode.endDate())
+        .as("Terminated user task flow node should have cascaded endDate from process instance")
+        .isEqualTo(processInstanceEndDate);
+  }
+
+  @Test
+  public void shouldCancelActiveUserTasksWhenAutoCanceling() {
+    // given - deploy and start a process instance with active user task
+    deployer.deployCamunda7Process("userTaskProcess.bpmn");
+    runtimeService.startProcessInstanceByKey("userTaskProcessId");
+
+    // when - migrate history
+    historyMigration.getMigrator().migrate();
+
+    // then - user task should be canceled
+    List<ProcessInstanceEntity> processInstances = historyMigration.searchHistoricProcessInstances("userTaskProcessId");
+    assertThat(processInstances).hasSize(1);
+
+    ProcessInstanceEntity migratedInstance = processInstances.getFirst();
+    Long processInstanceKey = migratedInstance.processInstanceKey();
+
+    List<UserTaskEntity> userTasks = historyMigration.searchHistoricUserTasks(processInstanceKey);
+    assertThat(userTasks).hasSize(1);
+
+    UserTaskEntity userTask = userTasks.getFirst();
+    assertThat(userTask.state()).isEqualTo(CANCELED);
+  }
+
+  @Test
+  public void shouldCascadeCompletionDateToUserTasksWhenAutoCanceling() {
+    // given - deploy and start a process instance with active user task
+    deployer.deployCamunda7Process("userTaskProcess.bpmn");
+    runtimeService.startProcessInstanceByKey("userTaskProcessId");
+
+    // when - migrate history
+    historyMigration.getMigrator().migrate();
+
+    // then - user task should inherit the process instance's end date as completion date
+    List<ProcessInstanceEntity> processInstances = historyMigration.searchHistoricProcessInstances("userTaskProcessId");
+    assertThat(processInstances).hasSize(1);
+
+    ProcessInstanceEntity migratedInstance = processInstances.getFirst();
+    Long processInstanceKey = migratedInstance.processInstanceKey();
+    OffsetDateTime processInstanceEndDate = migratedInstance.endDate();
+
+    List<UserTaskEntity> userTasks = historyMigration.searchHistoricUserTasks(processInstanceKey);
+    assertThat(userTasks).hasSize(1);
+
+    UserTaskEntity userTask = userTasks.getFirst();
+    assertThat(userTask.state()).isEqualTo(CANCELED);
+    // Verify the completionDate was cascaded from process instance (allow small timing differences)
+    assertThat(userTask.completionDate())
+        .as("User task completion date should be cascaded from process instance")
+        .isNotNull()
+        .isEqualTo(processInstanceEndDate);
+  }
+
+  @Test
+  public void shouldNotCascadeEndDatesToCompletedEntities() {
+    // given - deploy and complete a process instance
+    deployer.deployCamunda7Process("userTaskProcess.bpmn");
+
+    Date startTime = new Date();
+    ClockUtil.setCurrentTime(startTime);
+    runtimeService.startProcessInstanceByKey("userTaskProcessId");
+
+    // Complete the user task at a later time
+    Date completionTime = new Date(startTime.getTime() + 5_000); // +5 seconds
+    ClockUtil.setCurrentTime(completionTime);
+    Task task = taskService.createTaskQuery().singleResult();
+    taskService.complete(task.getId());
+
+    // when - migrate history
+    historyMigration.getMigrator().migrate();
+
+    // then - completed entities should keep their original end dates
+    List<ProcessInstanceEntity> processInstances = historyMigration.searchHistoricProcessInstances("userTaskProcessId");
+    assertThat(processInstances).hasSize(1);
+
+    ProcessInstanceEntity migratedInstance = processInstances.getFirst();
+    Long processInstanceKey = migratedInstance.processInstanceKey();
+    OffsetDateTime processInstanceEndDate = migratedInstance.endDate();
+
+    // Flow nodes should have their own end dates
+    var startEvents = historyMigration.searchHistoricFlowNodesForType(processInstanceKey, START_EVENT);
+    assertThat(startEvents).hasSize(1);
+    assertThat(startEvents.getFirst().endDate())
+        .isNotNull()
+        .isEqualTo(convertDate(startTime))
+        .isNotEqualTo(processInstanceEndDate);
+
+    var userTaskFlowNodes = historyMigration.searchHistoricFlowNodesForType(processInstanceKey, USER_TASK);
+    assertThat(userTaskFlowNodes).hasSize(1);
+    assertThat(userTaskFlowNodes.getFirst().endDate())
+        .isNotNull()
+        .isEqualTo(convertDate(completionTime));
+
+    // User task should have its own completion date
+    List<UserTaskEntity> userTasks = historyMigration.searchHistoricUserTasks(processInstanceKey);
+    assertThat(userTasks).hasSize(1);
+    UserTaskEntity userTask = userTasks.getFirst();
+    assertThat(userTask.state()).isEqualTo(COMPLETED);
+    assertThat(userTask.completionDate())
+        .isNotNull()
+        .isEqualTo(convertDate(completionTime))
+        .isEqualTo(processInstanceEndDate);
+  }
+
+  @Test
+  public void shouldAutoCancelMultipleActiveProcessInstancesConsistently() {
+    // given - deploy and start multiple active process instances
+    deployer.deployCamunda7Process("userTaskProcess.bpmn");
+
+    for (int i = 0; i < 5; i++) {
+      runtimeService.startProcessInstanceByKey("userTaskProcessId");
+    }
+
+    Date migrationTime = new Date();
+    ClockUtil.setCurrentTime(migrationTime);
+
+    // when - migrate history
+    historyMigration.getMigrator().migrate();
+
+    // then - all process instances should be auto-canceled with consistent behavior
+    List<ProcessInstanceEntity> processInstances = historyMigration.searchHistoricProcessInstances("userTaskProcessId");
+    assertThat(processInstances).hasSize(5);
+
+    for (ProcessInstanceEntity instance : processInstances) {
+      // All should be auto-canceled with endDate set
+      assertThat(instance.state()).isEqualTo(ProcessInstanceEntity.ProcessInstanceState.CANCELED);
+      assertThat(instance.endDate())
+          .isNotNull()
+          .isEqualTo(convertDate(migrationTime));
+    }
+  }
+
+  @Test
+  public void shouldCascadeEndDateToAllChildEntitiesConsistently() {
+    // given - deploy and start multiple active process instances
+    deployer.deployCamunda7Process("userTaskProcess.bpmn");
+    for (int i = 0; i < 5; i++) {
+      runtimeService.startProcessInstanceByKey("userTaskProcessId");
+    }
+
+    // when - migrate history
+    historyMigration.getMigrator().migrate();
+
+    // then - all instances and their cancelled children should have cascaded end dates
+    List<ProcessInstanceEntity> processInstances = historyMigration.searchHistoricProcessInstances("userTaskProcessId");
+    assertThat(processInstances).hasSize(5);
+
+    for (ProcessInstanceEntity instance : processInstances) {
+      assertThat(instance.state()).isEqualTo(ProcessInstanceEntity.ProcessInstanceState.CANCELED);
+      assertThat(instance.endDate()).isNotNull();
+
+      // Verify only TERMINATED child flow nodes have cascaded end dates
+      Long processInstanceKey = instance.processInstanceKey();
+
+      // Start events should be COMPLETED with their own end dates
+      var startEvents = historyMigration.searchHistoricFlowNodesForType(processInstanceKey, START_EVENT);
+      for (FlowNodeInstanceEntity flowNode : startEvents) {
+        assertThat(flowNode.state()).isEqualTo(FlowNodeInstanceEntity.FlowNodeState.COMPLETED);
+        assertThat(flowNode.endDate())
+            .as("Completed start event should have its own endDate, not cascaded")
+            .isNotEqualTo(instance.endDate());
+      }
+
+      // User task flow nodes should be TERMINATED with cascaded end dates
+      var userTaskFlowNodes = historyMigration.searchHistoricFlowNodesForType(processInstanceKey, USER_TASK);
+      for (FlowNodeInstanceEntity flowNode : userTaskFlowNodes) {
+        assertThat(flowNode.state()).isEqualTo(FlowNodeInstanceEntity.FlowNodeState.TERMINATED);
+        assertThat(flowNode.endDate())
+            .as("Terminated flow node should have cascaded endDate")
+            .isEqualTo(instance.endDate());
+      }
+    }
+  }
+
+  @Test
+  public void shouldHandleMixedStateProcessInstancesCorrectly() {
+    // given - deploy and start mixed process instances (some active, some completed)
+    deployer.deployCamunda7Process("userTaskProcess.bpmn");
+
+    Date startTime = new Date();
+    ClockUtil.setCurrentTime(startTime);
+
+    // Start 3 active instances
+    for (int i = 0; i < 3; i++) {
+      runtimeService.startProcessInstanceByKey("userTaskProcessId");
+    }
+
+    // Start and complete 2 instances
+    for (int i = 0; i < 2; i++) {
+      runtimeService.startProcessInstanceByKey("userTaskProcessId");
+      Task task = taskService.createTaskQuery().list().get(i);
+      taskService.complete(task.getId());
+    }
+
+    Date migrationTime = new Date(startTime.getTime() + 10_000); // +10 seconds
+    ClockUtil.setCurrentTime(migrationTime);
+
+    // when - migrate history
+    historyMigration.getMigrator().migrate();
+
+    // then - verify state-specific behavior
+    List<ProcessInstanceEntity> processInstances = historyMigration.searchHistoricProcessInstances("userTaskProcessId");
+    assertThat(processInstances).hasSize(5);
+
+    // Verify all have end dates
+    var canceledPis = processInstances.stream()
+        .filter(pi -> pi.state() == ProcessInstanceEntity.ProcessInstanceState.CANCELED)
+        .toList();
+
+    assertThat(canceledPis).hasSize(3);
+
+    for (ProcessInstanceEntity instance : canceledPis) {
+      assertThat(instance.endDate()).isEqualTo(convertDate(migrationTime));
+    }
+
+    var completedPis = processInstances.stream()
+        .filter(pi -> pi.state() == ProcessInstanceEntity.ProcessInstanceState.COMPLETED)
+        .toList();
+
+    assertThat(completedPis).hasSize(2);
+
+    for (ProcessInstanceEntity instance : completedPis) {
+      assertThat(instance.endDate()).isEqualTo(convertDate(startTime));
+    }
+  }
+
+  @Test
+  public void shouldUseOriginalEndDateForCompletedFlowNodes() {
+    // given
+    deployer.deployCamunda7Process("userTaskProcess.bpmn");
+
+    Date initialTime = new Date();
+    ClockUtil.setCurrentTime(initialTime);
+
+    // Start process instance at T0
+    runtimeService.startProcessInstanceByKey("userTaskProcessId");
+
+    // Advance time before completing task
+    Date taskCompletionTime = new Date(initialTime.getTime() + 10_000); // +10 seconds
+    ClockUtil.setCurrentTime(taskCompletionTime);
+
+    Task task = taskService.createTaskQuery().singleResult();
+    taskService.complete(task.getId());
+
+    // when - migrate history
+    historyMigration.getMigrator().migrate();
+
+    // then - completed flow nodes should keep their original end dates
+    List<ProcessInstanceEntity> processInstances = historyMigration.searchHistoricProcessInstances("userTaskProcessId");
+    assertThat(processInstances).hasSize(1);
+
+    ProcessInstanceEntity migratedInstance = processInstances.getFirst();
+    Long processInstanceKey = migratedInstance.processInstanceKey();
+
+    // Start event should have its own end date from T0
+    var startEvents = historyMigration.searchHistoricFlowNodesForType(processInstanceKey, START_EVENT);
+    assertThat(startEvents).hasSize(1);
+    assertThat(startEvents.getFirst().endDate())
+        .isNotNull()
+        .isEqualTo(convertDate(initialTime));
+
+    // User task flow node should have end date from task completion time
+    var userTaskFlowNodes = historyMigration.searchHistoricFlowNodesForType(processInstanceKey, USER_TASK);
+    assertThat(userTaskFlowNodes).hasSize(1);
+    assertThat(userTaskFlowNodes.getFirst().endDate())
+        .isNotNull()
+        .isEqualTo(convertDate(taskCompletionTime));
+
+    // End event should have the same end date as process instance (task completion time)
+    var endEvents = historyMigration.searchHistoricFlowNodesForType(processInstanceKey, END_EVENT);
+    assertThat(endEvents).hasSize(1);
+    assertThat(endEvents.getFirst().endDate())
+        .isNotNull()
+        .isEqualTo(convertDate(taskCompletionTime));
+  }
+
+  @Test
+  public void shouldUseOriginalCompletionDateForCompletedUserTasks() {
+    // given - deploy and complete a process instance
+    deployer.deployCamunda7Process("twoUserTasksProcess.bpmn");
+    runtimeService.startProcessInstanceByKey("twoUserTasksProcessId");
+
+    Date taskCompletionTime = new Date();
+    ClockUtil.setCurrentTime(taskCompletionTime);
+    var tasks = taskService.createTaskQuery().list();
+    taskService.complete(tasks.getFirst().getId());
+
+    Date processCompletionTime = new Date(taskCompletionTime.getTime() + 10_000); // +10 seconds
+    ClockUtil.setCurrentTime(processCompletionTime);
+
+    // when - migrate history
+    historyMigration.getMigrator().migrate();
+
+    // then - completed user task should keep its original completion date
+    List<ProcessInstanceEntity> processInstances = historyMigration.searchHistoricProcessInstances("twoUserTasksProcessId");
+    assertThat(processInstances).hasSize(1);
+
+    ProcessInstanceEntity migratedInstance = processInstances.getFirst();
+    Long processInstanceKey = migratedInstance.processInstanceKey();
+    OffsetDateTime processInstanceEndDate = migratedInstance.endDate();
+
+    List<UserTaskEntity> userTasks = historyMigration.searchHistoricUserTasks(processInstanceKey);
+    assertThat(userTasks).hasSize(2);
+
+    assertThat(userTasks).extracting("completionDate", "state").containsExactlyInAnyOrder(
+        tuple(convertDate(taskCompletionTime), COMPLETED),
+        tuple(processInstanceEndDate, CANCELED)
+    );
+  }
+
+}
+

--- a/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/history/cleanup/HistoryCleanupDisabledMigrationTest.java
+++ b/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/history/cleanup/HistoryCleanupDisabledMigrationTest.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.migration.data.qa.history.cleanup;
+
+import static io.camunda.search.entities.FlowNodeInstanceEntity.FlowNodeType.*;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.migration.data.qa.AbstractMigratorTest;
+import io.camunda.migration.data.qa.extension.CleanupExtension;
+import io.camunda.migration.data.qa.extension.HistoryMigrationExtension;
+import io.camunda.migration.data.qa.extension.RdbmsQueryExtension;
+import io.camunda.migration.data.qa.util.ProcessDefinitionDeployer;
+import io.camunda.search.entities.FlowNodeInstanceEntity;
+import io.camunda.search.entities.ProcessInstanceEntity;
+import io.camunda.search.entities.UserTaskEntity;
+import java.time.OffsetDateTime;
+import java.util.List;
+import org.camunda.bpm.engine.RuntimeService;
+import org.camunda.bpm.engine.TaskService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
+
+/**
+ * Integration tests for disabled auto-cancel cleanup.
+ * When auto-cancel cleanup is disabled, history cleanup dates should be null.
+ */
+@SpringBootTest
+@TestPropertySource(properties = {
+    "camunda.migrator.history.auto-cancel.cleanup.enabled=false",
+    "logging.level.io.camunda.migration.data.HistoryMigrator=DEBUG"
+})
+public class HistoryCleanupDisabledMigrationTest extends AbstractMigratorTest {
+
+  @RegisterExtension
+  HistoryMigrationExtension historyMigration = new HistoryMigrationExtension();
+
+  @RegisterExtension
+  RdbmsQueryExtension rdbmsQuery = new RdbmsQueryExtension();
+
+  @RegisterExtension
+  CleanupExtension cleanup = new CleanupExtension(rdbmsQuery);
+
+  @Autowired
+  protected ProcessDefinitionDeployer deployer;
+
+  @Autowired
+  protected RuntimeService runtimeService;
+
+  @Autowired
+  protected TaskService taskService;
+
+  @Test
+  public void shouldSetNullCleanupDateWhenAutoCancelDisabled() {
+    // given - deploy and start a process instance that remains active
+    deployer.deployCamunda7Process("userTaskProcess.bpmn");
+    runtimeService.startProcessInstanceByKey("userTaskProcessId");
+
+    // when - migrate history with auto-cancel TTL disabled
+    historyMigration.getMigrator().migrate();
+
+    // then - process instance should be auto-canceled but with null history cleanup date
+    List<ProcessInstanceEntity> processInstances = historyMigration.searchHistoricProcessInstances("userTaskProcessId");
+    assertThat(processInstances).hasSize(1);
+
+    ProcessInstanceEntity migratedInstance = processInstances.getFirst();
+    assertThat(migratedInstance.state()).isEqualTo(ProcessInstanceEntity.ProcessInstanceState.CANCELED);
+    assertThat(migratedInstance.endDate()).isNotNull();
+
+    // Verify cleanup date is null using direct SQL query
+    OffsetDateTime cleanupDate = cleanup.getProcessInstanceCleanupDate(migratedInstance.processInstanceKey());
+    assertThat(cleanupDate).isNull();
+  }
+
+  @Test
+  public void shouldSetNullCleanupDateForFlowNodesWhenAutoCancelDisabled() {
+    // given - deploy and start a process instance with flow nodes
+    deployer.deployCamunda7Process("userTaskProcess.bpmn");
+    runtimeService.startProcessInstanceByKey("userTaskProcessId");
+
+    // when - migrate history with auto-cancel TTL disabled
+    historyMigration.getMigrator().migrate();
+
+    // then - flow nodes should have null cleanup dates
+    var processInstances = historyMigration.searchHistoricProcessInstances("userTaskProcessId");
+    assertThat(processInstances).hasSize(1);
+    Long processInstanceKey = processInstances.getFirst().processInstanceKey();
+
+    var flowNodes = historyMigration.searchHistoricFlowNodesForType(processInstanceKey, USER_TASK);
+    assertThat(flowNodes).isNotEmpty();
+
+    for (FlowNodeInstanceEntity flowNode : flowNodes) {
+      OffsetDateTime cleanupDate = cleanup.getFlowNodeCleanupDate(flowNode.flowNodeInstanceKey());
+      assertThat(cleanupDate).isNull();
+    }
+  }
+
+  @Test
+  public void shouldSetNullCleanupDateForUserTasksWhenAutoCancelDisabled() {
+    // given - deploy and start a process instance with a user task
+    deployer.deployCamunda7Process("userTaskProcess.bpmn");
+    runtimeService.startProcessInstanceByKey("userTaskProcessId");
+
+    // when - migrate history with auto-cancel TTL disabled
+    historyMigration.getMigrator().migrate();
+
+    // then - user tasks should have null cleanup dates
+    var processInstances = historyMigration.searchHistoricProcessInstances("userTaskProcessId");
+    assertThat(processInstances).hasSize(1);
+    Long processInstanceKey = processInstances.getFirst().processInstanceKey();
+
+    var userTasks = historyMigration.searchHistoricUserTasks(processInstanceKey);
+    assertThat(userTasks).isNotEmpty();
+
+    for (UserTaskEntity userTask : userTasks) {
+      OffsetDateTime cleanupDate = cleanup.getUserTaskCleanupDate(userTask.userTaskKey());
+      assertThat(cleanupDate).isNull();
+    }
+  }
+
+  @Test
+  public void shouldSetNullCleanupDateForVariablesWhenAutoCancelDisabled() {
+    // given - deploy and start a process instance with variables
+    deployer.deployCamunda7Process("userTaskProcess.bpmn");
+    String processInstanceId = runtimeService.startProcessInstanceByKey("userTaskProcessId").getId();
+    runtimeService.setVariable(processInstanceId, "testVar", "testValue");
+
+    // when - migrate history with auto-cancel TTL disabled
+    historyMigration.getMigrator().migrate();
+
+    // then - variables should have null cleanup dates
+    List<ProcessInstanceEntity> processInstances = historyMigration.searchHistoricProcessInstances("userTaskProcessId");
+    assertThat(processInstances).hasSize(1);
+
+    Long processInstanceKey = processInstances.getFirst().processInstanceKey();
+    List<OffsetDateTime> variableCleanupDates = cleanup.getVariableCleanupDates(processInstanceKey);
+
+    assertThat(variableCleanupDates).isNotEmpty();
+    for (OffsetDateTime cleanupDate : variableCleanupDates) {
+      assertThat(cleanupDate).isNull();
+    }
+  }
+}
+

--- a/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/history/cleanup/HistoryCleanupMigrationTest.java
+++ b/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/history/cleanup/HistoryCleanupMigrationTest.java
@@ -1,0 +1,307 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.migration.data.qa.history.cleanup;
+
+import static io.camunda.migration.data.impl.util.ConverterUtil.convertDate;
+import static io.camunda.search.entities.FlowNodeInstanceEntity.FlowNodeType.START_EVENT;
+import static io.camunda.search.entities.FlowNodeInstanceEntity.FlowNodeType.USER_TASK;
+import static io.camunda.search.entities.UserTaskEntity.UserTaskState.CANCELED;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.migration.data.qa.AbstractMigratorTest;
+import io.camunda.migration.data.qa.extension.CleanupExtension;
+import io.camunda.migration.data.qa.extension.HistoryMigrationExtension;
+import io.camunda.migration.data.qa.extension.RdbmsQueryExtension;
+import io.camunda.migration.data.qa.util.ProcessDefinitionDeployer;
+import io.camunda.search.entities.FlowNodeInstanceEntity;
+import io.camunda.search.entities.ProcessInstanceEntity;
+import io.camunda.search.entities.UserTaskEntity;
+import java.time.Duration;
+import java.time.OffsetDateTime;
+import java.util.Date;
+import java.util.List;
+import org.camunda.bpm.engine.RuntimeService;
+import org.camunda.bpm.engine.TaskService;
+import org.camunda.bpm.engine.impl.util.ClockUtil;
+import org.camunda.bpm.engine.task.Task;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
+
+/**
+ * Integration tests for history cleanup date calculation and cascading end dates.
+ *
+ * <p>Uses whitebox testing approach to verify history cleanup behavior:</p>
+ * <ul>
+ *   <li>Direct SQL queries to C8 database tables using {@link RdbmsQueryExtension}</li>
+ *   <li>Verification of HISTORY_CLEANUP_DATE column values</li>
+ *   <li>State conversions (ACTIVE -> CANCELED)</li>
+ *   <li>End date cascading from process instance to child entities</li>
+ * </ul>
+ *
+ * <p>The historyCleanupDate is not exposed via public API, so these tests query
+ * the database directly to verify correct cleanup date calculation (endDate + TTL).</p>
+ */
+@SpringBootTest
+@TestPropertySource(properties = {
+    "camunda.migrator.history.auto-cancel.cleanup.ttl=P30D",
+    "logging.level.io.camunda.migration.data.HistoryMigrator=DEBUG"
+})
+public class HistoryCleanupMigrationTest extends AbstractMigratorTest {
+
+  @RegisterExtension
+  HistoryMigrationExtension historyMigration = new HistoryMigrationExtension();
+
+  @RegisterExtension
+  RdbmsQueryExtension rdbmsQuery = new RdbmsQueryExtension();
+
+  @RegisterExtension
+  CleanupExtension cleanup = new CleanupExtension(rdbmsQuery);
+
+  @Autowired
+  protected ProcessDefinitionDeployer deployer;
+
+  @Autowired
+  protected RuntimeService runtimeService;
+
+  @Autowired
+  protected TaskService taskService;
+
+  @AfterEach
+  public void resetClock() {
+    ClockUtil.reset();
+  }
+
+  @Test
+  public void shouldAutoCancelActiveProcessInstanceWithEndDate() {
+    // given - deploy and start a process instance that remains active
+    deployer.deployCamunda7Process("userTaskProcess.bpmn");
+
+    Date startTime = new Date();
+    ClockUtil.setCurrentTime(startTime);
+    runtimeService.startProcessInstanceByKey("userTaskProcessId");
+
+    Date migrationTime = new Date(startTime.getTime() + 5_000); // +5 seconds
+    ClockUtil.setCurrentTime(migrationTime);
+
+    // when - migrate history
+    historyMigration.getMigrator().migrate();
+
+    // then - process instance should be auto-canceled with endDate set to "now"
+    List<ProcessInstanceEntity> processInstances = historyMigration.searchHistoricProcessInstances("userTaskProcessId");
+    assertThat(processInstances).hasSize(1);
+
+    ProcessInstanceEntity migratedInstance = processInstances.getFirst();
+    // Verify state conversion: ACTIVE -> CANCELED
+    assertThat(migratedInstance.state()).isEqualTo(ProcessInstanceEntity.ProcessInstanceState.CANCELED);
+    // Verify endDate was set to "startTime" during migration
+    assertThat(migratedInstance.endDate())
+        .isNotNull()
+        .isEqualTo(convertDate(migrationTime));
+
+    // Whitebox test: Query database directly to verify history cleanup date
+    Long processInstanceKey = migratedInstance.processInstanceKey();
+    OffsetDateTime cleanupDate = cleanup.getProcessInstanceCleanupDate(processInstanceKey);
+
+    // Verify cleanup date is calculated as endDate + 30 days (from test property)
+    assertThat(cleanupDate).isEqualTo(migratedInstance.endDate().plus(Duration.ofDays(30)));
+  }
+
+  @Test
+  public void shouldKeepOriginalEndDateForCompletedProcessInstance() {
+    // given - deploy and complete a process instance
+    deployer.deployCamunda7Process("userTaskProcess.bpmn");
+
+    Date startTime = new Date();
+    ClockUtil.setCurrentTime(startTime);
+    runtimeService.startProcessInstanceByKey("userTaskProcessId");
+
+    // Complete the user task at a later time
+    Date completionTime = new Date(startTime.getTime() + 5_000); // +5 seconds
+    ClockUtil.setCurrentTime(completionTime);
+    Task task = taskService.createTaskQuery().singleResult();
+    taskService.complete(task.getId());
+
+    // when - migrate history
+    historyMigration.getMigrator().migrate();
+
+    // then - completed process instance should keep its original end date
+    List<ProcessInstanceEntity> processInstances = historyMigration.searchHistoricProcessInstances("userTaskProcessId");
+    assertThat(processInstances).hasSize(1);
+
+    ProcessInstanceEntity migratedInstance = processInstances.getFirst();
+    // Verify state remains COMPLETED
+    assertThat(migratedInstance.state()).isEqualTo(ProcessInstanceEntity.ProcessInstanceState.COMPLETED);
+    // Verify endDate exists and matches the completion time (from C7)
+    assertThat(migratedInstance.endDate())
+        .isNotNull()
+        .isEqualTo(convertDate(completionTime));
+  }
+
+  @Test
+  public void shouldCascadeEndDateToFlowNodesForActiveProcessInstance() {
+    // given - deploy and start a process instance
+    deployer.deployCamunda7Process("userTaskProcess.bpmn");
+    runtimeService.startProcessInstanceByKey("userTaskProcessId");
+
+    // when - migrate history
+    historyMigration.getMigrator().migrate();
+
+    // then - only cancelled/terminated flow nodes should inherit the process instance's end date
+    var processInstances = historyMigration.searchHistoricProcessInstances("userTaskProcessId");
+    assertThat(processInstances).hasSize(1);
+
+    ProcessInstanceEntity migratedInstance = processInstances.getFirst();
+    Long processInstanceKey = migratedInstance.processInstanceKey();
+    OffsetDateTime processInstanceEndDate = migratedInstance.endDate();
+
+    assertThat(processInstanceEndDate).isNotNull();
+
+    // Check start event - should be COMPLETED with its own end date (not cascaded)
+    var startEvents = historyMigration.searchHistoricFlowNodesForType(processInstanceKey, START_EVENT);
+    assertThat(startEvents).hasSize(1);
+    FlowNodeInstanceEntity startEvent = startEvents.getFirst();
+    assertThat(startEvent.state()).isEqualTo(FlowNodeInstanceEntity.FlowNodeState.COMPLETED);
+    assertThat(startEvent.endDate()).isNotEqualTo(processInstanceEndDate);
+
+    // Whitebox: Verify start event cleanup date is cascaded endDate
+    OffsetDateTime startEventCleanupDate = cleanup.getFlowNodeCleanupDate(startEvent.flowNodeInstanceKey());
+    assertThat(startEventCleanupDate).isEqualTo(processInstanceEndDate.plus(Duration.ofDays(30)));
+
+    // Check user task flow node - should be TERMINATED and inherit process instance end date
+    var userTaskFlowNodes = historyMigration.searchHistoricFlowNodesForType(processInstanceKey, USER_TASK);
+    assertThat(userTaskFlowNodes).hasSize(1);
+    FlowNodeInstanceEntity userTaskFlowNode = userTaskFlowNodes.getFirst();
+    assertThat(userTaskFlowNode.state()).isEqualTo(FlowNodeInstanceEntity.FlowNodeState.TERMINATED);
+    assertThat(userTaskFlowNode.endDate()).isEqualTo(processInstanceEndDate);
+
+    // Whitebox: Verify user task flow node cleanup date and cascaded endDate
+    OffsetDateTime userTaskFlowNodeCleanupDate = cleanup.getFlowNodeCleanupDate(userTaskFlowNode.flowNodeInstanceKey());
+    assertThat(userTaskFlowNodeCleanupDate).isEqualTo(processInstanceEndDate.plus(Duration.ofDays(30)));
+  }
+
+  @Test
+  public void shouldCascadeCompletionDateToUserTasksForActiveProcessInstance() {
+    // given - deploy and start a process instance with active user task
+    deployer.deployCamunda7Process("userTaskProcess.bpmn");
+    runtimeService.startProcessInstanceByKey("userTaskProcessId");
+
+    // when - migrate history
+    historyMigration.getMigrator().migrate();
+
+    // then - user task should inherit the process instance's end date as completion date
+    var processInstances = historyMigration.searchHistoricProcessInstances("userTaskProcessId");
+    assertThat(processInstances).hasSize(1);
+
+    ProcessInstanceEntity migratedInstance = processInstances.getFirst();
+    Long processInstanceKey = migratedInstance.processInstanceKey();
+    OffsetDateTime processInstanceEndDate = migratedInstance.endDate();
+
+    List<UserTaskEntity> userTasks = historyMigration.searchHistoricUserTasks(processInstanceKey);
+    assertThat(userTasks).hasSize(1);
+
+    UserTaskEntity userTask = userTasks.getFirst();
+    assertThat(userTask.state()).isEqualTo(CANCELED);
+    assertThat(userTask.completionDate()).isEqualTo(processInstanceEndDate);
+
+    // Whitebox: Verify user task cleanup date and completion date from database
+    OffsetDateTime userTaskCleanupDate = cleanup.getUserTaskCleanupDate(userTask.userTaskKey());
+
+    // Verify cleanup date exists and is properly calculated (completionDate + 30 days)
+    assertThat(userTaskCleanupDate)
+        .as("User task should have history cleanup date")
+        .isNotNull()
+        .isEqualTo(processInstanceEndDate.plusDays(30));
+  }
+
+  @Test
+  public void shouldHandleMultipleActiveProcessInstancesConsistently() {
+    // given - deploy and start multiple active process instances
+    deployer.deployCamunda7Process("userTaskProcess.bpmn");
+    for (int i = 0; i < 3; i++) {
+      runtimeService.startProcessInstanceByKey("userTaskProcessId");
+    }
+
+    // when - migrate history
+    historyMigration.getMigrator().migrate();
+
+    // then - all process instances should be migrated with consistent behavior
+    List<ProcessInstanceEntity> processInstances = historyMigration.searchHistoricProcessInstances("userTaskProcessId");
+    assertThat(processInstances).hasSize(3);
+
+    for (ProcessInstanceEntity instance : processInstances) {
+      // All should be auto-canceled with endDate set
+      assertThat(instance.state()).isEqualTo(ProcessInstanceEntity.ProcessInstanceState.CANCELED);
+      assertThat(instance.endDate()).isNotNull();
+      OffsetDateTime cleanupDate = cleanup.getProcessInstanceCleanupDate(instance.processInstanceKey());
+      assertThat(cleanupDate).isNotNull();
+    }
+  }
+
+  @Test
+  public void shouldCalculateCleanupDateForAllEntityTypes() {
+    // given - deploy and start a process instance with variables
+    deployer.deployCamunda7Process("userTaskProcess.bpmn");
+    runtimeService.startProcessInstanceByKey("userTaskProcessId",
+        java.util.Map.of("testVar1", "value1", "testVar2", 123));
+
+    // when - migrate history
+    historyMigration.getMigrator().migrate();
+
+    // then - verify cleanup dates for all entity types
+    List<ProcessInstanceEntity> processInstances = historyMigration.searchHistoricProcessInstances("userTaskProcessId");
+    assertThat(processInstances).hasSize(1);
+
+    ProcessInstanceEntity migratedInstance = processInstances.getFirst();
+    Long processInstanceKey = migratedInstance.processInstanceKey();
+    OffsetDateTime processInstanceEndDate = migratedInstance.endDate();
+    assertThat(processInstanceEndDate).isNotNull();
+
+    // 1. Verify process instance cleanup date
+    OffsetDateTime piCleanupDate = cleanup.getProcessInstanceCleanupDate(processInstanceKey);
+    assertThat(piCleanupDate).isEqualTo(processInstanceEndDate.plus(Duration.ofDays(30)));
+
+    // 2. Verify all flow node cleanup dates
+    var allFlowNodes = historyMigration.searchHistoricFlowNodesForType(processInstanceKey, START_EVENT);
+    allFlowNodes.addAll(historyMigration.searchHistoricFlowNodesForType(processInstanceKey, USER_TASK));
+
+    for (FlowNodeInstanceEntity flowNode : allFlowNodes) {
+      OffsetDateTime fnCleanupDate = cleanup.getFlowNodeCleanupDate(flowNode.flowNodeInstanceKey());
+      assertThat(fnCleanupDate).isEqualTo(piCleanupDate);
+    }
+
+    // 3. Verify user task cleanup date
+    List<UserTaskEntity> userTasks = historyMigration.searchHistoricUserTasks(processInstanceKey);
+    for (UserTaskEntity userTask : userTasks) {
+      OffsetDateTime utCleanupDate = cleanup.getUserTaskCleanupDate(userTask.userTaskKey());
+
+      // Verify cleanup date is calculated as completionDate + 30 days
+      assertThat(utCleanupDate)
+          .as("User task should have history cleanup date")
+          .isNotNull()
+          .isEqualTo(piCleanupDate);
+    }
+
+    // 4. Verify variable cleanup dates (variables don't have endDate, only cleanup date)
+    List<OffsetDateTime> variableCleanupDates = cleanup.getVariableCleanupDates(processInstanceKey);
+    assertThat(variableCleanupDates).isNotEmpty();
+
+    for (OffsetDateTime varCleanupDate : variableCleanupDates) {
+      // Variables inherit cleanup date from process instance
+      assertThat(varCleanupDate)
+          .as("Variable cleanup date should match process instance cleanup date")
+          .isNotNull()
+          .isEqualTo(piCleanupDate);
+    }
+  }
+
+}
+

--- a/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/history/entity/HistoryProcessInstanceTest.java
+++ b/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/history/entity/HistoryProcessInstanceTest.java
@@ -8,6 +8,7 @@
 package io.camunda.migration.data.qa.history.entity;
 
 import static io.camunda.migration.data.constants.MigratorConstants.C8_DEFAULT_TENANT;
+import static io.camunda.migration.data.impl.util.ConverterUtil.convertDate;
 import static io.camunda.migration.data.impl.util.ConverterUtil.prefixDefinitionId;
 import static io.camunda.migration.data.qa.util.LogMessageFormatter.formatMessage;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -176,9 +177,9 @@ public class HistoryProcessInstanceTest extends HistoryMigrationAbstractTest {
     assertThat(processInstance.processDefinitionKey()).isNotNull();
     assertThat(processInstance.tenantId()).isEqualTo(tenantId);
     assertThat(processInstance.startDate())
-        .isEqualTo(historicProcessInstance.getStartTime().toInstant().atOffset(ZoneOffset.UTC));
+        .isEqualTo(convertDate(historicProcessInstance.getStartTime()));
     assertThat(processInstance.endDate())
-        .isEqualTo(historicProcessInstance.getEndTime().toInstant().atOffset(ZoneOffset.UTC));
+        .isEqualTo(convertDate(historicProcessInstance.getEndTime()));
     assertThat(processInstance.processDefinitionVersion()).isEqualTo(1);
     assertThat(processInstance.processDefinitionVersionTag()).isEqualTo(versionTag);
 

--- a/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/history/entity/HistoryUserTaskTest.java
+++ b/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/history/entity/HistoryUserTaskTest.java
@@ -10,6 +10,7 @@ package io.camunda.migration.data.qa.history.entity;
 import static io.camunda.migration.data.constants.MigratorConstants.C8_DEFAULT_TENANT;
 import static io.camunda.migration.data.impl.util.ConverterUtil.prefixDefinitionId;
 import static io.camunda.migration.data.qa.util.LogMessageFormatter.formatMessage;
+import static io.camunda.search.entities.UserTaskEntity.UserTaskState.CANCELED;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.migration.data.HistoryMigrator;
@@ -166,14 +167,14 @@ public class HistoryUserTaskTest extends HistoryMigrationAbstractTest {
 
     // Check active task
     ProcessInstanceEntity activeProcessInstance = processInstances.stream()
-        .filter(pi -> pi.state() == ProcessInstanceEntity.ProcessInstanceState.ACTIVE)
+        .filter(pi -> pi.state() == ProcessInstanceEntity.ProcessInstanceState.CANCELED)
         .findFirst()
         .orElseThrow();
 
     List<UserTaskEntity> activeUserTasks = searchHistoricUserTasks(activeProcessInstance.processInstanceKey());
     assertThat(activeUserTasks).hasSize(1);
-    assertThat(activeUserTasks.getFirst().state()).isEqualTo(UserTaskEntity.UserTaskState.CREATED);
-    assertThat(activeUserTasks.getFirst().completionDate()).isNull();
+    assertThat(activeUserTasks.getFirst().state()).isEqualTo(CANCELED);
+    assertThat(activeUserTasks.getFirst().completionDate()).isNotNull();
   }
   @Test
   public void shouldMigrateTaskCancelState() {
@@ -238,7 +239,7 @@ public class HistoryUserTaskTest extends HistoryMigrationAbstractTest {
     assertThat(completedTask.elementId()).isEqualTo("userTask1");
 
     UserTaskEntity activeTask = userTasks.stream()
-        .filter(ut -> ut.state() == UserTaskEntity.UserTaskState.CREATED)
+        .filter(ut -> ut.state() == CANCELED)
         .findFirst()
         .orElseThrow();
     assertThat(activeTask.assignee()).isEqualTo("user2");

--- a/data-migrator/qa/integration-tests/src/test/resources/io/camunda/migration/data/bpmn/c7/twoUserTasksProcess.bpmn
+++ b/data-migrator/qa/integration-tests/src/test/resources/io/camunda/migration/data/bpmn/c7/twoUserTasksProcess.bpmn
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1a10piy" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.41.0" modeler:executionPlatform="Camunda Platform" modeler:executionPlatformVersion="7.21.0">
+  <bpmn:process id="twoUserTasksProcessId" name="UserTaskProcess" isExecutable="true" camunda:versionTag="custom-version-tag" camunda:historyTimeToLive="1">
+    <bpmn:startEvent id="StartEvent_1" name="Start">
+      <bpmn:outgoing>Flow_0xg7od7</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_0xg7od7" sourceRef="StartEvent_1" targetRef="userTaskId" />
+    <bpmn:endEvent id="Event_0togu4y" name="End">
+      <bpmn:incoming>Flow_1tr87r0</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1ur86ut" sourceRef="userTaskId" targetRef="Activity_12ansq9" />
+    <bpmn:userTask id="userTaskId" name="task one">
+      <bpmn:incoming>Flow_0xg7od7</bpmn:incoming>
+      <bpmn:outgoing>Flow_1ur86ut</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:userTask id="Activity_12ansq9" name="task two">
+      <bpmn:incoming>Flow_1ur86ut</bpmn:incoming>
+      <bpmn:outgoing>Flow_1tr87r0</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:sequenceFlow id="Flow_1tr87r0" sourceRef="Activity_12ansq9" targetRef="Event_0togu4y" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="userTaskProcessId">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="99" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="186" y="142" width="24" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0yurv1b_di" bpmnElement="userTaskId">
+        <dc:Bounds x="270" y="77" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0togu4y_di" bpmnElement="Event_0togu4y">
+        <dc:Bounds x="642" y="99" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="650" y="142" width="20" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1gzvxr0" bpmnElement="Activity_12ansq9">
+        <dc:Bounds x="450" y="77" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0xg7od7_di" bpmnElement="Flow_0xg7od7">
+        <di:waypoint x="215" y="117" />
+        <di:waypoint x="270" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1ur86ut_di" bpmnElement="Flow_1ur86ut">
+        <di:waypoint x="370" y="117" />
+        <di:waypoint x="450" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1tr87r0_di" bpmnElement="Flow_1tr87r0">
+        <di:waypoint x="550" y="117" />
+        <di:waypoint x="642" y="117" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>


### PR DESCRIPTION
related to camunda/camunda-7-to-8-migration-tooling#599

# Pull Request Template

## Description
<!-- Describe your changes in detail -->

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Test-only changes (no production code changes)

## Testing Checklist

### Black-Box Testing Requirements
- [ ] Tests follow **black-box testing approach**: verify behavior through observable outputs (logs, C8 API queries, real-world skip scenarios)
- [ ] Tests **DO NOT** access implementation details (`DbClient`, `IdKeyMapper`, `..impl..` packages except logging constants)
- [ ] Architecture tests pass (`ArchitectureTest` validates these rules)

### Test Coverage
- [ ] Added tests for new functionality
- [ ] Updated tests for modified functionality
- [ ] All tests pass locally

## Architecture Compliance

Run architecture tests to ensure compliance:
```bash
mvn test -Dtest=ArchitectureTest
```

If architecture tests fail, refactor your tests to use:
- `LogCapturer` for log assertions
- `camundaClient.new*SearchRequest()` for C8 queries
- Real-World skip scenarios (e.g., migrate children without parents)

## Documentation
- [ ] Updated TESTING_GUIDELINES.md if adding new test patterns
- [ ] Added Javadoc comments for public APIs
- [ ] Updated README if user-facing changes

## Checklist
- [ ] Code follows project style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments for complex logic
- [ ] No new compiler warnings
- [ ] Dependent changes have been merged

## Related Issues
<!-- Link to related issues: Fixes #123, Related to #456 -->

