### PR TITLE
chore(data-migrator): support multiple C8 version via parallel source

### DIFF
--- a/data-migrator/assembly/assembly.xml
+++ b/data-migrator/assembly/assembly.xml
@@ -39,7 +39,13 @@
       <lineEnding>crlf</lineEnding>
     </file>
     <file>
-      <source>${project.build.directory}/dependency/camunda-7-to-8-data-migrator-distro-${project.version}.jar</source>
+      <!--
+        Sourced from the distro module's target/ directly (not via the copied
+        dependency in target/dependency/) so the C8-version suffix on distro's
+        finalName is honored — maven-dependency-plugin's copy-dependencies names
+        the copy by GAV, ignoring finalName.
+      -->
+      <source>${project.basedir}/../distro/target/camunda-7-to-8-data-migrator-distro-${project.version}${c8.artifact.version.suffix}.jar</source>
       <outputDirectory>internal</outputDirectory>
       <destName>camunda-7-to-8-data-migrator.jar</destName>
       <fileMode>0644</fileMode>

--- a/data-migrator/assembly/pom.xml
+++ b/data-migrator/assembly/pom.xml
@@ -58,6 +58,13 @@
           <appendAssemblyId>false</appendAssemblyId>
           <outputDirectory>target/</outputDirectory>
           <tarLongFileMode>gnu</tarLongFileMode>
+          <!--
+            finalName on the assembly matches the distro's suffix scheme so both
+            `camunda-7-to-8-data-migrator-${project.version}.zip` (default) and
+            `camunda-7-to-8-data-migrator-${project.version}-c8-previous.zip`
+            (under the `c8-previous-api` profile) coexist in target/.
+          -->
+          <finalName>camunda-7-to-8-data-migrator-${project.version}${c8.artifact.version.suffix}</finalName>
         </configuration>
         <executions>
           <execution>

--- a/data-migrator/core/pom.xml
+++ b/data-migrator/core/pom.xml
@@ -15,6 +15,16 @@
 
   <name>Camunda 7 to 8 Migration Tooling - Data - Core</name>
 
+  <properties>
+    <!--
+      Selects which C8-version-specific source folder is compiled alongside
+      `src/main/java`. The `c8-previous-api` profile below flips this to
+      `src/main/java-c8-previous` when building against the previous C8 minor.
+    -->
+    <c8.compat.source.dir>src/main/java-c8-current</c8.compat.source.dir>
+    <plugin.version.build-helper>3.6.0</plugin.version.build-helper>
+  </properties>
+
   <dependencyManagement>
     <dependencies>
       <dependency>
@@ -263,6 +273,40 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <version>3.5.5</version>
       </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
+        <version>${plugin.version.build-helper}</version>
+        <executions>
+          <execution>
+            <id>add-c8-compat-source</id>
+            <phase>generate-sources</phase>
+            <goals>
+              <goal>add-source</goal>
+            </goals>
+            <configuration>
+              <sources>
+                <source>${c8.compat.source.dir}</source>
+              </sources>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
+
+  <profiles>
+    <profile>
+      <id>c8-previous-api</id>
+      <activation>
+        <property>
+          <name>version.camunda-8</name>
+          <value>8.9.0</value>
+        </property>
+      </activation>
+      <properties>
+        <c8.compat.source.dir>src/main/java-c8-previous</c8.compat.source.dir>
+      </properties>
+    </profile>
+  </profiles>
 </project>

--- a/data-migrator/core/pom.xml
+++ b/data-migrator/core/pom.xml
@@ -17,11 +17,10 @@
 
   <properties>
     <!--
-      Selects which C8-version-specific source folder is compiled alongside
-      `src/main/java`. The `c8-previous-api` profile below flips this to
-      `src/main/java-c8-previous` when building against the previous C8 minor.
+      c8.compat.source.dir is defined at the root pom and flipped by the
+      root-level `c8-previous-api` profile (activated via
+      -Dversion.camunda-8=8.9.0).
     -->
-    <c8.compat.source.dir>src/main/java-c8-current</c8.compat.source.dir>
     <plugin.version.build-helper>3.6.0</plugin.version.build-helper>
   </properties>
 
@@ -294,19 +293,4 @@
       </plugin>
     </plugins>
   </build>
-
-  <profiles>
-    <profile>
-      <id>c8-previous-api</id>
-      <activation>
-        <property>
-          <name>version.camunda-8</name>
-          <value>8.9.0</value>
-        </property>
-      </activation>
-      <properties>
-        <c8.compat.source.dir>src/main/java-c8-previous</c8.compat.source.dir>
-      </properties>
-    </profile>
-  </profiles>
 </project>

