### PR TITLE
fix(tests): fix identity authorization registry tests

### DIFF
--- a/data-migrator/core/src/test/java/io/camunda/migration/data/impl/identity/AuthorizationEntityRegistryTest.java
+++ b/data-migrator/core/src/test/java/io/camunda/migration/data/impl/identity/AuthorizationEntityRegistryTest.java
@@ -11,6 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.client.api.search.enums.PermissionType;
 import io.camunda.client.api.search.enums.ResourceType;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import java.util.Set;
 import org.camunda.bpm.engine.authorization.BatchPermissions;
 import org.camunda.bpm.engine.authorization.Permissions;
@@ -53,7 +54,7 @@ class AuthorizationEntityRegistryTest {
     assertThat(entry.needsToAdaptId()).isTrue();
 
     assertThat(entry.getMappedPermissions(Permissions.ACCESS)).containsExactlyInAnyOrder(PermissionType.ACCESS);
-    assertThat(entry.getMappedPermissions(Permissions.ALL)).containsExactlyInAnyOrder(PermissionType.ACCESS);
+    assertThat(entry.getMappedPermissions(Permissions.ALL)).containsExactlyInAnyOrder(getAllSupportedPerms(ResourceType.COMPONENT));
   }
 
   @Test
@@ -70,11 +71,7 @@ class AuthorizationEntityRegistryTest {
     assertThat(entry.getMappedPermissions(Permissions.UPDATE)).containsExactlyInAnyOrder(PermissionType.UPDATE);
     assertThat(entry.getMappedPermissions(Permissions.CREATE)).containsExactlyInAnyOrder(PermissionType.CREATE);
     assertThat(entry.getMappedPermissions(Permissions.DELETE)).containsExactlyInAnyOrder(PermissionType.DELETE);
-    assertThat(entry.getMappedPermissions(Permissions.ALL)).containsExactlyInAnyOrder(
-        PermissionType.READ,
-        PermissionType.UPDATE,
-        PermissionType.CREATE,
-        PermissionType.DELETE);
+    assertThat(entry.getMappedPermissions(Permissions.ALL)).containsExactlyInAnyOrder(getAllSupportedPerms(ResourceType.AUTHORIZATION));
   }
 
   @Test
@@ -91,11 +88,7 @@ class AuthorizationEntityRegistryTest {
     assertThat(entry.getMappedPermissions(Permissions.UPDATE)).containsExactlyInAnyOrder(PermissionType.UPDATE);
     assertThat(entry.getMappedPermissions(Permissions.CREATE)).containsExactlyInAnyOrder(PermissionType.CREATE);
     assertThat(entry.getMappedPermissions(Permissions.DELETE)).containsExactlyInAnyOrder(PermissionType.DELETE);
-    assertThat(entry.getMappedPermissions(Permissions.ALL)).containsExactlyInAnyOrder(
-        PermissionType.READ,
-        PermissionType.UPDATE,
-        PermissionType.CREATE,
-        PermissionType.DELETE);
+    assertThat(entry.getMappedPermissions(Permissions.ALL)).containsExactlyInAnyOrder(getAllSupportedPerms(ResourceType.GROUP));
   }
 
   @Test
@@ -122,10 +115,7 @@ class AuthorizationEntityRegistryTest {
     assertThat(entry.needsToAdaptId()).isFalse();
 
     assertThat(entry.getMappedPermissions(SystemPermissions.READ)).containsExactlyInAnyOrder(PermissionType.READ, PermissionType.READ_USAGE_METRIC);
-    assertThat(entry.getMappedPermissions(SystemPermissions.ALL)).containsExactlyInAnyOrder(
-        PermissionType.READ,
-        PermissionType.READ_USAGE_METRIC,
-        PermissionType.UPDATE);
+    assertThat(entry.getMappedPermissions(SystemPermissions.ALL)).containsExactlyInAnyOrder(getAllSupportedPerms(ResourceType.SYSTEM));
   }
 
   @Test
