### PR TITLE
feat(diagram-converter): POC map C7 jobPriority to C8 zeebe:jobPriori…

### DIFF
--- a/diagram-converter/POC_JOB_PRIORITY.md
+++ b/diagram-converter/POC_JOB_PRIORITY.md
@@ -44,6 +44,36 @@ carries both `camunda:jobPriority` and `camunda:taskPriority`:
 Raw C7 values (not FEEL-transformed) are used in the message so an author
 auditing against their C7 source sees what they wrote.
 
+### Out-of-range literals (C7 long → C8 int32)
+
+C7 stores priority as `long`; C8's `zeebe:jobPriorityDefinition priority`
+attribute is an int32. For literal numeric values outside
+`[-2147483648, 2147483647]`:
+
+- **No `zeebe:jobPriorityDefinition` is emitted.**
+- A **TASK** severity message is emitted telling the user to set a valid
+  value manually.
+
+**Why skip rather than clamp**: clamping to `Integer.MAX_VALUE` would turn
+"not representable" into a substantive business decision the converter
+cannot justify. For a C7 value like `-9999999999` (low priority),
+clamping to `Integer.MAX_VALUE` produces the opposite intent silently. Even
+sign-aware clamping leaves a large-magnitude value in the user's BPMN that
+looks deliberate. TASK severity matches the codebase convention for "manual
+action required" (vs. REVIEW which is "verify the converter's call").
+
+Expression values (`${x}` / `=x`) can't be validated at conversion time —
+they're passed through unchanged.
+
+**Edge case — taskPriority out-of-range on an element that also has a valid
+jobPriority**: the out-of-range TASK wins over the collision REVIEW and
+taskPriority is dropped per the usual policy; the in-range jobPriority is
+*also* dropped because `JobPriorityVisitor` short-circuits whenever a
+sibling `camunda:taskPriority` is present. Net effect: no priority set,
+single TASK message. A smarter policy could fall back to jobPriority in this
+niche case, but it wasn't requested and adds branching to something
+specified as a simple precedence rule. Flagged here for visibility.
+
 ## Design decisions
 
 ### Decision 1 — Refactor the existing `JobPriorityVisitor` (chosen)
@@ -120,7 +150,8 @@ fixtures. No API, no public extension-point surface depends on it.
 | `conversion/ProcessElementConversion.java` | Emits `<zeebe:jobPriorityDefinition priority="..."/>` when set. |
 | `visitor/impl/attribute/JobPriorityVisitor.java` | Refactored to extend `AbstractSupportedAttributeVisitor`; transforms value and calls `addConversion`. Short-circuits (no transform, no message) when sibling `camunda:taskPriority` present. |
 | `visitor/impl/attribute/TaskPriorityVisitor.java` | Refactored from "not supported" to converting visitor. Owns the write + emits the collision REVIEW message when both attributes present. |
-| `message/MessageFactory.java` + `resources/message-templates.properties` | New `job-priority-collision` REVIEW message. |
+| `visitor/impl/attribute/PriorityRangeValidator.java` | Shared helper: returns a TASK message when a literal priority is outside int32 range; null otherwise. |
+| `message/MessageFactory.java` + `resources/message-templates.properties` | New `job-priority-collision` REVIEW and `priority-out-of-range` TASK messages. |
 | `test/resources/BPMN_CONVERSION.yaml` | Test cases: literal/FEEL on service/send/user task, literal/FEEL taskPriority, collision (both attrs). |
 | `test/resources/job-priority.bpmn` + Java test | Process-level + element-level assertions including the collision path. |
 | `test/resources/collaboration.bpmn` | (unchanged fixture; smoke-test still exercises the conversion on a process.) |
@@ -130,9 +161,11 @@ fixtures. No API, no public extension-point surface depends on it.
 - No explicit filter on element type. The visitor runs whenever the attribute
   is present on any BPMN element — same as before. If C8 ends up restricting
   `jobPriorityDefinition` to a specific subset, add a `canVisit` override.
-- No priority-range validation (C7 allowed any long; C8 proposal does not
-  pin a range yet).
 - No message-template localization: the POC currently reuses the generic
   `ExpressionTransformationResultMessageFactory` message for expressions,
   which references the generic migration-docs link. A dedicated message
   entry + docs link can be added once the C8 docs page exists.
+- The taskPriority-out-of-range + in-range-jobPriority edge case
+  (documented above) could fall back to jobPriority instead of dropping
+  both. Intentionally not implemented — the precedence rule was specified
+  as deterministic.