--- a/data-migrator/core/src/main/java-c8-current/io/camunda/migration/data/config/mybatis/RdbmsServiceFactory.java
+++ b/data-migrator/core/src/main/java-c8-current/io/camunda/migration/data/config/mybatis/RdbmsServiceFactory.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.migration.data.config.mybatis;
+
+import io.camunda.db.rdbms.RdbmsService;
+import io.camunda.db.rdbms.read.service.AuditLogDbReader;
+import io.camunda.db.rdbms.read.service.AuthorizationDbReader;
+import io.camunda.db.rdbms.read.service.BatchOperationDbReader;
+import io.camunda.db.rdbms.read.service.BatchOperationItemDbReader;
+import io.camunda.db.rdbms.read.service.ClusterVariableDbReader;
+import io.camunda.db.rdbms.read.service.CorrelatedMessageSubscriptionDbReader;
+import io.camunda.db.rdbms.read.service.DecisionDefinitionDbReader;
+import io.camunda.db.rdbms.read.service.DecisionInstanceDbReader;
+import io.camunda.db.rdbms.read.service.DecisionRequirementsDbReader;
+import io.camunda.db.rdbms.read.service.DeployedResourceDbReader;
+import io.camunda.db.rdbms.read.service.FlowNodeInstanceDbReader;
+import io.camunda.db.rdbms.read.service.FormDbReader;
+import io.camunda.db.rdbms.read.service.GlobalListenerDbReader;
+import io.camunda.db.rdbms.read.service.GroupDbReader;
+import io.camunda.db.rdbms.read.service.GroupMemberDbReader;
+import io.camunda.db.rdbms.read.service.HistoryDeletionDbReader;
+import io.camunda.db.rdbms.read.service.IncidentDbReader;
+import io.camunda.db.rdbms.read.service.IncidentProcessInstanceStatisticsByDefinitionDbReader;
+import io.camunda.db.rdbms.read.service.IncidentProcessInstanceStatisticsByErrorDbReader;
+import io.camunda.db.rdbms.read.service.JobDbReader;
+import io.camunda.db.rdbms.read.service.JobMetricsBatchDbReader;
+import io.camunda.db.rdbms.read.service.MappingRuleDbReader;
+import io.camunda.db.rdbms.read.service.MessageSubscriptionDbReader;
+import io.camunda.db.rdbms.read.service.ProcessDefinitionDbReader;
+import io.camunda.db.rdbms.read.service.ProcessDefinitionInstanceStatisticsDbReader;
+import io.camunda.db.rdbms.read.service.ProcessDefinitionInstanceVersionStatisticsDbReader;
+import io.camunda.db.rdbms.read.service.ProcessDefinitionMessageSubscriptionStatisticsDbReader;
+import io.camunda.db.rdbms.read.service.ProcessInstanceDbReader;
+import io.camunda.db.rdbms.read.service.RoleDbReader;
+import io.camunda.db.rdbms.read.service.RoleMemberDbReader;
+import io.camunda.db.rdbms.read.service.SequenceFlowDbReader;
+import io.camunda.db.rdbms.read.service.TenantDbReader;
+import io.camunda.db.rdbms.read.service.TenantMemberDbReader;
+import io.camunda.db.rdbms.read.service.UsageMetricTUDbReader;
+import io.camunda.db.rdbms.read.service.UsageMetricsDbReader;
+import io.camunda.db.rdbms.read.service.UserDbReader;
+import io.camunda.db.rdbms.read.service.UserTaskDbReader;
+import io.camunda.db.rdbms.read.service.VariableDbReader;
+import io.camunda.db.rdbms.sql.DeployedResourceMapper;
+import io.camunda.db.rdbms.write.RdbmsWriterFactory;
+import io.camunda.migration.data.config.C8DataSourceConfigured;
+import org.apache.ibatis.session.SqlSessionFactory;
+import org.mybatis.spring.mapper.MapperFactoryBean;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@Conditional(C8DataSourceConfigured.class)
+public class RdbmsServiceFactory {
+
+  @Bean
+  public MapperFactoryBean<DeployedResourceMapper> deployedResourceMapper(
+      @Qualifier("c8SqlSessionFactory") final SqlSessionFactory c8SqlSessionFactory) {
+    final MapperFactoryBean<DeployedResourceMapper> factoryBean =
+        new MapperFactoryBean<>(DeployedResourceMapper.class);
+    factoryBean.setSqlSessionFactory(c8SqlSessionFactory);
+    return factoryBean;
+  }
+
+  @Bean
+  public DeployedResourceDbReader deployedResourceRdbmsReader(
+      final DeployedResourceMapper deployedResourceMapper) {
+    return new DeployedResourceDbReader(deployedResourceMapper);
+  }
+
+  @Bean
+  public RdbmsService rdbmsService(
+      final RdbmsWriterFactory rdbmsWriterFactory,
+      final AuditLogDbReader auditLogReader,
+      final AuthorizationDbReader authorizationReader,
+      final DecisionDefinitionDbReader decisionDefinitionReader,
+      final DecisionInstanceDbReader decisionInstanceReader,
+      final DecisionRequirementsDbReader decisionRequirementsReader,
+      final FlowNodeInstanceDbReader flowNodeInstanceReader,
+      final GroupDbReader groupReader,
+      final GroupMemberDbReader groupMemberReader,
+      final IncidentDbReader incidentReader,
+      final ProcessDefinitionDbReader processDefinitionReader,
+      final ProcessInstanceDbReader processInstanceReader,
+      final VariableDbReader variableReader,
+      final ClusterVariableDbReader clusterVariableReader,
+      final RoleDbReader roleReader,
+      final RoleMemberDbReader roleMemberReader,
+      final TenantDbReader tenantReader,
+      final TenantMemberDbReader tenantMemberReader,
+      final UserDbReader userReader,
+      final UserTaskDbReader userTaskReader,
+      final FormDbReader formReader,
+      final MappingRuleDbReader mappingRuleReader,
+      final BatchOperationDbReader batchOperationReader,
+      final SequenceFlowDbReader sequenceFlowReader,
+      final BatchOperationItemDbReader batchOperationItemReader,
+      final JobDbReader jobReader,
+      final JobMetricsBatchDbReader jobMetricsBatchDbReader,
+      final UsageMetricsDbReader usageMetricsReader,
+      final UsageMetricTUDbReader usageMetricTUDbReader,
+      final MessageSubscriptionDbReader messageSubscriptionDbReader,
+      final ProcessDefinitionMessageSubscriptionStatisticsDbReader
+          processDefinitionMessageSubscriptionStatisticsDbReader,
+      final CorrelatedMessageSubscriptionDbReader correlatedMessageDbReader,
+      final ProcessDefinitionInstanceStatisticsDbReader
+          processDefinitionInstanceStatisticsDbReader,
+      final ProcessDefinitionInstanceVersionStatisticsDbReader
+          processDefinitionInstanceVersionStatisticsDbReader,
+      final HistoryDeletionDbReader historyDeletionReader,
+      final IncidentProcessInstanceStatisticsByErrorDbReader
+          incidentProcessInstanceStatisticsByErrorDbReader,
+      final IncidentProcessInstanceStatisticsByDefinitionDbReader
+          incidentProcessInstanceStatisticsByDefinitionDbReader,
+      final GlobalListenerDbReader globalListenerReader,
+      final DeployedResourceDbReader deployedResourceReader) {
+    return new RdbmsService(
+        rdbmsWriterFactory,
+        auditLogReader,
+        authorizationReader,
+        decisionDefinitionReader,
+        decisionInstanceReader,
+        decisionRequirementsReader,
+        flowNodeInstanceReader,
+        groupReader,
+        groupMemberReader,
+        incidentReader,
+        processDefinitionReader,
+        processInstanceReader,
+        variableReader,
+        clusterVariableReader,
+        roleReader,
+        roleMemberReader,
+        tenantReader,
+        tenantMemberReader,
+        userReader,
+        userTaskReader,
+        formReader,
+        mappingRuleReader,
+        batchOperationReader,
+        sequenceFlowReader,
+        batchOperationItemReader,
+        jobReader,
+        jobMetricsBatchDbReader,
+        usageMetricsReader,
+        usageMetricTUDbReader,
+        messageSubscriptionDbReader,
+        processDefinitionMessageSubscriptionStatisticsDbReader,
+        correlatedMessageDbReader,
+        processDefinitionInstanceStatisticsDbReader,
+        processDefinitionInstanceVersionStatisticsDbReader,
+        historyDeletionReader,
+        incidentProcessInstanceStatisticsByErrorDbReader,
+        incidentProcessInstanceStatisticsByDefinitionDbReader,
+        globalListenerReader,
+        deployedResourceReader);
+  }
+}

