### PR TITLE
chore(ci): add support for dual Camunda 8 versions in CI workflow (8.10/8.9)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,57 @@ on:
     - cron: "0 5 * * 1-5"  # Weekday mornings for general CI
 
 jobs:
+  # Read Camunda 8 versions from pom.xml to avoid hard-coding in CI
+  read-versions:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      camunda-8-version: ${{ steps.versions.outputs.camunda-8-version }}
+      camunda-8-previous-version: ${{ steps.versions.outputs.camunda-8-previous-version }}
+      camunda-8-docker-image-version: ${{ steps.versions.outputs.camunda-8-docker-image-version }}
+      camunda-8-previous-docker-image-version: ${{ steps.versions.outputs.camunda-8-previous-docker-image-version }}
+      camunda-versions: ${{ steps.versions.outputs.camunda-versions }}
+    steps:
+      - name: Checkout pom.xml
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          sparse-checkout: pom.xml
+          sparse-checkout-cone-mode: false
+
+      - name: Extract Camunda 8 versions from pom.xml
+        id: versions
+        run: |
+          CURRENT=$(sed -n 's/.*<version\.camunda-8>\([^<]*\)<\/version\.camunda-8>.*/\1/p' pom.xml)
+          PREVIOUS=$(sed -n 's/.*<version\.camunda-8\.previous>\([^<]*\)<\/version\.camunda-8\.previous>.*/\1/p' pom.xml)
+          
+          if [ -z "$CURRENT" ]; then
+            echo "::error::Failed to extract <version.camunda-8> from pom.xml"
+            exit 1
+          fi
+          
+          if [ -z "$PREVIOUS" ]; then
+            echo "::error::Failed to extract <version.camunda-8.previous> from pom.xml"
+            exit 1
+          fi
+
+          # Docker image version: for SNAPSHOT versions, current uses SNAPSHOT and previous uses MAJOR.MINOR-SNAPSHOT
+          # For release versions (no -SNAPSHOT suffix), the Docker tag equals the Maven version as-is
+          if echo "$CURRENT" | grep -q '\-SNAPSHOT$'; then
+            CURRENT_DOCKER="SNAPSHOT"
+          else
+            CURRENT_DOCKER="$CURRENT"
+          fi
+          PREVIOUS_DOCKER=$(echo "$PREVIOUS" | sed 's/\([0-9]*\.[0-9]*\)\.[0-9]*-SNAPSHOT/\1-SNAPSHOT/')
+
+          echo "camunda-8-version=${CURRENT}" >> $GITHUB_OUTPUT
+          echo "camunda-8-previous-version=${PREVIOUS}" >> $GITHUB_OUTPUT
+          echo "camunda-8-docker-image-version=${CURRENT_DOCKER}" >> $GITHUB_OUTPUT
+          echo "camunda-8-previous-docker-image-version=${PREVIOUS_DOCKER}" >> $GITHUB_OUTPUT
+          echo "camunda-versions=[\"${CURRENT}\",\"${PREVIOUS}\"]" >> $GITHUB_OUTPUT
+
+          echo "Camunda 8 current: ${CURRENT} (docker: ${CURRENT_DOCKER})"
+          echo "Camunda 8 previous: ${PREVIOUS} (docker: ${PREVIOUS_DOCKER})"
+
   distro:
     runs-on: ubuntu-latest
     timeout-minutes: 70
@@ -185,6 +236,49 @@ jobs:
           name: diagram-converter
           path: ${{ steps.diagram-converter-artifacts.outputs.dir }}
           retention-days: 7
