### PR TITLE
fix(dmn): fix dmn output ruleindex

### DIFF
--- a/data-migrator/core/src/main/java/io/camunda/migration/data/impl/clients/C7Client.java
+++ b/data-migrator/core/src/main/java/io/camunda/migration/data/impl/clients/C7Client.java
@@ -96,6 +96,7 @@ import org.springframework.stereotype.Component;
 @Component
 public class C7Client {
 
+
   @Autowired
   protected RuntimeService runtimeService;
 

--- a/data-migrator/core/src/main/java/io/camunda/migration/data/impl/interceptor/history/entity/DecisionInstanceTransformer.java
+++ b/data-migrator/core/src/main/java/io/camunda/migration/data/impl/interceptor/history/entity/DecisionInstanceTransformer.java
@@ -16,16 +16,26 @@ import static io.camunda.migration.data.impl.util.ConverterUtil.prefixDefinition
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.migration.data.exception.EntityInterceptorException;
+import io.camunda.migration.data.impl.VariableService;
+import io.camunda.migration.data.impl.clients.C7Client;
+import io.camunda.migration.data.impl.logging.HistoryMigratorLogs;
 import io.camunda.migration.data.interceptor.EntityInterceptor;
 import io.camunda.search.entities.DecisionInstanceEntity;
-import io.camunda.migration.data.impl.VariableService;
-import io.camunda.migration.data.exception.EntityInterceptorException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import org.camunda.bpm.engine.history.HistoricDecisionInputInstance;
 import org.camunda.bpm.engine.history.HistoricDecisionInstance;
 import org.camunda.bpm.engine.history.HistoricDecisionOutputInstance;
 import org.camunda.bpm.engine.impl.variable.serializer.ValueFields;
+import org.camunda.bpm.model.dmn.DmnModelInstance;
+import org.camunda.bpm.model.dmn.instance.Decision;
+import org.camunda.bpm.model.dmn.instance.DecisionTable;
+import org.camunda.bpm.model.dmn.instance.Rule;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
@@ -33,6 +43,9 @@ import org.springframework.stereotype.Component;
 @Order(11)
 @Component
 public class DecisionInstanceTransformer implements EntityInterceptor<HistoricDecisionInstance, Builder> {
+
+  @Autowired
+  protected C7Client c7Client;
 
   @Autowired
   protected VariableService variableService;
@@ -47,7 +60,7 @@ public class DecisionInstanceTransformer implements EntityInterceptor<HistoricDe
 
   @Override
   public void execute(HistoricDecisionInstance entity, Builder builder) {
-    var evaluatedOutputs = mapOutputs(entity.getId(), entity.getOutputs());
+    var evaluatedOutputs = mapOutputs(entity, entity.getOutputs());
 
     String resultJsonString;
     var collectResultValue = entity.getCollectResultValue();
@@ -82,14 +95,67 @@ public class DecisionInstanceTransformer implements EntityInterceptor<HistoricDe
     )).toList();
   }
 
