### PR TITLE
chore(data-migrator): fix e2e flakiness

### DIFF
--- a/data-migrator/qa/e2e-tests/tests/operate-processes.spec.ts
+++ b/data-migrator/qa/e2e-tests/tests/operate-processes.spec.ts
@@ -11,14 +11,20 @@ import { test, expect } from '@playwright/test';
 const OPERATE_URL = 'http://localhost:8088/operate';
 
 /**
- * Helper: dismiss the "Here's what moved in Operate" changelog modal if present.
+ * Helper: install a persistent handler that auto-dismisses Operate's
+ * "Here's what moved in Operate" changelog modal whenever it appears.
+ *
+ * The modal can render asynchronously after login and intercept pointer
+ * events on tab buttons — particularly on Firefox, which hydrates the
+ * Operate React UI more slowly on CI and often misses a one-shot probe.
+ * `page.addLocatorHandler` makes Playwright dismiss the modal before every
+ * subsequent action, eliminating the race.
  */
-async function dismissChangelogModal(page: any) {
+async function installChangelogHandler(page: any) {
   const gotItButton = page.locator('button:has-text("Got it")');
-  if (await gotItButton.isVisible({ timeout: 2000 }).catch(() => false)) {
+  await page.addLocatorHandler(gotItButton, async () => {
     await gotItButton.click();
-    await gotItButton.waitFor({ state: 'hidden', timeout: 5000 });
-  }
+  });
 }
 
 /**
@@ -43,7 +49,7 @@ async function login(page: any) {
       .waitFor({ state: 'hidden', timeout: 15000 });
   }
 
-  await dismissChangelogModal(page);
+  await installChangelogHandler(page);
 }
 
 /**
@@ -78,8 +84,6 @@ async function openProcessInstance(page: any, processName: string) {
 
   await page.waitForURL('**/processes/**', { timeout: 10000 });
   await page.waitForTimeout(3000);
-
-  await dismissChangelogModal(page);
 }
 
 /**
@@ -270,8 +274,6 @@ test.describe('Operate - Process Instances & Audit Logs', () => {
 
     await page.waitForURL('**/processes/**', { timeout: 10000 });
     await page.waitForLoadState('networkidle');
-
-    await dismissChangelogModal(page);
 
     // "Operations Log" is a tab button in the right panel (next to Variables, Listeners)
     const operationsLogTab = page


### PR DESCRIPTION
# Pull Request Template
The `what changed` modal might take longer to appear in the browser which caused flakiness.

## Description
<!-- Describe your changes in detail -->

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Test-only changes (no production code changes)

## Testing Checklist

### Black-Box Testing Requirements
- [ ] Tests follow **black-box testing approach**: verify behavior through observable outputs (logs, C8 API queries, real-world skip scenarios)
- [ ] Tests **DO NOT** access implementation details (`DbClient`, `IdKeyMapper`, `..impl..` packages except logging constants)
- [ ] Architecture tests pass (`ArchitectureTest` validates these rules)

### Test Coverage
- [ ] Added tests for new functionality
- [ ] Updated tests for modified functionality
- [ ] All tests pass locally

## Architecture Compliance

Run architecture tests to ensure compliance:
```bash
mvn test -Dtest=ArchitectureTest
```

If architecture tests fail, refactor your tests to use:
- `LogCapturer` for log assertions
- `camundaClient.new*SearchRequest()` for C8 queries
- Real-World skip scenarios (e.g., migrate children without parents)

## Documentation
- [ ] Updated TESTING_GUIDELINES.md if adding new test patterns
- [ ] Added Javadoc comments for public APIs
- [ ] Updated README if user-facing changes

## Checklist
- [ ] Code follows project style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments for complex logic
- [ ] No new compiler warnings
- [ ] Dependent changes have been merged

## Related Issues
<!-- Link to related issues: Fixes #123, Related to #456 -->