--- a/data-migrator/core/src/main/java-c8-previous/io/camunda/migration/data/config/mybatis/RdbmsServiceFactory.java
+++ b/data-migrator/core/src/main/java-c8-previous/io/camunda/migration/data/config/mybatis/RdbmsServiceFactory.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.migration.data.config.mybatis;
+
+import io.camunda.db.rdbms.RdbmsService;
+import io.camunda.db.rdbms.read.service.AuditLogDbReader;
+import io.camunda.db.rdbms.read.service.AuthorizationDbReader;
+import io.camunda.db.rdbms.read.service.BatchOperationDbReader;
+import io.camunda.db.rdbms.read.service.BatchOperationItemDbReader;
+import io.camunda.db.rdbms.read.service.ClusterVariableDbReader;
+import io.camunda.db.rdbms.read.service.CorrelatedMessageSubscriptionDbReader;
+import io.camunda.db.rdbms.read.service.DecisionDefinitionDbReader;
+import io.camunda.db.rdbms.read.service.DecisionInstanceDbReader;
+import io.camunda.db.rdbms.read.service.DecisionRequirementsDbReader;
+import io.camunda.db.rdbms.read.service.FlowNodeInstanceDbReader;
+import io.camunda.db.rdbms.read.service.FormDbReader;
+import io.camunda.db.rdbms.read.service.GlobalListenerDbReader;
+import io.camunda.db.rdbms.read.service.GroupDbReader;
+import io.camunda.db.rdbms.read.service.GroupMemberDbReader;
+import io.camunda.db.rdbms.read.service.HistoryDeletionDbReader;
+import io.camunda.db.rdbms.read.service.IncidentDbReader;
+import io.camunda.db.rdbms.read.service.IncidentProcessInstanceStatisticsByDefinitionDbReader;
+import io.camunda.db.rdbms.read.service.IncidentProcessInstanceStatisticsByErrorDbReader;
+import io.camunda.db.rdbms.read.service.JobDbReader;
+import io.camunda.db.rdbms.read.service.JobMetricsBatchDbReader;
+import io.camunda.db.rdbms.read.service.MappingRuleDbReader;
+import io.camunda.db.rdbms.read.service.MessageSubscriptionDbReader;
+import io.camunda.db.rdbms.read.service.ProcessDefinitionDbReader;
+import io.camunda.db.rdbms.read.service.ProcessDefinitionInstanceStatisticsDbReader;
+import io.camunda.db.rdbms.read.service.ProcessDefinitionInstanceVersionStatisticsDbReader;
+import io.camunda.db.rdbms.read.service.ProcessDefinitionMessageSubscriptionStatisticsDbReader;
+import io.camunda.db.rdbms.read.service.ProcessInstanceDbReader;
+import io.camunda.db.rdbms.read.service.RoleDbReader;
+import io.camunda.db.rdbms.read.service.RoleMemberDbReader;
+import io.camunda.db.rdbms.read.service.SequenceFlowDbReader;
+import io.camunda.db.rdbms.read.service.TenantDbReader;
+import io.camunda.db.rdbms.read.service.TenantMemberDbReader;
+import io.camunda.db.rdbms.read.service.UsageMetricTUDbReader;
+import io.camunda.db.rdbms.read.service.UsageMetricsDbReader;
+import io.camunda.db.rdbms.read.service.UserDbReader;
+import io.camunda.db.rdbms.read.service.UserTaskDbReader;
+import io.camunda.db.rdbms.read.service.VariableDbReader;
+import io.camunda.db.rdbms.write.RdbmsWriterFactory;
+import io.camunda.migration.data.config.C8DataSourceConfigured;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@Conditional(C8DataSourceConfigured.class)
+public class RdbmsServiceFactory {
+
+  @Bean
+  public RdbmsService rdbmsService(
+      final RdbmsWriterFactory rdbmsWriterFactory,
+      final AuditLogDbReader auditLogReader,
+      final AuthorizationDbReader authorizationReader,
+      final DecisionDefinitionDbReader decisionDefinitionReader,
+      final DecisionInstanceDbReader decisionInstanceReader,
+      final DecisionRequirementsDbReader decisionRequirementsReader,
+      final FlowNodeInstanceDbReader flowNodeInstanceReader,
+      final GroupDbReader groupReader,
+      final GroupMemberDbReader groupMemberReader,
+      final IncidentDbReader incidentReader,
+      final ProcessDefinitionDbReader processDefinitionReader,
+      final ProcessInstanceDbReader processInstanceReader,
+      final VariableDbReader variableReader,
+      final ClusterVariableDbReader clusterVariableReader,
+      final RoleDbReader roleReader,
+      final RoleMemberDbReader roleMemberReader,
+      final TenantDbReader tenantReader,
+      final TenantMemberDbReader tenantMemberReader,
+      final UserDbReader userReader,
+      final UserTaskDbReader userTaskReader,
+      final FormDbReader formReader,
+      final MappingRuleDbReader mappingRuleReader,
+      final BatchOperationDbReader batchOperationReader,
+      final SequenceFlowDbReader sequenceFlowReader,
+      final BatchOperationItemDbReader batchOperationItemReader,
+      final JobDbReader jobReader,
+      final JobMetricsBatchDbReader jobMetricsBatchDbReader,
+      final UsageMetricsDbReader usageMetricsReader,
+      final UsageMetricTUDbReader usageMetricTUDbReader,
+      final MessageSubscriptionDbReader messageSubscriptionDbReader,
+      final ProcessDefinitionMessageSubscriptionStatisticsDbReader
+          processDefinitionMessageSubscriptionStatisticsDbReader,
+      final CorrelatedMessageSubscriptionDbReader correlatedMessageDbReader,
+      final ProcessDefinitionInstanceStatisticsDbReader
+          processDefinitionInstanceStatisticsDbReader,
+      final ProcessDefinitionInstanceVersionStatisticsDbReader
+          processDefinitionInstanceVersionStatisticsDbReader,
+      final HistoryDeletionDbReader historyDeletionReader,
+      final IncidentProcessInstanceStatisticsByErrorDbReader
+          incidentProcessInstanceStatisticsByErrorDbReader,
+      final IncidentProcessInstanceStatisticsByDefinitionDbReader
+          incidentProcessInstanceStatisticsByDefinitionDbReader,
+      final GlobalListenerDbReader globalListenerReader) {
+    return new RdbmsService(
+        rdbmsWriterFactory,
+        auditLogReader,
+        authorizationReader,
+        decisionDefinitionReader,
+        decisionInstanceReader,
+        decisionRequirementsReader,
+        flowNodeInstanceReader,
+        groupReader,
+        groupMemberReader,
+        incidentReader,
+        processDefinitionReader,
+        processInstanceReader,
+        variableReader,
+        clusterVariableReader,
+        roleReader,
+        roleMemberReader,
+        tenantReader,
+        tenantMemberReader,
+        userReader,
+        userTaskReader,
+        formReader,
+        mappingRuleReader,
+        batchOperationReader,
+        sequenceFlowReader,
+        batchOperationItemReader,
+        jobReader,
+        jobMetricsBatchDbReader,
+        usageMetricsReader,
+        usageMetricTUDbReader,
+        messageSubscriptionDbReader,
+        processDefinitionMessageSubscriptionStatisticsDbReader,
+        correlatedMessageDbReader,
+        processDefinitionInstanceStatisticsDbReader,
+        processDefinitionInstanceVersionStatisticsDbReader,
+        historyDeletionReader,
+        incidentProcessInstanceStatisticsByErrorDbReader,
+        incidentProcessInstanceStatisticsByDefinitionDbReader,
+        globalListenerReader);
+  }
+}