-  protected List<EvaluatedOutput> mapOutputs(String decisionInstanceId,
+
+  protected List<EvaluatedOutput> mapOutputs(HistoricDecisionInstance decisionInstance,
                                              List<HistoricDecisionOutputInstance> c7Outputs) {
-    return c7Outputs.stream().map(output -> new EvaluatedOutput(decisionInstanceId,
-        output.getId(),
-        output.getClauseName(),
-        variableService.convertValue((ValueFields) output),
-        output.getRuleId(),
-        output.getRuleOrder() != null ? output.getRuleOrder() : 1)).toList();
+    Map<String, Integer> ruleIndexById = buildRuleIndexMap(decisionInstance);
+
+    return c7Outputs.stream()
+        .map(output -> new EvaluatedOutput(
+            decisionInstance.getId(),
+            output.getId(),
+            output.getClauseName(),
+            variableService.convertValue((ValueFields) output),
+            output.getRuleId(),
+            resolveRuleIndex(output, ruleIndexById)))
+        .toList();
+  }
+
+  /**
+   * Builds a map of DMN rule ID to 1-based row index for the given decision definition.
+   * Falls back to an empty map when the DMN cannot be resolved or is not a decision table.
+   *
+   * @param entity the C7 historic decision instance whose definition should be looked up
+   * @return a map of rule ID to 1-based row index; empty on any resolution failure
+   */
+  protected Map<String, Integer> buildRuleIndexMap(HistoricDecisionInstance entity) {
+    try {
+      DmnModelInstance dmn = c7Client.getDmnModelInstance(entity.getDecisionDefinitionId());
+      Decision decision = dmn.getModelElementById(entity.getDecisionDefinitionKey());
+      if (decision == null || !(decision.getExpression() instanceof DecisionTable decisionTable)) {
+        return Collections.emptyMap();
+      }
+      Map<String, Integer> ruleIndexMap = new HashMap<>();
+      int index = 1;
+      for (Rule rule : decisionTable.getRules()) {
+        String ruleId = rule.getId();
+        if (ruleId != null && !ruleId.isEmpty()) {
+          ruleIndexMap.put(ruleId, index);
+        }
+        index++;
+      }
+      return Collections.unmodifiableMap(ruleIndexMap);
+    } catch (Exception e) {
+      HistoryMigratorLogs.logCouldNotBuildDecisionRuleIndex(entity.getDecisionDefinitionId());
+      return Collections.emptyMap();
+    }
+  }
+
+  /**
+   * Resolves the 1-based row index for an output from the DMN rule ID map.
+   * Falls back to 1 if the rule ID is absent or not found in the map.
+   *
+   * @param output        the C7 decision output instance whose rule ID is to be looked up
+   * @param ruleIndexById map of DMN rule ID to 1-based row index, built from the DMN model
+   * @return the resolved 1-based row index, or 1 as a fallback
+   */
+  protected int resolveRuleIndex(HistoricDecisionOutputInstance output,
+                                 Map<String, Integer> ruleIndexById) {
+    String ruleId = output.getRuleId();
+    if (ruleId != null && !ruleId.isEmpty()) {
+      return ruleIndexById.getOrDefault(ruleId, 1);
+    }
+    return 1;
   }
 
   protected String constructResultFromCollectValue(Double collectResultValue) {
@@ -111,7 +177,7 @@ public class DecisionInstanceTransformer implements EntityInterceptor<HistoricDe
     }
 
     try {
-      List<Object> parsedValues = new java.util.ArrayList<>();
+      List<Object> parsedValues = new ArrayList<>();
       for (EvaluatedOutput output : outputValues) {
         String jsonValue = output.value();
         Object parsedValue = objectMapper.readValue(jsonValue, Object.class);
@@ -119,7 +185,7 @@ public class DecisionInstanceTransformer implements EntityInterceptor<HistoricDe
       }
 
       if (parsedValues.size() == 1) {
-        return objectMapper.writeValueAsString(parsedValues.get(0));
+        return objectMapper.writeValueAsString(parsedValues.getFirst());
       }
 
       return objectMapper.writeValueAsString(parsedValues);

--- a/data-migrator/core/src/main/java/io/camunda/migration/data/impl/logging/HistoryMigratorLogs.java
+++ b/data-migrator/core/src/main/java/io/camunda/migration/data/impl/logging/HistoryMigratorLogs.java
@@ -78,6 +78,8 @@ public class HistoryMigratorLogs {
   public static final String UNSUPPORTED_AUDIT_LOG_OPERATION_TYPE = "Unsupported audit log operation type";
   public static final String INSERT_VARIABLE_WITH_LEGACY_C7_ID = "Inserted variable [{}] to "
       + "migrated process instance with legacy C7 ID [{}].";
+  public static final String COULD_NOT_BUILD_DECISION_RULE_INDEX = "Could not build ruleIndex map for decision "
+    + "definition [{}]; rule indices will fallback to 1.";
 
   public static void logMigrating(IdKeyMapper.TYPE type) {
     LOGGER.info(MIGRATING, type.getDisplayName());
@@ -163,5 +165,9 @@ public class HistoryMigratorLogs {
 
   public static void logInsertLegacyIdAsVariable(String c7Id) {
     LOGGER.debug(INSERT_VARIABLE_WITH_LEGACY_C7_ID, LEGACY_ID_VAR_NAME, c7Id);
+  }
+
+  public static void logCouldNotBuildDecisionRuleIndex(String c7Id) {
+    LOGGER.warn(COULD_NOT_BUILD_DECISION_RULE_INDEX, c7Id);
   }
 }

--- a/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/history/HistoryMigrationAbstractTest.java
+++ b/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/history/HistoryMigrationAbstractTest.java
@@ -335,7 +335,9 @@ public abstract class HistoryMigrationAbstractTest extends AbstractMigratorTest 
       String inputName,
       String inputValue,
       String outputName,
-      String outputValue) {
+      String outputValue,
+      String outputRuleId,
+      int outputRuleIndex) {
     assertThat(instance.decisionInstanceId()).isNotNull();
     assertThat(instance.decisionInstanceKey()).isNotNull();
     assertThat(instance.state()).isEqualTo(EVALUATED);
@@ -360,6 +362,8 @@ public abstract class HistoryMigrationAbstractTest extends AbstractMigratorTest 
       assertThat(output.outputId()).isNotNull();
       assertThat(output.outputName()).isEqualTo(outputName);
       assertThat(output.outputValue()).isEqualTo(outputValue);
+      assertThat(output.ruleId()).isEqualTo(outputRuleId);
+      assertThat(output.ruleIndex()).isEqualTo(outputRuleIndex);
     });
   }
 }