+
+  # Compile-check all modules against the previous Camunda 8 version
+  # to catch API-level incompatibilities before merge.
+  compile-previous-version:
+    needs: [read-versions]
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    if: |
+      github.event_name == 'pull_request' ||
+      github.event_name == 'workflow_dispatch'
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+
+      - name: Import secrets
+        id: secrets
+        uses: hashicorp/vault-action@4c06c5ccf5c0761b6029f56cfb1dcf5565918a3b # v3.4.0
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secrets: |
+            secret/data/products/cambpm/ci/nexus NEXUS_APP_CAMUNDA_COM_USR;
+            secret/data/products/cambpm/ci/nexus NEXUS_APP_CAMUNDA_COM_PSW;
+
+      - name: Setup Maven
+        uses: ./.github/actions/setup-maven
+        with:
+          vault-address: ${{ secrets.VAULT_ADDR }}
+          vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
+          vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+
+      - name: Compile-check against previous Camunda 8 version
+        # Compiles all modules (except cockpit plugin which requires Node.js and
+        # assembly which is packaging-only) against the previous version to detect incompatible API usage.
+        run: >-
+          mvn compile test-compile
+          -Dversion.camunda-8=${{ needs.read-versions.outputs.camunda-8-previous-version }}
+          -pl '!data-migrator/plugins/cockpit,!data-migrator/assembly'
+          --batch-mode
 
   it-runtime-postgresql:
     runs-on: ubuntu-latest
@@ -991,20 +1085,18 @@ jobs:
           path: data-migrator/qa/e2e-tests/test-results/
           retention-days: 7
 
-  # Database matrix testing - runs daily on main branch
-  it-database-matrix:
+  # Nightly: verify code-conversion against previous Camunda 8 version
+  code-conversion-previous-version:
+    needs: [read-versions]
     runs-on: ubuntu-latest
-    timeout-minutes: 90
-    permissions:
-      contents: read
+    timeout-minutes: 30
     if: |
       github.event_name == 'schedule' ||
       (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
-      github.event_name == 'workflow_dispatch'
-    strategy:
-      fail-fast: false
-      matrix:
-        database: [postgresql, postgresql-15, oracle, oracle-19, mysql, mariadb, mariadb-10, sqlserver]
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request' &&
+        contains(github.event.pull_request.labels.*.name, 'ci:previous-c8-version')
+      )
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -1030,9 +1122,184 @@ jobs:
           vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
 
-      - name: Run integration tests with ${{ matrix.database }}
+      - name: Build code-conversion module against previous Camunda 8 version
+        working-directory: code-conversion
+        run: >-
+          mvn verify -PcheckFormat
+          -Dversion.camunda-8=${{ needs.read-versions.outputs.camunda-8-previous-version }}
+          --batch-mode
+
+  # Nightly: verify diagram-converter against previous Camunda 8 version
+  diagram-converter-previous-version:
+    needs: [read-versions]
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    if: |
+      github.event_name == 'schedule' ||
+      (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request' &&
+        contains(github.event.pull_request.labels.*.name, 'ci:previous-c8-version')
+      )
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+
+      - name: Import secrets
+        id: secrets
+        uses: hashicorp/vault-action@4c06c5ccf5c0761b6029f56cfb1dcf5565918a3b # v3.4.0
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secrets: |
+            secret/data/products/cambpm/ci/nexus NEXUS_APP_CAMUNDA_COM_USR;
+            secret/data/products/cambpm/ci/nexus NEXUS_APP_CAMUNDA_COM_PSW;
+
+      - name: Setup Maven
+        uses: ./.github/actions/setup-maven
+        with:
+          vault-address: ${{ secrets.VAULT_ADDR }}
+          vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
+          vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+
+      - name: Build and test diagram-converter against previous Camunda 8 version
+        working-directory: diagram-converter
+        run: >-
+          mvn verify -Pdistro,checkFormat
+          -Dversion.camunda-8=${{ needs.read-versions.outputs.camunda-8-previous-version }}
+          --batch-mode
+
+  # Nightly: run E2E tests against previous Camunda 8 version
+  e2e-previous-version:
+    needs: [read-versions]
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    if: |
+      github.event_name == 'schedule' ||
+      (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request' &&
+        contains(github.event.pull_request.labels.*.name, 'ci:previous-c8-version')
+      )
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+
+      - name: Import secrets
+        id: secrets
+        uses: hashicorp/vault-action@4c06c5ccf5c0761b6029f56cfb1dcf5565918a3b # v3.4.0
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secrets: |
+            secret/data/products/cambpm/ci/nexus NEXUS_APP_CAMUNDA_COM_USR;
+            secret/data/products/cambpm/ci/nexus NEXUS_APP_CAMUNDA_COM_PSW;
+
+      - name: Setup Maven
+        uses: ./.github/actions/setup-maven
+        with:
+          vault-address: ${{ secrets.VAULT_ADDR }}
+          vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
+          vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+
+      - name: Login to Camunda Registry
+        uses: docker/login-action@v4
+        with:
+          registry: registry.camunda.cloud
+          username: ${{ steps.secrets.outputs.NEXUS_APP_CAMUNDA_COM_USR }}
+          password: ${{ steps.secrets.outputs.NEXUS_APP_CAMUNDA_COM_PSW }}
+
+      - name: Run E2E tests against previous Camunda 8 version
         working-directory: data-migrator