--- a/diagram-converter/POC_JOB_PRIORITY.md
+++ b/diagram-converter/POC_JOB_PRIORITY.md
@@ -6,11 +6,13 @@ activation](https://github.com/camunda/camunda/issues) (C8 epic — Aug 2026).
 
 ## Scope
 
-- Source: `camunda:jobPriority` attribute, on any BPMN element the C7 engine
-  accepts it on (process, activities, events).
-- Target: `<zeebe:jobPriorityDefinition priority="..." />` extension element.
-- Out of scope for this POC: `camunda:taskPriority` (external task topics) and
-  `camunda:priority` (user task) — both remain unsupported as before.
+- Sources: `camunda:jobPriority` (internal job executor acquisition order) and
+  `camunda:taskPriority` (external-task worker fetch order) on any BPMN
+  element the C7 engine accepts them on (process, activities, events).
+- Target: single `<zeebe:jobPriorityDefinition priority="..." />` extension
+  element (C8 has one job-worker priority slot per element).
+- Out of scope: `camunda:priority` (user task priority) — remains unsupported
+  as before.
 
 ### Value handling
 
@@ -19,6 +21,28 @@ activation](https://github.com/camunda/camunda/issues) (C8 epic — Aug 2026).
   `ExpressionTransformer.transformToFeel(...)` → `priority="=jobPriority"`.
 
 This matches how `camunda:dueDate` is already handled.
+
+### Collision policy (both attributes on the same element)
+
+C7 defines two independent priority queues; C8 has one. When an element
+carries both `camunda:jobPriority` and `camunda:taskPriority`:
+
+1. **`taskPriority` wins** — it maps to how external-task users already
+   expect worker fetch order to behave, which is closer to C8's pull-based
+   job activation semantics.
+2. **`jobPriority` is dropped — never transformed.** Detection happens
+   before FEEL transformation to avoid polluting the message stream with
+   warnings about a discarded expression (e.g. `expression-execution-not-available`
+   messages for the loser).
+3. **A REVIEW message is emitted** on the element reporting both raw C7
+   values and the policy applied:
+
+   > Both `camunda:jobPriority` (value 'X') and `camunda:taskPriority` (value 'Y')
+   > are defined on 'serviceTask'. The converter used `taskPriority` per default
+   > policy; `jobPriority` was ignored.
+
+Raw C7 values (not FEEL-transformed) are used in the message so an author
+auditing against their C7 source sees what they wrote.
 
 ## Design decisions
 
@@ -92,11 +116,14 @@ fixtures. No API, no public extension-point surface depends on it.
 
 | File | Change |
 |---|---|
-| `convertible/AbstractProcessElementConvertible.java` | Added `ZeebeJobPriorityDefinition` holder + getter/setter. |
+| `convertible/AbstractProcessElementConvertible.java` | Added `ZeebeJobPriorityDefinition` holder. |
 | `conversion/ProcessElementConversion.java` | Emits `<zeebe:jobPriorityDefinition priority="..."/>` when set. |
-| `visitor/impl/attribute/JobPriorityVisitor.java` | Refactored to extend `AbstractSupportedAttributeVisitor`; transforms value and calls `addConversion`. |
-| `test/resources/BPMN_CONVERSION.yaml` | Test cases: literal on service task, FEEL on service task, literal on send task. |
-| `test/resources/collaboration.bpmn` | (unchanged, but the existing smoke-test now exercises the conversion on a process.) |
+| `visitor/impl/attribute/JobPriorityVisitor.java` | Refactored to extend `AbstractSupportedAttributeVisitor`; transforms value and calls `addConversion`. Short-circuits (no transform, no message) when sibling `camunda:taskPriority` present. |
+| `visitor/impl/attribute/TaskPriorityVisitor.java` | Refactored from "not supported" to converting visitor. Owns the write + emits the collision REVIEW message when both attributes present. |
+| `message/MessageFactory.java` + `resources/message-templates.properties` | New `job-priority-collision` REVIEW message. |
+| `test/resources/BPMN_CONVERSION.yaml` | Test cases: literal/FEEL on service/send/user task, literal/FEEL taskPriority, collision (both attrs). |
+| `test/resources/job-priority.bpmn` + Java test | Process-level + element-level assertions including the collision path. |
+| `test/resources/collaboration.bpmn` | (unchanged fixture; smoke-test still exercises the conversion on a process.) |
 
 ## Limitations / follow-ups
 

--- a/diagram-converter/POC_JOB_PRIORITY.md
+++ b/diagram-converter/POC_JOB_PRIORITY.md
@@ -1,0 +1,111 @@
+# POC: C7 `camunda:jobPriority` → C8 `<zeebe:jobPriorityDefinition>`
+
+Proof of concept for mapping the Camunda 7 job priority attribute to the new
+Camunda 8 Zeebe extension element proposed for [job pull priority
+activation](https://github.com/camunda/camunda/issues) (C8 epic — Aug 2026).
+
+## Scope
+
+- Source: `camunda:jobPriority` attribute, on any BPMN element the C7 engine
+  accepts it on (process, activities, events).
+- Target: `<zeebe:jobPriorityDefinition priority="..." />` extension element.
+- Out of scope for this POC: `camunda:taskPriority` (external task topics) and
+  `camunda:priority` (user task) — both remain unsupported as before.
+
+### Value handling
+
+- Numeric literal `"90"` → emitted as-is: `priority="90"`.
+- JUEL expression `"${jobPriority}"` → transformed via the existing
+  `ExpressionTransformer.transformToFeel(...)` → `priority="=jobPriority"`.
+
+This matches how `camunda:dueDate` is already handled.
+
+## Design decisions
+
+### Decision 1 — Refactor the existing `JobPriorityVisitor` (chosen)
+
+Before this POC, [JobPriorityVisitor](core/src/main/java/io/camunda/migration/diagram/converter/visitor/impl/attribute/JobPriorityVisitor.java)
+extended `AbstractRemoveAttributeVisitor` — it silently removed the attribute
+and emitted an "attribute removed" message. The POC changes its base class to
+`AbstractSupportedAttributeVisitor` so it can now produce output.
+
+**Option A — Refactor the existing visitor (chosen).**
+
+- One attribute → one visitor. Matches the pattern used by `TaskTopicVisitor`,
+  `DueDateVisitor`, `FollowUpDateVisitor`, etc. (all converting attributes
+  extend `AbstractSupportedAttributeVisitor` from day one).
+- No double-processing risk. `AbstractAttributeVisitor#visitFilteredElement`
+  (line 18) unconditionally queues the attribute for removal via
+  `addAttributeToRemove`, so two visitors on the same attribute would both
+  declare it for removal *and* each emit its own message — noisy and
+  redundant.
+- Single registration in the `META-INF/services` file.
+- The existing "attribute removed" message becomes misleading once the value
+  is preserved; refactoring fixes that at the same time.
+
+**Option B — Keep the old visitor, add a new `JobPriorityDefinitionVisitor` (not chosen).**
+
+- Pro: smallest surface-area diff to the existing class.
+- Cons:
+  - The old visitor still emits `MessageFactory.attributeRemoved(...)`, which
+    now contradicts the new behavior. You would either have to gut the old
+    visitor (equivalent effort to refactoring it) or tolerate a stale
+    message.
+  - Two visitors on the same `{BPMN, camunda:jobPriority}` pair both run —
+    order is SPI-load-order dependent; either one of them would have to
+    override `canVisit` to short-circuit, or the old one would need
+    deregistering. Either way the "small diff" argument disappears.
+  - Diverges from the convention used everywhere else in the codebase.
+- Estimated effort to adopt Option B later anyway: ~15 min (same code, just
+  split across two classes and re-registered). The refactor in Option A is
+  not a one-way door.
+
+### Decision 2 — Emit `<zeebe:jobPriorityDefinition>` on the common base convertible
+
+The convertible hierarchy rooted at `AbstractProcessElementConvertible` covers
+every BPMN element that can carry the attribute: process, all activities
+(service/user/send/receive/business-rule/script/manual tasks, sub-processes,
+call activities, transactions) and events. Placing the field on the common
+base means:
+
+- One field, one conversion writer (`ProcessElementConversion`).
+- Works automatically on every new element type that extends the base.
+
+Field lives on `AbstractProcessElementConvertible` as an inner
+`ZeebeJobPriorityDefinition` holder, paralleling `ZeebeProperty` already on
+the same class. Output serialization is added to
+[ProcessElementConversion](core/src/main/java/io/camunda/migration/diagram/converter/conversion/ProcessElementConversion.java),
+which already handles extension-element creation for this base type.
+
+### Decision 3 — Zeebe extension element name
+
+The C8 proposal lists two candidates: `zeebe:jobPriorityDefinition` and
+`zeebe:taskPriorityDefinition`. This POC uses **`zeebe:jobPriorityDefinition`**
+— the proposal's stated preference and the name that contrasts most clearly
+with the existing `zeebe:priorityDefinition` (user task).
+
+Effort to switch to the alternative name: **trivial** (~2 min). The name
+appears in exactly two places — the conversion writer and the YAML test
+fixtures. No API, no public extension-point surface depends on it.
+
+## What changed
+
+| File | Change |
+|---|---|
+| `convertible/AbstractProcessElementConvertible.java` | Added `ZeebeJobPriorityDefinition` holder + getter/setter. |
+| `conversion/ProcessElementConversion.java` | Emits `<zeebe:jobPriorityDefinition priority="..."/>` when set. |
+| `visitor/impl/attribute/JobPriorityVisitor.java` | Refactored to extend `AbstractSupportedAttributeVisitor`; transforms value and calls `addConversion`. |
+| `test/resources/BPMN_CONVERSION.yaml` | Test cases: literal on service task, FEEL on service task, literal on send task. |
+| `test/resources/collaboration.bpmn` | (unchanged, but the existing smoke-test now exercises the conversion on a process.) |
+
+## Limitations / follow-ups
+
+- No explicit filter on element type. The visitor runs whenever the attribute
+  is present on any BPMN element — same as before. If C8 ends up restricting
+  `jobPriorityDefinition` to a specific subset, add a `canVisit` override.
+- No priority-range validation (C7 allowed any long; C8 proposal does not
+  pin a range yet).
+- No message-template localization: the POC currently reuses the generic
+  `ExpressionTransformationResultMessageFactory` message for expressions,
+  which references the generic migration-docs link. A dedicated message
+  entry + docs link can be added once the C8 docs page exists.

--- a/diagram-converter/core/src/main/java/io/camunda/migration/diagram/converter/conversion/ProcessElementConversion.java
+++ b/diagram-converter/core/src/main/java/io/camunda/migration/diagram/converter/conversion/ProcessElementConversion.java
@@ -11,6 +11,7 @@ import static io.camunda.migration.diagram.converter.BpmnElementFactory.*;
 
 import io.camunda.migration.diagram.converter.NamespaceUri;
 import io.camunda.migration.diagram.converter.convertible.AbstractProcessElementConvertible;
+import io.camunda.migration.diagram.converter.convertible.AbstractProcessElementConvertible.ZeebeJobPriorityDefinition;
 import io.camunda.migration.diagram.converter.convertible.AbstractProcessElementConvertible.ZeebeProperty;
 import org.camunda.bpm.model.xml.instance.DomDocument;
 import org.camunda.bpm.model.xml.instance.DomElement;
@@ -29,6 +30,18 @@ public class ProcessElementConversion
     if (convertible.getZeebeProperties() != null && !convertible.getZeebeProperties().isEmpty()) {
       extensionElements.appendChild(createProperties(element.getDocument(), convertible));
     }
+    if (convertible.getZeebeJobPriorityDefinition().getPriority() != null) {
+      extensionElements.appendChild(
+          createJobPriorityDefinition(
+              element.getDocument(), convertible.getZeebeJobPriorityDefinition()));
+    }
+  }
+
+  private DomElement createJobPriorityDefinition(
+      DomDocument document, ZeebeJobPriorityDefinition jobPriorityDefinition) {
+    DomElement element = document.createElement(NamespaceUri.ZEEBE, "jobPriorityDefinition");
+    element.setAttribute("priority", jobPriorityDefinition.getPriority());
+    return element;
   }
 
   private DomElement createProperties(

--- a/diagram-converter/core/src/main/java/io/camunda/migration/diagram/converter/convertible/AbstractProcessElementConvertible.java
+++ b/diagram-converter/core/src/main/java/io/camunda/migration/diagram/converter/convertible/AbstractProcessElementConvertible.java
@@ -12,6 +12,8 @@ import java.util.Set;
 
 public abstract class AbstractProcessElementConvertible implements Convertible {
   private Set<ZeebeProperty> zeebeProperties;
+  private final ZeebeJobPriorityDefinition zeebeJobPriorityDefinition =
+      new ZeebeJobPriorityDefinition();
 
   public Set<ZeebeProperty> getZeebeProperties() {
     return zeebeProperties;
@@ -29,6 +31,22 @@ public abstract class AbstractProcessElementConvertible implements Convertible {
       zeebeProperties = new HashSet<>();
     }
     zeebeProperties.add(property);
+  }
+
+  public ZeebeJobPriorityDefinition getZeebeJobPriorityDefinition() {
+    return zeebeJobPriorityDefinition;
+  }
+
+  public static class ZeebeJobPriorityDefinition {
+    private String priority;
+
+    public String getPriority() {
+      return priority;
+    }
+
+    public void setPriority(String priority) {
+      this.priority = priority;
+    }
   }
 
   public static class ZeebeProperty {

--- a/diagram-converter/core/src/main/java/io/camunda/migration/diagram/converter/message/MessageFactory.java
+++ b/diagram-converter/core/src/main/java/io/camunda/migration/diagram/converter/message/MessageFactory.java
@@ -659,6 +659,17 @@ public class MessageFactory {
     return INSTANCE.staticMessage("modeler-template");
   }
 
+  public static Message jobPriorityCollision(
+      String elementLocalName, String jobPriority, String taskPriority) {
+    return INSTANCE.composeMessage(
+        "job-priority-collision",
+        ContextBuilder.builder()
+            .entry("elementLocalName", elementLocalName)
+            .entry("jobPriority", jobPriority)
+            .entry("taskPriority", taskPriority)
+            .build());
+  }
+
   public static Message modelerTemplateVersion() {
     return INSTANCE.staticMessage("modeler-template-version");
   }

--- a/diagram-converter/core/src/main/java/io/camunda/migration/diagram/converter/message/MessageFactory.java
+++ b/diagram-converter/core/src/main/java/io/camunda/migration/diagram/converter/message/MessageFactory.java
@@ -670,6 +670,15 @@ public class MessageFactory {
             .build());
   }
 
+  public static Message priorityOutOfRange(String elementLocalName, String value) {
+    return INSTANCE.composeMessage(
+        "priority-out-of-range",
+        ContextBuilder.builder()
+            .entry("elementLocalName", elementLocalName)
+            .entry("value", value)
+            .build());
+  }
+
   public static Message modelerTemplateVersion() {
     return INSTANCE.staticMessage("modeler-template-version");
   }

--- a/diagram-converter/core/src/main/java/io/camunda/migration/diagram/converter/visitor/impl/attribute/JobPriorityVisitor.java
+++ b/diagram-converter/core/src/main/java/io/camunda/migration/diagram/converter/visitor/impl/attribute/JobPriorityVisitor.java
@@ -7,11 +7,29 @@
  */
 package io.camunda.migration.diagram.converter.visitor.impl.attribute;
 
-import io.camunda.migration.diagram.converter.visitor.AbstractRemoveAttributeVisitor;
+import io.camunda.migration.diagram.converter.DomElementVisitorContext;
+import io.camunda.migration.diagram.converter.convertible.AbstractProcessElementConvertible;
+import io.camunda.migration.diagram.converter.expression.ExpressionTransformationResult;
+import io.camunda.migration.diagram.converter.expression.ExpressionTransformationResultMessageFactory;
+import io.camunda.migration.diagram.converter.expression.ExpressionTransformer;
+import io.camunda.migration.diagram.converter.message.Message;
+import io.camunda.migration.diagram.converter.visitor.AbstractSupportedAttributeVisitor;
 
-public class JobPriorityVisitor extends AbstractRemoveAttributeVisitor {
+public class JobPriorityVisitor extends AbstractSupportedAttributeVisitor {
   @Override
   public String attributeLocalName() {
     return "jobPriority";
+  }
+
+  @Override
+  protected Message visitSupportedAttribute(DomElementVisitorContext context, String attribute) {
+    ExpressionTransformationResult priority =
+        ExpressionTransformer.transformToFeel("Job priority", attribute);
+    context.addConversion(
+        AbstractProcessElementConvertible.class,
+        conv -> conv.getZeebeJobPriorityDefinition().setPriority(priority.result()));
+    return ExpressionTransformationResultMessageFactory.getMessage(
+        priority,
+        "https://docs.camunda.io/docs/components/concepts/job-workers/#job-prioritization");
   }
 }

--- a/diagram-converter/core/src/main/java/io/camunda/migration/diagram/converter/visitor/impl/attribute/JobPriorityVisitor.java
+++ b/diagram-converter/core/src/main/java/io/camunda/migration/diagram/converter/visitor/impl/attribute/JobPriorityVisitor.java
@@ -8,12 +8,14 @@
 package io.camunda.migration.diagram.converter.visitor.impl.attribute;
 
 import io.camunda.migration.diagram.converter.DomElementVisitorContext;
+import io.camunda.migration.diagram.converter.NamespaceUri;
 import io.camunda.migration.diagram.converter.convertible.AbstractProcessElementConvertible;
 import io.camunda.migration.diagram.converter.expression.ExpressionTransformationResult;
 import io.camunda.migration.diagram.converter.expression.ExpressionTransformationResultMessageFactory;
 import io.camunda.migration.diagram.converter.expression.ExpressionTransformer;
 import io.camunda.migration.diagram.converter.message.Message;
 import io.camunda.migration.diagram.converter.visitor.AbstractSupportedAttributeVisitor;
+import org.apache.commons.lang3.StringUtils;
 
 public class JobPriorityVisitor extends AbstractSupportedAttributeVisitor {
   @Override
@@ -23,6 +25,15 @@ public class JobPriorityVisitor extends AbstractSupportedAttributeVisitor {
 
   @Override
   protected Message visitSupportedAttribute(DomElementVisitorContext context, String attribute) {
+    // When camunda:taskPriority is also present, TaskPriorityVisitor owns the write and emits the
+    // collision message. Drop jobPriority here without transforming to avoid noise from the
+    // discarded expression.
+    String siblingTaskPriority =
+        context.getElement().getAttribute(NamespaceUri.CAMUNDA, "taskPriority");
+    if (StringUtils.isNotBlank(siblingTaskPriority)) {
+      return null;
+    }
+
     ExpressionTransformationResult priority =
         ExpressionTransformer.transformToFeel("Job priority", attribute);
     context.addConversion(

--- a/diagram-converter/core/src/main/java/io/camunda/migration/diagram/converter/visitor/impl/attribute/JobPriorityVisitor.java
+++ b/diagram-converter/core/src/main/java/io/camunda/migration/diagram/converter/visitor/impl/attribute/JobPriorityVisitor.java
@@ -36,6 +36,11 @@ public class JobPriorityVisitor extends AbstractSupportedAttributeVisitor {
 
     ExpressionTransformationResult priority =
         ExpressionTransformer.transformToFeel("Job priority", attribute);
+    Message outOfRange =
+        PriorityRangeValidator.outOfRangeOrNull(priority, context.getElement().getLocalName());
+    if (outOfRange != null) {
+      return outOfRange;
+    }
     context.addConversion(
         AbstractProcessElementConvertible.class,
         conv -> conv.getZeebeJobPriorityDefinition().setPriority(priority.result()));

--- a/diagram-converter/core/src/main/java/io/camunda/migration/diagram/converter/visitor/impl/attribute/PriorityRangeValidator.java
+++ b/diagram-converter/core/src/main/java/io/camunda/migration/diagram/converter/visitor/impl/attribute/PriorityRangeValidator.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.migration.diagram.converter.visitor.impl.attribute;
+
+import io.camunda.migration.diagram.converter.expression.ExpressionTransformationResult;
+import io.camunda.migration.diagram.converter.message.Message;
+import io.camunda.migration.diagram.converter.message.MessageFactory;
+import java.util.Objects;
+
+final class PriorityRangeValidator {
+  private PriorityRangeValidator() {}
+
+  /**
+   * Returns a TASK message if the priority resolves to a literal long value that doesn't fit into
+   * C8's int32 priority slot. Returns {@code null} for expressions (can't be validated at
+   * conversion time), for in-range numeric literals, and for non-numeric literals (malformed C7,
+   * passed through unchanged).
+   */
+  static Message outOfRangeOrNull(
+      ExpressionTransformationResult priority, String elementLocalName) {
+    boolean isLiteral = Objects.equals(priority.result(), priority.juelExpression());
+    if (!isLiteral) {
+      return null;
+    }
+    try {
+      long value = Long.parseLong(priority.result().trim());
+      if (value < Integer.MIN_VALUE || value > Integer.MAX_VALUE) {
+        return MessageFactory.priorityOutOfRange(elementLocalName, priority.juelExpression());
+      }
+    } catch (NumberFormatException ignored) {
+      // Non-numeric literal — malformed C7 input. Preserve existing pass-through behavior.
+    }
+    return null;
+  }
+}

--- a/diagram-converter/core/src/main/java/io/camunda/migration/diagram/converter/visitor/impl/attribute/TaskPriorityVisitor.java
+++ b/diagram-converter/core/src/main/java/io/camunda/migration/diagram/converter/visitor/impl/attribute/TaskPriorityVisitor.java
@@ -28,6 +28,11 @@ public class TaskPriorityVisitor extends AbstractSupportedAttributeVisitor {
   protected Message visitSupportedAttribute(DomElementVisitorContext context, String attribute) {
     ExpressionTransformationResult priority =
         ExpressionTransformer.transformToFeel("Task priority", attribute);
+    Message outOfRange =
+        PriorityRangeValidator.outOfRangeOrNull(priority, context.getElement().getLocalName());
+    if (outOfRange != null) {
+      return outOfRange;
+    }
     context.addConversion(
         AbstractProcessElementConvertible.class,
         conv -> conv.getZeebeJobPriorityDefinition().setPriority(priority.result()));

--- a/diagram-converter/core/src/main/java/io/camunda/migration/diagram/converter/visitor/impl/attribute/TaskPriorityVisitor.java
+++ b/diagram-converter/core/src/main/java/io/camunda/migration/diagram/converter/visitor/impl/attribute/TaskPriorityVisitor.java
@@ -7,11 +7,39 @@
  */
 package io.camunda.migration.diagram.converter.visitor.impl.attribute;
 
-import io.camunda.migration.diagram.converter.visitor.AbstractCurrentlyNotSupportedAttributeVisitor;
+import io.camunda.migration.diagram.converter.DomElementVisitorContext;
+import io.camunda.migration.diagram.converter.NamespaceUri;
+import io.camunda.migration.diagram.converter.convertible.AbstractProcessElementConvertible;
+import io.camunda.migration.diagram.converter.expression.ExpressionTransformationResult;
+import io.camunda.migration.diagram.converter.expression.ExpressionTransformationResultMessageFactory;
+import io.camunda.migration.diagram.converter.expression.ExpressionTransformer;
+import io.camunda.migration.diagram.converter.message.Message;
+import io.camunda.migration.diagram.converter.message.MessageFactory;
+import io.camunda.migration.diagram.converter.visitor.AbstractSupportedAttributeVisitor;
+import org.apache.commons.lang3.StringUtils;
 
-public class TaskPriorityVisitor extends AbstractCurrentlyNotSupportedAttributeVisitor {
+public class TaskPriorityVisitor extends AbstractSupportedAttributeVisitor {
   @Override
   public String attributeLocalName() {
     return "taskPriority";
+  }
+
+  @Override
+  protected Message visitSupportedAttribute(DomElementVisitorContext context, String attribute) {
+    ExpressionTransformationResult priority =
+        ExpressionTransformer.transformToFeel("Task priority", attribute);
+    context.addConversion(
+        AbstractProcessElementConvertible.class,
+        conv -> conv.getZeebeJobPriorityDefinition().setPriority(priority.result()));
+
+    String siblingJobPriority =
+        context.getElement().getAttribute(NamespaceUri.CAMUNDA, "jobPriority");
+    if (StringUtils.isNotBlank(siblingJobPriority)) {
+      return MessageFactory.jobPriorityCollision(
+          context.getElement().getLocalName(), siblingJobPriority, attribute);
+    }
+    return ExpressionTransformationResultMessageFactory.getMessage(
+        priority,
+        "https://docs.camunda.io/docs/components/concepts/job-workers/#job-prioritization");
   }
 }

--- a/diagram-converter/core/src/main/resources/message-templates.properties
+++ b/diagram-converter/core/src/main/resources/message-templates.properties
@@ -86,6 +86,9 @@ resource.severity=REVIEW
 topic.message={{ templates.supported-attribute-prefix }} Is set as job type.
 topic.severity=REVIEW
 #
+job-priority-collision.message=Both 'camunda:jobPriority' (value '{{ jobPriority }}') and 'camunda:taskPriority' (value '{{ taskPriority }}') are defined on '{{ elementLocalName }}'. The converter used 'taskPriority' per default policy; 'jobPriority' was ignored.
+job-priority-collision.severity=REVIEW
+#
 form-key.message={{ templates.supported-attribute-prefix }} Form key is now set in Zeebe namespace. If you plan to use Camunda forms, please switch to form id and binding.
 form-key.severity=TASK
 form-key.link=https://docs.camunda.io/docs/components/modeler/bpmn/user-tasks/#user-task-forms

--- a/diagram-converter/core/src/main/resources/message-templates.properties
+++ b/diagram-converter/core/src/main/resources/message-templates.properties
@@ -89,6 +89,9 @@ topic.severity=REVIEW
 job-priority-collision.message=Both 'camunda:jobPriority' (value '{{ jobPriority }}') and 'camunda:taskPriority' (value '{{ taskPriority }}') are defined on '{{ elementLocalName }}'. The converter used 'taskPriority' per default policy; 'jobPriority' was ignored.
 job-priority-collision.severity=REVIEW
 #
+priority-out-of-range.message=Priority '{{ value }}' on '{{ elementLocalName }}' is outside the Camunda 8 int range (-2147483648 to 2147483647). Priority was not set; please define a valid value manually.
+priority-out-of-range.severity=TASK
+#
 form-key.message={{ templates.supported-attribute-prefix }} Form key is now set in Zeebe namespace. If you plan to use Camunda forms, please switch to form id and binding.
 form-key.severity=TASK
 form-key.link=https://docs.camunda.io/docs/components/modeler/bpmn/user-tasks/#user-task-forms

--- a/diagram-converter/core/src/test/java/io/camunda/migration/diagram/converter/DiagramConverterTest.java
+++ b/diagram-converter/core/src/test/java/io/camunda/migration/diagram/converter/DiagramConverterTest.java
@@ -572,6 +572,39 @@ public class DiagramConverterTest {
   }
 
   @Test
+  void testJobPriorityOnProcessAndServiceTask() {
+    BpmnModelInstance modelInstance = loadAndConvert("job-priority.bpmn");
+
+    DomElement process = modelInstance.getDocument().getElementById("JobPriorityProcess");
+    assertThat(jobPriority(process)).isEqualTo("50");
+
+    DomElement literalTask = modelInstance.getDocument().getElementById("ServiceTaskLiteral");
+    assertThat(jobPriority(literalTask)).isEqualTo("90");
+
+    DomElement feelTask = modelInstance.getDocument().getElementById("ServiceTaskFeel");
+    assertThat(jobPriority(feelTask)).isEqualTo("=jobPriority");
+
+    DiagramCheckResult result = loadAndCheck("job-priority.bpmn");
+    List<ElementCheckMessage> feelMessages = result.getResult("ServiceTaskFeel").getMessages();
+    assertThat(feelMessages)
+        .extracting(ElementCheckMessage::getMessage)
+        .anyMatch(
+            m ->
+                m.contains("Job priority")
+                    && m.contains("${jobPriority}")
+                    && m.contains("=jobPriority"));
+  }
+
+  private static String jobPriority(DomElement element) {
+    DomElement extensionElements =
+        element.getChildElementsByNameNs(BPMN, "extensionElements").get(0);
+    return extensionElements
+        .getChildElementsByNameNs(ZEEBE, "jobPriorityDefinition")
+        .get(0)
+        .getAttribute("priority");
+  }
+
+  @Test
   void shouldGenerateReviewMessageForConditionalEventDefinitionWithGeneratedId() {
     DefaultConverterProperties properties = new DefaultConverterProperties();
     properties.setPlatformVersion("8.9");

--- a/diagram-converter/core/src/test/java/io/camunda/migration/diagram/converter/DiagramConverterTest.java
+++ b/diagram-converter/core/src/test/java/io/camunda/migration/diagram/converter/DiagramConverterTest.java
@@ -576,7 +576,7 @@ public class DiagramConverterTest {
     BpmnModelInstance modelInstance = loadAndConvert("job-priority.bpmn");
 
     DomElement process = modelInstance.getDocument().getElementById("JobPriorityProcess");
-    assertThat(jobPriority(process)).isEqualTo("50");
+    assertThat(jobPriority(process)).isEqualTo("70");
 
     DomElement literalTask = modelInstance.getDocument().getElementById("ServiceTaskLiteral");
     assertThat(jobPriority(literalTask)).isEqualTo("90");
@@ -584,15 +584,25 @@ public class DiagramConverterTest {
     DomElement feelTask = modelInstance.getDocument().getElementById("ServiceTaskFeel");
     assertThat(jobPriority(feelTask)).isEqualTo("=jobPriority");
 
+    DomElement externalOnly = modelInstance.getDocument().getElementById("ServiceTaskExternalOnly");
+    assertThat(jobPriority(externalOnly)).isEqualTo("60");
+
     DiagramCheckResult result = loadAndCheck("job-priority.bpmn");
-    List<ElementCheckMessage> feelMessages = result.getResult("ServiceTaskFeel").getMessages();
-    assertThat(feelMessages)
+    assertThat(result.getResult("ServiceTaskFeel").getMessages())
         .extracting(ElementCheckMessage::getMessage)
         .anyMatch(
             m ->
                 m.contains("Job priority")
                     && m.contains("${jobPriority}")
                     && m.contains("=jobPriority"));
+    assertThat(result.getResult("JobPriorityProcess").getMessages())
+        .extracting(ElementCheckMessage::getMessage)
+        .anyMatch(
+            m ->
+                m.contains("Both 'camunda:jobPriority'")
+                    && m.contains("'50'")
+                    && m.contains("'70'")
+                    && m.contains("used 'taskPriority'"));
   }
 
   private static String jobPriority(DomElement element) {

--- a/diagram-converter/core/src/test/resources/BPMN_CONVERSION.yaml
+++ b/diagram-converter/core/src/test/resources/BPMN_CONVERSION.yaml
@@ -1112,3 +1112,48 @@ categories:
             </bpmn:extensionElements>
           </bpmn:userTask>
         expectedMessages: |
+      - name: Task priority literal on service task
+        givenBpmn: |
+          <bpmn:serviceTask id="payService" name="Collect payment" camunda:taskPriority="80" />
+        expectedBpmn: |
+          <bpmn:serviceTask completionQuantity="1" id="payService" implementation="##WebService" isForCompensation="false" name="Collect payment" startQuantity="1">
+            <bpmn:extensionElements>
+              <zeebe:jobPriorityDefinition priority="80"/>
+            </bpmn:extensionElements>
+          </bpmn:serviceTask>
+        expectedMessages: |
+      - name: Task priority FEEL variable on service task
+        givenBpmn: |
+          <bpmn:serviceTask id="payService" name="Collect payment" camunda:taskPriority="${externalPriority}" />
+        expectedBpmn: |
+          <bpmn:serviceTask completionQuantity="1" id="payService" implementation="##WebService" isForCompensation="false" name="Collect payment" startQuantity="1">
+            <bpmn:extensionElements>
+              <zeebe:jobPriorityDefinition priority="=externalPriority"/>
+            </bpmn:extensionElements>
+          </bpmn:serviceTask>
+        expectedMessages: |
+          <conversion:message severity="REVIEW">Task priority: Please review transformed expression: '${externalPriority}' -&gt; '=externalPriority'.</conversion:message>
+      - name: Both jobPriority and taskPriority on same service task uses taskPriority
+        description: When both attributes are present on the same element, the converter uses taskPriority as the winner and emits a REVIEW message flagging the ignored jobPriority.
+        givenBpmn: |
+          <bpmn:serviceTask id="payService" name="Collect payment" camunda:jobPriority="20" camunda:taskPriority="80" />
+        expectedBpmn: |
+          <bpmn:serviceTask completionQuantity="1" id="payService" implementation="##WebService" isForCompensation="false" name="Collect payment" startQuantity="1">
+            <bpmn:extensionElements>
+              <zeebe:jobPriorityDefinition priority="80"/>
+            </bpmn:extensionElements>
+          </bpmn:serviceTask>
+        expectedMessages: |
+          <conversion:message severity="REVIEW">Both 'camunda:jobPriority' (value '20') and 'camunda:taskPriority' (value '80') are defined on 'serviceTask'. The converter used 'taskPriority' per default policy; 'jobPriority' was ignored.</conversion:message>
+      - name: Both jobPriority and taskPriority with FEEL expressions
+        description: Collision detection runs before expression transformation, so only the winning taskPriority is transformed. The discarded jobPriority value is reported raw in the collision message.
+        givenBpmn: |
+          <bpmn:serviceTask id="payService" name="Collect payment" camunda:jobPriority="${jobPriority}" camunda:taskPriority="${externalPriority}" />
+        expectedBpmn: |
+          <bpmn:serviceTask completionQuantity="1" id="payService" implementation="##WebService" isForCompensation="false" name="Collect payment" startQuantity="1">
+            <bpmn:extensionElements>
+              <zeebe:jobPriorityDefinition priority="=externalPriority"/>
+            </bpmn:extensionElements>
+          </bpmn:serviceTask>
+        expectedMessages: |
+          <conversion:message severity="REVIEW">Both 'camunda:jobPriority' (value '${jobPriority}') and 'camunda:taskPriority' (value '${externalPriority}') are defined on 'serviceTask'. The converter used 'taskPriority' per default policy; 'jobPriority' was ignored.</conversion:message>

--- a/diagram-converter/core/src/test/resources/BPMN_CONVERSION.yaml
+++ b/diagram-converter/core/src/test/resources/BPMN_CONVERSION.yaml
@@ -1157,3 +1157,36 @@ categories:
           </bpmn:serviceTask>
         expectedMessages: |
           <conversion:message severity="REVIEW">Both 'camunda:jobPriority' (value '${jobPriority}') and 'camunda:taskPriority' (value '${externalPriority}') are defined on 'serviceTask'. The converter used 'taskPriority' per default policy; 'jobPriority' was ignored.</conversion:message>
+      - name: Job priority at int max boundary is accepted
+        description: C7 allows long priorities; C8 uses int32. Integer.MAX_VALUE (2147483647) is the largest value that still fits and should pass through.
+        givenBpmn: |
+          <bpmn:serviceTask id="payService" name="Collect payment" camunda:jobPriority="2147483647" />
+        expectedBpmn: |
+          <bpmn:serviceTask completionQuantity="1" id="payService" implementation="##WebService" isForCompensation="false" name="Collect payment" startQuantity="1">
+            <bpmn:extensionElements>
+              <zeebe:jobPriorityDefinition priority="2147483647"/>
+            </bpmn:extensionElements>
+          </bpmn:serviceTask>
+        expectedMessages: |
+      - name: Job priority above int max is skipped with TASK
+        description: C7 long value that does not fit in the C8 int32 priority slot. The converter emits no jobPriorityDefinition and flags the element as needing manual attention.
+        givenBpmn: |
+          <bpmn:serviceTask id="payService" name="Collect payment" camunda:jobPriority="9999999999" />
+        expectedBpmn: |
+          <bpmn:serviceTask completionQuantity="1" id="payService" implementation="##WebService" isForCompensation="false" name="Collect payment" startQuantity="1"/>
+        expectedMessages: |
+          <conversion:message severity="TASK">Priority '9999999999' on 'serviceTask' is outside the Camunda 8 int range (-2147483648 to 2147483647). Priority was not set; please define a valid value manually.</conversion:message>
+      - name: Job priority below int min is skipped with TASK
+        givenBpmn: |
+          <bpmn:serviceTask id="payService" name="Collect payment" camunda:jobPriority="-9999999999" />
+        expectedBpmn: |
+          <bpmn:serviceTask completionQuantity="1" id="payService" implementation="##WebService" isForCompensation="false" name="Collect payment" startQuantity="1"/>
+        expectedMessages: |
+          <conversion:message severity="TASK">Priority '-9999999999' on 'serviceTask' is outside the Camunda 8 int range (-2147483648 to 2147483647). Priority was not set; please define a valid value manually.</conversion:message>
+      - name: Task priority above int max is skipped with TASK
+        givenBpmn: |
+          <bpmn:serviceTask id="payService" name="Collect payment" camunda:taskPriority="9999999999" />
+        expectedBpmn: |
+          <bpmn:serviceTask completionQuantity="1" id="payService" implementation="##WebService" isForCompensation="false" name="Collect payment" startQuantity="1"/>
+        expectedMessages: |
+          <conversion:message severity="TASK">Priority '9999999999' on 'serviceTask' is outside the Camunda 8 int range (-2147483648 to 2147483647). Priority was not set; please define a valid value manually.</conversion:message>

--- a/diagram-converter/core/src/test/resources/BPMN_CONVERSION.yaml
+++ b/diagram-converter/core/src/test/resources/BPMN_CONVERSION.yaml
@@ -1062,9 +1062,53 @@ categories:
             </bpmn:extensionElements>
           </bpmn:sequenceFlow>
         expectedBpmn: |
-          <bpmn:task completionQuantity="1" id="task1" isForCompensation="false" name="Task1" startQuantity="1"/>  
+          <bpmn:task completionQuantity="1" id="task1" isForCompensation="false" name="Task1" startQuantity="1"/>
           <bpmn:task completionQuantity="1" id="task2" isForCompensation="false" name="Task2" startQuantity="1"/>
           <bpmn:sequenceFlow id="takeListenerFlow" sourceRef="task1" targetRef="task2">
           </bpmn:sequenceFlow>
         expectedMessages: |
           <conversion:message severity="WARNING">Execution Listener at 'take' with implementation 'class' 'abc.def' cannot be transformed.</conversion:message>
+  - category: Job Priority
+    cases:
+      - name: Job priority literal on service task
+        givenBpmn: |
+          <bpmn:serviceTask id="payService" name="Collect payment" camunda:jobPriority="90" />
+        expectedBpmn: |
+          <bpmn:serviceTask completionQuantity="1" id="payService" implementation="##WebService" isForCompensation="false" name="Collect payment" startQuantity="1">
+            <bpmn:extensionElements>
+              <zeebe:jobPriorityDefinition priority="90"/>
+            </bpmn:extensionElements>
+          </bpmn:serviceTask>
+        expectedMessages: |
+      - name: Job priority FEEL variable on service task
+        givenBpmn: |
+          <bpmn:serviceTask id="payService" name="Collect payment" camunda:jobPriority="${jobPriority}" />
+        expectedBpmn: |
+          <bpmn:serviceTask completionQuantity="1" id="payService" implementation="##WebService" isForCompensation="false" name="Collect payment" startQuantity="1">
+            <bpmn:extensionElements>
+              <zeebe:jobPriorityDefinition priority="=jobPriority"/>
+            </bpmn:extensionElements>
+          </bpmn:serviceTask>
+        expectedMessages: |
+          <conversion:message severity="REVIEW">Job priority: Please review transformed expression: '${jobPriority}' -&gt; '=jobPriority'.</conversion:message>
+      - name: Job priority literal on send task
+        givenBpmn: |
+          <bpmn:sendTask id="notify" name="Notify" camunda:jobPriority="50" />
+        expectedBpmn: |
+          <bpmn:sendTask completionQuantity="1" id="notify" implementation="##WebService" isForCompensation="false" name="Notify" startQuantity="1">
+            <bpmn:extensionElements>
+              <zeebe:jobPriorityDefinition priority="50"/>
+            </bpmn:extensionElements>
+          </bpmn:sendTask>
+        expectedMessages: |
+      - name: Job priority literal on user task
+        givenBpmn: |
+          <bpmn:userTask id="review" name="Review" camunda:jobPriority="30" />
+        expectedBpmn: |
+          <bpmn:userTask completionQuantity="1" id="review" implementation="##unspecified" isForCompensation="false" name="Review" startQuantity="1">
+            <bpmn:extensionElements>
+              <zeebe:jobPriorityDefinition priority="30"/>
+              <zeebe:userTask/>
+            </bpmn:extensionElements>
+          </bpmn:userTask>
+        expectedMessages: |

--- a/diagram-converter/core/src/test/resources/job-priority.bpmn
+++ b/diagram-converter/core/src/test/resources/job-priority.bpmn
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+                  xmlns:camunda="http://camunda.org/schema/1.0/bpmn"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xmlns:modeler="http://camunda.org/schema/modeler/1.0"
+                  id="Definitions_jobPriority"
+                  targetNamespace="http://bpmn.io/schema/bpmn"
+                  modeler:executionPlatform="Camunda Platform"
+                  modeler:executionPlatformVersion="7.23.0">
+  <bpmn:process id="JobPriorityProcess" isExecutable="true" camunda:jobPriority="50">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:serviceTask id="ServiceTaskLiteral" name="Pay" camunda:jobPriority="90">
+      <bpmn:incoming>Flow_1</bpmn:incoming>
+      <bpmn:outgoing>Flow_2</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:serviceTask id="ServiceTaskFeel" name="Notify" camunda:jobPriority="${jobPriority}">
+      <bpmn:incoming>Flow_2</bpmn:incoming>
+      <bpmn:outgoing>Flow_3</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:endEvent id="EndEvent_1">
+      <bpmn:incoming>Flow_3</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1" sourceRef="StartEvent_1" targetRef="ServiceTaskLiteral" />
+    <bpmn:sequenceFlow id="Flow_2" sourceRef="ServiceTaskLiteral" targetRef="ServiceTaskFeel" />
+    <bpmn:sequenceFlow id="Flow_3" sourceRef="ServiceTaskFeel" targetRef="EndEvent_1" />
+  </bpmn:process>
+</bpmn:definitions>

--- a/diagram-converter/core/src/test/resources/job-priority.bpmn
+++ b/diagram-converter/core/src/test/resources/job-priority.bpmn
@@ -7,7 +7,7 @@
                   targetNamespace="http://bpmn.io/schema/bpmn"
                   modeler:executionPlatform="Camunda Platform"
                   modeler:executionPlatformVersion="7.23.0">
-  <bpmn:process id="JobPriorityProcess" isExecutable="true" camunda:jobPriority="50">
+  <bpmn:process id="JobPriorityProcess" isExecutable="true" camunda:jobPriority="50" camunda:taskPriority="70">
     <bpmn:startEvent id="StartEvent_1">
       <bpmn:outgoing>Flow_1</bpmn:outgoing>
     </bpmn:startEvent>
@@ -19,11 +19,16 @@
       <bpmn:incoming>Flow_2</bpmn:incoming>
       <bpmn:outgoing>Flow_3</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:endEvent id="EndEvent_1">
+    <bpmn:serviceTask id="ServiceTaskExternalOnly" name="External" camunda:taskPriority="60">
       <bpmn:incoming>Flow_3</bpmn:incoming>
+      <bpmn:outgoing>Flow_4</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:endEvent id="EndEvent_1">
+      <bpmn:incoming>Flow_4</bpmn:incoming>
     </bpmn:endEvent>
     <bpmn:sequenceFlow id="Flow_1" sourceRef="StartEvent_1" targetRef="ServiceTaskLiteral" />
     <bpmn:sequenceFlow id="Flow_2" sourceRef="ServiceTaskLiteral" targetRef="ServiceTaskFeel" />
-    <bpmn:sequenceFlow id="Flow_3" sourceRef="ServiceTaskFeel" targetRef="EndEvent_1" />
+    <bpmn:sequenceFlow id="Flow_3" sourceRef="ServiceTaskFeel" targetRef="ServiceTaskExternalOnly" />
+    <bpmn:sequenceFlow id="Flow_4" sourceRef="ServiceTaskExternalOnly" targetRef="EndEvent_1" />
   </bpmn:process>
 </bpmn:definitions>


### PR DESCRIPTION
…tyDefinition

Preserves the C7 camunda:jobPriority value instead of silently dropping it, emitting the proposed <zeebe:jobPriorityDefinition priority="..."/> extension element on the converted C8 model. Supports literal and FEEL-transformed values across process, service/send/user tasks and any other element that extends AbstractProcessElementConvertible.

See diagram-converter/POC_JOB_PRIORITY.md for design decisions.

# Pull Request Template

## Description
<!-- Describe your changes in detail -->

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Test-only changes (no production code changes)

## Testing Checklist

### Black-Box Testing Requirements
- [ ] Tests follow **black-box testing approach**: verify behavior through observable outputs (logs, C8 API queries, real-world skip scenarios)
- [ ] Tests **DO NOT** access implementation details (`DbClient`, `IdKeyMapper`, `..impl..` packages except logging constants)
- [ ] Architecture tests pass (`ArchitectureTest` validates these rules)

### Test Coverage
- [ ] Added tests for new functionality
- [ ] Updated tests for modified functionality
- [ ] All tests pass locally

## Architecture Compliance

Run architecture tests to ensure compliance:
```bash
mvn test -Dtest=ArchitectureTest
```

If architecture tests fail, refactor your tests to use:
- `LogCapturer` for log assertions
- `camundaClient.new*SearchRequest()` for C8 queries
- Real-World skip scenarios (e.g., migrate children without parents)

## Documentation
- [ ] Updated TESTING_GUIDELINES.md if adding new test patterns
- [ ] Added Javadoc comments for public APIs
- [ ] Updated README if user-facing changes

## Checklist
- [ ] Code follows project style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments for complex logic
- [ ] No new compiler warnings
- [ ] Dependent changes have been merged

## Related Issues
<!-- Link to related issues: Fixes #123, Related to #456 -->