--- a/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/history/entity/HistoryDecisionMigrationTest.java
+++ b/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/history/entity/HistoryDecisionMigrationTest.java
@@ -179,6 +179,52 @@ public class HistoryDecisionMigrationTest extends HistoryMigrationAbstractTest {
   }
 
   @Test
+  public void shouldMigrateCorrectRuleId() {
+    // given
+    deployer.deployCamunda7Decision("dish-decision.dmn");
+    Map<String, Object> variables = Variables.createVariables()
+        .putValue("dayType", stringValue("Weekend"))
+        .putValue("temperature", 15);
+    decisionService.evaluateDecisionTableByKey("Dish", variables);
+
+    // when
+    historyMigrator.migrate();
+
+    // then
+    List<DecisionInstanceEntity> migratedInstances = searchHistoricDecisionInstances("Dish");
+    assertThat(migratedInstances).singleElement().satisfies(instance ->
+        assertThat(instance.evaluatedOutputs()).singleElement().satisfies(output -> {
+          assertThat(output.ruleId()).isEqualTo("row-445981423-4");
+          assertThat(output.ruleIndex()).isEqualTo(6);
+        }));
+  }
+
+  @Test
+  public void shouldMigrateRuleIndexForMultipleMatchedRules() {
+    // given
+    deployer.deployCamunda7Decision("hitPolicyRuleOrderDmn.dmn");
+    Map<String, Object> variables = Variables.createVariables().putValue("input", stringValue("A"));
+    decisionService.evaluateDecisionTableByKey("hitPolicyRuleOrderDecisionId", variables);
+
+    // when
+    historyMigrator.migrate();
+
+    // then
+    List<DecisionInstanceEntity> migratedInstances = searchHistoricDecisionInstances("hitPolicyRuleOrderDecisionId");
+    assertThat(migratedInstances).singleElement().satisfies(instance -> {
+      assertThat(instance.evaluatedOutputs()).hasSize(2);
+      assertThat(instance.evaluatedOutputs()).anySatisfy(output -> {
+        assertThat(output.ruleId()).isEqualTo("DecisionRule_0i50yb6");
+        assertThat(output.ruleIndex()).isEqualTo(1);
+      });
+      assertThat(instance.evaluatedOutputs()).anySatisfy(output -> {
+        assertThat(output.ruleId()).isEqualTo("DecisionRule_0rmuml0");
+        assertThat(output.ruleIndex()).isEqualTo(2);
+      });
+    });
+  }
+
+  @Test
   public void shouldMigrateHistoricDecisionInstance() {
     // given
     Date now = ClockUtil.now();
@@ -214,7 +260,8 @@ public class HistoryDecisionMigrationTest extends HistoryMigrationAbstractTest {
             DecisionInstanceEntity.DecisionDefinitionType.DECISION_TABLE,
             "\"B\"",
             "inputA", "\"A\"",
-            "outputB", "\"B\""));
+            "outputB", "\"B\"",
+            "DecisionRule_0rh3id4", 1));
   }
 
   @Test
@@ -247,7 +294,8 @@ public class HistoryDecisionMigrationTest extends HistoryMigrationAbstractTest {
             DecisionInstanceEntity.DecisionDefinitionType.DECISION_TABLE,
             "\"B\"",
             "inputA", "\"A\"",
-            "outputB", "\"B\""));
+            "outputB", "\"B\"",
+            "DecisionRule_0rh3id4", 1));
   }
 
   @Test
