### PR TITLE
exclude DropSchemaTest from pg/orcl CI

### DIFF
--- a/data-migrator/qa/integration-tests/pom.xml
+++ b/data-migrator/qa/integration-tests/pom.xml
@@ -183,6 +183,9 @@
               <systemPropertyVariables>
                 <spring.profiles.active>postgresql</spring.profiles.active>
               </systemPropertyVariables>
+              <excludes>
+                <exclude>**/DropSchemaTest.java</exclude>
+              </excludes>
             </configuration>
           </plugin>
         </plugins>
@@ -199,6 +202,9 @@
               <systemPropertyVariables>
                 <spring.profiles.active>oracle</spring.profiles.active>
               </systemPropertyVariables>
+              <excludes>
+                <exclude>**/DropSchemaTest.java</exclude>
+              </excludes>
             </configuration>
           </plugin>
         </plugins>
@@ -232,10 +238,12 @@
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
-              <excludes>
-                <exclude>**/history/**</exclude>
-                <exclude>**/identity/**</exclude>
-              </excludes>
+              <includes>
+                <include>**/distribution/**</include>
+                <include>**/persistence/**</include>
+                <include>**/runtime/**</include>
+                <include>ArchitectureTest.java</include>
+              </includes>
             </configuration>
           </plugin>
         </plugins>
@@ -251,6 +259,7 @@
             <configuration>
               <includes>
                 <include>**/history/**</include>
+                <include>ArchitectureTest.java</include>
               </includes>
             </configuration>
           </plugin>
@@ -267,6 +276,7 @@
             <configuration>
               <includes>
                 <include>**/identity/**</include>
+                <include>ArchitectureTest.java</include>
               </includes>
             </configuration>
           </plugin>

--- a/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/persistence/DropSchemaTest.java
+++ b/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/persistence/DropSchemaTest.java
@@ -12,7 +12,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.zaxxer.hikari.HikariDataSource;
 import io.camunda.migration.data.HistoryMigrator;
 import io.camunda.migration.data.qa.MigrationTestApplication;
-import io.camunda.migration.data.qa.util.WithMultiDb;
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
 import java.sql.PreparedStatement;
@@ -23,13 +22,10 @@ import javax.sql.DataSource;
 import org.camunda.bpm.engine.RepositoryService;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.context.ConfigurableApplicationContext;
 
-@WithMultiDb
-@Disabled
 public class DropSchemaTest {
 
   protected static final String MIGRATION_MAPPING_TABLE = "MIGRATION_MAPPING";


### PR DESCRIPTION
https://github.com/camunda/camunda-7-to-8-migration-tooling/issues/945

# Pull Request Template

## Description
<!-- Describe your changes in detail -->

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Test-only changes (no production code changes)

## Testing Checklist

### Black-Box Testing Requirements
- [ ] Tests follow **black-box testing approach**: verify behavior through observable outputs (logs, C8 API queries, real-world skip scenarios)
- [ ] Tests **DO NOT** access implementation details (`DbClient`, `IdKeyMapper`, `..impl..` packages except logging constants)
- [ ] Architecture tests pass (`ArchitectureTest` validates these rules)

### Test Coverage
- [ ] Added tests for new functionality
- [ ] Updated tests for modified functionality
- [ ] All tests pass locally

## Architecture Compliance

Run architecture tests to ensure compliance:
```bash
mvn test -Dtest=ArchitectureTest
```

If architecture tests fail, refactor your tests to use:
- `LogCapturer` for log assertions
- `camundaClient.new*SearchRequest()` for C8 queries
- Real-World skip scenarios (e.g., migrate children without parents)

## Documentation
- [ ] Updated TESTING_GUIDELINES.md if adding new test patterns
- [ ] Added Javadoc comments for public APIs
- [ ] Updated README if user-facing changes

## Checklist
- [ ] Code follows project style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments for complex logic
- [ ] No new compiler warnings
- [ ] Dependent changes have been merged

## Related Issues
<!-- Link to related issues: Fixes #123, Related to #456 -->

