### PR TITLE
fix(diagram-converter): declare version for zeebe-bpmn-model

### DIFF
--- a/diagram-converter/pom.xml
+++ b/diagram-converter/pom.xml
@@ -55,6 +55,11 @@
         <scope>import</scope>
       </dependency>
       <dependency>
+        <groupId>io.camunda</groupId>
+        <artifactId>zeebe-bpmn-model</artifactId>
+        <version>${version.camunda-8}</version>
+      </dependency>
+      <dependency>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-dependencies</artifactId>
         <version>${version.spring-boot}</version>


### PR DESCRIPTION
Fixing main CI.
This is related to: https://github.com/camunda/camunda/commit/a2c3939ee300e0f6497ecff61c86da2d43c93b91
Camunda BOM changed and we need to specify the version for `zeebe-bpmn-model`