--- a/data-migrator/core/src/main/java/io/camunda/migration/data/config/mybatis/C8Configuration.java
+++ b/data-migrator/core/src/main/java/io/camunda/migration/data/config/mybatis/C8Configuration.java
@@ -8,7 +8,6 @@
 package io.camunda.migration.data.config.mybatis;
 
 import io.camunda.client.metrics.MetricsRecorder;
-import io.camunda.db.rdbms.RdbmsService;
 import io.camunda.db.rdbms.config.VendorDatabaseProperties;
 import io.camunda.db.rdbms.read.RdbmsReaderConfig;
 import io.camunda.db.rdbms.read.service.AuditLogDbReader;
@@ -563,85 +562,8 @@ public class C8Configuration extends AbstractConfiguration {
         historyDeletionMapper);
   }
 
-  @Bean
-  public RdbmsService rdbmsService(
-      RdbmsWriterFactory rdbmsWriterFactory,
-      AuditLogDbReader auditLogReader,
-      AuthorizationDbReader authorizationReader,
-      DecisionDefinitionDbReader decisionDefinitionReader,
-      DecisionInstanceDbReader decisionInstanceReader,
-      DecisionRequirementsDbReader decisionRequirementsReader,
-      FlowNodeInstanceDbReader flowNodeInstanceReader,
-      GroupDbReader groupReader,
-      GroupMemberDbReader groupMemberReader,
-      IncidentDbReader incidentReader,
-      ProcessDefinitionDbReader processDefinitionReader,
-      ProcessInstanceDbReader processInstanceReader,
-      VariableDbReader variableReader,
-      ClusterVariableDbReader clusterVariableReader,
-      RoleDbReader roleReader,
-      RoleMemberDbReader roleMemberReader,
-      TenantDbReader tenantReader,
-      TenantMemberDbReader tenantMemberReader,
-      UserDbReader userReader,
-      UserTaskDbReader userTaskReader,
-      FormDbReader formReader,
-      MappingRuleDbReader mappingRuleReader,
-      BatchOperationDbReader batchOperationReader,
-      SequenceFlowDbReader sequenceFlowReader,
-      BatchOperationItemDbReader batchOperationItemReader,
-      JobDbReader jobReader,
-      JobMetricsBatchDbReader jobMetricsBatchDbReader,
-      UsageMetricsDbReader usageMetricsReader,
-      UsageMetricTUDbReader usageMetricTUDbReader,
-      MessageSubscriptionDbReader messageSubscriptionDbReader,
-      ProcessDefinitionMessageSubscriptionStatisticsDbReader processDefinitionMessageSubscriptionStatisticsDbReader,
-      CorrelatedMessageSubscriptionDbReader correlatedMessageDbReader,
-      ProcessDefinitionInstanceStatisticsDbReader processDefinitionInstanceStatisticsDbReader,
-      ProcessDefinitionInstanceVersionStatisticsDbReader processDefinitionInstanceVersionStatisticsDbReader,
-      HistoryDeletionDbReader historyDeletionReader,
-      IncidentProcessInstanceStatisticsByErrorDbReader incidentProcessInstanceStatisticsByErrorDbReader,
-      IncidentProcessInstanceStatisticsByDefinitionDbReader incidentProcessInstanceStatisticsByDefinitionDbReader,
-      GlobalListenerDbReader globalListenerReader) {
-    return new RdbmsService(
-        rdbmsWriterFactory,
-        auditLogReader,
-        authorizationReader,
-        decisionDefinitionReader,
-        decisionInstanceReader,
-        decisionRequirementsReader,
-        flowNodeInstanceReader,
-        groupReader,
-        groupMemberReader,
-        incidentReader,
-        processDefinitionReader,
-        processInstanceReader,
-        variableReader,
-        clusterVariableReader,
-        roleReader,
-        roleMemberReader,
-        tenantReader,
-        tenantMemberReader,
-        userReader,
-        userTaskReader,
-        formReader,
-        mappingRuleReader,
-        batchOperationReader,
-        sequenceFlowReader,
-        batchOperationItemReader,
-        jobReader,
-        jobMetricsBatchDbReader,
-        usageMetricsReader,
-        usageMetricTUDbReader,
-        messageSubscriptionDbReader,
-        processDefinitionMessageSubscriptionStatisticsDbReader,
-        correlatedMessageDbReader,
-        processDefinitionInstanceStatisticsDbReader,
-        processDefinitionInstanceVersionStatisticsDbReader,
-        historyDeletionReader,
-        incidentProcessInstanceStatisticsByErrorDbReader,
-        incidentProcessInstanceStatisticsByDefinitionDbReader,
-        globalListenerReader);
-  }
-
+  // The `rdbmsService` @Bean lives in `RdbmsServiceFactory`, which has a
+  // version-specific copy under `src/main/java-c8-current` (8.10) and
+  // `src/main/java-c8-previous` (8.9). Maven selects one of them at compile
+  // time via the `c8.compat.source.dir` property.
 }

