### PR TITLE
fix(code-converion): handle none bpmn files

### DIFF
--- a/code-conversion/recipes/src/main/java/io/camunda/migration/code/recipes/client/MigrateMessageMethodsRecipe.java
+++ b/code-conversion/recipes/src/main/java/io/camunda/migration/code/recipes/client/MigrateMessageMethodsRecipe.java
@@ -21,6 +21,7 @@ import org.openrewrite.Preconditions;
 import org.openrewrite.Tree;
 import org.openrewrite.TreeVisitor;
 import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.JavaVisitor;
 import org.openrewrite.java.JavaTemplate;
 import org.openrewrite.java.MethodMatcher;
 import org.openrewrite.java.search.UsesMethod;
@@ -277,7 +278,7 @@ public class MigrateMessageMethodsRecipe extends AbstractMigrationRecipe {
   public @NonNull TreeVisitor<?, ExecutionContext> getVisitor() {
     TreeVisitor<?, ExecutionContext> base = MigrateMessageMethodsRecipe.super.getVisitor();
 
-    return new TreeVisitor<>() {
+    return new JavaVisitor<>() {
       @Override
       public J visit(@Nullable Tree tree, ExecutionContext ctx) {
         J afterBase = (J) base.visit(tree, ctx);

--- a/code-conversion/recipes/src/test/java/io/camunda/migration/code/recipes/client/migrate/ReplaceMessageMethodsTest.java
+++ b/code-conversion/recipes/src/test/java/io/camunda/migration/code/recipes/client/migrate/ReplaceMessageMethodsTest.java
@@ -8,11 +8,19 @@
 package io.camunda.migration.code.recipes.client.migrate;
 
 import static org.openrewrite.java.Assertions.java;
+import static org.openrewrite.xml.Assertions.xml;
 import io.camunda.migration.code.recipes.client.MigrateMessageMethodsRecipe;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.test.RewriteTest;
 
 class ReplaceMessageMethodsTest implements RewriteTest {
+
+  @Test
+  void doesNotFailOnNonJavaSourceFiles() {
+    rewriteRun(
+        spec -> spec.recipe(new MigrateMessageMethodsRecipe()),
+        xml("<process id=\"test\"/>"));
+  }
 
   @Test
   void replaceMessageMethodsTest() {


### PR DESCRIPTION
related to: camunda/camunda-7-to-8-migration-tooling/issues/1342

# Pull Request Template

## Description
<!-- Describe your changes in detail -->

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Test-only changes (no production code changes)

## Testing Checklist

### Black-Box Testing Requirements
- [ ] Tests follow **black-box testing approach**: verify behavior through observable outputs (logs, C8 API queries, real-world skip scenarios)
- [ ] Tests **DO NOT** access implementation details (`DbClient`, `IdKeyMapper`, `..impl..` packages except logging constants)
- [ ] Architecture tests pass (`ArchitectureTest` validates these rules)

### Test Coverage
- [ ] Added tests for new functionality
- [ ] Updated tests for modified functionality
- [ ] All tests pass locally

## Architecture Compliance

Run architecture tests to ensure compliance:
```bash
mvn test -Dtest=ArchitectureTest
```

If architecture tests fail, refactor your tests to use:
- `LogCapturer` for log assertions
- `camundaClient.new*SearchRequest()` for C8 queries
- Real-World skip scenarios (e.g., migrate children without parents)

## Documentation
- [ ] Updated TESTING_GUIDELINES.md if adding new test patterns
- [ ] Added Javadoc comments for public APIs
- [ ] Updated README if user-facing changes

## Checklist
- [ ] Code follows project style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments for complex logic
- [ ] No new compiler warnings
- [ ] Dependent changes have been merged

## Related Issues
<!-- Link to related issues: Fixes #123, Related to #456 -->