-        run: mvn verify -P${{ matrix.database }},integration
+        run: >-
+          mvn clean install -Pe2e -Dmaven.test.skip
+          -Dversion.camunda-8=${{ needs.read-versions.outputs.camunda-8-previous-version }}
+          -Dcamunda8.docker.image=camunda/camunda:${{ needs.read-versions.outputs.camunda-8-previous-docker-image-version }}
+          --batch-mode
+        env:
+          CI: true
+
+      - name: Upload test results
+        uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: playwright-report-previous-version
+          path: data-migrator/qa/e2e-tests/playwright-report/
+          retention-days: 7
+
+      - name: Upload screenshots
+        uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: e2e-screenshots-previous-version
+          path: data-migrator/qa/e2e-tests/test-results/
+          retention-days: 7
+
+  # Database and Camunda version compatibility matrix testing - runs daily on main branch
+  it-database-camunda-matrix:
+    needs: [read-versions]
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    permissions:
+      contents: read
+    if: |
+      github.event_name == 'schedule' ||
+      (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request' &&
+        contains(github.event.pull_request.labels.*.name, 'ci:previous-c8-version')
+      )
+    strategy:
+      fail-fast: false
+      matrix:
+        database: [postgresql, postgresql-15, oracle, oracle-19, mysql, mariadb, mariadb-10, sqlserver]
+        camunda-version: ${{ fromJSON(needs.read-versions.outputs.camunda-versions) }}
+        include:
+          - camunda-version: ${{ needs.read-versions.outputs.camunda-8-version }}
+            camunda-docker-image-version: ${{ needs.read-versions.outputs.camunda-8-docker-image-version }}
+          - camunda-version: ${{ needs.read-versions.outputs.camunda-8-previous-version }}
+            camunda-docker-image-version: ${{ needs.read-versions.outputs.camunda-8-previous-docker-image-version }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+
+      - name: Import secrets
+        id: secrets
+        uses: hashicorp/vault-action@4c06c5ccf5c0761b6029f56cfb1dcf5565918a3b # v3.4.0
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secrets: |
+            secret/data/products/cambpm/ci/nexus NEXUS_APP_CAMUNDA_COM_USR;
+            secret/data/products/cambpm/ci/nexus NEXUS_APP_CAMUNDA_COM_PSW;
+
+      - name: Setup Maven
+        uses: ./.github/actions/setup-maven
+        with:
+          vault-address: ${{ secrets.VAULT_ADDR }}
+          vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
+          vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+
+      - name: Run integration tests with ${{ matrix.database }} (Camunda ${{ matrix.camunda-version }})
+        working-directory: data-migrator
+        run: >-
+          mvn verify -P${{ matrix.database }},integration
+          -Dversion.camunda-8=${{ matrix.camunda-version }}
+          -Dcamunda.process-test.camunda-docker-image-version=${{ matrix.camunda-docker-image-version }}
 
   # Rerun failed jobs running on self-hosted runners in case of network issues or node preemption
   rerun-failed-jobs:
@@ -1040,6 +1307,7 @@ jobs:
       - distro
       - code-conversion
       - diagram-converter
+      - compile-previous-version
       - it-runtime-h2
       - it-history-h2
       - it-history-h2-windows

--- a/data-migrator/qa/e2e-tests/src/main/resources/docker-compose.yml.template
+++ b/data-migrator/qa/e2e-tests/src/main/resources/docker-compose.yml.template
@@ -105,7 +105,7 @@ services:
       - e2e-network
 
   camunda8: # Consolidated Zeebe + Operate + Tasklist - https://docs.camunda.io/docs/self-managed/setup/deploy/other/docker/#zeebe
-    image: camunda/camunda:SNAPSHOT
+    image: ${camunda8.docker.image}
     container_name: camunda8
     ports:
       - "26500:26500"

--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,8 @@
 
     <version.camunda-7>7.24.6-ee</version.camunda-7>
     <version.camunda-8>8.10.0-SNAPSHOT</version.camunda-8>
+    <version.camunda-8.previous>8.9.0</version.camunda-8.previous>
+    <camunda8.docker.image>camunda/camunda:SNAPSHOT</camunda8.docker.image>
     <version.elasticsearch>8.19.6</version.elasticsearch>
     <version.spring-boot>4.0.5</version.spring-boot>
     <version.assertj>3.27.7</version.assertj>


### PR DESCRIPTION
# Pull Request Template

Decision making on how to add the additional CI: https://github.com/camunda/camunda-7-to-8-migration-tooling/issues/1199#issuecomment-4204845904

## Description
<!-- Describe your changes in detail -->
https://github.com/camunda/camunda-7-to-8-migration-tooling/issues/1199

This PR updates the build/CI setup to target Camunda 8.10 development while adding CI coverage for verifying compatibility against a “previous” Camunda 8 version, aligning with the goal of keeping `main` compatible across multiple Camunda 8 minor versions.

**Changes:**
- Introduces a “previous” Camunda 8 version property plus a configurable Camunda 8 Docker image property.
- Adds a `read-versions` CI job and extends CI to compile/test selected modules and run integration/E2E workflows against the previous Camunda 8 version.
- Updates integration-test and E2E docker configuration to support parameterized Camunda 8 Docker image selection.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Test-only changes (no production code changes)

## Testing Checklist

### Black-Box Testing Requirements
- [ ] Tests follow **black-box testing approach**: verify behavior through observable outputs (logs, C8 API queries, real-world skip scenarios)
- [ ] Tests **DO NOT** access implementation details (`DbClient`, `IdKeyMapper`, `..impl..` packages except logging constants)
- [ ] Architecture tests pass (`ArchitectureTest` validates these rules)

### Test Coverage
- [ ] Added tests for new functionality
- [ ] Updated tests for modified functionality
- [ ] All tests pass locally

## Architecture Compliance

Run architecture tests to ensure compliance:
```bash
mvn test -Dtest=ArchitectureTest
```

If architecture tests fail, refactor your tests to use:
- `LogCapturer` for log assertions
- `camundaClient.new*SearchRequest()` for C8 queries
- Real-World skip scenarios (e.g., migrate children without parents)

## Documentation
- [ ] Updated TESTING_GUIDELINES.md if adding new test patterns
- [ ] Added Javadoc comments for public APIs
- [ ] Updated README if user-facing changes

## Checklist
- [ ] Code follows project style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments for complex logic
- [ ] No new compiler warnings
- [ ] Dependent changes have been merged

## Related Issues
<!-- Link to related issues: Fixes #123, Related to #456 -->

https://github.com/camunda/camunda-7-to-8-migration-tooling/issues/1199