### PR TITLE
fix(migrator): enhance multi-instance detection in history migration

### DIFF
--- a/data-migrator/core/src/main/java/io/camunda/migration/data/impl/clients/C7Client.java
+++ b/data-migrator/core/src/main/java/io/camunda/migration/data/impl/clients/C7Client.java
@@ -203,6 +203,24 @@ public class C7Client {
   }
 
   /**
+   * Finds all historic activity instances for a given BPMN activity ID within a process instance.
+   *
+   * <p>This is used to detect multi-instance activities: when more than one activity instance exists
+   * for the same {@code activityId} within a process instance, the activity is part of a
+   * multi-instance configuration.
+   *
+   * @param activityId        the BPMN element ID (e.g., {@code "userTask1"})
+   * @param processInstanceId the C7 process instance ID
+   * @return list of matching historic activity instances, empty if none exist
+   */
+  public List<HistoricActivityInstance> findHistoricActivityInstances(String activityId, String processInstanceId) {
+    var query = historyService.createHistoricActivityInstanceQuery()
+        .activityId(activityId)
+        .processInstanceId(processInstanceId);
+    return callApi(query::list, format(FAILED_TO_FETCH_HISTORIC_ELEMENT, "HistoricActivityInstance", activityId));
+  }
+
+  /**
    * Finds the activity that started a child process instance.
    */
   public HistoricActivityInstance findCallActivityByCalledProcessInstanceId(String parentProcessInstanceId,

--- a/data-migrator/core/src/main/java/io/camunda/migration/data/impl/history/migrator/HistoryEntityMigrator.java
+++ b/data-migrator/core/src/main/java/io/camunda/migration/data/impl/history/migrator/HistoryEntityMigrator.java
@@ -10,6 +10,7 @@ package io.camunda.migration.data.impl.history.migrator;
 import static io.camunda.migration.data.MigratorMode.MIGRATE;
 import static io.camunda.migration.data.MigratorMode.RETRY_SKIPPED;
 import static io.camunda.migration.data.config.property.history.CleanupProperties.DEFAULT_TTL;
+import static io.camunda.migration.data.constants.MigratorConstants.C7_MULTI_INSTANCE_BODY_SUFFIX;
 import static io.camunda.migration.data.impl.logging.HistoryMigratorLogs.logMigrating;
 import static io.camunda.migration.data.impl.logging.HistoryMigratorLogs.logMigrationCompleted;
 import static io.camunda.migration.data.impl.logging.HistoryMigratorLogs.logRetrying;
@@ -18,6 +19,7 @@ import static io.camunda.migration.data.impl.persistence.IdKeyMapper.TYPE;
 import static io.camunda.migration.data.impl.persistence.IdKeyMapper.TYPE.HISTORY_FLOW_NODE;
 import static io.camunda.migration.data.impl.persistence.IdKeyMapper.TYPE.HISTORY_PROCESS_INSTANCE;
 import static io.camunda.migration.data.impl.util.ConverterUtil.convertDate;
+import static io.camunda.migration.data.impl.util.ConverterUtil.sanitizeFlowNodeId;
 
 import io.camunda.db.rdbms.read.domain.FlowNodeInstanceDbQuery;
 import io.camunda.db.rdbms.read.domain.ProcessDefinitionDbQuery;
@@ -319,17 +321,28 @@ public abstract class HistoryEntityMigrator<C7, C8> {
   /**
    * Finds the C8 flow node instance key by C7 activity ID and process instance ID.
    *
-   * <p>When exactly one C8 flow node matches the given {@code activityId} and process instance,
-   * its key is returned directly. When multiple flow nodes match (multi-instance activities),
-   * the method sets {@code isMultiInstance} to {@code true} and returns {@code null} because
-   * a deterministic mapping to the correct flow node instance is not possible.
-   * Callers should inspect {@code isMultiInstance} to distinguish "not found" from
-   * "ambiguous due to multi-instance".
+   * <p>The method first checks whether the {@code activityId} contains the
+   * {@code #multiInstanceBody} suffix. If so, {@code isMultiInstance} is set to {@code true}
+   * and {@code null} is returned immediately — a multi-instance body cannot be mapped to a single
+   * flow node instance.
    *
-   * @param activityId        the C7 activity ID (BPMN element ID)
+   * <p>Otherwise, the method searches C8 for flow nodes matching the sanitized {@code activityId}
+   * within the migrated process instance. When at least one C8 flow node exists, the method queries
+   * C7 for all historic activity instances with the same {@code activityId} and
+   * {@code processInstanceId}. This is necessary because only some of the flow nodes may have been
+   * migrated at this point. If more than one C7 activity instance exists, the activity is part of a
+   * multi-instance configuration, so {@code isMultiInstance} is set to {@code true} and {@code null}
+   * is returned. When exactly one C8 flow node matches and the activity is not multi-instance, its
+   * key is returned directly.
+   *
+   * <p>Callers should inspect {@code isMultiInstance} to distinguish "not found" from "ambiguous
+   * due to multi-instance".
+   *
+   * @param activityId        the C7 activity ID (BPMN element ID), may include the
+   *                          {@code #multiInstanceBody} suffix
    * @param processInstanceId the C7 process instance ID
-   * @param isMultiInstance   mutable flag set to {@code true} when multiple C8 flow nodes exist
-   *                          for the same activity, indicating a multi-instance scenario
+   * @param isMultiInstance   mutable flag set to {@code true} when the activity is detected as
+   *                          multi-instance, indicating an ambiguous mapping
    * @return the C8 flow node instance key, or {@code null} if not found or ambiguous
    */
   protected Long findFlowNodeInstanceKey(String activityId, String processInstanceId, AtomicBoolean isMultiInstance) {
@@ -338,16 +351,26 @@ public abstract class HistoryEntityMigrator<C7, C8> {
       return null;
     }
 
+    if (activityId.endsWith(C7_MULTI_INSTANCE_BODY_SUFFIX)) {
+      // C8 flow node can't be determinated
+      isMultiInstance.set(true);
+      return null;
+    }
+
     List<FlowNodeInstanceDbModel> flowNodes = c8Client.searchFlowNodeInstances(FlowNodeInstanceDbQuery.of(
         builder -> builder.filter(FlowNodeInstanceFilter.of(
-            filter -> filter.flowNodeIds(activityId).processInstanceKeys(processInstanceKey)))));
+            filter -> filter.flowNodeIds(sanitizeFlowNodeId(activityId)).processInstanceKeys(processInstanceKey)))));
 
     if (!flowNodes.isEmpty()) {
+      // only some of the flow nodes might have been migrated at this point so first check how many entities are in C7
+      var historicActivityInstances = c7Client.findHistoricActivityInstances(activityId, processInstanceId);
+      if (historicActivityInstances != null && historicActivityInstances.size() > 1) {
+        // C8 flow node can't be determinated
+        isMultiInstance.set(true);
+        return null;
+      }
       if (flowNodes.size() == 1) {
         return flowNodes.getFirst().flowNodeInstanceKey();
-      }
-      if (flowNodes.size() > 1) {
-        isMultiInstance.set(true);
       }
     }
     return null;

