### PR TITLE
chore(data-migrator): resolve multi C8 version failiures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -277,6 +277,7 @@ jobs:
         run: >-
           mvn compile test-compile
           -Dversion.camunda-8=${{ needs.read-versions.outputs.camunda-8-previous-version }}
+          -Dc8.api=previous
           -pl '!data-migrator/plugins/cockpit,!data-migrator/assembly'
           --batch-mode
 
@@ -845,8 +846,10 @@ jobs:
         include:
           - camunda-version: ${{ needs.read-versions.outputs.camunda-8-version }}
             camunda-docker-image-version: ${{ needs.read-versions.outputs.camunda-8-docker-image-version }}
+            c8-api: current
           - camunda-version: ${{ needs.read-versions.outputs.camunda-8-previous-version }}
             camunda-docker-image-version: ${{ needs.read-versions.outputs.camunda-8-previous-docker-image-version }}
+            c8-api: previous
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -877,6 +880,7 @@ jobs:
         run: >-
           mvn verify -P${{ matrix.database }},integration
           -Dversion.camunda-8=${{ matrix.camunda-version }}
+          -Dc8.api=${{ matrix.c8-api }}
           -Dcamunda.process-test.camunda-docker-image-version=${{ matrix.camunda-docker-image-version }}
 
   # Rerun failed jobs running on self-hosted runners in case of network issues or node preemption

--- a/data-migrator/core/src/main/java/io/camunda/migration/data/config/mybatis/C8Configuration.java
+++ b/data-migrator/core/src/main/java/io/camunda/migration/data/config/mybatis/C8Configuration.java
@@ -8,7 +8,6 @@
 package io.camunda.migration.data.config.mybatis;
 
 import io.camunda.client.metrics.MetricsRecorder;
-import io.camunda.db.rdbms.RdbmsService;
 import io.camunda.db.rdbms.config.VendorDatabaseProperties;
 import io.camunda.db.rdbms.read.RdbmsReaderConfig;
 import io.camunda.db.rdbms.read.service.AuditLogDbReader;
@@ -78,7 +77,6 @@ import io.camunda.db.rdbms.sql.UserMapper;
 import io.camunda.db.rdbms.sql.UserTaskMapper;
 import io.camunda.db.rdbms.sql.VariableMapper;
 import io.camunda.db.rdbms.sql.ClusterVariableMapper;
-import io.camunda.db.rdbms.write.RdbmsWriterFactory;
 import io.camunda.migration.data.config.C8DataSourceConfigured;
 import io.camunda.migration.data.impl.DataSourceRegistry;
 import io.camunda.migration.data.config.property.MigratorProperties;
