### PR TITLE
fix(ci): use dedicated Artifactory credentials for deploy

### DIFF
--- a/.github/actions/setup-maven/action.yml
+++ b/.github/actions/setup-maven/action.yml
@@ -55,6 +55,8 @@ runs:
       secrets: |
         secret/data/products/cambpm/ci/nexus USER | NEXUS_APP_CAMUNDA_COM_USR;
         secret/data/products/cambpm/ci/nexus PASSWORD | NEXUS_APP_CAMUNDA_COM_PSW;
+        secret/data/products/cambpm/ci/artifactory USER | ARTIFACTORY_USR;
+        secret/data/products/cambpm/ci/artifactory TOKEN | ARTIFACTORY_PSW;
   - name: Setup Java
     uses: actions/setup-java@v5
     with:
@@ -87,6 +89,11 @@ runs:
           "id": "camunda-nexus",
           "username": "${{ steps.secrets.outputs.NEXUS_APP_CAMUNDA_COM_USR }}",
           "password": "${{ steps.secrets.outputs.NEXUS_APP_CAMUNDA_COM_PSW }}"
+        },
+        {
+          "id": "camunda-artifactory",
+          "username": "${{ steps.secrets.outputs.ARTIFACTORY_USR }}",
+          "password": "${{ steps.secrets.outputs.ARTIFACTORY_PSW }}"
         }]
       EXTRA_MAVEN_MIRRORS: ${{ inputs.maven-mirrors }}
       EXTRA_MAVEN_SERVERS: ${{ inputs.maven-servers }}

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,10 @@
     <project.build.resourceEncoding>UTF-8</project.build.resourceEncoding>
 
     <nexus.snapshot.repository>https://artifacts.camunda.com/artifactory/zeebe-io-snapshots/</nexus.snapshot.repository>
+    <nexus.snapshot.repository.id>camunda-artifactory</nexus.snapshot.repository.id>
     <nexus.release.repository>https://artifacts.camunda.com/artifactory/zeebe-io/</nexus.release.repository>
+    <nexus.release.repository.id>camunda-artifactory</nexus.release.repository.id>
+    <nexus.staging.deploy.id>camunda-artifactory</nexus.staging.deploy.id>
     <central.sonatype.deployment.name>${project.groupId}:${project.artifactId}:${project.version}</central.sonatype.deployment.name>
   </properties>
 


### PR DESCRIPTION
## What

Use dedicated Artifactory credentials for Maven deploy instead of the old Nexus credentials.

## Why

The release job fails with 401 Unauthorized when deploying to `https://artifacts.camunda.com/artifactory/zeebe-io/` because the old credentials at `secret/data/products/cambpm/ci/nexus` no longer have write access.

## How

1. Fetch dedicated deploy credentials from `secret/data/products/cambpm/ci/artifactory` (USER + TOKEN)
2. Configure a `camunda-artifactory` server entry in Maven settings.xml
3. Override `nexus.staging.deploy.id`, `nexus.release.repository.id`, and `nexus.snapshot.repository.id` properties in pom.xml to point deploy operations at the new server entry

Same fix pattern as applied to other repos (camunda, connectors, identity, etc.).