--- a/data-migrator/distro/pom.xml
+++ b/data-migrator/distro/pom.xml
@@ -44,6 +44,12 @@
   </dependencies>
 
   <build>
+    <!--
+      finalName gets `${c8.artifact.version.suffix}` appended so the default (current
+      C8) build keeps the historical filename and the `c8-previous-api` profile
+      produces `…-distro-${project.version}-c8-previous.jar`, a side-by-side output.
+    -->
+    <finalName>${project.artifactId}-${project.version}${c8.artifact.version.suffix}</finalName>
     <plugins>
       <plugin>
         <artifactId>maven-jar-plugin</artifactId>

--- a/data-migrator/plugins/cockpit/frontend/package-lock.json
+++ b/data-migrator/plugins/cockpit/frontend/package-lock.json
@@ -2273,9 +2273,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2290,9 +2287,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2307,9 +2301,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2324,9 +2315,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2341,9 +2329,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2358,9 +2343,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2375,9 +2357,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2392,9 +2371,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2409,9 +2385,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2426,9 +2399,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2443,9 +2413,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2460,9 +2427,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2477,9 +2441,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/data-migrator/qa/e2e-tests/src/main/resources/docker-compose.yml.template
+++ b/data-migrator/qa/e2e-tests/src/main/resources/docker-compose.yml.template
@@ -62,7 +62,7 @@ services:
   data-migrator:
     image: eclipse-temurin:21-jdk
     volumes:
-      - ../../assembly/target/camunda-7-to-8-data-migrator-${project.version}.zip:/tmp/migrator.zip:ro
+      - ../../assembly/target/camunda-7-to-8-data-migrator-${project.version}${c8.artifact.version.suffix}.zip:/tmp/migrator.zip:ro
       - ./src/main/resources/invoice-example:/app/configuration/resources/invoice:ro
       - ./src/main/resources/process-example-c8:/app/configuration/resources/process:ro
       - ./src/main/resources/process-example:/tmp/c7-bpmns:ro

--- a/data-migrator/qa/e2e-tests/tests/operate-processes.spec.ts
+++ b/data-migrator/qa/e2e-tests/tests/operate-processes.spec.ts
@@ -11,14 +11,20 @@ import { test, expect } from '@playwright/test';
 const OPERATE_URL = 'http://localhost:8088/operate';
 
 /**
- * Helper: dismiss the "Here's what moved in Operate" changelog modal if present.
+ * Helper: install a persistent handler that auto-dismisses Operate's
+ * "Here's what moved in Operate" changelog modal whenever it appears.
+ *
+ * The modal can render asynchronously after login and intercept pointer
+ * events on tab buttons — particularly on Firefox, which hydrates the
+ * Operate React UI more slowly on CI and often misses a one-shot probe.
+ * `page.addLocatorHandler` makes Playwright dismiss the modal before every
+ * subsequent action, eliminating the race.
  */