@@ -504,144 +502,6 @@ public class C8Configuration extends AbstractConfiguration {
   @Bean
   public IncidentProcessInstanceStatisticsByDefinitionDbReader incidentProcessInstanceStatisticsByDefinitionDbReader(IncidentMapper incidentMapper, RdbmsReaderConfig rdbmsReaderConfig) {
     return new IncidentProcessInstanceStatisticsByDefinitionDbReader(incidentMapper, rdbmsReaderConfig);
-  }
-
-  @Bean
-  public RdbmsWriterFactory rdbmsWriterFactory(
-      @Qualifier("c8SqlSessionFactory") SqlSessionFactory c8SqlSessionFactory,
-      ExporterPositionMapper exporterPositionMapper,
-      VendorDatabaseProperties dbVendorProvider,
-      AuditLogMapper auditLogMapper,
-      DecisionInstanceMapper decisionInstanceMapper,
-      DecisionDefinitionMapper decisionDefinitionMapper,
-      DecisionRequirementsMapper decisionRequirementsMapper,
-      FlowNodeInstanceMapper flowNodeInstanceMapper,
-      IncidentMapper incidentMapper,
-      ProcessInstanceMapper processInstanceMapper,
-      ProcessDefinitionMapper processDefinitionMapper,
-      PurgeMapper purgeMapper,
-      UserTaskMapper userTaskMapper,
-      VariableMapper variableMapper,
-      MeterRegistry meterRegistry,
-      BatchOperationDbReader batchOperationReader,
-      JobMapper jobMapper,
-      JobMetricsBatchMapper jobMetricsBatchMapper,
-      SequenceFlowMapper sequenceFlowMapper,
-      UsageMetricMapper usageMetricMapper,
-      UsageMetricTUMapper usageMetricTUMapper,
-      BatchOperationMapper batchOperationMapper,
-      MessageSubscriptionMapper messageSubscriptionMapper,
-      CorrelatedMessageSubscriptionMapper correlatedMessageMapper,
-      ClusterVariableMapper clusterVariableMapper,
-      HistoryDeletionMapper historyDeletionMapper) {
-    return new RdbmsWriterFactory(
-        c8SqlSessionFactory,
-        exporterPositionMapper,
-        dbVendorProvider,
-        auditLogMapper,
-        decisionInstanceMapper,
-        decisionDefinitionMapper,
-        decisionRequirementsMapper,
-        flowNodeInstanceMapper,
-        incidentMapper,
-        processInstanceMapper,
-        processDefinitionMapper,
-        purgeMapper,
-        userTaskMapper,
-        variableMapper,
-        meterRegistry,
-        batchOperationReader,
-        jobMapper,
-        jobMetricsBatchMapper,
-        sequenceFlowMapper,
-        usageMetricMapper,
-        usageMetricTUMapper,
-        batchOperationMapper,
-        messageSubscriptionMapper,
-        correlatedMessageMapper,
-        clusterVariableMapper,
-        historyDeletionMapper);
-  }
-
-  @Bean
-  public RdbmsService rdbmsService(
-      RdbmsWriterFactory rdbmsWriterFactory,
-      AuditLogDbReader auditLogReader,
-      AuthorizationDbReader authorizationReader,
-      DecisionDefinitionDbReader decisionDefinitionReader,
-      DecisionInstanceDbReader decisionInstanceReader,
-      DecisionRequirementsDbReader decisionRequirementsReader,
-      FlowNodeInstanceDbReader flowNodeInstanceReader,
-      GroupDbReader groupReader,
-      GroupMemberDbReader groupMemberReader,
-      IncidentDbReader incidentReader,
-      ProcessDefinitionDbReader processDefinitionReader,
-      ProcessInstanceDbReader processInstanceReader,
-      VariableDbReader variableReader,
-      ClusterVariableDbReader clusterVariableReader,
-      RoleDbReader roleReader,
-      RoleMemberDbReader roleMemberReader,
-      TenantDbReader tenantReader,
-      TenantMemberDbReader tenantMemberReader,
-      UserDbReader userReader,
-      UserTaskDbReader userTaskReader,
-      FormDbReader formReader,
-      MappingRuleDbReader mappingRuleReader,
-      BatchOperationDbReader batchOperationReader,
-      SequenceFlowDbReader sequenceFlowReader,
-      BatchOperationItemDbReader batchOperationItemReader,
-      JobDbReader jobReader,
-      JobMetricsBatchDbReader jobMetricsBatchDbReader,
-      UsageMetricsDbReader usageMetricsReader,
-      UsageMetricTUDbReader usageMetricTUDbReader,
-      MessageSubscriptionDbReader messageSubscriptionDbReader,
-      ProcessDefinitionMessageSubscriptionStatisticsDbReader processDefinitionMessageSubscriptionStatisticsDbReader,
-      CorrelatedMessageSubscriptionDbReader correlatedMessageDbReader,
-      ProcessDefinitionInstanceStatisticsDbReader processDefinitionInstanceStatisticsDbReader,
-      ProcessDefinitionInstanceVersionStatisticsDbReader processDefinitionInstanceVersionStatisticsDbReader,
-      HistoryDeletionDbReader historyDeletionReader,
-      IncidentProcessInstanceStatisticsByErrorDbReader incidentProcessInstanceStatisticsByErrorDbReader,
-      IncidentProcessInstanceStatisticsByDefinitionDbReader incidentProcessInstanceStatisticsByDefinitionDbReader,
-      GlobalListenerDbReader globalListenerReader) {
-    return new RdbmsService(
-        rdbmsWriterFactory,
-        auditLogReader,
-        authorizationReader,
-        decisionDefinitionReader,
-        decisionInstanceReader,
-        decisionRequirementsReader,
-        flowNodeInstanceReader,
-        groupReader,
-        groupMemberReader,
-        incidentReader,
-        processDefinitionReader,
-        processInstanceReader,
-        variableReader,
-        clusterVariableReader,
-        roleReader,
-        roleMemberReader,
-        tenantReader,
-        tenantMemberReader,
-        userReader,
-        userTaskReader,
-        formReader,
-        mappingRuleReader,
-        batchOperationReader,
-        sequenceFlowReader,
-        batchOperationItemReader,
-        jobReader,
-        jobMetricsBatchDbReader,
-        usageMetricsReader,
-        usageMetricTUDbReader,
-        messageSubscriptionDbReader,
-        processDefinitionMessageSubscriptionStatisticsDbReader,
-        correlatedMessageDbReader,
-        processDefinitionInstanceStatisticsDbReader,
-        processDefinitionInstanceVersionStatisticsDbReader,
-        historyDeletionReader,
-        incidentProcessInstanceStatisticsByErrorDbReader,
-        incidentProcessInstanceStatisticsByDefinitionDbReader,
-        globalListenerReader);
   }
 
 }

--- a/data-migrator/plugins/cockpit/frontend/package-lock.json
+++ b/data-migrator/plugins/cockpit/frontend/package-lock.json
@@ -2273,9 +2273,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2290,9 +2287,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2307,9 +2301,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2324,9 +2315,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2341,9 +2329,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2358,9 +2343,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2375,9 +2357,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2392,9 +2371,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2409,9 +2385,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2426,9 +2399,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2443,9 +2413,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2460,9 +2427,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2477,9 +2441,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/data-migrator/plugins/cockpit/frontend/package-lock.json
+++ b/data-migrator/plugins/cockpit/frontend/package-lock.json
@@ -2273,6 +2273,9 @@
         "arm"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2287,6 +2290,9 @@
         "arm"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2301,6 +2307,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2315,6 +2324,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2329,6 +2341,9 @@
         "loong64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2343,6 +2358,9 @@
         "loong64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2357,6 +2375,9 @@
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2371,6 +2392,9 @@
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2385,6 +2409,9 @@
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2399,6 +2426,9 @@
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2413,6 +2443,9 @@
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2427,6 +2460,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2441,6 +2477,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/data-migrator/qa/integration-tests/pom.xml
+++ b/data-migrator/qa/integration-tests/pom.xml
@@ -255,15 +255,16 @@
       section wires in ${c8.compat.source.dir}; this profile overrides that
       property when building against the previous C8 version.
 
-      When bumping version.camunda-8.previous in the parent POM, update the
-      activation <value> below to match.
+      Activate via -Dc8.api=previous alongside -Dversion.camunda-8=<previous-version>.
+      Using a dedicated flag (rather than matching on the version literal)
+      decouples this activation from version bumps in the parent POM.
     -->
     <profile>
       <id>c8-previous-api</id>
       <activation>
         <property>
-          <name>version.camunda-8</name>
-          <value>8.9.0</value>
+          <name>c8.api</name>
+          <value>previous</value>
         </property>
       </activation>
       <properties>

--- a/data-migrator/qa/integration-tests/pom.xml
+++ b/data-migrator/qa/integration-tests/pom.xml
@@ -22,6 +22,12 @@
     <version.mariadb>3.5.8</version.mariadb>
     <version.sqlserver>13.4.0.jre11</version.sqlserver>
     <version.jakarta-xml-bind-api>4.0.5</version.jakarta-xml-bind-api>
