### PR TITLE
fix(diagram-converter): bubble up already converted error

### DIFF
--- a/diagram-converter/core/src/main/java/io/camunda/migration/diagram/converter/DiagramConverter.java
+++ b/diagram-converter/core/src/main/java/io/camunda/migration/diagram/converter/DiagramConverter.java
@@ -21,6 +21,7 @@ import io.camunda.migration.diagram.converter.DiagramConverter.MustacheContext.M
 import io.camunda.migration.diagram.converter.DiagramConverter.MustacheContext.MustacheResultContext.MustacheElementResultContext.MustacheSeverityContext.MustacheMessageContext;
 import io.camunda.migration.diagram.converter.DomElementVisitorContext.DefaultDomElementVisitorContext;
 import io.camunda.migration.diagram.converter.conversion.Conversion;
+import io.camunda.migration.diagram.converter.exception.DiagramAlreadyConvertedException;
 import io.camunda.migration.diagram.converter.visitor.AbstractDecisionElementVisitor;
 import io.camunda.migration.diagram.converter.visitor.AbstractProcessElementVisitor;
 import io.camunda.migration.diagram.converter.visitor.DomElementVisitor;
@@ -90,6 +91,10 @@ public class DiagramConverter {
   private DiagramCheckResult check(
       String filename, DomElement rootElement, ConverterProperties properties) {
     LOG.info("Start checking " + filename);
+    String executionPlatformVersion = rootElement.getAttribute(MODELER, "executionPlatformVersion");
+    if (executionPlatformVersion != null && executionPlatformVersion.startsWith("8")) {
+      throw new DiagramAlreadyConvertedException(executionPlatformVersion);
+    }
     DiagramCheckResult result = new DiagramCheckResult();
     result.setFilename(filename);
     result.setConverterVersion(getClass().getPackage().getImplementationVersion());

--- a/diagram-converter/core/src/main/java/io/camunda/migration/diagram/converter/exception/DiagramAlreadyConvertedException.java
+++ b/diagram-converter/core/src/main/java/io/camunda/migration/diagram/converter/exception/DiagramAlreadyConvertedException.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.migration.diagram.converter.exception;
+
+public class DiagramAlreadyConvertedException extends DiagramConverterException {
+
+  public DiagramAlreadyConvertedException(String executionPlatformVersion) {
+    super(
+        "This diagram is already a Camunda 8 diagram (executionPlatformVersion="
+            + executionPlatformVersion
+            + ")");
+  }
+}

--- a/diagram-converter/core/src/main/java/io/camunda/migration/diagram/converter/exception/DiagramConverterException.java
+++ b/diagram-converter/core/src/main/java/io/camunda/migration/diagram/converter/exception/DiagramConverterException.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.migration.diagram.converter.exception;
+
+public class DiagramConverterException extends RuntimeException {
+
+  public DiagramConverterException(String message) {
+    super(message);
+  }
+
+  public DiagramConverterException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/diagram-converter/core/src/main/java/io/camunda/migration/diagram/converter/visitor/impl/BpmnDefinitionsVisitor.java
+++ b/diagram-converter/core/src/main/java/io/camunda/migration/diagram/converter/visitor/impl/BpmnDefinitionsVisitor.java
@@ -33,10 +33,6 @@ public class BpmnDefinitionsVisitor extends AbstractBpmnElementVisitor {
     SemanticVersion desiredVersion =
         SemanticVersion.parse(context.getProperties().getPlatformVersion());
     DomElement element = context.getElement();
-    String executionPlatform = element.getAttribute(NamespaceUri.MODELER, VERSION_HEADER);
-    if (executionPlatform != null && executionPlatform.startsWith("8")) {
-      throw new RuntimeException("This diagram is already a Camunda 8 diagram");
-    }
     // TODO in case there is a requirement to override the BPMN namespace name, this can be enabled
     //    String prefix = element.getPrefix();
     //    if (prefix == null || !prefix.equals("bpmn")) {

--- a/diagram-converter/core/src/main/java/io/camunda/migration/diagram/converter/visitor/impl/DmnDefinitionsVisitor.java
+++ b/diagram-converter/core/src/main/java/io/camunda/migration/diagram/converter/visitor/impl/DmnDefinitionsVisitor.java
@@ -29,10 +29,6 @@ public class DmnDefinitionsVisitor extends AbstractDmnElementVisitor {
     SemanticVersion desiredVersion =
         SemanticVersion.parse(context.getProperties().getPlatformVersion());
     DomElement element = context.getElement();
-    String executionPlatform = element.getAttribute(NamespaceUri.MODELER, VERSION_HEADER);
-    if (executionPlatform != null && executionPlatform.startsWith("8")) {
-      throw new RuntimeException("This diagram is already a Camunda 8 diagram");
-    }
     element.registerNamespace(MODELER_NAMESPACE_NAME, NamespaceUri.MODELER);
     element.registerNamespace(ZEEBE_NAMESPACE_NAME, NamespaceUri.ZEEBE);
     element.registerNamespace(CONVERSION_NAMESPACE_NAME, CONVERSION);

--- a/diagram-converter/core/src/test/java/io/camunda/migration/diagram/converter/DiagramConverterTest.java
+++ b/diagram-converter/core/src/test/java/io/camunda/migration/diagram/converter/DiagramConverterTest.java
@@ -14,6 +14,7 @@ import static org.assertj.core.api.Assertions.*;
 import io.camunda.migration.diagram.converter.DiagramCheckResult.ElementCheckMessage;
 import io.camunda.migration.diagram.converter.DiagramCheckResult.ElementCheckResult;
 import io.camunda.migration.diagram.converter.DiagramCheckResult.Severity;
+import io.camunda.migration.diagram.converter.exception.DiagramAlreadyConvertedException;
 import io.camunda.migration.diagram.converter.message.MessageFactory;
 import java.io.ByteArrayInputStream;
 import java.io.StringWriter;
@@ -106,7 +107,28 @@ public class DiagramConverterTest {
         Bpmn.readModelFromStream(
             this.getClass().getClassLoader().getResourceAsStream("c8_simple.bpmn"));
     Assertions.assertThrows(
-        RuntimeException.class, () -> converter.convert(modelInstance, properties));
+        DiagramAlreadyConvertedException.class, () -> converter.convert(modelInstance, properties));
+  }
+
+  @Test
+  public void shouldFailPreFlightAndLeaveC8DiagramUnmodified() {
+    DiagramConverter converter = DiagramConverterFactory.getInstance().get();
+    ConverterProperties properties = ConverterPropertiesFactory.getInstance().get();
+    BpmnModelInstance modelInstance =
+        Bpmn.readModelFromStream(
+            this.getClass().getClassLoader().getResourceAsStream("c8_simple.bpmn"));
+    String xmlBefore = Bpmn.convertToString(modelInstance);
+
+    DiagramAlreadyConvertedException thrown =
+        Assertions.assertThrows(
+            DiagramAlreadyConvertedException.class,
+            () -> converter.convert(modelInstance, properties));
+
+    assertThat(thrown).hasMessageContaining("already a Camunda 8 diagram");
+    String xmlAfter = Bpmn.convertToString(modelInstance);
+    assertThat(xmlAfter)
+        .as("pre-flight check must reject the diagram before any modification")
+        .isEqualTo(xmlBefore);
   }
 
   @Test

--- a/diagram-converter/core/src/test/java/io/camunda/migration/diagram/converter/DiagramConverterTest.java
+++ b/diagram-converter/core/src/test/java/io/camunda/migration/diagram/converter/DiagramConverterTest.java
@@ -14,6 +14,7 @@ import static org.assertj.core.api.Assertions.*;
 import io.camunda.migration.diagram.converter.DiagramCheckResult.ElementCheckMessage;
 import io.camunda.migration.diagram.converter.DiagramCheckResult.ElementCheckResult;
 import io.camunda.migration.diagram.converter.DiagramCheckResult.Severity;
+import io.camunda.migration.diagram.converter.exception.DiagramAlreadyConvertedException;
 import java.io.ByteArrayInputStream;
 import java.io.StringWriter;
 import java.util.List;
@@ -105,7 +106,28 @@ public class DiagramConverterTest {
         Bpmn.readModelFromStream(
             this.getClass().getClassLoader().getResourceAsStream("c8_simple.bpmn"));
     Assertions.assertThrows(
-        RuntimeException.class, () -> converter.convert(modelInstance, properties));
+        DiagramAlreadyConvertedException.class, () -> converter.convert(modelInstance, properties));
+  }
+
+  @Test
+  public void shouldFailPreFlightAndLeaveC8DiagramUnmodified() {
+    DiagramConverter converter = DiagramConverterFactory.getInstance().get();
+    ConverterProperties properties = ConverterPropertiesFactory.getInstance().get();
+    BpmnModelInstance modelInstance =
+        Bpmn.readModelFromStream(
+            this.getClass().getClassLoader().getResourceAsStream("c8_simple.bpmn"));
+    String xmlBefore = Bpmn.convertToString(modelInstance);
+
+    DiagramAlreadyConvertedException thrown =
+        Assertions.assertThrows(
+            DiagramAlreadyConvertedException.class,
+            () -> converter.convert(modelInstance, properties));
+
+    assertThat(thrown).hasMessageContaining("already a Camunda 8 diagram");
+    String xmlAfter = Bpmn.convertToString(modelInstance);
+    assertThat(xmlAfter)
+        .as("pre-flight check must reject the diagram before any modification")
+        .isEqualTo(xmlBefore);
   }
 
   @Test

--- a/diagram-converter/webapp/src/main/java/io/camunda/migration/diagram/converter/webapp/ConverterController.java
+++ b/diagram-converter/webapp/src/main/java/io/camunda/migration/diagram/converter/webapp/ConverterController.java
@@ -11,6 +11,7 @@ import io.camunda.migration.diagram.converter.DiagramCheckResult;
 import io.camunda.migration.diagram.converter.DiagramConverterResultDTO;
 import io.camunda.migration.diagram.converter.DiagramType;
 import io.camunda.migration.diagram.converter.excel.ExcelWriter;
+import io.camunda.migration.diagram.converter.exception.DiagramAlreadyConvertedException;
 import java.io.BufferedOutputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -230,6 +231,8 @@ public class ConverterController {
           .body(file);
     } catch (IOException e) {
       return ResponseEntity.badRequest().body(e.getMessage());
+    } catch (DiagramAlreadyConvertedException e) {
+      throw e;
     } catch (Exception e) {
       LOG.error("Error while converting resources", e);
       return ResponseEntity.internalServerError().body(e.getMessage());

--- a/diagram-converter/webapp/src/main/java/io/camunda/migration/diagram/converter/webapp/ConverterExceptionHandler.java
+++ b/diagram-converter/webapp/src/main/java/io/camunda/migration/diagram/converter/webapp/ConverterExceptionHandler.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.migration.diagram.converter.webapp;
 
+import io.camunda.migration.diagram.converter.exception.DiagramAlreadyConvertedException;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import org.apache.tomcat.util.http.fileupload.impl.FileCountLimitExceededException;
@@ -14,6 +15,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.multipart.MultipartException;
@@ -22,6 +24,12 @@ import org.springframework.web.multipart.MultipartException;
 public class ConverterExceptionHandler {
 
   private static final Logger LOG = LoggerFactory.getLogger(ConverterExceptionHandler.class);
+
+  @ExceptionHandler(DiagramAlreadyConvertedException.class)
+  public ResponseEntity<String> handleDiagramAlreadyConverted(DiagramAlreadyConvertedException ex) {
+    LOG.warn("Rejecting diagram that is already a Camunda 8 model: {}", ex.getMessage());
+    return ResponseEntity.status(HttpStatus.UNPROCESSABLE_ENTITY).body(ex.getMessage());
+  }
 
   @ExceptionHandler(MultipartException.class)
   public void handleMultipartException(MultipartException ex, HttpServletResponse response)

--- a/diagram-converter/webapp/src/main/javascript/src/App.jsx
+++ b/diagram-converter/webapp/src/main/javascript/src/App.jsx
@@ -155,9 +155,12 @@ function App() {
         });
 
         if (!checkResponse.ok) {
+          const reason = (await checkResponse.text())?.trim();
           const result = {
             status: "error",
-            errorMessage: `Analysis failed (HTTP ${checkResponse.status})`,
+            errorMessage: reason
+              ? `Analysis failed (HTTP ${checkResponse.status}): ${reason}`
+              : `Analysis failed (HTTP ${checkResponse.status})`,
             originalModelXml: originalModelXml,
             checkResponseJson: null,
           };

--- a/diagram-converter/webapp/src/main/javascript/src/App.jsx
+++ b/diagram-converter/webapp/src/main/javascript/src/App.jsx
@@ -219,9 +219,12 @@ function App() {
         });
 
         if (!checkResponse.ok) {
+          const reason = (await checkResponse.text())?.trim();
           const result = {
             status: "error",
-            errorMessage: `Analysis failed (HTTP ${checkResponse.status})`,
+            errorMessage: reason
+              ? `Analysis failed (HTTP ${checkResponse.status}): ${reason}`
+              : `Analysis failed (HTTP ${checkResponse.status})`,
             originalModelXml: originalModelXml,
             checkResponseJson: null,
           };


### PR DESCRIPTION
related to: camunda/camunda-7-to-8-migration-tooling/issues/693

# Pull Request Template

## Description
<!-- Describe your changes in detail -->

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Test-only changes (no production code changes)

## Testing Checklist

### Black-Box Testing Requirements
- [ ] Tests follow **black-box testing approach**: verify behavior through observable outputs (logs, C8 API queries, real-world skip scenarios)
- [ ] Tests **DO NOT** access implementation details (`DbClient`, `IdKeyMapper`, `..impl..` packages except logging constants)
- [ ] Architecture tests pass (`ArchitectureTest` validates these rules)

### Test Coverage
- [ ] Added tests for new functionality
- [ ] Updated tests for modified functionality
- [ ] All tests pass locally

## Architecture Compliance

Run architecture tests to ensure compliance:
```bash
mvn test -Dtest=ArchitectureTest
```

If architecture tests fail, refactor your tests to use:
- `LogCapturer` for log assertions
- `camundaClient.new*SearchRequest()` for C8 queries
- Real-World skip scenarios (e.g., migrate children without parents)

## Documentation
- [ ] Updated TESTING_GUIDELINES.md if adding new test patterns
- [ ] Added Javadoc comments for public APIs
- [ ] Updated README if user-facing changes

## Checklist
- [ ] Code follows project style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments for complex logic
- [ ] No new compiler warnings
- [ ] Dependent changes have been merged

## Related Issues
<!-- Link to related issues: Fixes #123, Related to #456 -->