--- a/data-migrator/core/src/main/java/io/camunda/migration/data/impl/history/migrator/IncidentMigrator.java
+++ b/data-migrator/core/src/main/java/io/camunda/migration/data/impl/history/migrator/IncidentMigrator.java
@@ -93,8 +93,8 @@ public class IncidentMigrator extends HistoryEntityMigrator<HistoricIncident, In
         processInstanceKey = c7ProcessInstance.processInstanceKey();
         builder.processInstanceKey(processInstanceKey);
         if (processInstanceKey != null) {
-          flowNodeInstanceKey = findFlowNodeInstanceKey(sanitizeFlowNodeId(c7Incident.getActivityId()),
-              c7Incident.getProcessInstanceId(), isMultiInstance);
+          flowNodeInstanceKey = findFlowNodeInstanceKey(c7Incident.getActivityId(), c7Incident.getProcessInstanceId(),
+              isMultiInstance);
           builder.flowNodeInstanceKey(flowNodeInstanceKey);
 
           String c7RootProcessInstanceId = c7Incident.getRootProcessInstanceId();

--- a/data-migrator/core/src/main/java/io/camunda/migration/data/impl/history/migrator/JobMigrator.java
+++ b/data-migrator/core/src/main/java/io/camunda/migration/data/impl/history/migrator/JobMigrator.java
@@ -116,8 +116,8 @@ public class JobMigrator extends HistoryEntityMigrator<HistoricJobLog, JobDbMode
           }
         }
 
-        final Long elementInstanceKey = findFlowNodeInstanceKey(sanitizeFlowNodeId(c7JobLog.getActivityId()),
-            c7ProcessInstanceId, isMultiInstance);
+        final Long elementInstanceKey = findFlowNodeInstanceKey(c7JobLog.getActivityId(), c7ProcessInstanceId,
+            isMultiInstance);
         builder.elementInstanceKey(elementInstanceKey);
       }
 


### PR DESCRIPTION
# Pull Request Template

## Description
<!-- Describe your changes in detail -->
https://github.com/camunda/camunda-7-to-8-migration-tooling/issues/1119

Improves history-migration multi-instance detection for jobs/incidents so that ambiguous flow node mappings (especially multi-instance scenarios) can be recognized earlier and skipped safely.

Changes:

- Move flow-node ID sanitization into HistoryEntityMigrator.findFlowNodeInstanceKey(...) and add an early multi-instance-body (#multiInstanceBody) detection shortcut.
- Add a C7 query (findHistoricActivityInstances) to detect multi-instance activities even when only a subset of flow nodes has been migrated to C8.
- Update job/incident migrators to call the new flow-node-instance resolution behavior using the raw C7 activityId.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Test-only changes (no production code changes)

## Testing Checklist

### Black-Box Testing Requirements
- [ ] Tests follow **black-box testing approach**: verify behavior through observable outputs (logs, C8 API queries, real-world skip scenarios)
- [ ] Tests **DO NOT** access implementation details (`DbClient`, `IdKeyMapper`, `..impl..` packages except logging constants)
- [ ] Architecture tests pass (`ArchitectureTest` validates these rules)

### Test Coverage
- [ ] Added tests for new functionality
- [ ] Updated tests for modified functionality
- [ ] All tests pass locally

## Architecture Compliance

Run architecture tests to ensure compliance:
```bash
mvn test -Dtest=ArchitectureTest
```

If architecture tests fail, refactor your tests to use:
- `LogCapturer` for log assertions
- `camundaClient.new*SearchRequest()` for C8 queries
- Real-World skip scenarios (e.g., migrate children without parents)

## Documentation
- [ ] Updated TESTING_GUIDELINES.md if adding new test patterns
- [ ] Added Javadoc comments for public APIs
- [ ] Updated README if user-facing changes

## Checklist
- [ ] Code follows project style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments for complex logic
- [ ] No new compiler warnings
- [ ] Dependent changes have been merged

## Related Issues
<!-- Link to related issues: Fixes #123, Related to #456 -->


https://github.com/camunda/camunda-7-to-8-migration-tooling/issues/1119