+    <!--
+      Camunda 8 API compat source directory. Defaults to the current C8 version.
+      Overridden by the c8-previous-api profile when building against the previous C8 version.
+      See the c8-previous-api profile below and C8QueryCompat.java for details.
+    -->
+    <c8.compat.source.dir>src/test/java-c8-current</c8.compat.source.dir>
   </properties>
 
   <dependencies>
@@ -216,10 +222,54 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <version>3.5.5</version>
       </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
+        <version>3.6.1</version>
+        <executions>
+          <execution>
+            <id>add-c8-compat-test-source</id>
+            <phase>generate-test-sources</phase>
+            <goals>
+              <goal>add-test-source</goal>
+            </goals>
+            <configuration>
+              <sources>
+                <source>${c8.compat.source.dir}</source>
+              </sources>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 
   <profiles>
+    <!--
+      Camunda 8 API compatibility profile.
+
+      The integration tests delegate version-specific query construction to
+      io.camunda.migration.data.qa.c8compat.C8QueryCompat. Two parallel
+      implementations live under src/test/java-c8-current (default) and
+      src/test/java-c8-previous. The build-helper plugin in the main <build>
+      section wires in ${c8.compat.source.dir}; this profile overrides that
+      property when building against the previous C8 version.
+
+      When bumping version.camunda-8.previous in the parent POM, update the
+      activation <value> below to match.
+    -->
+    <profile>
+      <id>c8-previous-api</id>
+      <activation>
+        <property>
+          <name>version.camunda-8</name>
+          <value>8.9.0</value>
+        </property>
+      </activation>
+      <properties>
+        <c8.compat.source.dir>src/test/java-c8-previous</c8.compat.source.dir>
+      </properties>
+    </profile>
     <profile>
       <id>postgresql</id>
       <build>

--- a/data-migrator/qa/integration-tests/src/test/java-c8-current/io/camunda/migration/data/qa/c8compat/C8QueryCompat.java
+++ b/data-migrator/qa/integration-tests/src/test/java-c8-current/io/camunda/migration/data/qa/c8compat/C8QueryCompat.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.migration.data.qa.c8compat;
+
+import io.camunda.search.query.FlowNodeInstanceQuery;
+import io.camunda.search.query.ProcessDefinitionQuery;
+import java.util.Arrays;
+
+/**
+ * Version-specific test query helpers for the current Camunda 8 version.
+ *
+ * <p>Lives under {@code src/test/java-c8-current} and is added to the test source set by the
+ * {@code c8-current-api} Maven profile. A parallel implementation exists under
+ * {@code src/test/java-c8-previous} for the previous Camunda 8 version.
+ */
+public final class C8QueryCompat {
+
+  private C8QueryCompat() {}
+
+  public static ProcessDefinitionQuery processDefinitionQueryWithBpmnXml(
+      final String prefixedProcessDefinitionId) {
+    return ProcessDefinitionQuery.of(
+        queryBuilder ->
+            queryBuilder
+                .filter(filterBuilder -> filterBuilder.processDefinitionIds(prefixedProcessDefinitionId))
+                .resultConfig(b -> b.includeXml(true)));
+  }
+
+  public static FlowNodeInstanceQuery flowNodeInstanceQueryByIds(final String... flowNodeIds) {
+    if (flowNodeIds.length == 0) {
+      throw new IllegalArgumentException("At least one flowNodeId is required");
+    }
+    final String first = flowNodeIds[0];
+    final String[] rest = Arrays.copyOfRange(flowNodeIds, 1, flowNodeIds.length);
+    return FlowNodeInstanceQuery.of(
+        queryBuilder ->
+            queryBuilder.filter(filterBuilder -> filterBuilder.flowNodeIds(first, rest)));
+  }
+}

--- a/data-migrator/qa/integration-tests/src/test/java-c8-previous/io/camunda/migration/data/qa/c8compat/C8QueryCompat.java
+++ b/data-migrator/qa/integration-tests/src/test/java-c8-previous/io/camunda/migration/data/qa/c8compat/C8QueryCompat.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.migration.data.qa.c8compat;
+
+import io.camunda.search.query.FlowNodeInstanceQuery;
+import io.camunda.search.query.ProcessDefinitionQuery;
+
+/**
+ * Version-specific test query helpers for the previous Camunda 8 version.
+ *
+ * <p>Lives under {@code src/test/java-c8-previous} and is added to the test source set by the
+ * {@code c8-previous-api} Maven profile (activated when {@code -Dversion.camunda-8} matches the
+ * previous version pin). A parallel implementation exists under {@code src/test/java-c8-current}
+ * for the current Camunda 8 version.
+ *
+ * <p>In 8.9 {@code ProcessDefinitionQuery.Builder} has no {@code resultConfig} — BPMN XML is
+ * included by default. {@code FlowNodeInstanceFilter.Builder.flowNodeIds} accepts a varargs
+ * {@code String[]} directly.
+ */
+public final class C8QueryCompat {
+
+  private C8QueryCompat() {}
+
+  public static ProcessDefinitionQuery processDefinitionQueryWithBpmnXml(
+      final String prefixedProcessDefinitionId) {
+    return ProcessDefinitionQuery.of(
+        queryBuilder ->
+            queryBuilder.filter(
+                filterBuilder -> filterBuilder.processDefinitionIds(prefixedProcessDefinitionId)));
+  }
+
+  public static FlowNodeInstanceQuery flowNodeInstanceQueryByIds(final String... flowNodeIds) {
+    return FlowNodeInstanceQuery.of(
+        queryBuilder ->
+            queryBuilder.filter(filterBuilder -> filterBuilder.flowNodeIds(flowNodeIds)));
+  }
+}

