### PR TITLE
fix(data-migrator): query RDBMS as workaround for enforced nullability

### DIFF
--- a/data-migrator/qa/integration-tests/src/test/java-c8-current/io/camunda/migration/data/qa/c8compat/C8QueryCompat.java
+++ b/data-migrator/qa/integration-tests/src/test/java-c8-current/io/camunda/migration/data/qa/c8compat/C8QueryCompat.java
@@ -7,9 +7,19 @@
  */
 package io.camunda.migration.data.qa.c8compat;
 
+import io.camunda.db.rdbms.read.domain.AuditLogAuthorizationFilter;
+import io.camunda.db.rdbms.read.domain.AuditLogDbQuery;
+import io.camunda.db.rdbms.read.service.AuditLogDbReader;
+import io.camunda.db.rdbms.read.service.IncidentDbReader;
+import io.camunda.db.rdbms.sql.AuditLogMapper;
+import io.camunda.db.rdbms.write.domain.AuditLogDbModel;
+import io.camunda.db.rdbms.write.domain.IncidentDbModel;
+import io.camunda.migration.data.qa.extension.RdbmsQueryExtension;
+import io.camunda.search.entities.IncidentEntity;
 import io.camunda.search.query.FlowNodeInstanceQuery;
 import io.camunda.search.query.ProcessDefinitionQuery;
 import java.util.Arrays;
+import java.util.List;
 
 /**
  * Version-specific test query helpers for the current Camunda 8 version.
@@ -40,5 +50,54 @@ public final class C8QueryCompat {
     return FlowNodeInstanceQuery.of(
         queryBuilder ->
             queryBuilder.filter(filterBuilder -> filterBuilder.flowNodeIds(first, rest)));
+  }
+
+  public static List<IncidentDbModel> searchHistoricIncidents(
+      @SuppressWarnings("unused") IncidentDbReader incidentReader, RdbmsQueryExtension rdbmsQuery, String prefixedProcessDefinitionId) {
+    String sql =
+        "SELECT INCIDENT_KEY, PROCESS_DEFINITION_KEY, PROCESS_DEFINITION_ID," +
+        " PROCESS_INSTANCE_KEY, ROOT_PROCESS_INSTANCE_KEY, FLOW_NODE_INSTANCE_KEY," +
+        " FLOW_NODE_ID, JOB_KEY, ERROR_TYPE, ERROR_MESSAGE, ERROR_MESSAGE_HASH," +
+        " STATE, CREATION_DATE, TREE_PATH, TENANT_ID, PARTITION_ID" +
+        " FROM INCIDENT WHERE PROCESS_DEFINITION_ID = ?";
+    return rdbmsQuery.query(sql, (rs, rowNum) -> {
+      String errorTypeStr = rs.getString("ERROR_TYPE");
+      String stateStr = rs.getString("STATE");
+      java.sql.Timestamp ts = rs.getTimestamp("CREATION_DATE");
+      return new IncidentDbModel.Builder()
+          .incidentKey(rs.getObject("INCIDENT_KEY", Long.class))
+          .processDefinitionKey(rs.getObject("PROCESS_DEFINITION_KEY", Long.class))
+          .processDefinitionId(rs.getString("PROCESS_DEFINITION_ID"))
+          .processInstanceKey(rs.getObject("PROCESS_INSTANCE_KEY", Long.class))
+          .rootProcessInstanceKey(rs.getObject("ROOT_PROCESS_INSTANCE_KEY", Long.class))
+          .flowNodeInstanceKey(rs.getObject("FLOW_NODE_INSTANCE_KEY", Long.class))
+          .flowNodeId(rs.getString("FLOW_NODE_ID"))
+          .jobKey(rs.getObject("JOB_KEY", Long.class))
+          .errorType(errorTypeStr != null ? IncidentEntity.ErrorType.valueOf(errorTypeStr) : null)
+          .errorMessage(rs.getString("ERROR_MESSAGE"))
+          .errorMessageHash(rs.getObject("ERROR_MESSAGE_HASH", Integer.class))
+          .state(stateStr != null ? IncidentEntity.IncidentState.valueOf(stateStr) : null)
+          .creationDate(ts != null ? ts.toInstant().atOffset(java.time.ZoneOffset.UTC) : null)
+          .treePath(rs.getString("TREE_PATH"))
+          .tenantId(rs.getString("TENANT_ID"))
+          .partitionId(rs.getInt("PARTITION_ID"))
+          .build();
+    }, prefixedProcessDefinitionId);
+  }
+
+  public static List<AuditLogDbModel> searchAuditLogs(
+      AuditLogMapper auditLogMapper, @SuppressWarnings("unused") AuditLogDbReader auditLogReader,
+      String prefixedProcessDefinitionId) {
+    return auditLogMapper.search(AuditLogDbQuery.of(b -> b
+        .authorizationFilter(AuditLogAuthorizationFilter.allowAll())
+        .filter(f -> f.processDefinitionIds(prefixedProcessDefinitionId))));
+  }
+
+  public static List<AuditLogDbModel> searchAuditLogsByCategory(
+      AuditLogMapper auditLogMapper, @SuppressWarnings("unused") AuditLogDbReader auditLogReader,
+      String category) {
+    return auditLogMapper.search(AuditLogDbQuery.of(b -> b
+        .authorizationFilter(AuditLogAuthorizationFilter.allowAll())
+        .filter(f -> f.categories(category))));
   }
 }

--- a/data-migrator/qa/integration-tests/src/test/java-c8-previous/io/camunda/migration/data/qa/c8compat/C8QueryCompat.java
+++ b/data-migrator/qa/integration-tests/src/test/java-c8-previous/io/camunda/migration/data/qa/c8compat/C8QueryCompat.java
@@ -7,8 +7,17 @@
  */
 package io.camunda.migration.data.qa.c8compat;
 
+import io.camunda.db.rdbms.read.service.AuditLogDbReader;
+import io.camunda.db.rdbms.read.service.IncidentDbReader;
+import io.camunda.db.rdbms.sql.AuditLogMapper;
+import io.camunda.db.rdbms.write.domain.AuditLogDbModel;
+import io.camunda.db.rdbms.write.domain.IncidentDbModel;
+import io.camunda.migration.data.qa.extension.RdbmsQueryExtension;
+import io.camunda.search.query.AuditLogQuery;
 import io.camunda.search.query.FlowNodeInstanceQuery;
+import io.camunda.search.query.IncidentQuery;
 import io.camunda.search.query.ProcessDefinitionQuery;
+import java.util.List;
 
 /**
  * Version-specific test query helpers for the previous Camunda 8 version.
@@ -41,5 +50,115 @@ public final class C8QueryCompat {
     return FlowNodeInstanceQuery.of(
         queryBuilder ->
             queryBuilder.filter(filterBuilder -> filterBuilder.flowNodeIds(flowNodeIds)));
+  }
+
+  public static List<IncidentDbModel> searchHistoricIncidents(
+      IncidentDbReader incidentReader, @SuppressWarnings("unused") RdbmsQueryExtension rdbmsQuery, String prefixedProcessDefinitionId) {
+    return incidentReader
+        .search(IncidentQuery.of(b -> b.filter(f -> f.processDefinitionIds(prefixedProcessDefinitionId))))
+        .items()
+        .stream()
+        .map(e -> new IncidentDbModel.Builder()
+            .incidentKey(e.incidentKey())
+            .processDefinitionKey(e.processDefinitionKey())
+            .processDefinitionId(e.processDefinitionId())
+            .processInstanceKey(e.processInstanceKey())
+            .rootProcessInstanceKey(e.rootProcessInstanceKey())
+            .flowNodeInstanceKey(e.flowNodeInstanceKey())
+            .flowNodeId(e.flowNodeId())
+            .jobKey(e.jobKey())
+            .errorType(e.errorType())
+            .errorMessage(e.errorMessage())
+            .state(e.state())
+            .creationDate(e.creationTime())
+            .tenantId(e.tenantId())
+            .build())
+        .toList();
+  }
+
+  public static List<AuditLogDbModel> searchAuditLogs(
+      @SuppressWarnings("unused") AuditLogMapper auditLogMapper,
+      AuditLogDbReader auditLogReader, String prefixedProcessDefinitionId) {
+    return auditLogReader
+        .search(AuditLogQuery.of(q -> q.filter(f -> f.processDefinitionIds(prefixedProcessDefinitionId))))
+        .items().stream()
+        .map(e -> new AuditLogDbModel.Builder()
+            .auditLogKey(e.auditLogKey())
+            .entityKey(e.entityKey())
+            .entityType(e.entityType())
+            .operationType(e.operationType())
+            .batchOperationKey(e.batchOperationKey())
+            .batchOperationType(e.batchOperationType())
+            .timestamp(e.timestamp())
+            .actorId(e.actorId())
+            .actorType(e.actorType())
+            .agentElementId(e.agentElementId())
+            .tenantId(e.tenantId())
+            .tenantScope(e.tenantScope())
+            .result(e.result())
+            .category(e.category())
+            .processDefinitionId(e.processDefinitionId())
+            .processDefinitionKey(e.processDefinitionKey())
+            .processInstanceKey(e.processInstanceKey())
+            .rootProcessInstanceKey(e.rootProcessInstanceKey())
+            .elementInstanceKey(e.elementInstanceKey())
+            .jobKey(e.jobKey())
+            .userTaskKey(e.userTaskKey())
+            .decisionRequirementsId(e.decisionRequirementsId())
+            .decisionRequirementsKey(e.decisionRequirementsKey())
+            .decisionDefinitionId(e.decisionDefinitionId())
+            .decisionDefinitionKey(e.decisionDefinitionKey())
+            .decisionEvaluationKey(e.decisionEvaluationKey())
+            .deploymentKey(e.deploymentKey())
+            .formKey(e.formKey())
+            .resourceKey(e.resourceKey())
+            .relatedEntityType(e.relatedEntityType())
+            .relatedEntityKey(e.relatedEntityKey())
+            .entityDescription(e.entityDescription())
+            .build())
+        .toList();
+  }
+
+  public static List<AuditLogDbModel> searchAuditLogsByCategory(
+      @SuppressWarnings("unused") AuditLogMapper auditLogMapper,
+      AuditLogDbReader auditLogReader, String category) {
+    return auditLogReader
+        .search(AuditLogQuery.of(q -> q.filter(f -> f.categories(category))))
+        .items().stream()
+        .map(e -> new AuditLogDbModel.Builder()
+            .auditLogKey(e.auditLogKey())
+            .entityKey(e.entityKey())
+            .entityType(e.entityType())
+            .operationType(e.operationType())
+            .batchOperationKey(e.batchOperationKey())
+            .batchOperationType(e.batchOperationType())
+            .timestamp(e.timestamp())
+            .actorId(e.actorId())
+            .actorType(e.actorType())
+            .agentElementId(e.agentElementId())
+            .tenantId(e.tenantId())
+            .tenantScope(e.tenantScope())
+            .result(e.result())
+            .category(e.category())
+            .processDefinitionId(e.processDefinitionId())
+            .processDefinitionKey(e.processDefinitionKey())
+            .processInstanceKey(e.processInstanceKey())
+            .rootProcessInstanceKey(e.rootProcessInstanceKey())
+            .elementInstanceKey(e.elementInstanceKey())
+            .jobKey(e.jobKey())
+            .userTaskKey(e.userTaskKey())
+            .decisionRequirementsId(e.decisionRequirementsId())
+            .decisionRequirementsKey(e.decisionRequirementsKey())
+            .decisionDefinitionId(e.decisionDefinitionId())
+            .decisionDefinitionKey(e.decisionDefinitionKey())
+            .decisionEvaluationKey(e.decisionEvaluationKey())
+            .deploymentKey(e.deploymentKey())
+            .formKey(e.formKey())
+            .resourceKey(e.resourceKey())
+            .relatedEntityType(e.relatedEntityType())
+            .relatedEntityKey(e.relatedEntityKey())
+            .entityDescription(e.entityDescription())
+            .build())
+        .toList();
   }
 }

--- a/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/extension/HistoryMigrationExtension.java
+++ b/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/extension/HistoryMigrationExtension.java
@@ -19,17 +19,18 @@ import io.camunda.db.rdbms.read.service.ProcessDefinitionDbReader;
 import io.camunda.db.rdbms.read.service.ProcessInstanceDbReader;
 import io.camunda.db.rdbms.read.service.UserTaskDbReader;
 import io.camunda.db.rdbms.read.service.VariableDbReader;
+import io.camunda.db.rdbms.write.domain.IncidentDbModel;
 import io.camunda.db.rdbms.write.service.RdbmsPurger;
 import io.camunda.migration.data.HistoryMigrator;
 import io.camunda.migration.data.MigratorMode;
 import io.camunda.migration.data.impl.clients.DbClient;
 import io.camunda.migration.data.qa.c8compat.C8QueryCompat;
+import io.camunda.migration.data.qa.extension.RdbmsQueryExtension;
 import io.camunda.migration.data.qa.util.SpringProfileResolver;
 import io.camunda.search.entities.DecisionDefinitionEntity;
 import io.camunda.search.entities.DecisionInstanceEntity;
 import io.camunda.search.entities.DecisionRequirementsEntity;
 import io.camunda.search.entities.FlowNodeInstanceEntity;
-import io.camunda.search.entities.IncidentEntity;
 import io.camunda.search.entities.ProcessDefinitionEntity;
 import io.camunda.search.entities.ProcessInstanceEntity;
 import io.camunda.search.entities.UserTaskEntity;
@@ -38,7 +39,6 @@ import io.camunda.search.query.DecisionDefinitionQuery;
 import io.camunda.search.query.DecisionInstanceQuery;
 import io.camunda.search.query.DecisionRequirementsQuery;
 import io.camunda.search.query.FlowNodeInstanceQuery;
-import io.camunda.search.query.IncidentQuery;
 import io.camunda.search.query.ProcessDefinitionQuery;
 import io.camunda.search.query.ProcessInstanceQuery;
 import io.camunda.search.query.UserTaskQuery;
@@ -236,12 +236,11 @@ public class HistoryMigrationExtension implements BeforeEachCallback, AfterEachC
         .items();
   }
 
-  public List<IncidentEntity> searchHistoricIncidents(String processDefinitionId) {
-    return requireBean(IncidentDbReader.class)
-        .search(IncidentQuery.of(queryBuilder ->
-            queryBuilder.filter(filterBuilder ->
-                filterBuilder.processDefinitionIds(prefixDefinitionId(processDefinitionId)))))
-        .items();
+  public List<IncidentDbModel> searchHistoricIncidents(String processDefinitionId) {
+    return C8QueryCompat.searchHistoricIncidents(
+        requireBean(IncidentDbReader.class),
+        requireBean(RdbmsQueryExtension.class),
+        prefixDefinitionId(processDefinitionId));
   }
 
   public List<VariableEntity> searchHistoricVariables(String... varName) {

--- a/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/extension/RdbmsQueryExtension.java
+++ b/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/extension/RdbmsQueryExtension.java
@@ -94,6 +94,12 @@ public class RdbmsQueryExtension implements BeforeEachCallback, AfterEachCallbac
    * @return the JdbcTemplate instance
    */
   public JdbcTemplate getJdbcTemplate() {
+    if (jdbcTemplate == null && applicationContext != null) {
+      DataSourceRegistry registry = applicationContext.getBean(DataSourceRegistry.class);
+      DataSource dataSource = registry.getMigratorDataSource();
+      jdbcTemplate = new JdbcTemplate(dataSource);
+      transactionTemplate = registry.getMigratorTxTemplate();
+    }
     if (jdbcTemplate == null) {
       throw new IllegalStateException("JdbcTemplate not initialized. Make sure the extension is properly registered.");
     }

--- a/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/history/HistoryMigrationAbstractTest.java
+++ b/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/history/HistoryMigrationAbstractTest.java
@@ -16,8 +16,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.db.rdbms.config.VendorDatabaseProperties;
 import io.camunda.db.rdbms.read.domain.FlowNodeInstanceDbQuery;
+import io.camunda.db.rdbms.read.domain.JobDbQuery;
 import io.camunda.db.rdbms.read.service.AuditLogDbReader;
 import io.camunda.db.rdbms.read.service.DecisionDefinitionDbReader;
+import io.camunda.db.rdbms.sql.AuditLogMapper;
+import io.camunda.db.rdbms.write.domain.AuditLogDbModel;
 import io.camunda.db.rdbms.read.service.DecisionInstanceDbReader;
 import io.camunda.db.rdbms.read.service.DecisionRequirementsDbReader;
 import io.camunda.db.rdbms.read.service.FlowNodeInstanceDbReader;
@@ -29,9 +32,11 @@ import io.camunda.db.rdbms.read.service.ProcessInstanceDbReader;
 import io.camunda.db.rdbms.read.service.UserTaskDbReader;
 import io.camunda.db.rdbms.read.service.VariableDbReader;
 import io.camunda.db.rdbms.sql.FlowNodeInstanceMapper;
+import io.camunda.db.rdbms.sql.JobMapper;
 import io.camunda.db.rdbms.sql.PurgeMapper;
 import io.camunda.db.rdbms.write.domain.FlowNodeInstanceDbModel;
 import io.camunda.db.rdbms.write.domain.IncidentDbModel;
+import io.camunda.db.rdbms.write.domain.JobDbModel;
 import io.camunda.db.rdbms.write.service.RdbmsPurger;
 import io.camunda.migration.data.HistoryMigrator;
 import io.camunda.migration.data.config.C8DataSourceConfigured;
@@ -42,28 +47,22 @@ import io.camunda.migration.data.qa.AbstractMigratorTest;
 import io.camunda.migration.data.qa.c8compat.C8QueryCompat;
 import io.camunda.migration.data.qa.extension.RdbmsQueryExtension;
 import io.camunda.migration.data.qa.util.WithSpringProfile;
-import io.camunda.search.entities.AuditLogEntity;
 import io.camunda.search.entities.DecisionDefinitionEntity;
 import io.camunda.search.entities.DecisionInstanceEntity;
 import io.camunda.search.entities.DecisionRequirementsEntity;
 import io.camunda.search.entities.FlowNodeInstanceEntity;
 import io.camunda.search.entities.FormEntity;
-import io.camunda.search.entities.IncidentEntity;
-import io.camunda.search.entities.JobEntity;
 import io.camunda.search.entities.ProcessDefinitionEntity;
 import io.camunda.search.entities.ProcessInstanceEntity;
 import io.camunda.search.entities.UserTaskEntity;
 import io.camunda.search.entities.VariableEntity;
 import io.camunda.search.filter.FilterBuilders;
 import io.camunda.search.page.SearchQueryPage;
-import io.camunda.search.query.AuditLogQuery;
 import io.camunda.search.query.DecisionDefinitionQuery;
 import io.camunda.search.query.DecisionInstanceQuery;
 import io.camunda.search.query.DecisionRequirementsQuery;
 import io.camunda.search.query.FlowNodeInstanceQuery;
 import io.camunda.search.query.FormQuery;
-import io.camunda.search.query.IncidentQuery;
-import io.camunda.search.query.JobQuery;
 import io.camunda.search.query.ProcessDefinitionQuery;
 import io.camunda.search.query.ProcessInstanceQuery;
 import io.camunda.search.query.UserTaskQuery;
@@ -115,6 +114,9 @@ public abstract class HistoryMigrationAbstractTest extends AbstractMigratorTest 
   protected AuditLogDbReader auditLogReader;
 
   @Autowired
+  protected AuditLogMapper auditLogMapper;
+
+  @Autowired
   protected ProcessInstanceDbReader processInstanceReader;
 
   @Autowired
@@ -140,6 +142,9 @@ public abstract class HistoryMigrationAbstractTest extends AbstractMigratorTest 
 
   @Autowired
   protected FlowNodeInstanceMapper flowNodeInstanceMapper;
+
+  @Autowired
+  protected JobMapper jobMapper;
 
   @RegisterExtension
   @Autowired
@@ -205,18 +210,13 @@ public abstract class HistoryMigrationAbstractTest extends AbstractMigratorTest 
     return searchHistoricProcessInstances(processDefinitionId, false);
   }
 