@@ -307,7 +355,8 @@ public class HistoryDecisionMigrationTest extends HistoryMigrationAbstractTest {
             DecisionInstanceEntity.DecisionDefinitionType.DECISION_TABLE,
             "\"B\"",
             "inputA", "\"A\"",
-            "outputB", "\"B\""));
+            "outputB", "\"B\"",
+            "DecisionRule_0ogxiwg", 1));
 
     assertThat(instances2).singleElement().satisfies(instance ->
         assertDecisionInstance(
@@ -322,7 +371,8 @@ public class HistoryDecisionMigrationTest extends HistoryMigrationAbstractTest {
             DecisionInstanceEntity.DecisionDefinitionType.DECISION_TABLE,
             "\"C\"",
             "inputB", "\"B\"",
-            "outputC", "\"C\""));
+            "outputC", "\"C\"",
+            "DecisionRule_1itcc5z", 1));
   }
 
   @Test
@@ -359,7 +409,8 @@ public class HistoryDecisionMigrationTest extends HistoryMigrationAbstractTest {
             DecisionInstanceEntity.DecisionDefinitionType.DECISION_TABLE,
             "\"B\"",
             "inputA", "\"A\"",
-            "outputB", "\"B\""));
+            "outputB", "\"B\"",
+            "DecisionRule_0ogxiwg", 1));
 
     assertThat(instances2).singleElement().satisfies(instance ->
         assertDecisionInstance(
@@ -374,7 +425,8 @@ public class HistoryDecisionMigrationTest extends HistoryMigrationAbstractTest {
             DecisionInstanceEntity.DecisionDefinitionType.DECISION_TABLE,
             "\"C\"",
             "inputB", "\"B\"",
-            "outputC", "\"C\""));
+            "outputC", "\"C\"",
+            "DecisionRule_1itcc5z", 1));
   }
 
   @Test

--- a/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/history/entity/interceptor/HistoryPresetParentPropertiesTest.java
+++ b/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/history/entity/interceptor/HistoryPresetParentPropertiesTest.java
@@ -129,7 +129,7 @@ public class HistoryPresetParentPropertiesTest extends HistoryMigrationAbstractT
     assertThat(migratedInstances).singleElement()
         .satisfies(instance -> assertDecisionInstance(instance, "simpleDecisionId", now, 7L, 5L, 1L, 2L, 3L,
             DecisionInstanceEntity.DecisionDefinitionType.DECISION_TABLE, "\"B\"", "inputA", "\"A\"", "outputB",
-            "\"B\""));
+            "\"B\"", "DecisionRule_0rh3id4", 1));
   }
 
   @Test


### PR DESCRIPTION
related to #1102

# Pull Request Template

## Description
Fix highlighted row in dmn result:
<img width="1694" height="726" alt="image" src="https://github.com/user-attachments/assets/39ad5098-0b1b-4039-936d-b05b394707cc" />

Includes a cache for faster rule index determination. If this is overkill or we do not yet want to introduce caching/wait for user feedback first I can remove this again as well.


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Test-only changes (no production code changes)

## Testing Checklist

### Black-Box Testing Requirements
- [ ] Tests follow **black-box testing approach**: verify behavior through observable outputs (logs, C8 API queries, real-world skip scenarios)
- [ ] Tests **DO NOT** access implementation details (`DbClient`, `IdKeyMapper`, `..impl..` packages except logging constants)
- [ ] Architecture tests pass (`ArchitectureTest` validates these rules)

### Test Coverage
- [x] Added tests for new functionality
- [x] Updated tests for modified functionality
- [x] All tests pass locally

## Architecture Compliance

Run architecture tests to ensure compliance:
```bash
mvn test -Dtest=ArchitectureTest
```

If architecture tests fail, refactor your tests to use:
- `LogCapturer` for log assertions
- `camundaClient.new*SearchRequest()` for C8 queries
- Real-World skip scenarios (e.g., migrate children without parents)

## Documentation
- [ ] Updated TESTING_GUIDELINES.md if adding new test patterns
- [ ] Added Javadoc comments for public APIs
- [ ] Updated README if user-facing changes

## Checklist
- [ ] Code follows project style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments for complex logic
- [ ] No new compiler warnings
- [ ] Dependent changes have been merged

## Related Issues
<!-- Link to related issues: Fixes #123, Related to #456 -->