@@ -148,18 +138,7 @@ class AuthorizationEntityRegistryTest {
     assertThat(entry.getMappedPermissions(BatchPermissions.CREATE_BATCH_DELETE_FINISHED_PROCESS_INSTANCES)).containsExactlyInAnyOrder(PermissionType.CREATE_BATCH_OPERATION_DELETE_PROCESS_INSTANCE);
     assertThat(entry.getMappedPermissions(BatchPermissions.CREATE_BATCH_DELETE_DECISION_INSTANCES)).containsExactlyInAnyOrder(PermissionType.CREATE_BATCH_OPERATION_DELETE_DECISION_INSTANCE);
 
-    assertThat(entry.getMappedPermissions(BatchPermissions.ALL)).containsExactlyInAnyOrder(
-        PermissionType.READ,
-        PermissionType.UPDATE,
-        PermissionType.CREATE,
-        PermissionType.CREATE_BATCH_OPERATION_RESOLVE_INCIDENT,
-        PermissionType.CREATE_BATCH_OPERATION_MODIFY_PROCESS_INSTANCE,
-        PermissionType.CREATE_BATCH_OPERATION_MIGRATE_PROCESS_INSTANCE,
-        PermissionType.CREATE_BATCH_OPERATION_DELETE_PROCESS_INSTANCE,
-        PermissionType.CREATE_BATCH_OPERATION_CANCEL_PROCESS_INSTANCE,
-        PermissionType.CREATE_BATCH_OPERATION_DELETE_DECISION_INSTANCE,
-        PermissionType.CREATE_BATCH_OPERATION_DELETE_PROCESS_DEFINITION,
-        PermissionType.CREATE_BATCH_OPERATION_DELETE_DECISION_DEFINITION);
+    assertThat(entry.getMappedPermissions(BatchPermissions.ALL)).containsExactlyInAnyOrder(getAllSupportedPerms(ResourceType.BATCH));
   }
 
   @Test
@@ -176,11 +155,7 @@ class AuthorizationEntityRegistryTest {
     assertThat(entry.getMappedPermissions(Permissions.UPDATE)).containsExactlyInAnyOrder(PermissionType.UPDATE);
     assertThat(entry.getMappedPermissions(Permissions.CREATE)).containsExactlyInAnyOrder(PermissionType.CREATE);
     assertThat(entry.getMappedPermissions(Permissions.DELETE)).containsExactlyInAnyOrder(PermissionType.DELETE);
-    assertThat(entry.getMappedPermissions(Permissions.ALL)).containsExactlyInAnyOrder(
-        PermissionType.READ,
-        PermissionType.UPDATE,
-        PermissionType.CREATE,
-        PermissionType.DELETE);
+    assertThat(entry.getMappedPermissions(Permissions.ALL)).containsExactlyInAnyOrder(getAllSupportedPerms(ResourceType.TENANT));
   }
 
   @Test
@@ -210,10 +185,15 @@ class AuthorizationEntityRegistryTest {
     assertThat(entry.getMappedPermissions(Permissions.UPDATE)).containsExactlyInAnyOrder(PermissionType.UPDATE);
     assertThat(entry.getMappedPermissions(Permissions.CREATE)).containsExactlyInAnyOrder(PermissionType.CREATE);
     assertThat(entry.getMappedPermissions(Permissions.DELETE)).containsExactlyInAnyOrder(PermissionType.DELETE);
-    assertThat(entry.getMappedPermissions(Permissions.ALL)).containsExactlyInAnyOrder(
-        PermissionType.READ,
-        PermissionType.UPDATE,
-        PermissionType.CREATE,
-        PermissionType.DELETE);
+    assertThat(entry.getMappedPermissions(Permissions.ALL)).containsExactlyInAnyOrder(getAllSupportedPerms(ResourceType.USER));
+  }
+
+  protected static PermissionType[] getAllSupportedPerms(ResourceType resourceType) {
+    return AuthorizationResourceType
+        .valueOf(resourceType.name())
+        .getSupportedPermissionTypes()
+        .stream()
+        .map(permissionType -> PermissionType.valueOf(permissionType.name()))
+        .toArray(PermissionType[]::new);
   }
 }


### PR DESCRIPTION
Context in this [thread](https://camunda.slack.com/archives/C036ZURJFMX/p1768323377894509).
CI failure github.com/camunda/camunda-7-to-8-migration-tooling/actions/runs/20956295333/job/60249831975.

# Pull Request Template

## Description
<!-- Describe your changes in detail -->

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Test-only changes (no production code changes)

## Testing Checklist

### Black-Box Testing Requirements
- [ ] Tests follow **black-box testing approach**: verify behavior through observable outputs (logs, C8 API queries, real-world skip scenarios)
- [ ] Tests **DO NOT** access implementation details (`DbClient`, `IdKeyMapper`, `..impl..` packages except logging constants)
- [ ] Architecture tests pass (`ArchitectureTest` validates these rules)

### Test Coverage
- [ ] Added tests for new functionality
- [ ] Updated tests for modified functionality
- [ ] All tests pass locally

## Architecture Compliance

Run architecture tests to ensure compliance:
```bash
mvn test -Dtest=ArchitectureTest
```

If architecture tests fail, refactor your tests to use:
- `LogCapturer` for log assertions
- `camundaClient.new*SearchRequest()` for C8 queries
- Real-World skip scenarios (e.g., migrate children without parents)

## Documentation
- [ ] Updated TESTING_GUIDELINES.md if adding new test patterns
- [ ] Added Javadoc comments for public APIs
- [ ] Updated README if user-facing changes

## Checklist
- [ ] Code follows project style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments for complex logic
- [ ] No new compiler warnings
- [ ] Dependent changes have been merged

## Related Issues
<!-- Link to related issues: Fixes #123, Related to #456 -->

