### PR TITLE
fix(IT): fix tenant retry IT

### DIFF
--- a/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/identity/IdentityTestHelper.java
+++ b/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/identity/IdentityTestHelper.java
@@ -178,6 +178,11 @@ public class IdentityTestHelper {
     logs.assertContains(formatMessage(SKIPPED_TENANT, tenantId, tenantName == null ? "null" : tenantName, reason));
   }
 
+  protected void assertNoMembershipsForTenant(String tenantId) {
+    List<TenantUser> usersForTenant = camundaClient.newUsersByTenantSearchRequest(tenantId).execute().items();
+    assertThat(usersForTenant).isEmpty();
+  }
+
   protected void assertThatUsersForTenantContainExactly(String tenantId, String... usernames) {
     List<TenantUser> usersForTenant = camundaClient.newUsersByTenantSearchRequest(tenantId).execute().items();
     assertThat(usersForTenant).extracting(TenantUser::getUsername).containsExactlyInAnyOrder(usernames);

--- a/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/identity/RetryTenantMigrationTest.java
+++ b/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/identity/RetryTenantMigrationTest.java
@@ -132,8 +132,11 @@ public class RetryTenantMigrationTest extends IdentityMigrationAbstractTest {
     testHelper.createUserInC8("userId2", "firstName2", "lastName2");
     identityService.createTenantUserMembership(t1.getId(), "userId1");
     identityService.createTenantUserMembership(t1.getId(), "userId2");
+
     identityMigrator.start();
-    testHelper.verifyTenantSkippedViaLogs(t1.getId(), t1.getName(), "No name provided.", logs);
+
+    // verify membership migration was skipped
+    testHelper.assertNoMembershipsForTenant(t1.getId());
 
     // when issue with tenant is fixed
     t1.setName("Tenant1");


### PR DESCRIPTION
related to failures on main

# Pull Request Template

## Description
Changing the tenant retry test case due to an [issue with oracle interpreting empty strings as null](https://confluence.camunda.com/pages/viewpage.action?pageId=110233192&spaceKey=AP&title=Empty%2BStrings) meaning the asserted logs are DB dependent. Adjusting the test case to avoid logs assertion

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Test-only changes (no production code changes)

## Testing Checklist

### Black-Box Testing Requirements
- [ ] Tests follow **black-box testing approach**: verify behavior through observable outputs (logs, C8 API queries, real-world skip scenarios)
- [ ] Tests **DO NOT** access implementation details (`DbClient`, `IdKeyMapper`, `..impl..` packages except logging constants)
- [ ] Architecture tests pass (`ArchitectureTest` validates these rules)

### Test Coverage
- [ ] Added tests for new functionality
- [ ] Updated tests for modified functionality
- [ ] All tests pass locally

## Architecture Compliance

Run architecture tests to ensure compliance:
```bash
mvn test -Dtest=ArchitectureTest
```

If architecture tests fail, refactor your tests to use:
- `LogCapturer` for log assertions
- `camundaClient.new*SearchRequest()` for C8 queries
- Real-World skip scenarios (e.g., migrate children without parents)

## Documentation
- [ ] Updated TESTING_GUIDELINES.md if adding new test patterns
- [ ] Added Javadoc comments for public APIs
- [ ] Updated README if user-facing changes

## Checklist
- [ ] Code follows project style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments for complex logic
- [ ] No new compiler warnings
- [ ] Dependent changes have been merged

## Related Issues
related to failures on main

