### PR TITLE
fix(oracle): catch IllegalArgumentException on CamundaClient calls

### DIFF
--- a/data-migrator/core/src/main/java/io/camunda/migration/data/impl/util/ExceptionUtils.java
+++ b/data-migrator/core/src/main/java/io/camunda/migration/data/impl/util/ExceptionUtils.java
@@ -44,12 +44,12 @@ public class ExceptionUtils {
   }
 
   /**
-   * Wraps {@link ClientException}, {@link ProcessEngineException}, and {@link PersistenceException} into {@link RuntimeMigratorException}.
+   * Wraps {@link ClientException}, {@link ProcessEngineException}, {@link IllegalArgumentException} and {@link PersistenceException} into {@link RuntimeMigratorException}.
    */
   public static <T> T callApi(Supplier<T> supplier, String message) {
     try {
       return supplier.get();
-    } catch (ClientException | ProcessEngineException | PersistenceException e) {
+    } catch (ClientException | ProcessEngineException | IllegalArgumentException | PersistenceException e) {
       throw wrapException(message, e);
     }
   }
@@ -59,12 +59,12 @@ public class ExceptionUtils {
   }
 
   /**
-   * Wraps {@link ClientException}, {@link ProcessEngineException}, and {@link PersistenceException} into {@link RuntimeMigratorException}.
+   * Wraps {@link ClientException}, {@link ProcessEngineException}, {@link IllegalArgumentException} and {@link PersistenceException} into {@link RuntimeMigratorException}.
    */
   public static void callApi(Runnable runnable, String message) {
     try {
       runnable.run();
-    } catch (ClientException | ProcessEngineException | PersistenceException e) {
+    } catch (ClientException | ProcessEngineException | IllegalArgumentException | PersistenceException e) {
       throw wrapException(message, e);
     }
   }


### PR DESCRIPTION
# Pull Request Template

## Description
<!-- Describe your changes in detail -->
fix for failing tests

<details><summary>Details</summary>

```
2026-03-30T06:18:07.3207512Z [ERROR] io.camunda.migration.data.qa.identity.RetryGroupMigrationTest.shouldNotReattemptSkippedOnRerun -- Time elapsed: 1.932 s <<< ERROR!
2026-03-30T06:18:07.3208263Z java.lang.IllegalArgumentException: name must not be null
2026-03-30T06:18:07.3208760Z 	at io.camunda.client.impl.command.ArgumentUtil.ensureNotNull(ArgumentUtil.java:27)
2026-03-30T06:18:07.3209400Z 	at io.camunda.client.impl.command.CreateGroupCommandImpl.send(CreateGroupCommandImpl.java:74)
2026-03-30T06:18:07.3210133Z 	at io.camunda.client.api.command.FinalCommandStep.execute(FinalCommandStep.java:60)
2026-03-30T06:18:07.3210734Z 	at io.camunda.migration.data.impl.util.ExceptionUtils.callApi(ExceptionUtils.java:51)
2026-03-30T06:18:07.3211328Z 	at io.camunda.migration.data.impl.clients.C8Client.createGroup(C8Client.java:557)
2026-03-30T06:18:07.3211920Z 	at io.camunda.migration.data.IdentityMigrator.migrateGroup(IdentityMigrator.java:169)
2026-03-30T06:18:07.3212569Z 	at io.camunda.migration.data.IdentityMigrator.lambda$migrateGroups$3(IdentityMigrator.java:136)
2026-03-30T06:18:07.3213392Z 	at org.springframework.transaction.support.TransactionOperations.lambda$executeWithoutResult$0(TransactionOperations.java:68)
2026-03-30T06:18:07.3214255Z 	at org.springframework.transaction.support.TransactionTemplate.execute(TransactionTemplate.java:137)
2026-03-30T06:18:07.3215097Z 	at org.springframework.transaction.support.TransactionOperations.executeWithoutResult(TransactionOperations.java:67)
2026-03-30T06:18:07.3216377Z 	at io.camunda.migration.data.IdentityMigrator.lambda$migrateGroups$4(IdentityMigrator.java:136)
2026-03-30T06:18:07.3216945Z 	at java.base/java.util.ArrayList.forEach(ArrayList.java:1596)
2026-03-30T06:18:07.3217423Z 	at io.camunda.migration.data.impl.Pagination.callback(Pagination.java:72)
2026-03-30T06:18:07.3218016Z 	at io.camunda.migration.data.impl.clients.C7Client.fetchAndHandleGroups(C7Client.java:697)
2026-03-30T06:18:07.3218813Z 	at io.camunda.migration.data.IdentityMigrator.fetchGroupsToMigrate(IdentityMigrator.java:318)
2026-03-30T06:18:07.3219523Z 	at io.camunda.migration.data.IdentityMigrator.migrateGroups(IdentityMigrator.java:136)
2026-03-30T06:18:07.3220169Z 	at io.camunda.migration.data.IdentityMigrator.migrate(IdentityMigrator.java:91)
2026-03-30T06:18:07.3220768Z 	at io.camunda.migration.data.IdentityMigrator.start(IdentityMigrator.java:78)
2026-03-30T06:18:07.3221580Z 	at io.camunda.migration.data.qa.identity.RetryGroupMigrationTest.shouldNotReattemptSkippedOnRerun(RetryGroupMigrationTest.java:88)
...
2026-03-30T06:22:12.0087712Z [ERROR]   RetryGroupMigrationTest.shouldListSkippedGroups:110 » IllegalArgument name must not be null
2026-03-30T06:22:12.0089503Z [ERROR]   RetryGroupMigrationTest.shouldMigrateMembershipsForSkippedGroupsOnRetry:133 » IllegalArgument name must not be null
2026-03-30T06:22:12.0091305Z [ERROR]   RetryGroupMigrationTest.shouldMigrateSkippedGroupsOnRetry:41 » IllegalArgument name must not be null
2026-03-30T06:22:12.0094528Z [ERROR]   RetryGroupMigrationTest.shouldNotReattemptSkippedOnRerun:88 » IllegalArgument name must not be null
2026-03-30T06:22:12.0098326Z [ERROR]   RetryGroupMigrationTest.shouldOnlyMigrateSkippedGroupsOnRetry:67 » IllegalArgument name must not be null
```

</details> 

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Test-only changes (no production code changes)

## Testing Checklist

### Black-Box Testing Requirements
- [ ] Tests follow **black-box testing approach**: verify behavior through observable outputs (logs, C8 API queries, real-world skip scenarios)
- [ ] Tests **DO NOT** access implementation details (`DbClient`, `IdKeyMapper`, `..impl..` packages except logging constants)
- [ ] Architecture tests pass (`ArchitectureTest` validates these rules)

### Test Coverage
- [ ] Added tests for new functionality
- [ ] Updated tests for modified functionality
- [ ] All tests pass locally

## Architecture Compliance

Run architecture tests to ensure compliance:
```bash
mvn test -Dtest=ArchitectureTest
```

If architecture tests fail, refactor your tests to use:
- `LogCapturer` for log assertions
- `camundaClient.new*SearchRequest()` for C8 queries
- Real-World skip scenarios (e.g., migrate children without parents)

## Documentation
- [ ] Updated TESTING_GUIDELINES.md if adding new test patterns
- [ ] Added Javadoc comments for public APIs
- [ ] Updated README if user-facing changes

## Checklist
- [ ] Code follows project style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments for complex logic
- [ ] No new compiler warnings
- [ ] Dependent changes have been merged

## Related Issues
<!-- Link to related issues: Fixes #123, Related to #456 -->

