### PR TITLE
fix(tests): adjust customHeaders assertion HistoryUserTaskTest

### DIFF
--- a/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/history/entity/HistoryUserTaskTest.java
+++ b/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/history/entity/HistoryUserTaskTest.java
@@ -16,7 +16,6 @@ import static io.camunda.search.entities.UserTaskEntity.UserTaskState.CANCELED;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.migration.data.HistoryMigrator;
-import io.camunda.migration.data.impl.persistence.IdKeyMapper;
 import io.camunda.migration.data.qa.history.HistoryMigrationAbstractTest;
 import io.camunda.search.entities.ProcessInstanceEntity;
 import io.camunda.search.entities.UserTaskEntity;
@@ -147,7 +146,7 @@ public class HistoryUserTaskTest extends HistoryMigrationAbstractTest {
     Task task1 = taskService.createTaskQuery().processInstanceId(processInstance1.getId()).singleResult();
     taskService.complete(task1.getId());
 
-    ProcessInstance processInstance2 = runtimeService.startProcessInstanceByKey("userTaskProcessId");
+    runtimeService.startProcessInstanceByKey("userTaskProcessId");
 
     // when
     historyMigrator.migrate();
@@ -210,7 +209,7 @@ public class HistoryUserTaskTest extends HistoryMigrationAbstractTest {
   public void shouldMigrateMultipleTasks() {
     // given
     deployer.deployCamunda7Process("simpleProcess.bpmn");
-    ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("simpleProcess");
+    runtimeService.startProcessInstanceByKey("simpleProcess");
 
     // Complete first user task
     Task task1 = taskService.createTaskQuery().taskDefinitionKey("userTask1").singleResult();
@@ -384,7 +383,7 @@ public class HistoryUserTaskTest extends HistoryMigrationAbstractTest {
     // Fields that are currently null in converter
     assertThat(userTask.formKey()).isNull();
     assertThat(userTask.externalFormReference()).isNull();
-    assertThat(userTask.customHeaders()).isNull();
+    assertThat(userTask.customHeaders()).isEmpty();
     assertThat(userTask.tags()).isEmpty();
     assertThat(userTask.candidateGroups()).isEmpty();
     assertThat(userTask.candidateUsers()).isEmpty();


### PR DESCRIPTION
# Pull Request Template

## Description
<!-- Describe your changes in detail -->
Fix test failure
```
[ERROR]   HistoryUserTaskTest.shouldMigrateTaskBasicFields:67->assertUserTaskFields:387 
2026-02-20T06:18:06.5945152Z expected: null
2026-02-20T06:18:06.5953512Z  but was: {}
```
related to https://github.com/camunda/camunda/pull/46228

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Test-only changes (no production code changes)

## Testing Checklist

### Black-Box Testing Requirements
- [ ] Tests follow **black-box testing approach**: verify behavior through observable outputs (logs, C8 API queries, real-world skip scenarios)
- [ ] Tests **DO NOT** access implementation details (`DbClient`, `IdKeyMapper`, `..impl..` packages except logging constants)
- [ ] Architecture tests pass (`ArchitectureTest` validates these rules)

### Test Coverage
- [ ] Added tests for new functionality
- [ ] Updated tests for modified functionality
- [ ] All tests pass locally

## Architecture Compliance

Run architecture tests to ensure compliance:
```bash
mvn test -Dtest=ArchitectureTest
```

If architecture tests fail, refactor your tests to use:
- `LogCapturer` for log assertions
- `camundaClient.new*SearchRequest()` for C8 queries
- Real-World skip scenarios (e.g., migrate children without parents)

## Documentation
- [ ] Updated TESTING_GUIDELINES.md if adding new test patterns
- [ ] Added Javadoc comments for public APIs
- [ ] Updated README if user-facing changes

## Checklist
- [ ] Code follows project style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments for complex logic
- [ ] No new compiler warnings
- [ ] Dependent changes have been merged

## Related Issues
<!-- Link to related issues: Fixes #123, Related to #456 -->