--- a/data-migrator/qa/integration-tests/src/test/java-c8-previous/io/camunda/migration/data/qa/c8compat/C8QueryCompat.java
+++ b/data-migrator/qa/integration-tests/src/test/java-c8-previous/io/camunda/migration/data/qa/c8compat/C8QueryCompat.java
@@ -35,6 +35,9 @@ public final class C8QueryCompat {
   }
 
   public static FlowNodeInstanceQuery flowNodeInstanceQueryByIds(final String... flowNodeIds) {
+    if (flowNodeIds.length == 0) {
+      throw new IllegalArgumentException("At least one flowNodeId is required");
+    }
     return FlowNodeInstanceQuery.of(
         queryBuilder ->
             queryBuilder.filter(filterBuilder -> filterBuilder.flowNodeIds(flowNodeIds)));

--- a/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/extension/HistoryMigrationExtension.java
+++ b/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/extension/HistoryMigrationExtension.java
@@ -15,6 +15,7 @@ import io.camunda.db.rdbms.write.service.RdbmsPurger;
 import io.camunda.migration.data.HistoryMigrator;
 import io.camunda.migration.data.MigratorMode;
 import io.camunda.migration.data.impl.clients.DbClient;
+import io.camunda.migration.data.qa.c8compat.C8QueryCompat;
 import io.camunda.migration.data.qa.util.SpringProfileResolver;
 import io.camunda.search.entities.DecisionDefinitionEntity;
 import io.camunda.search.entities.DecisionInstanceEntity;
@@ -255,9 +256,7 @@ public class HistoryMigrationExtension implements BeforeEachCallback, AfterEachC
       throw new IllegalStateException("RdbmsService is not available in the Spring context");
     }
     return rdbmsService.getFlowNodeInstanceReader()
-        .search(FlowNodeInstanceQuery.of(queryBuilder ->
-            queryBuilder.filter(filterBuilder ->
-                filterBuilder.flowNodeIds(flowNodeIds))))
+        .search(C8QueryCompat.flowNodeInstanceQueryByIds(flowNodeIds))
         .items();
   }
 

--- a/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/extension/HistoryMigrationExtension.java
+++ b/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/extension/HistoryMigrationExtension.java
@@ -10,7 +10,15 @@ package io.camunda.migration.data.qa.extension;
 import static io.camunda.migration.data.impl.util.ConverterUtil.prefixDefinitionId;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.camunda.db.rdbms.RdbmsService;
+import io.camunda.db.rdbms.read.service.DecisionDefinitionDbReader;
+import io.camunda.db.rdbms.read.service.DecisionInstanceDbReader;
+import io.camunda.db.rdbms.read.service.DecisionRequirementsDbReader;
+import io.camunda.db.rdbms.read.service.FlowNodeInstanceDbReader;
+import io.camunda.db.rdbms.read.service.IncidentDbReader;
+import io.camunda.db.rdbms.read.service.ProcessDefinitionDbReader;
+import io.camunda.db.rdbms.read.service.ProcessInstanceDbReader;
+import io.camunda.db.rdbms.read.service.UserTaskDbReader;
+import io.camunda.db.rdbms.read.service.VariableDbReader;
 import io.camunda.db.rdbms.write.service.RdbmsPurger;
 import io.camunda.migration.data.HistoryMigrator;
 import io.camunda.migration.data.MigratorMode;
@@ -88,8 +96,12 @@ public class HistoryMigrationExtension implements BeforeEachCallback, AfterEachC
     return applicationContext != null ? applicationContext.getBean(RdbmsPurger.class) : null;
   }
 
