### PR TITLE
chore(migrator): remove empty business key test

### DIFF
--- a/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/history/entity/HistoryProcessInstanceTest.java
+++ b/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/history/entity/HistoryProcessInstanceTest.java
@@ -405,30 +405,6 @@ public class HistoryProcessInstanceTest extends HistoryMigrationAbstractTest {
   }
 
   @Test
-  public void shouldMigrateProcessInstanceTagsWithEmptyBusinessKey() {
-    // given
-    deployer.deployCamunda7Process("simpleProcess.bpmn");
-
-    var processInstance = runtimeService.startProcessInstanceByKey("simpleProcess", "");
-
-    var task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
-    if (task != null) {
-      taskService.complete(task.getId());
-    }
-
-    // when
-    historyMigrator.migrate();
-
-    // then
-    List<ProcessInstanceEntity> migratedProcessInstances =
-        searchHistoricProcessInstances("simpleProcess");
-    assertThat(migratedProcessInstances).isNotEmpty();
-
-    assertThat(migratedProcessInstances.getFirst().tags()).containsOnly(C7_LEGACY_ID_PREFIX + processInstance.getId());
-    assertThat(migratedProcessInstances.getFirst().businessId()).isEmpty();
-  }
-
-  @Test
   public void shouldMigrateProcessInstanceTags() {
     // given
     deployer.deployCamunda7Process("simpleProcess.bpmn");


### PR DESCRIPTION
# Pull Request Template

## Description
<!-- Describe your changes in detail -->
Empty strings are stores as `null` in Oracle. ref: https://docs.oracle.com/en/database/oracle/oracle-database/26/sqlrf/Nulls.html#GUID-B0BA4751-9D88-426A-84AD-BCDBD5584071

The test with empty businessKey is passing for all db except for Oracle.
Have an empty string for a businessKey is a corner case that's unlikely in C7.
When evaluating to fix/exclude the test for Oracle, I think the test doesn't bring so much value as we migrate the data as it is.


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Test-only changes (no production code changes)

## Testing Checklist

### Black-Box Testing Requirements
- [ ] Tests follow **black-box testing approach**: verify behavior through observable outputs (logs, C8 API queries, real-world skip scenarios)
- [ ] Tests **DO NOT** access implementation details (`DbClient`, `IdKeyMapper`, `..impl..` packages except logging constants)
- [ ] Architecture tests pass (`ArchitectureTest` validates these rules)

### Test Coverage
- [ ] Added tests for new functionality
- [ ] Updated tests for modified functionality
- [ ] All tests pass locally

## Architecture Compliance

Run architecture tests to ensure compliance:
```bash
mvn test -Dtest=ArchitectureTest
```

If architecture tests fail, refactor your tests to use:
- `LogCapturer` for log assertions
- `camundaClient.new*SearchRequest()` for C8 queries
- Real-World skip scenarios (e.g., migrate children without parents)

## Documentation
- [ ] Updated TESTING_GUIDELINES.md if adding new test patterns
- [ ] Added Javadoc comments for public APIs
- [ ] Updated README if user-facing changes

## Checklist
- [ ] Code follows project style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments for complex logic
- [ ] No new compiler warnings
- [ ] Dependent changes have been merged

## Related Issues
<!-- Link to related issues: Fixes #123, Related to #456 -->

