### PR TITLE
fix: migrate Nexus vault keys to Terraform-managed credentials (0.1)

### DIFF
--- a/.github/actions/setup-maven/action.yml
+++ b/.github/actions/setup-maven/action.yml
@@ -53,8 +53,8 @@ runs:
       roleId: ${{ inputs.vault-role-id }}
       secretId: ${{ inputs.vault-secret-id }}
       secrets: |
-        secret/data/products/cambpm/ci/nexus NEXUS_APP_CAMUNDA_COM_USR;
-        secret/data/products/cambpm/ci/nexus NEXUS_APP_CAMUNDA_COM_PSW;
+        secret/data/products/cambpm/ci/nexus USER | NEXUS_APP_CAMUNDA_COM_USR;
+        secret/data/products/cambpm/ci/nexus PASSWORD | NEXUS_APP_CAMUNDA_COM_PSW;
   - name: Setup Java
     uses: actions/setup-java@v5
     with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,8 +29,8 @@ jobs:
           roleId: ${{ secrets.VAULT_ROLE_ID }}
           secretId: ${{ secrets.VAULT_SECRET_ID }}
           secrets: |
-            secret/data/products/cambpm/ci/nexus NEXUS_APP_CAMUNDA_COM_USR;
-            secret/data/products/cambpm/ci/nexus NEXUS_APP_CAMUNDA_COM_PSW;
+            secret/data/products/cambpm/ci/nexus USER | NEXUS_APP_CAMUNDA_COM_USR;
+            secret/data/products/cambpm/ci/nexus PASSWORD | NEXUS_APP_CAMUNDA_COM_PSW;
 
       - name: Setup Maven
         uses: ./.github/actions/setup-maven
@@ -75,8 +75,8 @@ jobs:
           roleId: ${{ secrets.VAULT_ROLE_ID }}
           secretId: ${{ secrets.VAULT_SECRET_ID }}
           secrets: |
-            secret/data/products/cambpm/ci/nexus NEXUS_APP_CAMUNDA_COM_USR;
-            secret/data/products/cambpm/ci/nexus NEXUS_APP_CAMUNDA_COM_PSW;
+            secret/data/products/cambpm/ci/nexus USER | NEXUS_APP_CAMUNDA_COM_USR;
+            secret/data/products/cambpm/ci/nexus PASSWORD | NEXUS_APP_CAMUNDA_COM_PSW;
 
       - name: Setup Maven
         uses: ./.github/actions/setup-maven
@@ -104,8 +104,8 @@ jobs:
           roleId: ${{ secrets.VAULT_ROLE_ID }}
           secretId: ${{ secrets.VAULT_SECRET_ID }}
           secrets: |
-            secret/data/products/cambpm/ci/nexus NEXUS_APP_CAMUNDA_COM_USR;
-            secret/data/products/cambpm/ci/nexus NEXUS_APP_CAMUNDA_COM_PSW;
+            secret/data/products/cambpm/ci/nexus USER | NEXUS_APP_CAMUNDA_COM_USR;
+            secret/data/products/cambpm/ci/nexus PASSWORD | NEXUS_APP_CAMUNDA_COM_PSW;
 
       - name: Setup Maven
         uses: ./.github/actions/setup-maven

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -211,8 +211,8 @@ jobs:
           roleId: ${{ secrets.VAULT_ROLE_ID }}
           secretId: ${{ secrets.VAULT_SECRET_ID }}
           secrets: |
-            secret/data/products/cambpm/ci/nexus NEXUS_APP_CAMUNDA_COM_USR;
-            secret/data/products/cambpm/ci/nexus NEXUS_APP_CAMUNDA_COM_PSW;
+            secret/data/products/cambpm/ci/nexus USER | NEXUS_APP_CAMUNDA_COM_USR;
+            secret/data/products/cambpm/ci/nexus PASSWORD | NEXUS_APP_CAMUNDA_COM_PSW;
 
       - name: Login to Camunda Registry
         uses: docker/login-action@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -211,15 +211,15 @@ jobs:
           roleId: ${{ secrets.VAULT_ROLE_ID }}
           secretId: ${{ secrets.VAULT_SECRET_ID }}
           secrets: |
-            secret/data/products/cambpm/ci/nexus USER | NEXUS_APP_CAMUNDA_COM_USR;
-            secret/data/products/cambpm/ci/nexus PASSWORD | NEXUS_APP_CAMUNDA_COM_PSW;
+            secret/data/products/cambpm/ci/harbor username | HARBOR_USERNAME;
+            secret/data/products/cambpm/ci/harbor password | HARBOR_PASSWORD;
 
       - name: Login to Camunda Registry
         uses: docker/login-action@v3
         with:
           registry: registry.camunda.cloud
-          username: ${{ steps.vault-secrets.outputs.NEXUS_APP_CAMUNDA_COM_USR }}
-          password: ${{ steps.vault-secrets.outputs.NEXUS_APP_CAMUNDA_COM_PSW }}
+          username: ${{ steps.vault-secrets.outputs.HARBOR_USERNAME }}
+          password: ${{ steps.vault-secrets.outputs.HARBOR_PASSWORD }}
 
       - name: Prepare Docker Context
         run: |


### PR DESCRIPTION
## What

Update `vault-action` secrets blocks to read the new Terraform-managed key names (`USER`/`PASSWORD`) from `secret/products/cambpm/ci/nexus`, using aliases to preserve existing output variable names (`NEXUS_APP_CAMUNDA_COM_USR`/`NEXUS_APP_CAMUNDA_COM_PSW`).

## Why

The Vault secret at `secret/products/cambpm/ci/nexus` was migrated to Terraform-managed credentials (camunda/infra-core#12687), which replaced the legacy `NEXUS_APP_CAMUNDA_COM_USR`/`NEXUS_APP_CAMUNDA_COM_PSW` keys with standardized `USER`/`PASSWORD` keys.

These workflows currently read the old key names which will be removed once all consumers are migrated.

## Changes

- `.github/actions/setup-maven/action.yml`: Updated vault secrets + output references
- `.github/workflows/ci.yml`: Updated vault secrets blocks + output references
- `.github/workflows/release.yml`: Updated vault secrets block + output references

related to camunda/team-infrastructure#1033

> **Note:** Companion PRs for `main` and `maintenance/0.2` branches also opened.