-  public List<AuditLogEntity> searchAuditLogs(String processDefinitionId) {
-    return auditLogReader
-        .search(AuditLogQuery.of(q -> q.filter(f ->
-            f.processDefinitionIds(prefixDefinitionId(processDefinitionId)))))
-        .items();
+  public List<AuditLogDbModel> searchAuditLogs(String processDefinitionId) {
+    return C8QueryCompat.searchAuditLogs(auditLogMapper, auditLogReader,
+        prefixDefinitionId(processDefinitionId));
   }
 
-  public List<AuditLogEntity> searchAuditLogsByCategory(String name) {
-    return auditLogReader
-        .search(AuditLogQuery.of(q -> q.filter(f ->
-            f.categories(name))))
-        .items();
+  public List<AuditLogDbModel> searchAuditLogsByCategory(String name) {
+    return C8QueryCompat.searchAuditLogsByCategory(auditLogMapper, auditLogReader, name);
   }
 
   /**
@@ -282,12 +282,13 @@ public abstract class HistoryMigrationAbstractTest extends AbstractMigratorTest 
         FlowNodeInstanceDbQuery.of(b -> b.filter(f -> f.processInstanceKeys(processInstanceKey))));
   }
 
-  public List<IncidentEntity> searchHistoricIncidents(String processDefinitionId) {
-    return incidentReader
-        .search(IncidentQuery.of(queryBuilder ->
-            queryBuilder.filter(filterBuilder ->
-                filterBuilder.processDefinitionIds(prefixDefinitionId(processDefinitionId)))))
-        .items();
+  public List<FlowNodeInstanceDbModel> searchFlowNodesByTenantId(String tenantId) {
+    return flowNodeInstanceMapper.search(
+        FlowNodeInstanceDbQuery.of(b -> b.filter(f -> f.tenantIds(tenantId))));
+  }
+
+  public List<IncidentDbModel> searchHistoricIncidents(String processDefinitionId) {
+    return C8QueryCompat.searchHistoricIncidents(incidentReader, rdbmsQuery, prefixDefinitionId(processDefinitionId));
   }
 
   public List<IncidentDbModel> searchIncidentsByProcessInstanceKeyAndReturnAsDbModel(Long processInstanceKey) {
@@ -346,18 +347,12 @@ public abstract class HistoryMigrationAbstractTest extends AbstractMigratorTest 
         .items();
   }
 
-  public List<JobEntity> searchJobs(long processInstanceKey) {
-    return jobReader
-        .search(JobQuery.of(queryBuilder ->
-            queryBuilder.filter(filterBuilder ->
-                filterBuilder.processInstanceKeys(processInstanceKey))))
-        .items();
+  public List<JobDbModel> searchJobs(long processInstanceKey) {
+    return jobMapper.search(JobDbQuery.of(b -> b.filter(f -> f.processInstanceKeys(processInstanceKey))));
   }
 
-  public List<JobEntity> searchJobs() {
-    return jobReader
-        .search(new JobQuery(FilterBuilders.job().build(), SortOptionBuilders.job().build(), SearchQueryPage.of((b) -> b)))
-        .items();
+  public List<JobDbModel> searchJobs() {
+    return jobMapper.search(JobDbQuery.of(b -> b));
   }
 
   public List<FormEntity> searchForms(String... formIds) {

--- a/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/history/HistoryMigrationOrderedByCreateTimeTest.java
+++ b/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/history/HistoryMigrationOrderedByCreateTimeTest.java
@@ -10,10 +10,10 @@ package io.camunda.migration.data.qa.history;
 import static io.camunda.search.entities.FlowNodeInstanceEntity.FlowNodeType.INTERMEDIATE_CATCH_EVENT;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.camunda.db.rdbms.write.domain.IncidentDbModel;
 import io.camunda.search.entities.DecisionDefinitionEntity;
 import io.camunda.search.entities.DecisionRequirementsEntity;
 import io.camunda.search.entities.FlowNodeInstanceEntity;
-import io.camunda.search.entities.IncidentEntity;
 import io.camunda.search.entities.ProcessDefinitionEntity;
 import io.camunda.search.entities.ProcessInstanceEntity;
 import io.camunda.search.entities.VariableEntity;
@@ -312,7 +312,7 @@ public class HistoryMigrationOrderedByCreateTimeTest extends HistoryMigrationAbs
     deployer.deployCamunda7Process("incidentProcess.bpmn");
     String instanceId = runtimeService.startProcessInstanceByKey("incidentProcessId").getProcessInstanceId();
     triggerIncident(instanceId);
-    Supplier<List<IncidentEntity>> incidentSupplier =
+    Supplier<List<IncidentDbModel>> incidentSupplier =
         () -> searchHistoricIncidents("incidentProcessId");
 
     // when

--- a/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/history/HistoryMigrationSkippingTest.java
+++ b/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/history/HistoryMigrationSkippingTest.java
@@ -33,9 +33,9 @@ import static io.camunda.migration.data.qa.util.LogMessageFormatter.formatMessag
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.camunda.bpm.engine.variable.Variables.stringValue;
 
+import io.camunda.db.rdbms.write.domain.IncidentDbModel;
+import io.camunda.db.rdbms.write.domain.JobDbModel;
 import io.camunda.migration.data.HistoryMigrator;
-import io.camunda.search.entities.IncidentEntity;
-import io.camunda.search.entities.JobEntity;
 import io.camunda.search.entities.ProcessInstanceEntity;
 import io.github.netmikey.logunit.api.LogCapturer;
 import java.util.ArrayList;
@@ -703,7 +703,7 @@ public class HistoryMigrationSkippingTest extends HistoryMigrationAbstractTest {
     List<ProcessInstanceEntity> processInstances = searchHistoricProcessInstances("miProcess");
     assertThat(processInstances).hasSize(1);
 
-    List<IncidentEntity> incidents = searchHistoricIncidents("miProcess");
+    List<IncidentDbModel> incidents = searchHistoricIncidents("miProcess");
     assertThat(incidents).isEmpty();
     incidentIds.forEach(id -> logs.assertContains(formatMessage(SKIPPING, HISTORY_INCIDENT.getDisplayName(), id,
         SKIP_REASON_CANNOT_DETERMINE_FLOW_NODE)));
@@ -726,7 +726,7 @@ public class HistoryMigrationSkippingTest extends HistoryMigrationAbstractTest {
     List<ProcessInstanceEntity> processInstances = searchHistoricProcessInstances("miProcess");
     assertThat(processInstances).hasSize(1);
 
-    List<JobEntity> c8Jobs = searchJobs(processInstances.getFirst().processInstanceKey());
+    List<JobDbModel> c8Jobs = searchJobs(processInstances.getFirst().processInstanceKey());
     assertThat(c8Jobs).isEmpty();
     jobs.forEach(j -> logs.assertContains(formatMessage(SKIPPING, HISTORY_JOB.getDisplayName(), j.getId(),
         SKIP_REASON_CANNOT_DETERMINE_FLOW_NODE)));
@@ -748,7 +748,7 @@ public class HistoryMigrationSkippingTest extends HistoryMigrationAbstractTest {
     List<ProcessInstanceEntity> processInstances = searchHistoricProcessInstances("miProcess");
     assertThat(processInstances).hasSize(1);
 
-    List<JobEntity> c8Jobs = searchJobs(processInstances.getFirst().processInstanceKey());
+    List<JobDbModel> c8Jobs = searchJobs(processInstances.getFirst().processInstanceKey());
     assertThat(c8Jobs).isEmpty();
     jobs.forEach(j -> logs.assertContains(formatMessage(SKIPPING, HISTORY_JOB.getDisplayName(), j.getId(),
         SKIP_REASON_CANNOT_DETERMINE_FLOW_NODE)));
@@ -795,9 +795,9 @@ public class HistoryMigrationSkippingTest extends HistoryMigrationAbstractTest {
     assertThat(processInstances).hasSize(1);
     long processInstanceKey = processInstances.getFirst().processInstanceKey();
 
-    List<JobEntity> c8Jobs = searchJobs(processInstanceKey);
+    List<JobDbModel> c8Jobs = searchJobs(processInstanceKey);
     assertThat(c8Jobs).isEmpty();
-    List<IncidentEntity> incidentEntities = searchHistoricIncidents(PROCESS_KEY);
+    List<IncidentDbModel> incidentEntities = searchHistoricIncidents(PROCESS_KEY);
     assertThat(incidentEntities).isEmpty();
     logs.assertContains(formatMessage(SKIPPING, HISTORY_INCIDENT.getDisplayName(), list.getFirst().getId(),
         SKIP_REASON_MISSING_JOB_REFERENCE));
@@ -832,7 +832,7 @@ public class HistoryMigrationSkippingTest extends HistoryMigrationAbstractTest {
     historyMigrator.migrateByType(HISTORY_EXTERNAL_TASK);
 
     // then
-    List<JobEntity> c8Jobs = searchJobs();
+    List<JobDbModel> c8Jobs = searchJobs();
     assertThat(c8Jobs).isEmpty();
     logs.assertContains(formatMessage(SKIPPING, HISTORY_EXTERNAL_TASK.getDisplayName(), list.getFirst().getExternalTaskId(),
         SKIP_REASON_MISSING_PROCESS_INSTANCE));

--- a/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/history/TransactionRollbackTest.java
+++ b/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/history/TransactionRollbackTest.java
@@ -28,11 +28,11 @@ import static org.mockito.Mockito.doAnswer;
 import io.camunda.migration.data.impl.clients.DbClient;
 import io.camunda.migration.data.impl.persistence.IdKeyMapper;
 import io.camunda.migration.data.qa.util.WhiteBox;
+import io.camunda.db.rdbms.write.domain.IncidentDbModel;
 import io.camunda.search.entities.DecisionDefinitionEntity;
 import io.camunda.search.entities.DecisionInstanceEntity;
 import io.camunda.search.entities.DecisionRequirementsEntity;
 import io.camunda.search.entities.FlowNodeInstanceEntity;
-import io.camunda.search.entities.IncidentEntity;
 import io.camunda.search.entities.ProcessDefinitionEntity;
 import io.camunda.search.entities.UserTaskEntity;
 import io.camunda.search.entities.VariableEntity;
@@ -240,13 +240,13 @@ public class TransactionRollbackTest extends HistoryMigrationAbstractTest {
         c7Id,
         () -> historyMigrator.migrateByType(HISTORY_INCIDENT),
         () -> {
-          List<IncidentEntity> incidents = searchHistoricIncidents("incidentProcessId");
+          List<IncidentDbModel> incidents = searchHistoricIncidents("incidentProcessId");
           assertThat(incidents)
               .as("C8 should contain NO incidents after rollback")
               .isEmpty();
         },
         () -> {
-          List<IncidentEntity> incidents = searchHistoricIncidents("incidentProcessId");
+          List<IncidentDbModel> incidents = searchHistoricIncidents("incidentProcessId");
           assertThat(incidents)
               .as("After retry, C8 should contain incidents")
               .isNotEmpty();

--- a/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/history/entity/HistoryAuditLogAdminTest.java
+++ b/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/history/entity/HistoryAuditLogAdminTest.java
@@ -10,6 +10,7 @@ package io.camunda.migration.data.qa.history.entity;
 import static io.camunda.migration.data.constants.MigratorConstants.C8_DEFAULT_TENANT;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.camunda.db.rdbms.write.domain.AuditLogDbModel;
 import io.camunda.migration.data.qa.history.HistoryMigrationAbstractTest;
 import io.camunda.search.entities.AuditLogEntity;
 import java.util.List;
@@ -62,9 +63,9 @@ public class HistoryAuditLogAdminTest extends HistoryMigrationAbstractTest {
     historyMigrator.migrate();
 
     // then
-    List<AuditLogEntity> logs = searchAuditLogsByCategory(AuditLogEntity.AuditLogOperationCategory.ADMIN.name());
+    List<AuditLogDbModel> logs = searchAuditLogsByCategory(AuditLogEntity.AuditLogOperationCategory.ADMIN.name());
     assertThat(logs).hasSize(1);
-    AuditLogEntity log = logs.getFirst();
+    AuditLogDbModel log = logs.getFirst();
 
     assertThat(log.auditLogKey()).isNotNull();
     assertThat(log.processInstanceKey()).isNull();
@@ -100,13 +101,13 @@ public class HistoryAuditLogAdminTest extends HistoryMigrationAbstractTest {
     historyMigrator.migrate();
 
     // then
-    List<AuditLogEntity> logs = searchAuditLogsByCategory(AuditLogEntity.AuditLogOperationCategory.ADMIN.name());
+    List<AuditLogDbModel> logs = searchAuditLogsByCategory(AuditLogEntity.AuditLogOperationCategory.ADMIN.name());
     assertThat(logs).hasSize(1);
 
-    assertThat(logs).extracting(AuditLogEntity::entityType).containsOnly(AuditLogEntity.AuditLogEntityType.USER);
-    assertThat(logs).extracting(AuditLogEntity::operationType)
+    assertThat(logs).extracting(AuditLogDbModel::entityType).containsOnly(AuditLogEntity.AuditLogEntityType.USER);
+    assertThat(logs).extracting(AuditLogDbModel::operationType)
         .containsOnly(AuditLogEntity.AuditLogOperationType.CREATE);
-    assertThat(logs).extracting(AuditLogEntity::entityDescription).contains("newUserId");
+    assertThat(logs).extracting(AuditLogDbModel::entityDescription).contains("newUserId");
   }
 
   @Test
@@ -128,13 +129,13 @@ public class HistoryAuditLogAdminTest extends HistoryMigrationAbstractTest {
     historyMigrator.migrate();
 
     // then
-    List<AuditLogEntity> logs = searchAuditLogsByCategory(AuditLogEntity.AuditLogOperationCategory.ADMIN.name());
+    List<AuditLogDbModel> logs = searchAuditLogsByCategory(AuditLogEntity.AuditLogOperationCategory.ADMIN.name());
     assertThat(logs).hasSize(1);
 
-    assertThat(logs).extracting(AuditLogEntity::entityType).containsOnly(AuditLogEntity.AuditLogEntityType.USER);
-    assertThat(logs).extracting(AuditLogEntity::operationType)
+    assertThat(logs).extracting(AuditLogDbModel::entityType).containsOnly(AuditLogEntity.AuditLogEntityType.USER);
+    assertThat(logs).extracting(AuditLogDbModel::operationType)
         .containsOnly(AuditLogEntity.AuditLogOperationType.UPDATE);
-    assertThat(logs).extracting(AuditLogEntity::entityDescription).contains("newUserId");
+    assertThat(logs).extracting(AuditLogDbModel::entityDescription).contains("newUserId");
   }
 
   @Test
@@ -154,13 +155,13 @@ public class HistoryAuditLogAdminTest extends HistoryMigrationAbstractTest {
     historyMigrator.migrate();
 
     // then
-    List<AuditLogEntity> logs = searchAuditLogsByCategory(AuditLogEntity.AuditLogOperationCategory.ADMIN.name());
+    List<AuditLogDbModel> logs = searchAuditLogsByCategory(AuditLogEntity.AuditLogOperationCategory.ADMIN.name());
     assertThat(logs).hasSize(1);
 
-    assertThat(logs).extracting(AuditLogEntity::entityType).containsOnly(AuditLogEntity.AuditLogEntityType.USER);
-    assertThat(logs).extracting(AuditLogEntity::operationType)
+    assertThat(logs).extracting(AuditLogDbModel::entityType).containsOnly(AuditLogEntity.AuditLogEntityType.USER);
+    assertThat(logs).extracting(AuditLogDbModel::operationType)
         .containsOnly(AuditLogEntity.AuditLogOperationType.DELETE);
-    assertThat(logs).extracting(AuditLogEntity::entityDescription).contains("newUserId");
+    assertThat(logs).extracting(AuditLogDbModel::entityDescription).contains("newUserId");
   }
 
   @Test
@@ -178,12 +179,12 @@ public class HistoryAuditLogAdminTest extends HistoryMigrationAbstractTest {
     historyMigrator.migrate();
 
     // then
-    List<AuditLogEntity> logs = searchAuditLogsByCategory(AuditLogEntity.AuditLogOperationCategory.ADMIN.name());
+    List<AuditLogDbModel> logs = searchAuditLogsByCategory(AuditLogEntity.AuditLogOperationCategory.ADMIN.name());
     assertThat(logs).hasSize(1);
 
-    assertThat(logs).extracting(AuditLogEntity::entityType).containsOnly(AuditLogEntity.AuditLogEntityType.GROUP);
-    assertThat(logs).extracting(AuditLogEntity::operationType).containsOnly(AuditLogEntity.AuditLogOperationType.CREATE);
-    assertThat(logs).extracting(AuditLogEntity::entityDescription).contains("newGroupId");
+    assertThat(logs).extracting(AuditLogDbModel::entityType).containsOnly(AuditLogEntity.AuditLogEntityType.GROUP);
+    assertThat(logs).extracting(AuditLogDbModel::operationType).containsOnly(AuditLogEntity.AuditLogOperationType.CREATE);
+    assertThat(logs).extracting(AuditLogDbModel::entityDescription).contains("newGroupId");
   }
 
   @Test
@@ -205,13 +206,13 @@ public class HistoryAuditLogAdminTest extends HistoryMigrationAbstractTest {
     historyMigrator.migrate();
 
     // then
-    List<AuditLogEntity> logs = searchAuditLogsByCategory(AuditLogEntity.AuditLogOperationCategory.ADMIN.name());
+    List<AuditLogDbModel> logs = searchAuditLogsByCategory(AuditLogEntity.AuditLogOperationCategory.ADMIN.name());
     assertThat(logs).hasSize(1);
 
-    assertThat(logs).extracting(AuditLogEntity::entityType).containsOnly(AuditLogEntity.AuditLogEntityType.GROUP);
-    assertThat(logs).extracting(AuditLogEntity::operationType)
+    assertThat(logs).extracting(AuditLogDbModel::entityType).containsOnly(AuditLogEntity.AuditLogEntityType.GROUP);
+    assertThat(logs).extracting(AuditLogDbModel::operationType)
         .containsOnly(AuditLogEntity.AuditLogOperationType.UPDATE);
-    assertThat(logs).extracting(AuditLogEntity::entityDescription).contains("newGroupId");
+    assertThat(logs).extracting(AuditLogDbModel::entityDescription).contains("newGroupId");
   }
 
   @Test
@@ -232,13 +233,13 @@ public class HistoryAuditLogAdminTest extends HistoryMigrationAbstractTest {
     historyMigrator.migrate();
 
     // then
-    List<AuditLogEntity> logs = searchAuditLogsByCategory(AuditLogEntity.AuditLogOperationCategory.ADMIN.name());
+    List<AuditLogDbModel> logs = searchAuditLogsByCategory(AuditLogEntity.AuditLogOperationCategory.ADMIN.name());
     assertThat(logs).hasSize(1);
 
-    assertThat(logs).extracting(AuditLogEntity::entityType).containsOnly(AuditLogEntity.AuditLogEntityType.GROUP);
-    assertThat(logs).extracting(AuditLogEntity::operationType)
+    assertThat(logs).extracting(AuditLogDbModel::entityType).containsOnly(AuditLogEntity.AuditLogEntityType.GROUP);
+    assertThat(logs).extracting(AuditLogDbModel::operationType)
         .containsOnly(AuditLogEntity.AuditLogOperationType.DELETE);
-    assertThat(logs).extracting(AuditLogEntity::entityDescription).contains("newGroupId");
+    assertThat(logs).extracting(AuditLogDbModel::entityDescription).contains("newGroupId");
   }
 
   @Test
@@ -257,12 +258,12 @@ public class HistoryAuditLogAdminTest extends HistoryMigrationAbstractTest {
     historyMigrator.migrate();
 
     // then
-    List<AuditLogEntity> logs = searchAuditLogsByCategory(AuditLogEntity.AuditLogOperationCategory.ADMIN.name());
+    List<AuditLogDbModel> logs = searchAuditLogsByCategory(AuditLogEntity.AuditLogOperationCategory.ADMIN.name());
     assertThat(logs).hasSize(1);
 
-    assertThat(logs).extracting(AuditLogEntity::entityType).containsOnly(AuditLogEntity.AuditLogEntityType.TENANT);
-    assertThat(logs).extracting(AuditLogEntity::operationType).containsOnly(AuditLogEntity.AuditLogOperationType.CREATE);
-    assertThat(logs).extracting(AuditLogEntity::entityDescription).contains("newTenantId");
+    assertThat(logs).extracting(AuditLogDbModel::entityType).containsOnly(AuditLogEntity.AuditLogEntityType.TENANT);
+    assertThat(logs).extracting(AuditLogDbModel::operationType).containsOnly(AuditLogEntity.AuditLogOperationType.CREATE);
+    assertThat(logs).extracting(AuditLogDbModel::entityDescription).contains("newTenantId");
   }
 
   @Test
@@ -284,13 +285,13 @@ public class HistoryAuditLogAdminTest extends HistoryMigrationAbstractTest {
     historyMigrator.migrate();
 
     // then
-    List<AuditLogEntity> logs = searchAuditLogsByCategory(AuditLogEntity.AuditLogOperationCategory.ADMIN.name());
+    List<AuditLogDbModel> logs = searchAuditLogsByCategory(AuditLogEntity.AuditLogOperationCategory.ADMIN.name());
     assertThat(logs).hasSize(1);
 
-    assertThat(logs).extracting(AuditLogEntity::entityType).containsOnly(AuditLogEntity.AuditLogEntityType.TENANT);
-    assertThat(logs).extracting(AuditLogEntity::operationType)
+    assertThat(logs).extracting(AuditLogDbModel::entityType).containsOnly(AuditLogEntity.AuditLogEntityType.TENANT);
+    assertThat(logs).extracting(AuditLogDbModel::operationType)
         .containsOnly(AuditLogEntity.AuditLogOperationType.UPDATE);
-    assertThat(logs).extracting(AuditLogEntity::entityDescription).contains("newTenantId");
+    assertThat(logs).extracting(AuditLogDbModel::entityDescription).contains("newTenantId");
   }
 
   @Test
@@ -311,13 +312,13 @@ public class HistoryAuditLogAdminTest extends HistoryMigrationAbstractTest {
     historyMigrator.migrate();
 
     // then
-    List<AuditLogEntity> logs = searchAuditLogsByCategory(AuditLogEntity.AuditLogOperationCategory.ADMIN.name());
+    List<AuditLogDbModel> logs = searchAuditLogsByCategory(AuditLogEntity.AuditLogOperationCategory.ADMIN.name());
     assertThat(logs).hasSize(1);
 
-    assertThat(logs).extracting(AuditLogEntity::entityType).containsOnly(AuditLogEntity.AuditLogEntityType.TENANT);
-    assertThat(logs).extracting(AuditLogEntity::operationType)
+    assertThat(logs).extracting(AuditLogDbModel::entityType).containsOnly(AuditLogEntity.AuditLogEntityType.TENANT);
+    assertThat(logs).extracting(AuditLogDbModel::operationType)
         .containsOnly(AuditLogEntity.AuditLogOperationType.DELETE);
-    assertThat(logs).extracting(AuditLogEntity::entityDescription).contains("newTenantId");
+    assertThat(logs).extracting(AuditLogDbModel::entityDescription).contains("newTenantId");
   }
 
   @Test
@@ -341,11 +342,11 @@ public class HistoryAuditLogAdminTest extends HistoryMigrationAbstractTest {
     historyMigrator.migrate();
 
     // then
-    List<AuditLogEntity> logs = searchAuditLogsByCategory(AuditLogEntity.AuditLogOperationCategory.ADMIN.name());
+    List<AuditLogDbModel> logs = searchAuditLogsByCategory(AuditLogEntity.AuditLogOperationCategory.ADMIN.name());
     assertThat(logs).hasSize(1);
 
-    assertThat(logs).extracting(AuditLogEntity::entityType).containsOnly(AuditLogEntity.AuditLogEntityType.AUTHORIZATION);
-    assertThat(logs).extracting(AuditLogEntity::operationType)
+    assertThat(logs).extracting(AuditLogDbModel::entityType).containsOnly(AuditLogEntity.AuditLogEntityType.AUTHORIZATION);
+    assertThat(logs).extracting(AuditLogDbModel::operationType)
         .containsOnly(AuditLogEntity.AuditLogOperationType.CREATE);
   }
 
@@ -372,11 +373,11 @@ public class HistoryAuditLogAdminTest extends HistoryMigrationAbstractTest {
     historyMigrator.migrate();
 
     // then
-    List<AuditLogEntity> logs = searchAuditLogsByCategory(AuditLogEntity.AuditLogOperationCategory.ADMIN.name());
+    List<AuditLogDbModel> logs = searchAuditLogsByCategory(AuditLogEntity.AuditLogOperationCategory.ADMIN.name());
     assertThat(logs).hasSize(1);
 
-    assertThat(logs).extracting(AuditLogEntity::entityType).containsOnly(AuditLogEntity.AuditLogEntityType.AUTHORIZATION);
-    assertThat(logs).extracting(AuditLogEntity::operationType)
+    assertThat(logs).extracting(AuditLogDbModel::entityType).containsOnly(AuditLogEntity.AuditLogEntityType.AUTHORIZATION);
+    assertThat(logs).extracting(AuditLogDbModel::operationType)
         .containsOnly(AuditLogEntity.AuditLogOperationType.UPDATE);
   }
 
@@ -403,11 +404,11 @@ public class HistoryAuditLogAdminTest extends HistoryMigrationAbstractTest {
     historyMigrator.migrate();
 
     // then
-    List<AuditLogEntity> logs = searchAuditLogsByCategory(AuditLogEntity.AuditLogOperationCategory.ADMIN.name());
+    List<AuditLogDbModel> logs = searchAuditLogsByCategory(AuditLogEntity.AuditLogOperationCategory.ADMIN.name());
     assertThat(logs).hasSize(1);
 
-    assertThat(logs).extracting(AuditLogEntity::entityType).containsOnly(AuditLogEntity.AuditLogEntityType.AUTHORIZATION);
-    assertThat(logs).extracting(AuditLogEntity::operationType)
+    assertThat(logs).extracting(AuditLogDbModel::entityType).containsOnly(AuditLogEntity.AuditLogEntityType.AUTHORIZATION);
+    assertThat(logs).extracting(AuditLogDbModel::operationType)
         .containsOnly(AuditLogEntity.AuditLogOperationType.DELETE);
   }
 
@@ -429,11 +430,11 @@ public class HistoryAuditLogAdminTest extends HistoryMigrationAbstractTest {
     historyMigrator.migrate();
 
     // then
-    List<AuditLogEntity> logs = searchAuditLogsByCategory(AuditLogEntity.AuditLogOperationCategory.ADMIN.name());
+    List<AuditLogDbModel> logs = searchAuditLogsByCategory(AuditLogEntity.AuditLogOperationCategory.ADMIN.name());
     assertThat(logs).hasSize(1);
 
-    assertThat(logs).extracting(AuditLogEntity::entityType).containsOnly(AuditLogEntity.AuditLogEntityType.GROUP);
-    assertThat(logs).extracting(AuditLogEntity::operationType)
+    assertThat(logs).extracting(AuditLogDbModel::entityType).containsOnly(AuditLogEntity.AuditLogEntityType.GROUP);
+    assertThat(logs).extracting(AuditLogDbModel::operationType)
         .containsOnly(AuditLogEntity.AuditLogOperationType.ASSIGN);
   }
 
@@ -456,11 +457,11 @@ public class HistoryAuditLogAdminTest extends HistoryMigrationAbstractTest {
     historyMigrator.migrate();
 
     // then
-    List<AuditLogEntity> logs = searchAuditLogsByCategory(AuditLogEntity.AuditLogOperationCategory.ADMIN.name());
+    List<AuditLogDbModel> logs = searchAuditLogsByCategory(AuditLogEntity.AuditLogOperationCategory.ADMIN.name());
     assertThat(logs).hasSize(1);
 
-    assertThat(logs).extracting(AuditLogEntity::entityType).containsOnly(AuditLogEntity.AuditLogEntityType.GROUP);
-    assertThat(logs).extracting(AuditLogEntity::operationType)
+    assertThat(logs).extracting(AuditLogDbModel::entityType).containsOnly(AuditLogEntity.AuditLogEntityType.GROUP);
+    assertThat(logs).extracting(AuditLogDbModel::operationType)
         .containsOnly(AuditLogEntity.AuditLogOperationType.UNASSIGN);
   }
 
@@ -482,11 +483,11 @@ public class HistoryAuditLogAdminTest extends HistoryMigrationAbstractTest {
     historyMigrator.migrate();
 
     // then
-    List<AuditLogEntity> logs = searchAuditLogsByCategory(AuditLogEntity.AuditLogOperationCategory.ADMIN.name());
+    List<AuditLogDbModel> logs = searchAuditLogsByCategory(AuditLogEntity.AuditLogOperationCategory.ADMIN.name());
     assertThat(logs).hasSize(1);
 
-    assertThat(logs).extracting(AuditLogEntity::entityType).containsOnly(AuditLogEntity.AuditLogEntityType.TENANT);
-    assertThat(logs).extracting(AuditLogEntity::operationType)
+    assertThat(logs).extracting(AuditLogDbModel::entityType).containsOnly(AuditLogEntity.AuditLogEntityType.TENANT);
+    assertThat(logs).extracting(AuditLogDbModel::operationType)
         .containsOnly(AuditLogEntity.AuditLogOperationType.ASSIGN);
   }
 
@@ -509,11 +510,11 @@ public class HistoryAuditLogAdminTest extends HistoryMigrationAbstractTest {
     historyMigrator.migrate();
 
     // then
-    List<AuditLogEntity> logs = searchAuditLogsByCategory(AuditLogEntity.AuditLogOperationCategory.ADMIN.name());
+    List<AuditLogDbModel> logs = searchAuditLogsByCategory(AuditLogEntity.AuditLogOperationCategory.ADMIN.name());
     assertThat(logs).hasSize(1);
 
-    assertThat(logs).extracting(AuditLogEntity::entityType).containsOnly(AuditLogEntity.AuditLogEntityType.TENANT);
-    assertThat(logs).extracting(AuditLogEntity::operationType)
+    assertThat(logs).extracting(AuditLogDbModel::entityType).containsOnly(AuditLogEntity.AuditLogEntityType.TENANT);
+    assertThat(logs).extracting(AuditLogDbModel::operationType)
         .containsOnly(AuditLogEntity.AuditLogOperationType.UNASSIGN);
   }
 
@@ -535,11 +536,11 @@ public class HistoryAuditLogAdminTest extends HistoryMigrationAbstractTest {
     historyMigrator.migrate();
 
     // then
-    List<AuditLogEntity> logs = searchAuditLogsByCategory(AuditLogEntity.AuditLogOperationCategory.ADMIN.name());
+    List<AuditLogDbModel> logs = searchAuditLogsByCategory(AuditLogEntity.AuditLogOperationCategory.ADMIN.name());
     assertThat(logs).hasSize(1);
 
-    assertThat(logs).extracting(AuditLogEntity::entityType).containsOnly(AuditLogEntity.AuditLogEntityType.TENANT);
-    assertThat(logs).extracting(AuditLogEntity::operationType)
+    assertThat(logs).extracting(AuditLogDbModel::entityType).containsOnly(AuditLogEntity.AuditLogEntityType.TENANT);
+    assertThat(logs).extracting(AuditLogDbModel::operationType)
         .containsOnly(AuditLogEntity.AuditLogOperationType.ASSIGN);
   }
 
@@ -563,11 +564,11 @@ public class HistoryAuditLogAdminTest extends HistoryMigrationAbstractTest {
     historyMigrator.migrate();
 
     // then
-    List<AuditLogEntity> logs = searchAuditLogsByCategory(AuditLogEntity.AuditLogOperationCategory.ADMIN.name());
+    List<AuditLogDbModel> logs = searchAuditLogsByCategory(AuditLogEntity.AuditLogOperationCategory.ADMIN.name());
     assertThat(logs).hasSize(1);
 
-    assertThat(logs).extracting(AuditLogEntity::entityType).containsOnly(AuditLogEntity.AuditLogEntityType.TENANT);
-    assertThat(logs).extracting(AuditLogEntity::operationType)
+    assertThat(logs).extracting(AuditLogDbModel::entityType).containsOnly(AuditLogEntity.AuditLogEntityType.TENANT);
+    assertThat(logs).extracting(AuditLogDbModel::operationType)
         .containsOnly(AuditLogEntity.AuditLogOperationType.UNASSIGN);
   }
 

--- a/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/history/entity/HistoryAuditLogTest.java
+++ b/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/history/entity/HistoryAuditLogTest.java
@@ -16,6 +16,7 @@ import static io.camunda.migration.data.impl.util.ConverterUtil.prefixDefinition
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.camunda.bpm.engine.variable.Variables.createVariables;
 
+import io.camunda.db.rdbms.write.domain.AuditLogDbModel;
 import io.camunda.migration.data.qa.history.HistoryMigrationAbstractTest;
 import io.camunda.search.entities.AuditLogEntity;
 import io.camunda.search.entities.ProcessInstanceEntity;
@@ -75,9 +76,9 @@ public class HistoryAuditLogTest extends HistoryMigrationAbstractTest {
     // then
     List<ProcessInstanceEntity> c8ProcessInstance = searchHistoricProcessInstances("simpleProcess");
     assertThat(c8ProcessInstance).hasSize(1);
-    List<AuditLogEntity> logs = searchAuditLogs("simpleProcess");
+    List<AuditLogDbModel> logs = searchAuditLogs("simpleProcess");
     assertThat(logs).hasSize(1);
-    AuditLogEntity log = logs.getFirst();
+    AuditLogDbModel log = logs.getFirst();
 
     assertThat(log.auditLogKey()).isNotNull();
 
@@ -119,9 +120,9 @@ public class HistoryAuditLogTest extends HistoryMigrationAbstractTest {
     // then
     List<ProcessInstanceEntity> c8ProcessInstance = searchHistoricProcessInstances("simpleProcess");
     assertThat(c8ProcessInstance).hasSize(1);
-    List<AuditLogEntity> logs = searchAuditLogs("simpleProcess");
+    List<AuditLogDbModel> logs = searchAuditLogs("simpleProcess");
     assertThat(logs).hasSize(1);
-    AuditLogEntity log = logs.getFirst();
+    AuditLogDbModel log = logs.getFirst();
 
     assertThat(log.tenantId()).isEqualTo("tenantA");
     assertThat(log.tenantScope()).isEqualTo(AuditLogEntity.AuditLogTenantScope.TENANT);
@@ -151,11 +152,11 @@ public class HistoryAuditLogTest extends HistoryMigrationAbstractTest {
     // then
     List<ProcessInstanceEntity> c8ProcessInstance = searchHistoricProcessInstances("simpleProcess");
     assertThat(c8ProcessInstance).hasSize(1);
-    List<AuditLogEntity> logs = searchAuditLogs("simpleProcess");
+    List<AuditLogDbModel> logs = searchAuditLogs("simpleProcess");
     assertThat(logs).hasSize(2);
-    assertThat(logs).extracting(AuditLogEntity::category).contains(AuditLogEntity.AuditLogOperationCategory.DEPLOYED_RESOURCES);
-    assertThat(logs).extracting(AuditLogEntity::entityType).containsOnly(AuditLogEntity.AuditLogEntityType.VARIABLE);
-    assertThat(logs).extracting(AuditLogEntity::operationType).containsOnly(AuditLogEntity.AuditLogOperationType.UPDATE);
+    assertThat(logs).extracting(AuditLogDbModel::category).contains(AuditLogEntity.AuditLogOperationCategory.DEPLOYED_RESOURCES);
+    assertThat(logs).extracting(AuditLogDbModel::entityType).containsOnly(AuditLogEntity.AuditLogEntityType.VARIABLE);
+    assertThat(logs).extracting(AuditLogDbModel::operationType).containsOnly(AuditLogEntity.AuditLogOperationType.UPDATE);
   }
 
   @Test
@@ -178,10 +179,10 @@ public class HistoryAuditLogTest extends HistoryMigrationAbstractTest {
     // then
     List<ProcessInstanceEntity> c8ProcessInstance = searchHistoricProcessInstances("simpleProcess");
     assertThat(c8ProcessInstance).hasSize(1);
-    List<AuditLogEntity> logs = searchAuditLogs("simpleProcess");
+    List<AuditLogDbModel> logs = searchAuditLogs("simpleProcess");
     assertThat(logs).hasSize(1);
-    assertThat(logs).extracting(AuditLogEntity::category).contains(AuditLogEntity.AuditLogOperationCategory.DEPLOYED_RESOURCES);
-    assertThat(logs).extracting(AuditLogEntity::operationType).contains(AuditLogEntity.AuditLogOperationType.CREATE);
+    assertThat(logs).extracting(AuditLogDbModel::category).contains(AuditLogEntity.AuditLogOperationCategory.DEPLOYED_RESOURCES);
+    assertThat(logs).extracting(AuditLogDbModel::operationType).contains(AuditLogEntity.AuditLogOperationType.CREATE);
   }
 
   @Test
@@ -209,10 +210,10 @@ public class HistoryAuditLogTest extends HistoryMigrationAbstractTest {
     // then
     List<ProcessInstanceEntity> c8ProcessInstance = searchHistoricProcessInstances("userTaskProcessId");
     assertThat(c8ProcessInstance).hasSize(1);
-    List<AuditLogEntity> logs = searchAuditLogs("userTaskProcessId");
+    List<AuditLogDbModel> logs = searchAuditLogs("userTaskProcessId");
     assertThat(logs).hasSize(1);
-    assertThat(logs).extracting(AuditLogEntity::category).contains(AuditLogEntity.AuditLogOperationCategory.DEPLOYED_RESOURCES);
-    assertThat(logs).extracting(AuditLogEntity::operationType).contains(AuditLogEntity.AuditLogOperationType.MODIFY);
+    assertThat(logs).extracting(AuditLogDbModel::category).contains(AuditLogEntity.AuditLogOperationCategory.DEPLOYED_RESOURCES);
+    assertThat(logs).extracting(AuditLogDbModel::operationType).contains(AuditLogEntity.AuditLogOperationType.MODIFY);
   }
 
   @Test
@@ -249,10 +250,10 @@ public class HistoryAuditLogTest extends HistoryMigrationAbstractTest {
     // then
     List<ProcessInstanceEntity> c8ProcessInstance = searchHistoricProcessInstances("simpleProcess");
     assertThat(c8ProcessInstance).hasSize(1);
-    List<AuditLogEntity> logs = searchAuditLogs("simpleProcess");
+    List<AuditLogDbModel> logs = searchAuditLogs("simpleProcess");
     assertThat(logs).hasSize(1);
-    assertThat(logs).extracting(AuditLogEntity::category).contains(AuditLogEntity.AuditLogOperationCategory.DEPLOYED_RESOURCES);
-    assertThat(logs).extracting(AuditLogEntity::operationType).contains(AuditLogEntity.AuditLogOperationType.MIGRATE);
+    assertThat(logs).extracting(AuditLogDbModel::category).contains(AuditLogEntity.AuditLogOperationCategory.DEPLOYED_RESOURCES);
+    assertThat(logs).extracting(AuditLogDbModel::operationType).contains(AuditLogEntity.AuditLogOperationType.MIGRATE);
   }
 
   @Test
@@ -277,11 +278,11 @@ public class HistoryAuditLogTest extends HistoryMigrationAbstractTest {
     historyMigrator.migrate();
 
     // then
-    List<AuditLogEntity> logs = searchAuditLogsByCategory(AuditLogEntity.AuditLogOperationCategory.DEPLOYED_RESOURCES.name());
+    List<AuditLogDbModel> logs = searchAuditLogsByCategory(AuditLogEntity.AuditLogOperationCategory.DEPLOYED_RESOURCES.name());
     assertThat(logs).hasSize(1);
-    assertThat(logs).extracting(AuditLogEntity::operationType).contains(AuditLogEntity.AuditLogOperationType.DELETE);
-    assertThat(logs).extracting(AuditLogEntity::entityType).contains(AuditLogEntity.AuditLogEntityType.RESOURCE);
-    assertThat(logs).extracting(AuditLogEntity::entityKey).contains(
+    assertThat(logs).extracting(AuditLogDbModel::operationType).contains(AuditLogEntity.AuditLogOperationType.DELETE);
+    assertThat(logs).extracting(AuditLogDbModel::entityType).contains(AuditLogEntity.AuditLogEntityType.RESOURCE);
+    assertThat(logs).extracting(AuditLogDbModel::entityKey).contains(
         String.valueOf(logs.getFirst().processDefinitionKey()));
   }
 
@@ -307,7 +308,7 @@ public class HistoryAuditLogTest extends HistoryMigrationAbstractTest {
     historyMigrator.migrate();
 
     // then logs are skipped
-    List<AuditLogEntity> logs = searchAuditLogsByCategory(AuditLogEntity.AuditLogOperationCategory.DEPLOYED_RESOURCES.name());
+    List<AuditLogDbModel> logs = searchAuditLogsByCategory(AuditLogEntity.AuditLogOperationCategory.DEPLOYED_RESOURCES.name());
     assertThat(logs).hasSize(0);
   }
 
@@ -341,7 +342,7 @@ public class HistoryAuditLogTest extends HistoryMigrationAbstractTest {
     historyMigrator.migrate();
 
     // then logs are skipped
-    List<AuditLogEntity> logs = searchAuditLogsByCategory(AuditLogEntity.AuditLogOperationCategory.DEPLOYED_RESOURCES.name());
+    List<AuditLogDbModel> logs = searchAuditLogsByCategory(AuditLogEntity.AuditLogOperationCategory.DEPLOYED_RESOURCES.name());
     assertThat(logs).hasSize(0);
   }
 
@@ -375,7 +376,7 @@ public class HistoryAuditLogTest extends HistoryMigrationAbstractTest {
     historyMigrator.migrate();
 
     // then logs are skipped
-    List<AuditLogEntity> logs = searchAuditLogsByCategory(AuditLogEntity.AuditLogOperationCategory.DEPLOYED_RESOURCES.name());
+    List<AuditLogDbModel> logs = searchAuditLogsByCategory(AuditLogEntity.AuditLogOperationCategory.DEPLOYED_RESOURCES.name());
     assertThat(logs).hasSize(0);
   }
 
@@ -410,7 +411,7 @@ public class HistoryAuditLogTest extends HistoryMigrationAbstractTest {
     historyMigrator.migrate();
 
     // then logs are skipped
-    List<AuditLogEntity> logs = searchAuditLogsByCategory(AuditLogEntity.AuditLogOperationCategory.DEPLOYED_RESOURCES.name());
+    List<AuditLogDbModel> logs = searchAuditLogsByCategory(AuditLogEntity.AuditLogOperationCategory.DEPLOYED_RESOURCES.name());
     assertThat(logs).hasSize(0);
   }
 
@@ -430,10 +431,10 @@ public class HistoryAuditLogTest extends HistoryMigrationAbstractTest {
     historyMigrator.migrate();
 
     // then
-    List<AuditLogEntity> logs = searchAuditLogsByCategory(AuditLogEntity.AuditLogOperationCategory.DEPLOYED_RESOURCES.name());
+    List<AuditLogDbModel> logs = searchAuditLogsByCategory(AuditLogEntity.AuditLogOperationCategory.DEPLOYED_RESOURCES.name());
     assertThat(logs).hasSize(1);
-    assertThat(logs).extracting(AuditLogEntity::entityType).contains(AuditLogEntity.AuditLogEntityType.RESOURCE);
-    assertThat(logs).extracting(AuditLogEntity::operationType).contains(AuditLogEntity.AuditLogOperationType.CREATE);
+    assertThat(logs).extracting(AuditLogDbModel::entityType).contains(AuditLogEntity.AuditLogEntityType.RESOURCE);
+    assertThat(logs).extracting(AuditLogDbModel::operationType).contains(AuditLogEntity.AuditLogOperationType.CREATE);
   }
 
   @Test
@@ -456,10 +457,10 @@ public class HistoryAuditLogTest extends HistoryMigrationAbstractTest {
     historyMigrator.migrate();
 
     // then
-    List<AuditLogEntity> logs = searchAuditLogsByCategory(AuditLogEntity.AuditLogOperationCategory.DEPLOYED_RESOURCES.name());
+    List<AuditLogDbModel> logs = searchAuditLogsByCategory(AuditLogEntity.AuditLogOperationCategory.DEPLOYED_RESOURCES.name());
     assertThat(logs).hasSize(1);
-    assertThat(logs).extracting(AuditLogEntity::operationType).contains(AuditLogEntity.AuditLogOperationType.DELETE);
-    assertThat(logs).extracting(AuditLogEntity::entityType).contains(AuditLogEntity.AuditLogEntityType.RESOURCE);
+    assertThat(logs).extracting(AuditLogDbModel::operationType).contains(AuditLogEntity.AuditLogOperationType.DELETE);
+    assertThat(logs).extracting(AuditLogDbModel::entityType).contains(AuditLogEntity.AuditLogEntityType.RESOURCE);
   }
 
   @Test
@@ -486,10 +487,10 @@ public class HistoryAuditLogTest extends HistoryMigrationAbstractTest {
     // then
     List<ProcessInstanceEntity> c8ProcessInstance = searchHistoricProcessInstances("simpleProcess");
     assertThat(c8ProcessInstance).hasSize(1);
-    List<AuditLogEntity> logs = searchAuditLogs("simpleProcess");
+    List<AuditLogDbModel> logs = searchAuditLogs("simpleProcess");
     assertThat(logs).hasSize(1);
-    assertThat(logs).extracting(AuditLogEntity::entityType).contains(AuditLogEntity.AuditLogEntityType.VARIABLE);
-    assertThat(logs).extracting(AuditLogEntity::operationType).contains(AuditLogEntity.AuditLogOperationType.DELETE);
+    assertThat(logs).extracting(AuditLogDbModel::entityType).contains(AuditLogEntity.AuditLogEntityType.VARIABLE);
+    assertThat(logs).extracting(AuditLogDbModel::operationType).contains(AuditLogEntity.AuditLogOperationType.DELETE);
   }
 
   @Test
@@ -521,11 +522,11 @@ public class HistoryAuditLogTest extends HistoryMigrationAbstractTest {
     // then
     List<ProcessInstanceEntity> c8ProcessInstance = searchHistoricProcessInstances("simpleProcess");
     assertThat(c8ProcessInstance).hasSize(1);
-    List<AuditLogEntity> logs = searchAuditLogs("simpleProcess");
+    List<AuditLogDbModel> logs = searchAuditLogs("simpleProcess");
     assertThat(logs).hasSize(1);
-    assertThat(logs).extracting(AuditLogEntity::entityType).contains(AuditLogEntity.AuditLogEntityType.VARIABLE);
-    assertThat(logs).extracting(AuditLogEntity::operationType).contains(AuditLogEntity.AuditLogOperationType.DELETE);
-    assertThat(logs).extracting(AuditLogEntity::entityDescription).contains("testVar");
+    assertThat(logs).extracting(AuditLogDbModel::entityType).contains(AuditLogEntity.AuditLogEntityType.VARIABLE);
+    assertThat(logs).extracting(AuditLogDbModel::operationType).contains(AuditLogEntity.AuditLogOperationType.DELETE);
+    assertThat(logs).extracting(AuditLogDbModel::entityDescription).contains("testVar");
   }
 
   @Test
@@ -544,10 +545,10 @@ public class HistoryAuditLogTest extends HistoryMigrationAbstractTest {
     // then
     List<ProcessInstanceEntity> c8ProcessInstance = searchHistoricProcessInstances("simpleProcess");
     assertThat(c8ProcessInstance).hasSize(1);
-    List<AuditLogEntity> logs = searchAuditLogsByCategory(AuditLogEntity.AuditLogOperationCategory.DEPLOYED_RESOURCES.name());
+    List<AuditLogDbModel> logs = searchAuditLogsByCategory(AuditLogEntity.AuditLogOperationCategory.DEPLOYED_RESOURCES.name());
     assertThat(logs).hasSize(1);
-    assertThat(logs).extracting(AuditLogEntity::entityType).contains(AuditLogEntity.AuditLogEntityType.INCIDENT);
-    assertThat(logs).extracting(AuditLogEntity::operationType).contains(AuditLogEntity.AuditLogOperationType.RESOLVE);
+    assertThat(logs).extracting(AuditLogDbModel::entityType).contains(AuditLogEntity.AuditLogEntityType.INCIDENT);
+    assertThat(logs).extracting(AuditLogDbModel::operationType).contains(AuditLogEntity.AuditLogOperationType.RESOLVE);
   }
 
   @Test
@@ -575,9 +576,9 @@ public class HistoryAuditLogTest extends HistoryMigrationAbstractTest {
     // then
     List<ProcessInstanceEntity> c8ProcessInstance = searchHistoricProcessInstances("asyncBeforeUserTaskProcessId");
     assertThat(c8ProcessInstance).hasSize(1);
-    List<AuditLogEntity> logs = searchAuditLogs("asyncBeforeUserTaskProcessId");
+    List<AuditLogDbModel> logs = searchAuditLogs("asyncBeforeUserTaskProcessId");
     assertThat(logs).hasSize(1);
-    AuditLogEntity log = logs.getFirst();
+    AuditLogDbModel log = logs.getFirst();
 
     assertThat(log.entityType()).isEqualTo(AuditLogEntity.AuditLogEntityType.JOB);
     assertThat(log.operationType()).isEqualTo(AuditLogEntity.AuditLogOperationType.COMPLETE);
@@ -616,9 +617,9 @@ public class HistoryAuditLogTest extends HistoryMigrationAbstractTest {
     // then
     List<ProcessInstanceEntity> c8ProcessInstance = searchHistoricProcessInstances("externalTaskProcess");
     assertThat(c8ProcessInstance).hasSize(1);
-    List<AuditLogEntity> logs = searchAuditLogs("externalTaskProcess");
+    List<AuditLogDbModel> logs = searchAuditLogs("externalTaskProcess");
     assertThat(logs).hasSize(1);
-    AuditLogEntity log = logs.getFirst();
+    AuditLogDbModel log = logs.getFirst();
 
     // External task audit logs are mapped to JOB entity type in C8
     assertThat(log.entityType()).isEqualTo(AuditLogEntity.AuditLogEntityType.JOB);
@@ -655,7 +656,7 @@ public class HistoryAuditLogTest extends HistoryMigrationAbstractTest {
     // then
     List<ProcessInstanceEntity> c8ProcessInstances = searchHistoricProcessInstances("asyncBeforeUserTaskProcessId");
     assertThat(c8ProcessInstances).hasSize(1);
-    List<AuditLogEntity> logs = searchAuditLogs("asyncBeforeUserTaskProcessId");
+    List<AuditLogDbModel> logs = searchAuditLogs("asyncBeforeUserTaskProcessId");
     assertThat(logs).isEmpty();
   }
 
@@ -683,7 +684,7 @@ public class HistoryAuditLogTest extends HistoryMigrationAbstractTest {
     // Verify process instance was migrated
     List<ProcessInstanceEntity> c8ProcessInstance = searchHistoricProcessInstances("simpleProcess");
     assertThat(c8ProcessInstance).hasSize(1);
-    List<AuditLogEntity> logs = searchAuditLogs("simpleProcess");
+    List<AuditLogDbModel> logs = searchAuditLogs("simpleProcess");
     assertThat(logs).hasSize(0);
   }
 
@@ -707,7 +708,7 @@ public class HistoryAuditLogTest extends HistoryMigrationAbstractTest {
     historyMigrator.migrateByType(HISTORY_AUDIT_LOG);
 
     // then
-    List<AuditLogEntity> logs = searchAuditLogsByCategory(AuditLogEntity.AuditLogOperationCategory.DEPLOYED_RESOURCES.name());
+    List<AuditLogDbModel> logs = searchAuditLogsByCategory(AuditLogEntity.AuditLogOperationCategory.DEPLOYED_RESOURCES.name());
     assertThat(logs).hasSize(0);
   }
 }

--- a/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/history/entity/HistoryAuditLogUserTaskTest.java
+++ b/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/history/entity/HistoryAuditLogUserTaskTest.java
@@ -14,6 +14,7 @@ import static io.camunda.migration.data.impl.persistence.IdKeyMapper.TYPE.HISTOR
 import static io.camunda.migration.data.impl.util.ConverterUtil.prefixDefinitionId;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.camunda.db.rdbms.write.domain.AuditLogDbModel;
 import io.camunda.migration.data.qa.history.HistoryMigrationAbstractTest;
 import io.camunda.search.entities.AuditLogEntity;
 import io.camunda.search.entities.ProcessInstanceEntity;
@@ -69,9 +70,9 @@ public class HistoryAuditLogUserTaskTest extends HistoryMigrationAbstractTest {
     assertThat(c8ProcessInstance).hasSize(1);
     List<UserTaskEntity> userTaskEntities = searchHistoricUserTasks(c8ProcessInstance.getFirst().processInstanceKey());
     assertThat(userTaskEntities).hasSize(1);
-    List<AuditLogEntity> logs = searchAuditLogs("userTaskProcessId");
+    List<AuditLogDbModel> logs = searchAuditLogs("userTaskProcessId");
     assertThat(logs).hasSize(1);
-    AuditLogEntity log = logs.getFirst();
+    AuditLogDbModel log = logs.getFirst();
 
     assertThat(log.auditLogKey()).isNotNull();
     assertThat(log.entityKey()).isEqualTo(String.valueOf(log.userTaskKey()));
@@ -114,9 +115,9 @@ public class HistoryAuditLogUserTaskTest extends HistoryMigrationAbstractTest {
     // then
     List<ProcessInstanceEntity> c8ProcessInstance = searchHistoricProcessInstances("userTaskProcessId");
     assertThat(c8ProcessInstance).hasSize(1);
-    List<AuditLogEntity> logs = searchAuditLogs("userTaskProcessId");
+    List<AuditLogDbModel> logs = searchAuditLogs("userTaskProcessId");
     assertThat(logs).hasSize(1);
-    AuditLogEntity log = logs.getFirst();
+    AuditLogDbModel log = logs.getFirst();
 
     assertThat(log.tenantId()).isEqualTo("tenantA");
     assertThat(log.tenantScope()).isEqualTo(AuditLogEntity.AuditLogTenantScope.TENANT);
@@ -144,7 +145,7 @@ public class HistoryAuditLogUserTaskTest extends HistoryMigrationAbstractTest {
     // then
     List<ProcessInstanceEntity> c8ProcessInstance = searchHistoricProcessInstances("userTaskProcessId");
     assertThat(c8ProcessInstance).hasSize(1);
-    List<AuditLogEntity> logs = searchAuditLogs("userTaskProcessId");
+    List<AuditLogDbModel> logs = searchAuditLogs("userTaskProcessId");
     assertThat(logs).hasSize(1);
     assertAuditLogProperties(logs, AuditLogEntity.AuditLogOperationType.COMPLETE);
   }
@@ -173,7 +174,7 @@ public class HistoryAuditLogUserTaskTest extends HistoryMigrationAbstractTest {
     // then
     List<ProcessInstanceEntity> c8ProcessInstance = searchHistoricProcessInstances("userTaskProcessId");
     assertThat(c8ProcessInstance).hasSize(1);
-    List<AuditLogEntity> logs = searchAuditLogs("userTaskProcessId");
+    List<AuditLogDbModel> logs = searchAuditLogs("userTaskProcessId");
     assertThat(logs).hasSize(1);
     assertAuditLogProperties(logs, AuditLogEntity.AuditLogOperationType.ASSIGN);
   }
@@ -202,7 +203,7 @@ public class HistoryAuditLogUserTaskTest extends HistoryMigrationAbstractTest {
     // then
     List<ProcessInstanceEntity> c8ProcessInstance = searchHistoricProcessInstances("userTaskProcessId");
     assertThat(c8ProcessInstance).hasSize(1);
-    List<AuditLogEntity> logs = searchAuditLogs("userTaskProcessId");
+    List<AuditLogDbModel> logs = searchAuditLogs("userTaskProcessId");
     assertThat(logs).hasSize(1);
     assertAuditLogProperties(logs, AuditLogEntity.AuditLogOperationType.ASSIGN);
   }
@@ -231,7 +232,7 @@ public class HistoryAuditLogUserTaskTest extends HistoryMigrationAbstractTest {
     // then
     List<ProcessInstanceEntity> c8ProcessInstance = searchHistoricProcessInstances("userTaskProcessId");
     assertThat(c8ProcessInstance).hasSize(1);
-    List<AuditLogEntity> logs = searchAuditLogs("userTaskProcessId");
+    List<AuditLogDbModel> logs = searchAuditLogs("userTaskProcessId");
     assertThat(logs.size()).isEqualTo(1);
     assertAuditLogProperties(logs, AuditLogEntity.AuditLogOperationType.ASSIGN);
   }
@@ -260,10 +261,10 @@ public class HistoryAuditLogUserTaskTest extends HistoryMigrationAbstractTest {
     // then
     List<ProcessInstanceEntity> c8ProcessInstance = searchHistoricProcessInstances("userTaskProcessId");
     assertThat(c8ProcessInstance).hasSize(1);
-    List<AuditLogEntity> logs = searchAuditLogs("userTaskProcessId");
+    List<AuditLogDbModel> logs = searchAuditLogs("userTaskProcessId");
     assertThat(logs.stream().filter(log -> log.operationType().equals(AuditLogEntity.AuditLogOperationType.UPDATE)).count()).isEqualTo(1);
-    assertThat(logs).extracting(AuditLogEntity::entityType).containsOnly(AuditLogEntity.AuditLogEntityType.USER_TASK);
-    assertThat(logs).extracting(AuditLogEntity::category).containsOnly(AuditLogEntity.AuditLogOperationCategory.USER_TASKS);
+    assertThat(logs).extracting(AuditLogDbModel::entityType).containsOnly(AuditLogEntity.AuditLogEntityType.USER_TASK);
+    assertThat(logs).extracting(AuditLogDbModel::category).containsOnly(AuditLogEntity.AuditLogOperationCategory.USER_TASKS);
   }
 
   @Test
@@ -290,7 +291,7 @@ public class HistoryAuditLogUserTaskTest extends HistoryMigrationAbstractTest {
     // then
     List<ProcessInstanceEntity> c8ProcessInstance = searchHistoricProcessInstances("userTaskProcessId");
     assertThat(c8ProcessInstance).hasSize(1);
-    List<AuditLogEntity> logs = searchAuditLogs("userTaskProcessId");
+    List<AuditLogDbModel> logs = searchAuditLogs("userTaskProcessId");
     assertThat(logs).hasSize(1);
     assertAuditLogProperties(logs, AuditLogEntity.AuditLogOperationType.UPDATE);
   }
@@ -319,7 +320,7 @@ public class HistoryAuditLogUserTaskTest extends HistoryMigrationAbstractTest {
     // then
     List<ProcessInstanceEntity> c8ProcessInstance = searchHistoricProcessInstances("userTaskProcessId");
     assertThat(c8ProcessInstance).hasSize(1);
-    List<AuditLogEntity> logs = searchAuditLogs("userTaskProcessId");
+    List<AuditLogDbModel> logs = searchAuditLogs("userTaskProcessId");
     assertThat(logs).hasSize(1);
     assertAuditLogProperties(logs, AuditLogEntity.AuditLogOperationType.UPDATE);
   }
@@ -349,7 +350,7 @@ public class HistoryAuditLogUserTaskTest extends HistoryMigrationAbstractTest {
     // then
     List<ProcessInstanceEntity> c8ProcessInstance = searchHistoricProcessInstances("userTaskProcessId");
     assertThat(c8ProcessInstance).hasSize(1);
-    List<AuditLogEntity> logs = searchAuditLogs("userTaskProcessId");
+    List<AuditLogDbModel> logs = searchAuditLogs("userTaskProcessId");
     assertThat(logs).hasSize(1);
     assertAuditLogProperties(logs, AuditLogEntity.AuditLogOperationType.UPDATE);
   }
@@ -378,14 +379,14 @@ public class HistoryAuditLogUserTaskTest extends HistoryMigrationAbstractTest {
     // then
     List<ProcessInstanceEntity> c8ProcessInstance = searchHistoricProcessInstances("userTaskProcessId");
     assertThat(c8ProcessInstance).hasSize(1);
-    List<AuditLogEntity> logs = searchAuditLogs("userTaskProcessId");
+    List<AuditLogDbModel> logs = searchAuditLogs("userTaskProcessId");
     assertThat(logs).hasSize(0);
   }
 
-  protected void assertAuditLogProperties(List<AuditLogEntity> logs, AuditLogEntity.AuditLogOperationType opType) {
+  protected void assertAuditLogProperties(List<AuditLogDbModel> logs, AuditLogEntity.AuditLogOperationType opType) {
     assertThat(logs.getFirst().category()).isEqualTo(AuditLogEntity.AuditLogOperationCategory.USER_TASKS);
-    assertThat(logs).extracting(AuditLogEntity::entityType).containsOnly(AuditLogEntity.AuditLogEntityType.USER_TASK);
-    assertThat(logs).extracting(AuditLogEntity::operationType).containsOnly(opType);
+    assertThat(logs).extracting(AuditLogDbModel::entityType).containsOnly(AuditLogEntity.AuditLogEntityType.USER_TASK);
+    assertThat(logs).extracting(AuditLogDbModel::operationType).containsOnly(opType);
   }
 
 }

--- a/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/history/entity/HistoryExternalTaskTest.java
+++ b/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/history/entity/HistoryExternalTaskTest.java
@@ -15,8 +15,8 @@ import static io.camunda.migration.data.impl.util.ConverterUtil.prefixDefinition
 import static io.camunda.migration.data.qa.extension.HistoryMigrationExtension.USER_TASK_ID;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.camunda.db.rdbms.write.domain.JobDbModel;
 import io.camunda.migration.data.qa.history.HistoryMigrationAbstractTest;
-import io.camunda.search.entities.JobEntity;
 import io.camunda.search.entities.JobEntity.JobKind;
 import io.camunda.search.entities.JobEntity.JobState;
 import io.camunda.search.entities.JobEntity.ListenerEventType;
@@ -65,11 +65,11 @@ public class HistoryExternalTaskTest extends HistoryMigrationAbstractTest {
     long processInstanceKey = processInstances.getFirst().processInstanceKey();
 
     // and: exactly one C8 job entry was created (deduplicated by external task ID)
-    List<JobEntity> c8Jobs = searchJobs(processInstanceKey);
+    List<JobDbModel> c8Jobs = searchJobs(processInstanceKey);
     assertThat(c8Jobs).as("One C8 job entry per C7 external task (deduplication by external task ID)").hasSize(1);
 
     // and: the job has the expected properties
-    JobEntity job = c8Jobs.getFirst();
+    JobDbModel job = c8Jobs.getFirst();
     assertExternalTaskJobProperties(job, processInstanceKey, processInstances.getFirst().processDefinitionKey(),
         null);
   }
@@ -107,13 +107,13 @@ public class HistoryExternalTaskTest extends HistoryMigrationAbstractTest {
     long processInstanceKey = processInstances.getFirst().processInstanceKey();
 
     // and: exactly one C8 job entry was created (deduplicated by external task ID)
-    List<JobEntity> c8Jobs = searchJobs(processInstanceKey);
+    List<JobDbModel> c8Jobs = searchJobs(processInstanceKey);
     assertThat(c8Jobs).as("One C8 job entry per C7 external task (deduplication by external task ID)").hasSize(1);
 
     // and: the job has the expected properties
     // Note: worker is null because the migrator picks up the first (creation) log entry per
     // external task ID, and the creation event does not yet have a workerId
-    JobEntity job = c8Jobs.getFirst();
+    JobDbModel job = c8Jobs.getFirst();
     assertExternalTaskJobProperties(job, processInstanceKey, processInstances.getFirst().processDefinitionKey(),
         null);
   }
@@ -161,7 +161,7 @@ public class HistoryExternalTaskTest extends HistoryMigrationAbstractTest {
     // then: only ONE C8 job entry created despite multiple log entries
     List<ProcessInstanceEntity> processInstances = searchHistoricProcessInstances(PROCESS_KEY);
     assertThat(processInstances).hasSize(1);
-    List<JobEntity> c8Jobs = searchJobs(processInstances.getFirst().processInstanceKey());
+    List<JobDbModel> c8Jobs = searchJobs(processInstances.getFirst().processInstanceKey());
     assertThat(c8Jobs).as("Exactly one C8 job per C7 external task despite multiple log entries").hasSize(1);
   }
 
@@ -189,7 +189,7 @@ public class HistoryExternalTaskTest extends HistoryMigrationAbstractTest {
     // then
     List<ProcessInstanceEntity> processInstances = searchHistoricProcessInstances(PROCESS_KEY);
     assertThat(processInstances).hasSize(1);
-    List<JobEntity> c8Jobs = searchJobs(processInstances.getFirst().processInstanceKey());
+    List<JobDbModel> c8Jobs = searchJobs(processInstances.getFirst().processInstanceKey());
     assertThat(c8Jobs).hasSize(1);
     assertThat(c8Jobs.getFirst().tenantId()).isEqualTo("tenantId");
   }
@@ -225,9 +225,9 @@ public class HistoryExternalTaskTest extends HistoryMigrationAbstractTest {
     assertThat(processInstances).hasSize(1);
     long processInstanceKey = processInstances.getFirst().processInstanceKey();
 
-    List<JobEntity> c8Jobs = searchJobs(processInstanceKey);
+    List<JobDbModel> c8Jobs = searchJobs(processInstanceKey);
     assertThat(c8Jobs).as("Exactly one C8 job entry").hasSize(1);
-    JobEntity job = c8Jobs.getFirst();
+    JobDbModel job = c8Jobs.getFirst();
 
     // and: the incident was migrated with jobKey pointing to the C8 job
     var incidents = searchHistoricIncidents(PROCESS_KEY);
@@ -264,7 +264,7 @@ public class HistoryExternalTaskTest extends HistoryMigrationAbstractTest {
     assertThat(processInstances).hasSize(1);
     long processInstanceKey = processInstances.getFirst().processInstanceKey();
 
-    List<JobEntity> c8Jobs = searchJobs(processInstanceKey);
+    List<JobDbModel> c8Jobs = searchJobs(processInstanceKey);
     assertThat(c8Jobs).as("External task should be migrated even without flow node").hasSize(1);
     assertThat(c8Jobs.getFirst().elementInstanceKey())
         .as("elementInstanceKey should be null when flow nodes are not migrated")
@@ -304,7 +304,7 @@ public class HistoryExternalTaskTest extends HistoryMigrationAbstractTest {
     assertThat(processInstances).hasSize(1);
     long processInstanceKey = processInstances.getFirst().processInstanceKey();
 
-    List<JobEntity> c8Jobs = searchJobs(processInstanceKey);
+    List<JobDbModel> c8Jobs = searchJobs(processInstanceKey);
     assertThat(c8Jobs).as("Completed external task should be migrated even without flow node").hasSize(1);
     assertThat(c8Jobs.getFirst().elementInstanceKey())
         .as("elementInstanceKey should be null when flow nodes are not migrated")
@@ -344,7 +344,7 @@ public class HistoryExternalTaskTest extends HistoryMigrationAbstractTest {
     assertThat(processInstances).hasSize(1);
 
     // and: exactly one C8 job entry was created for the external task
-    List<JobEntity> c8Jobs = searchJobs(processInstances.getFirst().processInstanceKey());
+    List<JobDbModel> c8Jobs = searchJobs(processInstances.getFirst().processInstanceKey());
     assertThat(c8Jobs).as("One C8 job entry per C7 external task").hasSize(1);
 
     // and: the rootProcessInstanceKey points to the root (calling) process instance
@@ -389,10 +389,10 @@ public class HistoryExternalTaskTest extends HistoryMigrationAbstractTest {
     long processInstanceKey = processInstances.getFirst().processInstanceKey();
 
     // and: exactly one C8 job entry was created (deduplicated by external task ID)
-    List<JobEntity> c8Jobs = searchJobs(processInstanceKey);
+    List<JobDbModel> c8Jobs = searchJobs(processInstanceKey);
     assertThat(c8Jobs).as("One C8 job entry per C7 external task (deduplication by external task ID)").hasSize(1);
 
-    JobEntity job = c8Jobs.getFirst();
+    JobDbModel job = c8Jobs.getFirst();
     assertExternalTaskJobProperties(job, processInstanceKey, processInstances.getFirst().processDefinitionKey(),
         null);
   }
@@ -408,7 +408,7 @@ public class HistoryExternalTaskTest extends HistoryMigrationAbstractTest {
     deployer.deployC7ModelInstance("callingProcessId", callingProcess);
   }
 
-  protected void assertExternalTaskJobProperties(JobEntity job, long processInstanceKey, Long processDefinitionKey,
+  protected void assertExternalTaskJobProperties(JobDbModel job, long processInstanceKey, Long processDefinitionKey,
                                                  String worker) {
     assertThat(job.jobKey()).isNotNull();
     assertThat(job.processInstanceKey()).isEqualTo(processInstanceKey);

--- a/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/history/entity/HistoryIncidentTest.java
+++ b/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/history/entity/HistoryIncidentTest.java
@@ -21,9 +21,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.db.rdbms.write.domain.FlowNodeInstanceDbModel;
 import io.camunda.db.rdbms.write.domain.IncidentDbModel;
+import io.camunda.db.rdbms.write.domain.JobDbModel;
 import io.camunda.migration.data.qa.history.HistoryMigrationAbstractTest;
 import io.camunda.search.entities.IncidentEntity;
-import io.camunda.search.entities.JobEntity;
 import io.camunda.search.entities.ProcessInstanceEntity;
 import java.util.Collections;
 import java.util.List;
@@ -67,12 +67,12 @@ public class HistoryIncidentTest extends HistoryMigrationAbstractTest {
     historyMigrator.migrate();
 
     // then
-    List<IncidentEntity> incidentsDefaultTenant = searchHistoricIncidents("incidentProcessId");
-    List<IncidentEntity> incidentsTenant1 = searchHistoricIncidents("incidentProcessId2");
+    List<IncidentDbModel> incidentsDefaultTenant = searchHistoricIncidents("incidentProcessId");
+    List<IncidentDbModel> incidentsTenant1 = searchHistoricIncidents("incidentProcessId2");
     assertThat(incidentsDefaultTenant).singleElement()
-        .extracting(IncidentEntity::tenantId)
+        .extracting(IncidentDbModel::tenantId)
         .isEqualTo(C8_DEFAULT_TENANT);
-    assertThat(incidentsTenant1).singleElement().extracting(IncidentEntity::tenantId).isEqualTo("tenant1");
+    assertThat(incidentsTenant1).singleElement().extracting(IncidentDbModel::tenantId).isEqualTo("tenant1");
   }
 
   @Test
@@ -92,9 +92,9 @@ public class HistoryIncidentTest extends HistoryMigrationAbstractTest {
     historyMigrator.migrate();
 
     // then
-    List<IncidentEntity> incidents = searchHistoricIncidents("userTaskProcessId");
+    List<IncidentDbModel> incidents = searchHistoricIncidents("userTaskProcessId");
     assertThat(incidents).hasSize(1);
-    IncidentEntity incident = incidents.getFirst();
+    IncidentDbModel incident = incidents.getFirst();
     assertOnIncidentBasicFields(incident, c7Incident, c7ProcessInstance, null);
   }
 
@@ -117,9 +117,9 @@ public class HistoryIncidentTest extends HistoryMigrationAbstractTest {
     historyMigrator.migrate();
 
     // then
-    List<IncidentEntity> incidents = searchHistoricIncidents("userTaskProcessId");
+    List<IncidentDbModel> incidents = searchHistoricIncidents("userTaskProcessId");
     assertThat(incidents).hasSize(1);
-    IncidentEntity incident = incidents.getFirst();
+    IncidentDbModel incident = incidents.getFirst();
     assertOnIncidentBasicFields(incident, c7Incident, c7ProcessInstance, null);
   }
 
@@ -150,13 +150,13 @@ public class HistoryIncidentTest extends HistoryMigrationAbstractTest {
     // then
 
     // child incident is migrated
-    List<IncidentEntity> childIncidents = searchHistoricIncidents(childProcess.getProcessDefinitionKey());
+    List<IncidentDbModel> childIncidents = searchHistoricIncidents(childProcess.getProcessDefinitionKey());
     assertThat(childIncidents).hasSize(1);
     assertOnIncidentBasicFields(childIncidents.getFirst(), c7ChildIncident, childProcess, parentProcess, UNKNOWN,
         false, false);
 
     // parent incident is migrated
-    List<IncidentEntity> parentIncidents = searchHistoricIncidents(parentProcess.getProcessDefinitionKey());
+    List<IncidentDbModel> parentIncidents = searchHistoricIncidents(parentProcess.getProcessDefinitionKey());
     assertThat(parentIncidents).hasSize(1);
     assertOnIncidentBasicFields(parentIncidents.getFirst(), c7ParentIncident, parentProcess, parentProcess);
   }
@@ -194,12 +194,12 @@ public class HistoryIncidentTest extends HistoryMigrationAbstractTest {
     // then both incidents are migrated
 
     // child incident has a job key (the failed job was migrated)
-    List<IncidentEntity> childIncidents = searchHistoricIncidents(childProcess.getProcessDefinitionKey());
+    List<IncidentDbModel> childIncidents = searchHistoricIncidents(childProcess.getProcessDefinitionKey());
     assertThat(childIncidents).as("child process incident should be migrated").hasSize(1);
     assertThat(childIncidents.getFirst().jobKey()).as("child incident should have a job key").isNotNull();
 
     // parent incident is migrated without a job key (propagated incident has no direct job reference)
-    List<IncidentEntity> parentIncidents = searchHistoricIncidents(parentProcess.getProcessDefinitionKey());
+    List<IncidentDbModel> parentIncidents = searchHistoricIncidents(parentProcess.getProcessDefinitionKey());
     assertThat(parentIncidents).as("parent process incident should be migrated").hasSize(1);
     assertThat(parentIncidents.getFirst().jobKey()).as("propagated parent incident should have no job key").isNull();
     assertThat(parentIncidents.getFirst().processInstanceKey()).isNotNull();
@@ -224,9 +224,9 @@ public class HistoryIncidentTest extends HistoryMigrationAbstractTest {
     historyMigrator.migrate();
 
     // then
-    List<IncidentEntity> incidents = searchHistoricIncidents("userTaskProcessId");
+    List<IncidentDbModel> incidents = searchHistoricIncidents("userTaskProcessId");
     assertThat(incidents).hasSize(1);
-    IncidentEntity incident = incidents.getFirst();
+    IncidentDbModel incident = incidents.getFirst();
     assertOnIncidentBasicFields(incident, c7Incident, c7ProcessInstance, null);
   }
 
@@ -247,9 +247,9 @@ public class HistoryIncidentTest extends HistoryMigrationAbstractTest {
     historyMigrator.migrate();
 
     // then
-    List<IncidentEntity> incidents = searchHistoricIncidents("userTaskProcessId");
+    List<IncidentDbModel> incidents = searchHistoricIncidents("userTaskProcessId");
     assertThat(incidents).hasSize(1);
-    IncidentEntity incident = incidents.getFirst();
+    IncidentDbModel incident = incidents.getFirst();
     assertOnIncidentBasicFields(incident, c7Incident, c7ProcessInstance, null);
   }
 
@@ -273,9 +273,9 @@ public class HistoryIncidentTest extends HistoryMigrationAbstractTest {
     historyMigrator.migrate();
 
     // then
-    List<IncidentEntity> incidents = searchHistoricIncidents("userTaskProcessId");
+    List<IncidentDbModel> incidents = searchHistoricIncidents("userTaskProcessId");
     assertThat(incidents).hasSize(1);
-    IncidentEntity incident = incidents.getFirst();
+    IncidentDbModel incident = incidents.getFirst();
     assertOnIncidentBasicFields(incident, c7Incident, c7ProcessInstance, null);
   }
 
@@ -298,9 +298,9 @@ public class HistoryIncidentTest extends HistoryMigrationAbstractTest {
     historyMigrator.migrate();
 
     // then
-    List<IncidentEntity> incidents = searchHistoricIncidents("userTaskProcessId");
+    List<IncidentDbModel> incidents = searchHistoricIncidents("userTaskProcessId");
     assertThat(incidents).hasSize(1);
-    IncidentEntity incident = incidents.getFirst();
+    IncidentDbModel incident = incidents.getFirst();
     assertOnIncidentBasicFields(incident, c7Incident, c7ProcessInstance, null);
   }
 
@@ -320,9 +320,9 @@ public class HistoryIncidentTest extends HistoryMigrationAbstractTest {
     historyMigrator.migrate();
 
     // then
-    List<IncidentEntity> incidents = searchHistoricIncidents("incidentProcessId");
+    List<IncidentDbModel> incidents = searchHistoricIncidents("incidentProcessId");
     assertThat(incidents).hasSize(1);
-    IncidentEntity c8Incident = incidents.getFirst();
+    IncidentDbModel c8Incident = incidents.getFirst();
     assertOnIncidentBasicFields(c8Incident, c7Incident, c7ProcessInstance, null, RESOURCE_NOT_FOUND, true, true);
   }
 
@@ -342,9 +342,9 @@ public class HistoryIncidentTest extends HistoryMigrationAbstractTest {
     historyMigrator.migrate();
 
     // then
-    List<IncidentEntity> incidents = searchHistoricIncidents("formNotFoundProcessId");
+    List<IncidentDbModel> incidents = searchHistoricIncidents("formNotFoundProcessId");
     assertThat(incidents).hasSize(1);
-    IncidentEntity c8Incident = incidents.getFirst();
+    IncidentDbModel c8Incident = incidents.getFirst();
     assertOnIncidentBasicFields(c8Incident, c7Incident, c7ProcessInstance, null, FORM_NOT_FOUND, true, true);
   }
 
@@ -366,9 +366,9 @@ public class HistoryIncidentTest extends HistoryMigrationAbstractTest {
     historyMigrator.migrate();
 
     // then
-    List<IncidentEntity> incidents = searchHistoricIncidents("ruleTaskProcessId");
+    List<IncidentDbModel> incidents = searchHistoricIncidents("ruleTaskProcessId");
     assertThat(incidents).hasSize(1);
-    IncidentEntity c8Incident = incidents.getFirst();
+    IncidentDbModel c8Incident = incidents.getFirst();
     assertOnIncidentBasicFields(c8Incident, c7Incident, c7ProcessInstance, null, DECISION_EVALUATION_ERROR, true, true);
   }
 
@@ -388,9 +388,9 @@ public class HistoryIncidentTest extends HistoryMigrationAbstractTest {
     historyMigrator.migrate();
 
     // then
-    List<IncidentEntity> incidents = searchHistoricIncidents("conditionErrorProcessId");
+    List<IncidentDbModel> incidents = searchHistoricIncidents("conditionErrorProcessId");
     assertThat(incidents).hasSize(1);
-    IncidentEntity c8Incident = incidents.getFirst();
+    IncidentDbModel c8Incident = incidents.getFirst();
     assertOnIncidentBasicFields(c8Incident, c7Incident, c7ProcessInstance, null, CONDITION_ERROR, true, true);
   }
 
@@ -411,9 +411,9 @@ public class HistoryIncidentTest extends HistoryMigrationAbstractTest {
     historyMigrator.migrate();
 
     // then
-    List<IncidentEntity> incidents = searchHistoricIncidents("unhandledErrorProcessId");
+    List<IncidentDbModel> incidents = searchHistoricIncidents("unhandledErrorProcessId");
     assertThat(incidents).hasSize(1);
-    IncidentEntity c8Incident = incidents.getFirst();
+    IncidentDbModel c8Incident = incidents.getFirst();
     assertOnIncidentBasicFields(c8Incident, c7Incident, c7ProcessInstance, null, UNHANDLED_ERROR_EVENT, true, true);
   }
 
@@ -434,9 +434,9 @@ public class HistoryIncidentTest extends HistoryMigrationAbstractTest {
     historyMigrator.migrate();
 
     // then
-    List<IncidentEntity> incidents = searchHistoricIncidents("noJobRetriesProcessId");
+    List<IncidentDbModel> incidents = searchHistoricIncidents("noJobRetriesProcessId");
     assertThat(incidents).hasSize(1);
-    IncidentEntity c8Incident = incidents.getFirst();
+    IncidentDbModel c8Incident = incidents.getFirst();
     assertOnIncidentBasicFields(c8Incident, c7Incident, c7ProcessInstance, null, JOB_NO_RETRIES, true, true);
   }
 
@@ -520,7 +520,7 @@ public class HistoryIncidentTest extends HistoryMigrationAbstractTest {
     List<ProcessInstanceEntity> processInstances = searchHistoricProcessInstances("miProcess");
     assertThat(processInstances).hasSize(1);
 
-    List<IncidentEntity> incidents = searchHistoricIncidents("miProcess");
+    List<IncidentDbModel> incidents = searchHistoricIncidents("miProcess");
     assertThat(incidents).hasSize(2);
 
     assertThat(incidents.getFirst().flowNodeInstanceKey()).isNotEqualTo(incidents.getLast().flowNodeInstanceKey());
@@ -547,10 +547,10 @@ public class HistoryIncidentTest extends HistoryMigrationAbstractTest {
     long processInstanceKey = processInstances.getFirst().processInstanceKey();
 
     // and: exactly one C8 job entry was created (deduplicated by external task ID)
-    List<JobEntity> c8Jobs = searchJobs(processInstanceKey);
+    List<JobDbModel> c8Jobs = searchJobs(processInstanceKey);
     assertThat(c8Jobs).as("One C8 job entry per C7 external task (deduplication by external task ID)").hasSize(1);
 
-    List<IncidentEntity> incidents = searchHistoricIncidents(EXT_PROCESS_KEY);
+    List<IncidentDbModel> incidents = searchHistoricIncidents(EXT_PROCESS_KEY);
     assertThat(incidents).hasSize(1);
     assertOnIncidentBasicFields(incidents.getFirst(), list.getFirst(), processInstance, null, UNKNOWN, false, true);
     assertThat(incidents.getFirst().jobKey()).isEqualTo(c8Jobs.getFirst().jobKey());
@@ -586,13 +586,13 @@ public class HistoryIncidentTest extends HistoryMigrationAbstractTest {
     historyMigrator.migrate();
 
     // then
-    List<IncidentEntity> incidentsDefaultTenant = searchHistoricIncidents(EXT_PROCESS_KEY);
-    List<IncidentEntity> incidentsTenant1 = searchHistoricIncidents(processKey2);
+    List<IncidentDbModel> incidentsDefaultTenant = searchHistoricIncidents(EXT_PROCESS_KEY);
+    List<IncidentDbModel> incidentsTenant1 = searchHistoricIncidents(processKey2);
     assertThat(incidentsDefaultTenant).singleElement()
-        .extracting(IncidentEntity::tenantId)
+        .extracting(IncidentDbModel::tenantId)
         .isEqualTo(C8_DEFAULT_TENANT);
     assertThat(incidentsTenant1).singleElement()
-        .extracting(IncidentEntity::tenantId)
+        .extracting(IncidentDbModel::tenantId)
         .isEqualTo("tenant1");
   }
 
@@ -617,7 +617,7 @@ public class HistoryIncidentTest extends HistoryMigrationAbstractTest {
     historyMigrator.migrate();
 
     // then
-    List<IncidentEntity> incidents = searchHistoricIncidents(EXT_PROCESS_KEY);
+    List<IncidentDbModel> incidents = searchHistoricIncidents(EXT_PROCESS_KEY);
     assertThat(incidents).hasSize(1);
     assertOnIncidentBasicFields(incidents.getFirst(), c7Incident, c7ProcessInstance, null, UNKNOWN, false, true);
   }
@@ -656,12 +656,12 @@ public class HistoryIncidentTest extends HistoryMigrationAbstractTest {
     historyMigrator.migrate();
 
     // then: child incident is migrated with jobKey
-    List<IncidentEntity> childIncidents = searchHistoricIncidents(EXT_PROCESS_KEY);
+    List<IncidentDbModel> childIncidents = searchHistoricIncidents(EXT_PROCESS_KEY);
     assertThat(childIncidents).as("child process incident should be migrated").hasSize(1);
     assertThat(childIncidents.getFirst().jobKey()).as("child incident should have a job key").isNotNull();
 
     // and: parent incident is migrated without jobKey (propagated)
-    List<IncidentEntity> parentIncidents = searchHistoricIncidents("callingProcessId");
+    List<IncidentDbModel> parentIncidents = searchHistoricIncidents("callingProcessId");
     assertThat(parentIncidents).as("parent process incident should be migrated").hasSize(1);
     assertThat(parentIncidents.getFirst().jobKey()).as("propagated parent incident should have no job key").isNull();
     assertThat(parentIncidents.getFirst().processInstanceKey()).isNotNull();
@@ -734,21 +734,21 @@ public class HistoryIncidentTest extends HistoryMigrationAbstractTest {
     List<ProcessInstanceEntity> processInstances = searchHistoricProcessInstances(processKey);
     assertThat(processInstances).hasSize(1);
 
-    List<IncidentEntity> incidents = searchHistoricIncidents(processKey);
+    List<IncidentDbModel> incidents = searchHistoricIncidents(processKey);
     assertThat(incidents).hasSize(2);
 
     assertThat(incidents.getFirst().flowNodeInstanceKey())
         .isNotEqualTo(incidents.getLast().flowNodeInstanceKey());
   }
 
-  protected void assertOnIncidentBasicFields(IncidentEntity c8Incident,
+  protected void assertOnIncidentBasicFields(IncidentDbModel c8Incident,
                                              HistoricIncident c7Incident,
                                              ProcessInstance c7ChildInstance,
                                              ProcessInstance c7ParentInstance) {
     assertOnIncidentBasicFields(c8Incident, c7Incident, c7ChildInstance, c7ParentInstance, UNKNOWN, false, false);
   }
 
-  protected void assertOnIncidentBasicFields(IncidentEntity c8Incident,
+  protected void assertOnIncidentBasicFields(IncidentDbModel c8Incident,
                                              HistoricIncident c7Incident,
                                              ProcessInstance c7ChildInstance,
                                              ProcessInstance c7ParentInstance,
@@ -771,7 +771,7 @@ public class HistoryIncidentTest extends HistoryMigrationAbstractTest {
 
     // non-null values
     assertThat(c8Incident.incidentKey()).isNotNull();
-    assertThat(c8Incident.creationTime()).isNotNull();
+    assertThat(c8Incident.creationDate()).isNotNull();
 
     if (hasMigratedJob) {
       assertThat(c8Incident.jobKey()).isNotNull();

--- a/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/history/entity/HistoryJobTest.java
+++ b/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/history/entity/HistoryJobTest.java
@@ -17,8 +17,8 @@ import static io.camunda.migration.data.qa.history.element.HistoryAbstractElemen
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.db.rdbms.write.domain.FlowNodeInstanceDbModel;
+import io.camunda.db.rdbms.write.domain.JobDbModel;
 import io.camunda.migration.data.qa.history.HistoryMigrationAbstractTest;
-import io.camunda.search.entities.JobEntity;
 import io.camunda.search.entities.JobEntity.JobKind;
 import io.camunda.search.entities.JobEntity.JobState;
 import io.camunda.search.entities.JobEntity.ListenerEventType;
@@ -55,10 +55,10 @@ public class HistoryJobTest extends HistoryMigrationAbstractTest {
     long processInstanceKey = processInstances.getFirst().processInstanceKey();
 
     // and: exactly one C8 job entry was created (deduplicated by job ID across multiple log entries)
-    List<JobEntity> c8Jobs = searchJobs(processInstanceKey);
+    List<JobDbModel> c8Jobs = searchJobs(processInstanceKey);
     assertThat(c8Jobs).as("One C8 job entry per C7 job (deduplication by job ID)").hasSize(1);
 
-    JobEntity job = c8Jobs.getFirst();
+    JobDbModel job = c8Jobs.getFirst();
     assertJobProperties(job, processInstanceKey, "asyncBeforeUserTaskProcessId", "asyncUserTaskId", false,
         processInstances.getFirst().processDefinitionKey());
   }
@@ -81,10 +81,10 @@ public class HistoryJobTest extends HistoryMigrationAbstractTest {
     long processInstanceKey = processInstances.getFirst().processInstanceKey();
 
     // and: exactly one C8 job entry was created (deduplicated by job ID across multiple log entries)
-    List<JobEntity> c8Jobs = searchJobs(processInstanceKey);
+    List<JobDbModel> c8Jobs = searchJobs(processInstanceKey);
     assertThat(c8Jobs).as("One C8 job entry per C7 job (deduplication by job ID)").hasSize(1);
 
-    JobEntity job = c8Jobs.getFirst();
+    JobDbModel job = c8Jobs.getFirst();
     assertJobProperties(job, processInstanceKey, PROCESS, "startEvent", true, processInstances.getFirst().processDefinitionKey());
 
     List<FlowNodeInstanceDbModel> startEvent = searchFlowNodeInstancesByName("startEvent");
@@ -119,9 +119,9 @@ public class HistoryJobTest extends HistoryMigrationAbstractTest {
     long processInstanceKey = processInstances.getFirst().processInstanceKey();
 
     // and: the failed job was migrated to C8
-    List<JobEntity> c8Jobs = searchJobs(processInstanceKey);
+    List<JobDbModel> c8Jobs = searchJobs(processInstanceKey);
     assertThat(c8Jobs).as("Exactly one C8 job entry (deduplication by job ID)").hasSize(1);
-    JobEntity job = c8Jobs.getFirst();
+    JobDbModel job = c8Jobs.getFirst();
 
     assertJobProperties(job, processInstanceKey, "failingServiceTaskProcessId", "serviceTaskId", false, processInstances.getFirst().processDefinitionKey());
 
@@ -153,9 +153,9 @@ public class HistoryJobTest extends HistoryMigrationAbstractTest {
     long processInstanceKey = processInstances.getFirst().processInstanceKey();
 
     // and: the failed job was migrated to C8
-    List<JobEntity> c8Jobs = searchJobs(processInstanceKey);
+    List<JobDbModel> c8Jobs = searchJobs(processInstanceKey);
     assertThat(c8Jobs).as("Exactly one C8 job entry (deduplication by job ID)").hasSize(1);
-    JobEntity job = c8Jobs.getFirst();
+    JobDbModel job = c8Jobs.getFirst();
     assertThat(job.tenantId()).isEqualTo("tenantId");
   }
 
@@ -190,7 +190,7 @@ public class HistoryJobTest extends HistoryMigrationAbstractTest {
     // then: only ONE C8 job entry created despite multiple log entries (tracked by job ID)
     List<ProcessInstanceEntity> processInstances = searchHistoricProcessInstances("failingServiceTaskProcessId");
     assertThat(processInstances).hasSize(1);
-    List<JobEntity> c8Jobs = searchJobs(processInstances.getFirst().processInstanceKey());
+    List<JobDbModel> c8Jobs = searchJobs(processInstances.getFirst().processInstanceKey());
     assertThat(c8Jobs).as("Exactly one C8 job per C7 job despite multiple log entries").hasSize(1);
   }
 
@@ -214,7 +214,7 @@ public class HistoryJobTest extends HistoryMigrationAbstractTest {
     assertThat(processInstances).hasSize(1);
 
     // and: exactly one C8 job entry was created
-    List<JobEntity> c8Jobs = searchJobs(processInstances.getFirst().processInstanceKey());
+    List<JobDbModel> c8Jobs = searchJobs(processInstances.getFirst().processInstanceKey());
     assertThat(c8Jobs).as("One C8 job entry per C7 job ").hasSize(1);
 
     assertThat(c8Jobs.getFirst().rootProcessInstanceKey()).isEqualTo(root.getFirst().processInstanceKey());
@@ -236,7 +236,7 @@ public class HistoryJobTest extends HistoryMigrationAbstractTest {
     List<ProcessInstanceEntity> processInstances = searchHistoricProcessInstances("timerDurationBoundaryEventProcessId");
     assertThat(processInstances).hasSize(1);
 
-    List<JobEntity> c8Jobs = searchJobs(processInstances.getFirst().processInstanceKey());
+    List<JobDbModel> c8Jobs = searchJobs(processInstances.getFirst().processInstanceKey());
     assertThat(c8Jobs).isEmpty();
   }
 
@@ -264,7 +264,7 @@ public class HistoryJobTest extends HistoryMigrationAbstractTest {
     assertThat(processInstances).hasSize(1);
     long processInstanceKey = processInstances.getFirst().processInstanceKey();
 
-    List<JobEntity> c8Jobs = searchJobs(processInstanceKey);
+    List<JobDbModel> c8Jobs = searchJobs(processInstanceKey);
     assertThat(c8Jobs).as("Async-before job should be migrated even without flow node").hasSize(1);
     assertThat(c8Jobs.getFirst().elementInstanceKey())
         .as("elementInstanceKey should be null for async-before without migrated flow node")
@@ -289,7 +289,7 @@ public class HistoryJobTest extends HistoryMigrationAbstractTest {
     List<ProcessInstanceEntity> processInstances = searchHistoricProcessInstances(PROCESS);
     assertThat(processInstances).hasSize(1);
 
-    List<JobEntity> c8Jobs = searchJobs(processInstances.getFirst().processInstanceKey());
+    List<JobDbModel> c8Jobs = searchJobs(processInstances.getFirst().processInstanceKey());
     assertThat(c8Jobs).as("Async-after job should NOT be migrated without flow node").isEmpty();
   }
 
@@ -311,7 +311,7 @@ public class HistoryJobTest extends HistoryMigrationAbstractTest {
     assertThat(processInstances).hasSize(1);
     Long processInstanceKey = processInstances.getFirst().processInstanceKey();
 
-    List<JobEntity> c8Jobs = searchJobs(processInstanceKey);
+    List<JobDbModel> c8Jobs = searchJobs(processInstanceKey);
     assertThat(c8Jobs.getFirst().elementInstanceKey()).isNotEqualTo(c8Jobs.getLast().elementInstanceKey());
   }
 
@@ -333,11 +333,11 @@ public class HistoryJobTest extends HistoryMigrationAbstractTest {
     assertThat(processInstances).hasSize(1);
     Long processInstanceKey = processInstances.getFirst().processInstanceKey();
 
-    List<JobEntity> c8Jobs = searchJobs(processInstanceKey);
+    List<JobDbModel> c8Jobs = searchJobs(processInstanceKey);
     assertThat(c8Jobs.getFirst().elementInstanceKey()).isNotEqualTo(c8Jobs.getLast().elementInstanceKey());
   }
 
-  protected void assertJobProperties(JobEntity job, long processInstanceKey, String c7ProcessDefinitionKey,
+  protected void assertJobProperties(JobDbModel job, long processInstanceKey, String c7ProcessDefinitionKey,
                                      String taskId, boolean isAsyncAfter, Long processDefinitionKey) {
     assertThat(job.jobKey()).isNotNull();
     assertThat(job.processInstanceKey()).isEqualTo(processInstanceKey);

--- a/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/history/entity/interceptor/HistoryDeclarativeConfigurationTest.java
+++ b/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/history/entity/interceptor/HistoryDeclarativeConfigurationTest.java
@@ -9,13 +9,13 @@ package io.camunda.migration.data.qa.history.entity.interceptor;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.camunda.db.rdbms.write.domain.FlowNodeInstanceDbModel;
 import io.camunda.migration.data.config.property.MigratorProperties;
 import io.camunda.migration.data.impl.interceptor.history.entity.FlowNodeTransformer;
 import io.camunda.migration.data.impl.interceptor.history.entity.ProcessInstanceTransformer;
 import io.camunda.migration.data.interceptor.EntityInterceptor;
 import io.camunda.migration.data.qa.history.HistoryMigrationAbstractTest;
 import io.camunda.migration.data.qa.util.WithSpringProfile;
-import io.camunda.search.entities.FlowNodeInstanceEntity;
 import io.camunda.search.entities.ProcessInstanceEntity;
 import java.util.List;
 import org.junit.jupiter.api.Test;
@@ -125,14 +125,7 @@ public class HistoryDeclarativeConfigurationTest extends HistoryMigrationAbstrac
 
     assertThat(migratedProcessInstances).isNotEmpty();
 
-    Long processInstanceKey = migratedProcessInstances.getFirst().processInstanceKey();
-
-    List<FlowNodeInstanceEntity> migratedFlowNodes =
-        flowNodeInstanceReader
-            .search(io.camunda.search.query.FlowNodeInstanceQuery.of(queryBuilder ->
-                queryBuilder.filter(filterBuilder ->
-                    filterBuilder.tenantIds("complex-tenant"))))
-            .items();
+    List<FlowNodeInstanceDbModel> migratedFlowNodes = searchFlowNodesByTenantId("complex-tenant");
 
     assertThat(migratedFlowNodes).isNotEmpty();
 
@@ -140,7 +133,7 @@ public class HistoryDeclarativeConfigurationTest extends HistoryMigrationAbstrac
     ProcessInstanceEntity migratedInstance = migratedProcessInstances.getFirst();
     assertThat(migratedInstance.tenantId()).isEqualTo("complex-tenant");
 
-    for (FlowNodeInstanceEntity flowNode : migratedFlowNodes) {
+    for (FlowNodeInstanceDbModel flowNode : migratedFlowNodes) {
       assertThat(flowNode.tenantId()).isEqualTo("complex-tenant");
     }
   }

--- a/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/history/entity/interceptor/HistoryPresetParentPropertiesTest.java
+++ b/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/history/entity/interceptor/HistoryPresetParentPropertiesTest.java
@@ -18,10 +18,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.camunda.bpm.engine.variable.Variables.stringValue;
 
 import io.camunda.db.rdbms.write.domain.FlowNodeInstanceDbModel;
+import io.camunda.db.rdbms.write.domain.IncidentDbModel;
 import io.camunda.migration.data.interceptor.EntityInterceptor;
 import io.camunda.migration.data.qa.history.HistoryMigrationAbstractTest;
 import io.camunda.search.entities.DecisionInstanceEntity;
-import io.camunda.search.entities.IncidentEntity;
 import io.camunda.search.entities.ProcessInstanceEntity;
 import io.camunda.search.entities.UserTaskEntity;
 import io.camunda.search.entities.VariableEntity;
@@ -225,10 +225,10 @@ public class HistoryPresetParentPropertiesTest extends HistoryMigrationAbstractT
     historyMigrator.migrateByType(HISTORY_INCIDENT);
 
     // then
-    List<IncidentEntity> incidents = searchHistoricIncidents("failingServiceTaskProcessId");
+    List<IncidentDbModel> incidents = searchHistoricIncidents("failingServiceTaskProcessId");
     assertThat(incidents).isNotEmpty();
 
-    IncidentEntity incident = incidents.getFirst();
+    IncidentDbModel incident = incidents.getFirst();
     assertThat(incident.processDefinitionKey()).isEqualTo(1L);
     assertThat(incident.processInstanceKey()).isEqualTo(2L);
     assertThat(incident.jobKey()).isEqualTo(3L);


### PR DESCRIPTION
# Pull Request Template

## Description
Temporary Fix for the CI failure caused by newly enforced none null in compact constructors. 
Related: https://github.com/camunda/camunda-7-to-8-migration-tooling/issues/1339
<!-- Describe your changes in detail -->

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Test-only changes (no production code changes)

## Testing Checklist

### Black-Box Testing Requirements
- [ ] Tests follow **black-box testing approach**: verify behavior through observable outputs (logs, C8 API queries, real-world skip scenarios)
- [ ] Tests **DO NOT** access implementation details (`DbClient`, `IdKeyMapper`, `..impl..` packages except logging constants)
- [ ] Architecture tests pass (`ArchitectureTest` validates these rules)

### Test Coverage
- [ ] Added tests for new functionality
- [ ] Updated tests for modified functionality
- [ ] All tests pass locally

## Architecture Compliance

Run architecture tests to ensure compliance:
```bash
mvn test -Dtest=ArchitectureTest
```

If architecture tests fail, refactor your tests to use:
- `LogCapturer` for log assertions
- `camundaClient.new*SearchRequest()` for C8 queries
- Real-World skip scenarios (e.g., migrate children without parents)

## Documentation
- [ ] Updated TESTING_GUIDELINES.md if adding new test patterns
- [ ] Added Javadoc comments for public APIs
- [ ] Updated README if user-facing changes

## Checklist
- [ ] Code follows project style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments for complex logic
- [ ] No new compiler warnings
- [ ] Dependent changes have been merged

## Related Issues
<!-- Link to related issues: Fixes #123, Related to #456 -->