-async function dismissChangelogModal(page: any) {
+async function installChangelogHandler(page: any) {
   const gotItButton = page.locator('button:has-text("Got it")');
-  if (await gotItButton.isVisible({ timeout: 2000 }).catch(() => false)) {
+  await page.addLocatorHandler(gotItButton, async () => {
     await gotItButton.click();
-    await gotItButton.waitFor({ state: 'hidden', timeout: 5000 });
-  }
+  });
 }
 
 /**
@@ -43,7 +49,7 @@ async function login(page: any) {
       .waitFor({ state: 'hidden', timeout: 15000 });
   }
 
-  await dismissChangelogModal(page);
+  await installChangelogHandler(page);
 }
 
 /**
@@ -78,8 +84,6 @@ async function openProcessInstance(page: any, processName: string) {
 
   await page.waitForURL('**/processes/**', { timeout: 10000 });
   await page.waitForTimeout(3000);
-
-  await dismissChangelogModal(page);
 }
 
 /**
@@ -270,8 +274,6 @@ test.describe('Operate - Process Instances & Audit Logs', () => {
 
     await page.waitForURL('**/processes/**', { timeout: 10000 });
     await page.waitForLoadState('networkidle');
-
-    await dismissChangelogModal(page);
 
     // "Operations Log" is a tab button in the right panel (next to Variables, Listeners)
     const operationsLogTab = page

--- a/data-migrator/qa/integration-tests/pom.xml
+++ b/data-migrator/qa/integration-tests/pom.xml
@@ -22,6 +22,12 @@
     <version.mariadb>3.5.8</version.mariadb>
     <version.sqlserver>13.4.0.jre11</version.sqlserver>
     <version.jakarta-xml-bind-api>4.0.5</version.jakarta-xml-bind-api>
+    <!--
+      Camunda 8 API compat source directory. Defaults to the current C8 version.
+      Overridden by the c8-previous-api profile when building against the previous C8 version.
+      See the c8-previous-api profile below and C8QueryCompat.java for details.
+    -->
+    <c8.compat.source.dir>src/test/java-c8-current</c8.compat.source.dir>
   </properties>
 
   <dependencies>
@@ -216,10 +222,54 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <version>3.5.5</version>
       </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
+        <version>3.6.1</version>
+        <executions>
+          <execution>
+            <id>add-c8-compat-test-source</id>
+            <phase>generate-test-sources</phase>
+            <goals>
+              <goal>add-test-source</goal>
+            </goals>
+            <configuration>
+              <sources>
+                <source>${c8.compat.source.dir}</source>
+              </sources>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 
   <profiles>
+    <!--
+      Camunda 8 API compatibility profile.
+
+      The integration tests delegate version-specific query construction to
+      io.camunda.migration.data.qa.c8compat.C8QueryCompat. Two parallel
+      implementations live under src/test/java-c8-current (default) and
+      src/test/java-c8-previous. The build-helper plugin in the main <build>
+      section wires in ${c8.compat.source.dir}; this profile overrides that
+      property when building against the previous C8 version.
+
+      When bumping version.camunda-8.previous in the parent POM, update the
+      activation <value> below to match.
+    -->
+    <profile>
+      <id>c8-previous-api</id>
+      <activation>
+        <property>
+          <name>version.camunda-8</name>
+          <value>8.9.0</value>
+        </property>
+      </activation>
+      <properties>
+        <c8.compat.source.dir>src/test/java-c8-previous</c8.compat.source.dir>
+      </properties>
+    </profile>
     <profile>
       <id>postgresql</id>
       <build>

--- a/data-migrator/qa/integration-tests/src/test/java-c8-current/io/camunda/migration/data/qa/c8compat/C8QueryCompat.java
+++ b/data-migrator/qa/integration-tests/src/test/java-c8-current/io/camunda/migration/data/qa/c8compat/C8QueryCompat.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.migration.data.qa.c8compat;
+
+import io.camunda.search.query.FlowNodeInstanceQuery;
+import io.camunda.search.query.ProcessDefinitionQuery;
+import java.util.Arrays;
+
+/**
+ * Version-specific test query helpers for the current Camunda 8 version.
+ *
+ * <p>Lives under {@code src/test/java-c8-current} and is added to the test source set by the
+ * {@code c8-current-api} Maven profile. A parallel implementation exists under
+ * {@code src/test/java-c8-previous} for the previous Camunda 8 version.
+ */
+public final class C8QueryCompat {
+
+  private C8QueryCompat() {}
+
+  public static ProcessDefinitionQuery processDefinitionQueryWithBpmnXml(
+      final String prefixedProcessDefinitionId) {
+    return ProcessDefinitionQuery.of(
+        queryBuilder ->
+            queryBuilder
+                .filter(filterBuilder -> filterBuilder.processDefinitionIds(prefixedProcessDefinitionId))
+                .resultConfig(b -> b.includeXml(true)));
+  }
+
+  public static FlowNodeInstanceQuery flowNodeInstanceQueryByIds(final String... flowNodeIds) {
+    if (flowNodeIds.length == 0) {
+      throw new IllegalArgumentException("At least one flowNodeId is required");
+    }
+    final String first = flowNodeIds[0];
+    final String[] rest = Arrays.copyOfRange(flowNodeIds, 1, flowNodeIds.length);
+    return FlowNodeInstanceQuery.of(
+        queryBuilder ->
+            queryBuilder.filter(filterBuilder -> filterBuilder.flowNodeIds(first, rest)));
+  }
+}

--- a/data-migrator/qa/integration-tests/src/test/java-c8-previous/io/camunda/migration/data/qa/c8compat/C8QueryCompat.java
+++ b/data-migrator/qa/integration-tests/src/test/java-c8-previous/io/camunda/migration/data/qa/c8compat/C8QueryCompat.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.migration.data.qa.c8compat;
+
+import io.camunda.search.query.FlowNodeInstanceQuery;
+import io.camunda.search.query.ProcessDefinitionQuery;
+
+/**
+ * Version-specific test query helpers for the previous Camunda 8 version.
+ *
+ * <p>Lives under {@code src/test/java-c8-previous} and is added to the test source set by the
+ * {@code c8-previous-api} Maven profile (activated when {@code -Dversion.camunda-8} matches the
+ * previous version pin). A parallel implementation exists under {@code src/test/java-c8-current}
+ * for the current Camunda 8 version.
+ *
+ * <p>In 8.9 {@code ProcessDefinitionQuery.Builder} has no {@code resultConfig} — BPMN XML is
+ * included by default. {@code FlowNodeInstanceFilter.Builder.flowNodeIds} accepts a varargs
+ * {@code String[]} directly.
+ */
+public final class C8QueryCompat {
+
+  private C8QueryCompat() {}
+
+  public static ProcessDefinitionQuery processDefinitionQueryWithBpmnXml(
+      final String prefixedProcessDefinitionId) {
+    return ProcessDefinitionQuery.of(
+        queryBuilder ->
+            queryBuilder.filter(
+                filterBuilder -> filterBuilder.processDefinitionIds(prefixedProcessDefinitionId)));
+  }
+
+  public static FlowNodeInstanceQuery flowNodeInstanceQueryByIds(final String... flowNodeIds) {
+    return FlowNodeInstanceQuery.of(
+        queryBuilder ->
+            queryBuilder.filter(filterBuilder -> filterBuilder.flowNodeIds(flowNodeIds)));
+  }
+}

--- a/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/extension/HistoryMigrationExtension.java
+++ b/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/extension/HistoryMigrationExtension.java
@@ -15,6 +15,7 @@ import io.camunda.db.rdbms.write.service.RdbmsPurger;
 import io.camunda.migration.data.HistoryMigrator;
 import io.camunda.migration.data.MigratorMode;
 import io.camunda.migration.data.impl.clients.DbClient;
+import io.camunda.migration.data.qa.c8compat.C8QueryCompat;
 import io.camunda.migration.data.qa.util.SpringProfileResolver;
 import io.camunda.search.entities.DecisionDefinitionEntity;
 import io.camunda.search.entities.DecisionInstanceEntity;
@@ -255,9 +256,7 @@ public class HistoryMigrationExtension implements BeforeEachCallback, AfterEachC
       throw new IllegalStateException("RdbmsService is not available in the Spring context");
     }
     return rdbmsService.getFlowNodeInstanceReader()