-  private RdbmsService getRdbmsServiceBean() {
-    return applicationContext != null ? applicationContext.getBean(RdbmsService.class) : null;
+  private static <T> T requireBean(Class<T> beanClass) {
+    if (applicationContext == null) {
+      throw new IllegalStateException(
+          beanClass.getSimpleName() + " is not available in the Spring context");
+    }
+    return applicationContext.getBean(beanClass);
   }
 
   private HistoryService getHistoryServiceBean() {
@@ -155,10 +167,6 @@ public class HistoryMigrationExtension implements BeforeEachCallback, AfterEachC
     return getHistoryMigratorBean();
   }
 
-  public RdbmsService getRdbmsService() {
-    return getRdbmsServiceBean();
-  }
-
   public HistoryService getHistoryService() {
     return getHistoryServiceBean();
   }
@@ -168,11 +176,7 @@ public class HistoryMigrationExtension implements BeforeEachCallback, AfterEachC
   }
 
   public List<ProcessDefinitionEntity> searchHistoricProcessDefinitions(String processDefinitionId) {
-    RdbmsService rdbmsService = getRdbmsServiceBean();
-    if (rdbmsService == null) {
-      throw new IllegalStateException("RdbmsService is not available in the Spring context");
-    }
-    return rdbmsService.getProcessDefinitionReader()
+    return requireBean(ProcessDefinitionDbReader.class)
         .search(ProcessDefinitionQuery.of(queryBuilder ->
             queryBuilder.filter(filterBuilder ->
                 filterBuilder.processDefinitionIds(prefixDefinitionId(processDefinitionId)))))
@@ -180,11 +184,7 @@ public class HistoryMigrationExtension implements BeforeEachCallback, AfterEachC
   }
 
   public List<DecisionDefinitionEntity> searchHistoricDecisionDefinitions(String decisionDefinitionId) {
-    RdbmsService rdbmsService = getRdbmsServiceBean();
-    if (rdbmsService == null) {
-      throw new IllegalStateException("RdbmsService is not available in the Spring context");
-    }
-    return rdbmsService.getDecisionDefinitionReader()
+    return requireBean(DecisionDefinitionDbReader.class)
         .search(DecisionDefinitionQuery.of(queryBuilder ->
             queryBuilder.filter(filterBuilder ->
                 filterBuilder.decisionDefinitionIds(prefixDefinitionId(decisionDefinitionId)))))
@@ -192,11 +192,7 @@ public class HistoryMigrationExtension implements BeforeEachCallback, AfterEachC
   }
 
   public List<DecisionRequirementsEntity> searchHistoricDecisionRequirementsDefinition(String decisionRequirementsId) {
-    RdbmsService rdbmsService = getRdbmsServiceBean();
-    if (rdbmsService == null) {
-      throw new IllegalStateException("RdbmsService is not available in the Spring context");
-    }
-    return rdbmsService.getDecisionRequirementsReader()
+    return requireBean(DecisionRequirementsDbReader.class)
         .search(DecisionRequirementsQuery.of(queryBuilder ->
             queryBuilder.filter(filterBuilder ->
                 filterBuilder.decisionRequirementsIds(prefixDefinitionId(decisionRequirementsId)))))
@@ -204,11 +200,7 @@ public class HistoryMigrationExtension implements BeforeEachCallback, AfterEachC
   }
 
   public List<ProcessInstanceEntity> searchHistoricProcessInstances(String processDefinitionId) {
-    RdbmsService rdbmsService = getRdbmsServiceBean();
-    if (rdbmsService == null) {
-      throw new IllegalStateException("RdbmsService is not available in the Spring context");
-    }
-    return rdbmsService.getProcessInstanceReader()
+    return requireBean(ProcessInstanceDbReader.class)
         .search(ProcessInstanceQuery.of(queryBuilder ->
             queryBuilder.filter(filterBuilder ->
                 filterBuilder.processDefinitionIds(prefixDefinitionId(processDefinitionId)))))
@@ -216,11 +208,7 @@ public class HistoryMigrationExtension implements BeforeEachCallback, AfterEachC
   }
 
   public List<DecisionInstanceEntity> searchHistoricDecisionInstances(String decisionDefinitionId) {
-    RdbmsService rdbmsService = getRdbmsServiceBean();
-    if (rdbmsService == null) {
-      throw new IllegalStateException("RdbmsService is not available in the Spring context");
-    }
-    return rdbmsService.getDecisionInstanceReader()
+    return requireBean(DecisionInstanceDbReader.class)
         .search(DecisionInstanceQuery.of(queryBuilder -> queryBuilder.filter(
                 filterBuilder -> filterBuilder.decisionDefinitionIds(prefixDefinitionId(decisionDefinitionId)))
             .resultConfig(DecisionInstanceQueryResultConfig.of(DecisionInstanceQueryResultConfig.Builder::includeAll))))
@@ -228,11 +216,7 @@ public class HistoryMigrationExtension implements BeforeEachCallback, AfterEachC
   }
 
   public List<UserTaskEntity> searchHistoricUserTasks(long processInstanceKey) {
-    RdbmsService rdbmsService = getRdbmsServiceBean();
-    if (rdbmsService == null) {
-      throw new IllegalStateException("RdbmsService is not available in the Spring context");
-    }
-    return rdbmsService.getUserTaskReader()
+    return requireBean(UserTaskDbReader.class)
         .search(UserTaskQuery.of(queryBuilder ->
             queryBuilder.filter(filterBuilder ->
                 filterBuilder.processInstanceKeys(processInstanceKey))))
@@ -240,32 +224,20 @@ public class HistoryMigrationExtension implements BeforeEachCallback, AfterEachC
   }
 
   public List<FlowNodeInstanceEntity> searchHistoricFlowNodesForType(long processInstanceKey, FlowNodeInstanceEntity.FlowNodeType type) {
-    RdbmsService rdbmsService = getRdbmsServiceBean();
-    if (rdbmsService == null) {
-      throw new IllegalStateException("RdbmsService is not available in the Spring context");
-    }
-    return new ArrayList<>(rdbmsService.getFlowNodeInstanceReader()
+    return new ArrayList<>(requireBean(FlowNodeInstanceDbReader.class)
         .search(FlowNodeInstanceQuery.of(queryBuilder -> queryBuilder.filter(
             filterBuilder -> filterBuilder.processInstanceKeys(processInstanceKey).types(type))))
         .items());
   }
 
   public List<FlowNodeInstanceEntity> searchHistoricFlowNodesById(String... flowNodeIds) {
-    RdbmsService rdbmsService = getRdbmsServiceBean();
-    if (rdbmsService == null) {
-      throw new IllegalStateException("RdbmsService is not available in the Spring context");
-    }
-    return rdbmsService.getFlowNodeInstanceReader()
+    return requireBean(FlowNodeInstanceDbReader.class)
         .search(C8QueryCompat.flowNodeInstanceQueryByIds(flowNodeIds))
         .items();
   }
 
   public List<IncidentEntity> searchHistoricIncidents(String processDefinitionId) {
-    RdbmsService rdbmsService = getRdbmsServiceBean();
-    if (rdbmsService == null) {
-      throw new IllegalStateException("RdbmsService is not available in the Spring context");
-    }
-    return rdbmsService.getIncidentReader()
+    return requireBean(IncidentDbReader.class)
         .search(IncidentQuery.of(queryBuilder ->
             queryBuilder.filter(filterBuilder ->
                 filterBuilder.processDefinitionIds(prefixDefinitionId(processDefinitionId)))))
@@ -273,11 +245,7 @@ public class HistoryMigrationExtension implements BeforeEachCallback, AfterEachC
   }
 
   public List<VariableEntity> searchHistoricVariables(String... varName) {
-    RdbmsService rdbmsService = getRdbmsServiceBean();
-    if (rdbmsService == null) {
-      throw new IllegalStateException("RdbmsService is not available in the Spring context");
-    }
-    return rdbmsService.getVariableReader()
+    return requireBean(VariableDbReader.class)
         .search(VariableQuery.of(queryBuilder ->
             queryBuilder.filter(filterBuilder ->
                 filterBuilder.names(Arrays.stream(varName).toList()))))

--- a/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/history/HistoryMigrationAbstractTest.java
+++ b/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/history/HistoryMigrationAbstractTest.java
@@ -14,10 +14,20 @@ import static io.camunda.migration.data.qa.extension.HistoryMigrationExtension.U
 import static io.camunda.search.entities.DecisionInstanceEntity.DecisionInstanceState.EVALUATED;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.camunda.db.rdbms.RdbmsService;
 import io.camunda.db.rdbms.config.VendorDatabaseProperties;
 import io.camunda.db.rdbms.read.domain.FlowNodeInstanceDbQuery;
+import io.camunda.db.rdbms.read.service.AuditLogDbReader;
+import io.camunda.db.rdbms.read.service.DecisionDefinitionDbReader;
+import io.camunda.db.rdbms.read.service.DecisionInstanceDbReader;
+import io.camunda.db.rdbms.read.service.DecisionRequirementsDbReader;
+import io.camunda.db.rdbms.read.service.FlowNodeInstanceDbReader;
 import io.camunda.db.rdbms.read.service.FormDbReader;
+import io.camunda.db.rdbms.read.service.IncidentDbReader;
+import io.camunda.db.rdbms.read.service.JobDbReader;
+import io.camunda.db.rdbms.read.service.ProcessDefinitionDbReader;
+import io.camunda.db.rdbms.read.service.ProcessInstanceDbReader;
+import io.camunda.db.rdbms.read.service.UserTaskDbReader;
+import io.camunda.db.rdbms.read.service.VariableDbReader;
 import io.camunda.db.rdbms.sql.FlowNodeInstanceMapper;
 import io.camunda.db.rdbms.sql.PurgeMapper;
 import io.camunda.db.rdbms.write.domain.FlowNodeInstanceDbModel;
@@ -93,7 +103,40 @@ public abstract class HistoryMigrationAbstractTest extends AbstractMigratorTest 
   protected RdbmsPurger rdbmsPurger;
 
   @Autowired
-  protected RdbmsService rdbmsService;
+  protected ProcessDefinitionDbReader processDefinitionReader;
+
+  @Autowired
+  protected DecisionDefinitionDbReader decisionDefinitionReader;
+
+  @Autowired
+  protected DecisionRequirementsDbReader decisionRequirementsReader;
+
+  @Autowired
+  protected AuditLogDbReader auditLogReader;
+
+  @Autowired
+  protected ProcessInstanceDbReader processInstanceReader;
+
+  @Autowired
+  protected DecisionInstanceDbReader decisionInstanceReader;
+
+  @Autowired
+  protected UserTaskDbReader userTaskReader;
+
+  @Autowired
+  protected FlowNodeInstanceDbReader flowNodeInstanceReader;
+
+  @Autowired
+  protected IncidentDbReader incidentReader;
+
+  @Autowired
+  protected VariableDbReader variableReader;
+
+  @Autowired
+  protected JobDbReader jobReader;
+
+  @Autowired
+  protected FormDbReader formReader;
 
   @Autowired
   protected FlowNodeInstanceMapper flowNodeInstanceMapper;
@@ -128,7 +171,7 @@ public abstract class HistoryMigrationAbstractTest extends AbstractMigratorTest 
   }
 
   public List<ProcessDefinitionEntity> searchHistoricProcessDefinitions(String processDefinitionId) {
-    return rdbmsService.getProcessDefinitionReader()
+    return processDefinitionReader
         .search(ProcessDefinitionQuery.of(queryBuilder ->
             queryBuilder.filter(filterBuilder ->
                 filterBuilder.processDefinitionIds(prefixDefinitionId(processDefinitionId)))))
@@ -136,13 +179,13 @@ public abstract class HistoryMigrationAbstractTest extends AbstractMigratorTest 
   }
 
   public List<ProcessDefinitionEntity> searchHistoricProcessDefinitionsWithBpmnXml(String processDefinitionId) {
-    return rdbmsService.getProcessDefinitionReader()
+    return processDefinitionReader
         .search(C8QueryCompat.processDefinitionQueryWithBpmnXml(prefixDefinitionId(processDefinitionId)))
         .items();
   }
 
   public List<DecisionDefinitionEntity> searchHistoricDecisionDefinitions(String decisionDefinitionId) {
-    return rdbmsService.getDecisionDefinitionReader()
+    return decisionDefinitionReader
         .search(DecisionDefinitionQuery.of(queryBuilder ->
             queryBuilder.filter(filterBuilder ->
                 filterBuilder.decisionDefinitionIds(prefixDefinitionId(decisionDefinitionId)))))
@@ -150,7 +193,7 @@ public abstract class HistoryMigrationAbstractTest extends AbstractMigratorTest 
   }
 
   public List<DecisionRequirementsEntity> searchHistoricDecisionRequirementsDefinition(String decisionRequirementsId) {
-    return rdbmsService.getDecisionRequirementsReader()
+    return decisionRequirementsReader
         .search(DecisionRequirementsQuery.of(queryBuilder -> queryBuilder.filter(
                 filterBuilder -> filterBuilder.decisionRequirementsIds(prefixDefinitionId(decisionRequirementsId)))
             .resultConfig(
@@ -163,14 +206,14 @@ public abstract class HistoryMigrationAbstractTest extends AbstractMigratorTest 
   }
 
   public List<AuditLogEntity> searchAuditLogs(String processDefinitionId) {
-    return rdbmsService.getAuditLogReader()
+    return auditLogReader
         .search(AuditLogQuery.of(q -> q.filter(f ->
             f.processDefinitionIds(prefixDefinitionId(processDefinitionId)))))
         .items();
   }
 
   public List<AuditLogEntity> searchAuditLogsByCategory(String name) {
-    return rdbmsService.getAuditLogReader()
+    return auditLogReader
         .search(AuditLogQuery.of(q -> q.filter(f ->
             f.categories(name))))
         .items();
@@ -185,14 +228,14 @@ public abstract class HistoryMigrationAbstractTest extends AbstractMigratorTest 
     String finalProcessDefinitionId = builtInTransformerDisabled ?
         processDefinitionId :
         prefixDefinitionId(processDefinitionId);
-    return rdbmsService.getProcessInstanceReader()
+    return processInstanceReader
         .search(ProcessInstanceQuery.of(queryBuilder -> queryBuilder.filter(
             filterBuilder -> filterBuilder.processDefinitionIds(finalProcessDefinitionId))))
         .items();
   }
 
   public List<DecisionInstanceEntity> searchHistoricDecisionInstances(String... decisionDefinitionIds) {
-    return rdbmsService.getDecisionInstanceReader()
+    return decisionInstanceReader
         .search(DecisionInstanceQuery.of(queryBuilder -> queryBuilder.filter(
                 filterBuilder -> filterBuilder.decisionDefinitionIds(Arrays.stream(decisionDefinitionIds).map(ConverterUtil::prefixDefinitionId).toList()))
             .resultConfig(DecisionInstanceQueryResultConfig.of(DecisionInstanceQueryResultConfig.Builder::includeAll))))
@@ -200,7 +243,7 @@ public abstract class HistoryMigrationAbstractTest extends AbstractMigratorTest 
   }
 
   public List<UserTaskEntity> searchHistoricUserTasks(long processInstanceKey) {
-    return rdbmsService.getUserTaskReader()
+    return userTaskReader
         .search(UserTaskQuery.of(queryBuilder ->
             queryBuilder.filter(filterBuilder ->
                 filterBuilder.processInstanceKeys(processInstanceKey))))
@@ -208,13 +251,13 @@ public abstract class HistoryMigrationAbstractTest extends AbstractMigratorTest 
   }
 
   public List<UserTaskEntity> searchHistoricUserTasks() {
-    return rdbmsService.getUserTaskReader()
+    return userTaskReader
         .search(new UserTaskQuery(FilterBuilders.userTask().build(), SortOptionBuilders.userTask().build(), SearchQueryPage.of((b) -> b)))
         .items();
   }
 
   public List<FlowNodeInstanceEntity> searchHistoricFlowNodesForType(long processInstanceKey, FlowNodeInstanceEntity.FlowNodeType type) {
-    return rdbmsService.getFlowNodeInstanceReader()
+    return flowNodeInstanceReader
         .search(FlowNodeInstanceQuery.of(queryBuilder ->
             queryBuilder.filter(filterBuilder ->
                 filterBuilder.processInstanceKeys(processInstanceKey).types(type))))
@@ -222,7 +265,7 @@ public abstract class HistoryMigrationAbstractTest extends AbstractMigratorTest 
   }
 
   public List<FlowNodeInstanceEntity> searchHistoricFlowNodes(long processInstanceKey) {
-    return rdbmsService.getFlowNodeInstanceReader()
+    return flowNodeInstanceReader
         .search(FlowNodeInstanceQuery.of(queryBuilder ->
             queryBuilder.filter(filterBuilder ->
                 filterBuilder.processInstanceKeys(processInstanceKey))))
@@ -240,7 +283,7 @@ public abstract class HistoryMigrationAbstractTest extends AbstractMigratorTest 
   }
 
   public List<IncidentEntity> searchHistoricIncidents(String processDefinitionId) {
-    return rdbmsService.getIncidentReader()
+    return incidentReader
         .search(IncidentQuery.of(queryBuilder ->
             queryBuilder.filter(filterBuilder ->
                 filterBuilder.processDefinitionIds(prefixDefinitionId(processDefinitionId)))))
@@ -282,7 +325,7 @@ public abstract class HistoryMigrationAbstractTest extends AbstractMigratorTest 
   }
 
   public List<VariableEntity> searchHistoricVariables(String varName) {
-    return rdbmsService.getVariableReader()
+    return variableReader
         .search(VariableQuery.of(queryBuilder ->
             queryBuilder.filter(filterBuilder ->
                 filterBuilder.names(varName))))
@@ -290,7 +333,7 @@ public abstract class HistoryMigrationAbstractTest extends AbstractMigratorTest 
   }
 
   public List<VariableEntity> searchHistoricVariables(Long processInstanceKey) {
-    return rdbmsService.getVariableReader()
+    return variableReader
         .search(VariableQuery.of(queryBuilder ->
             queryBuilder.filter(filterBuilder ->
                 filterBuilder.processInstanceKeys(processInstanceKey))))
@@ -298,13 +341,13 @@ public abstract class HistoryMigrationAbstractTest extends AbstractMigratorTest 
   }
 
   public List<VariableEntity> searchHistoricVariables() {
-    return rdbmsService.getVariableReader()
+    return variableReader
         .search(new VariableQuery(FilterBuilders.variable().build(), SortOptionBuilders.variable().build(), SearchQueryPage.of((b) -> b)))
         .items();
   }
 
   public List<JobEntity> searchJobs(long processInstanceKey) {
-    return rdbmsService.getJobReader()
+    return jobReader
         .search(JobQuery.of(queryBuilder ->
             queryBuilder.filter(filterBuilder ->
                 filterBuilder.processInstanceKeys(processInstanceKey))))
@@ -312,13 +355,12 @@ public abstract class HistoryMigrationAbstractTest extends AbstractMigratorTest 
   }
 
   public List<JobEntity> searchJobs() {
-    return rdbmsService.getJobReader()
+    return jobReader
         .search(new JobQuery(FilterBuilders.job().build(), SortOptionBuilders.job().build(), SearchQueryPage.of((b) -> b)))
         .items();
   }
 
   public List<FormEntity> searchForms(String... formIds) {
-    FormDbReader formReader = rdbmsService.getFormReader();
     if (formIds.length != 0) {
       return formReader
           .search(FormQuery.of(queryBuilder ->

--- a/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/history/HistoryMigrationAbstractTest.java
+++ b/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/history/HistoryMigrationAbstractTest.java
@@ -29,6 +29,7 @@ import io.camunda.migration.data.config.MigratorAutoConfiguration;
 import io.camunda.migration.data.impl.clients.DbClient;
 import io.camunda.migration.data.impl.util.ConverterUtil;
 import io.camunda.migration.data.qa.AbstractMigratorTest;
+import io.camunda.migration.data.qa.c8compat.C8QueryCompat;
 import io.camunda.migration.data.qa.extension.RdbmsQueryExtension;
 import io.camunda.migration.data.qa.util.WithSpringProfile;
 import io.camunda.search.entities.AuditLogEntity;
@@ -136,11 +137,7 @@ public abstract class HistoryMigrationAbstractTest extends AbstractMigratorTest 
 
   public List<ProcessDefinitionEntity> searchHistoricProcessDefinitionsWithBpmnXml(String processDefinitionId) {
     return rdbmsService.getProcessDefinitionReader()
-        .search(ProcessDefinitionQuery.of(queryBuilder ->
-            queryBuilder
-                .filter(filterBuilder ->
-                    filterBuilder.processDefinitionIds(prefixDefinitionId(processDefinitionId)))
-                .resultConfig(b -> b.includeXml(true))))
+        .search(C8QueryCompat.processDefinitionQueryWithBpmnXml(prefixDefinitionId(processDefinitionId)))
         .items();
   }
 

--- a/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/history/entity/HistoryProcessInstanceTest.java
+++ b/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/history/entity/HistoryProcessInstanceTest.java
@@ -269,7 +269,7 @@ public class HistoryProcessInstanceTest extends HistoryMigrationAbstractTest {
     );
 
     // Verify that variables also have rootProcessInstanceKey
-    List<VariableEntity> variables = rdbmsService.getVariableReader()
+    List<VariableEntity> variables = variableReader
         .search(VariableQuery.of(queryBuilder ->
             queryBuilder.filter(filterBuilder ->
                 filterBuilder.processInstanceKeys(sub.processInstanceKey()))))

--- a/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/history/entity/interceptor/HistoryDeclarativeConfigurationTest.java
+++ b/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/history/entity/interceptor/HistoryDeclarativeConfigurationTest.java
@@ -128,7 +128,7 @@ public class HistoryDeclarativeConfigurationTest extends HistoryMigrationAbstrac
     Long processInstanceKey = migratedProcessInstances.getFirst().processInstanceKey();
 
     List<FlowNodeInstanceEntity> migratedFlowNodes =
-        rdbmsService.getFlowNodeInstanceReader()
+        flowNodeInstanceReader
             .search(io.camunda.search.query.FlowNodeInstanceQuery.of(queryBuilder ->
                 queryBuilder.filter(filterBuilder ->
                     filterBuilder.tenantIds("complex-tenant"))))

--- a/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/history/entity/interceptor/HistoryInterceptorTest.java
+++ b/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/history/entity/interceptor/HistoryInterceptorTest.java
@@ -73,7 +73,7 @@ public class HistoryInterceptorTest extends HistoryMigrationAbstractTest {
 
     // Verify flow nodes were migrated with modified tenant ID
     List<FlowNodeInstanceEntity> migratedFlowNodes =
-        rdbmsService.getFlowNodeInstanceReader()
+        flowNodeInstanceReader
             .search(io.camunda.search.query.FlowNodeInstanceQuery.of(queryBuilder ->
                 queryBuilder.filter(filterBuilder ->
                     filterBuilder.processInstanceKeys(processInstanceKey))))

--- a/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/runtime/SkipAndRetryProcessInstancesTest.java
+++ b/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/runtime/SkipAndRetryProcessInstancesTest.java
@@ -18,7 +18,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.client.api.command.ClientException;
 import io.camunda.client.api.search.response.ProcessInstance;
-import io.camunda.db.rdbms.RdbmsService;
+import io.camunda.db.rdbms.read.service.ProcessInstanceDbReader;
 import io.camunda.migration.data.HistoryMigrator;
 import io.camunda.migration.data.RuntimeMigrator;
 import io.camunda.migration.data.impl.persistence.IdKeyMapper;
@@ -59,7 +59,7 @@ class SkipAndRetryProcessInstancesTest extends RuntimeMigrationAbstractTest {
   protected HistoryMigrator historyMigrator;
 
   @Autowired
-  protected RdbmsService rdbmsService;
+  protected ProcessInstanceDbReader processInstanceReader;
 
   @Test
   public void shouldSkipMultiInstanceProcessMigration() {
@@ -286,7 +286,7 @@ class SkipAndRetryProcessInstancesTest extends RuntimeMigrationAbstractTest {
 
 
     // and verify historic process instance exists in RDBMS
-    List<ProcessInstanceEntity> historicProcessInstances = rdbmsService.getProcessInstanceReader()
+    List<ProcessInstanceEntity> historicProcessInstances = processInstanceReader
         .search(ProcessInstanceQuery.of(queryBuilder ->
             queryBuilder.filter(filterBuilder ->
                 filterBuilder.processDefinitionIds(prefixDefinitionId(c7ProcDefKey))))).items();


### PR DESCRIPTION
# Pull Request Template
related to: https://github.com/camunda/camunda-7-to-8-migration-tooling/issues/1299
## Description
<!-- Describe your changes in detail -->

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Test-only changes (no production code changes)

## Testing Checklist

### Black-Box Testing Requirements
- [ ] Tests follow **black-box testing approach**: verify behavior through observable outputs (logs, C8 API queries, real-world skip scenarios)
- [ ] Tests **DO NOT** access implementation details (`DbClient`, `IdKeyMapper`, `..impl..` packages except logging constants)
- [ ] Architecture tests pass (`ArchitectureTest` validates these rules)

### Test Coverage
- [ ] Added tests for new functionality
- [ ] Updated tests for modified functionality
- [ ] All tests pass locally

## Architecture Compliance

Run architecture tests to ensure compliance:
```bash
mvn test -Dtest=ArchitectureTest
```

If architecture tests fail, refactor your tests to use:
- `LogCapturer` for log assertions
- `camundaClient.new*SearchRequest()` for C8 queries
- Real-World skip scenarios (e.g., migrate children without parents)

## Documentation
- [ ] Updated TESTING_GUIDELINES.md if adding new test patterns
- [ ] Added Javadoc comments for public APIs
- [ ] Updated README if user-facing changes

## Checklist
- [ ] Code follows project style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments for complex logic
- [ ] No new compiler warnings
- [ ] Dependent changes have been merged

## Related Issues
<!-- Link to related issues: Fixes #123, Related to #456 -->