-        .search(FlowNodeInstanceQuery.of(queryBuilder ->
-            queryBuilder.filter(filterBuilder ->
-                filterBuilder.flowNodeIds(flowNodeIds))))
+        .search(C8QueryCompat.flowNodeInstanceQueryByIds(flowNodeIds))
         .items();
   }
 

--- a/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/history/HistoryMigrationAbstractTest.java
+++ b/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/history/HistoryMigrationAbstractTest.java
@@ -29,6 +29,7 @@ import io.camunda.migration.data.config.MigratorAutoConfiguration;
 import io.camunda.migration.data.impl.clients.DbClient;
 import io.camunda.migration.data.impl.util.ConverterUtil;
 import io.camunda.migration.data.qa.AbstractMigratorTest;
+import io.camunda.migration.data.qa.c8compat.C8QueryCompat;
 import io.camunda.migration.data.qa.extension.RdbmsQueryExtension;
 import io.camunda.migration.data.qa.util.WithSpringProfile;
 import io.camunda.search.entities.AuditLogEntity;
@@ -136,11 +137,7 @@ public abstract class HistoryMigrationAbstractTest extends AbstractMigratorTest 
 
   public List<ProcessDefinitionEntity> searchHistoricProcessDefinitionsWithBpmnXml(String processDefinitionId) {
     return rdbmsService.getProcessDefinitionReader()
-        .search(ProcessDefinitionQuery.of(queryBuilder ->
-            queryBuilder
-                .filter(filterBuilder ->
-                    filterBuilder.processDefinitionIds(prefixDefinitionId(processDefinitionId)))
-                .resultConfig(b -> b.includeXml(true))))
+        .search(C8QueryCompat.processDefinitionQueryWithBpmnXml(prefixDefinitionId(processDefinitionId)))
         .items();
   }
 

--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,21 @@
     <version.camunda-7>7.24.6-ee</version.camunda-7>
     <version.camunda-8>8.10.0-SNAPSHOT</version.camunda-8>
     <version.camunda-8.previous>8.9.0</version.camunda-8.previous>
+
+    <!--
+      C8-version-specific build knobs. Default values target the "current" C8 minor
+      (same as ${version.camunda-8}). The `c8-previous-api` profile below overrides
+      them to compile/package against ${version.camunda-8.previous}.
+
+      - c8.compat.source.dir: consumed by data-migrator/core; picks the parallel
+        source folder (java-c8-current vs. java-c8-previous) compiled alongside
+        src/main/java.
+      - c8.artifact.version.suffix: appended to distro/assembly filenames and the
+        e2e docker-compose template so the two C8 versions produce side-by-side,
+        non-colliding artifacts. Empty for the default (current) build.
+    -->
+    <c8.compat.source.dir>src/main/java-c8-current</c8.compat.source.dir>
+    <c8.artifact.version.suffix></c8.artifact.version.suffix>
     <camunda8.docker.image>camunda/camunda:SNAPSHOT</camunda8.docker.image>
     <version.elasticsearch>8.19.6</version.elasticsearch>
     <version.spring-boot>4.0.5</version.spring-boot>
@@ -229,4 +244,20 @@
       </plugin>
     </plugins>
   </build>
+
+  <profiles>
+    <profile>
+      <id>c8-previous-api</id>
+      <activation>
+        <property>
+          <name>version.camunda-8</name>
+          <value>8.9.0</value>
+        </property>
+      </activation>
+      <properties>
+        <c8.compat.source.dir>src/main/java-c8-previous</c8.compat.source.dir>
+        <c8.artifact.version.suffix>-c8-previous</c8.artifact.version.suffix>
+      </properties>
+    </profile>
+  </profiles>
 </project>


### PR DESCRIPTION

related to #1299

# Pull Request Template

## Description
<!-- Describe your changes in detail -->

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Test-only changes (no production code changes)

## Testing Checklist

### Black-Box Testing Requirements
- [ ] Tests follow **black-box testing approach**: verify behavior through observable outputs (logs, C8 API queries, real-world skip scenarios)
- [ ] Tests **DO NOT** access implementation details (`DbClient`, `IdKeyMapper`, `..impl..` packages except logging constants)
- [ ] Architecture tests pass (`ArchitectureTest` validates these rules)

### Test Coverage
- [ ] Added tests for new functionality
- [ ] Updated tests for modified functionality
- [ ] All tests pass locally

## Architecture Compliance

Run architecture tests to ensure compliance:
```bash
mvn test -Dtest=ArchitectureTest
```

If architecture tests fail, refactor your tests to use:
- `LogCapturer` for log assertions
- `camundaClient.new*SearchRequest()` for C8 queries
- Real-World skip scenarios (e.g., migrate children without parents)

## Documentation
- [ ] Updated TESTING_GUIDELINES.md if adding new test patterns
- [ ] Added Javadoc comments for public APIs
- [ ] Updated README if user-facing changes

## Checklist
- [ ] Code follows project style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments for complex logic
- [ ] No new compiler warnings
- [ ] Dependent changes have been merged

## Related Issues
<!-- Link to related issues: Fixes #123, Related to #456 -->

