### PR TITLE
Update agentic skill to 8.9

### DIFF
--- a/agentic-migration-skills/skills/migrate-c7-to-c8-code/SKILL.md
+++ b/agentic-migration-skills/skills/migrate-c7-to-c8-code/SKILL.md
@@ -11,9 +11,9 @@ You are a migration expert helping the user migrate a Java codebase from Camunda
 
 ## Step 1: Gather inputs
 
-Call `AskUserQuestion` to confirm the project root first (use the provided argument if present, otherwise the current working directory as a proposed default).
-After you have the confirmed project root, detect the build tool by checking that directory for `pom.xml` (Maven) or `build.gradle` / `build.gradle.kts` (Gradle).
-Use a single `AskUserQuestion` call for Questions 1–3 below; only ask the build-tool question as a follow-up if needed.
+Before calling `AskUserQuestion`, pick a candidate project root (use the provided argument if present, otherwise the current working directory), then detect the build tool by checking that directory for `pom.xml` (Maven) or `build.gradle` / `build.gradle.kts` (Gradle).
+
+Then call `AskUserQuestion` **once** with Questions 1-3 below (combine them in a single call — do not ask one at a time):
 
 **Question 1 — Code location**
 
@@ -39,10 +39,16 @@ Ask the user to choose one of:
 - **B. AI only** — AI migrates everything directly without OpenRewrite. Use this when you can't run OpenRewrite (non-Maven/Gradle builds, restricted environments) or want to review every change individually.
 - **C. Assessment only** — Scan the codebase and produce a report: file inventory, complexity estimate, effort breakdown. No code changes. Use this first if you want to understand the scope before committing.
 
-**Question 4 — Build tool** (include only when detection is ambiguous; relevant only if the user later chooses approach A)
+**Question 4 — Build tool**
 
-- If exactly one build tool was detected, do not ask — state the detection in the question text of Question 3 (e.g. "Detected Maven."). Only ask if both or neither were found.
-- When you do ask it, use explicit question text such as: "Which build tool should I use for the OpenRewrite step: Maven or Gradle?"
+Ask this only as a follow-up `AskUserQuestion` call after the user answers Question 3, and only if both conditions are true:
+
+- The user chose **A. OpenRewrite + AI**.
+- Build-tool detection was ambiguous (both Maven and Gradle were found, or neither was found).
+
+If exactly one build tool was detected, do not ask Question 4; state the detection in the question text of Question 3 instead (for example, "Detected Maven.").
+
+When you do ask Question 4, use explicit question text such as: "Which build tool should I use for the OpenRewrite step: Maven or Gradle?" Do not proceed until you have the answer.
 
 ---
 

--- a/agentic-migration-skills/skills/migrate-c7-to-c8-code/SKILL.md
+++ b/agentic-migration-skills/skills/migrate-c7-to-c8-code/SKILL.md
@@ -217,7 +217,7 @@ Then:
 - Remove all `org.camunda.bpm.*` dependencies and `camunda-bom` from `pom.xml` / `build.gradle`
 - Remove embedded-engine dependencies (H2, JDBC starter) — no longer needed without the embedded engine
 - Add the resolved starter at the resolved version; add `io.camunda:camunda-process-test-spring` at the same version in test scope if tests exist
-- Also add `org.springframework.boot:spring-boot-starter` if not already transitively available (needed for `jakarta.annotation` and common Spring Boot auto-config)
+- Ensure Spring Boot dependency management is correctly configured (e.g., `spring-boot-starter-parent` or the Spring Boot BOM); avoid adding `org.springframework.boot:spring-boot-starter` solely to “get jakarta.annotation”.
 - Replace `@EnableProcessApplication` with `@Deployment`
 - Update `application.properties` / `application.yaml` — replace `camunda.*` keys with `camunda.client.*` equivalents (see the [properties reference](https://docs.camunda.io/docs/apis-tools/camunda-spring-boot-starter/properties-reference/))
 - Reference: "Maven dependency and configuration" section in patterns

--- a/agentic-migration-skills/skills/migrate-c7-to-c8-code/SKILL.md
+++ b/agentic-migration-skills/skills/migrate-c7-to-c8-code/SKILL.md
@@ -192,10 +192,32 @@ If context budget is tight, fetch only the individual pattern files you need fro
 Work through each phase sequentially. Confirm completion of each phase before moving to the next. Do not auto-commit; ask whether to commit after each phase and commit only with explicit user approval.
 
 **Phase 1: Dependencies and configuration**
-- Remove all `org.camunda.bpm.*` dependencies from `pom.xml` / `build.gradle`
-- Add `io.camunda:camunda-spring-boot-starter` and `camunda-process-test-spring` (pick the release matching the target minor version)
+
+Before modifying the build file, resolve the latest released Camunda version via WebFetch:
+- `https://search.maven.org/solrsearch/select?q=g:io.camunda+AND+a:camunda-spring-boot-starter&rows=1&wt=json` → read `response.docs[0].latestVersion` as `CAMUNDA_VERSION`
+
+If the user's target is 8.8, use the latest 8.8.x patch (`8.8.x`); if 8.9+, `CAMUNDA_VERSION` is fine as-is.
+
+Detect the Spring Boot version from the existing `pom.xml` or `build.gradle`:
+- Spring Boot 3.x → use `io.camunda:camunda-spring-boot-3-starter` (supported for 8.9+; use for 8.8 too)
+- Spring Boot 4.x → use `io.camunda:camunda-spring-boot-starter`
+
+Add the Camunda public repository if not already present (artifacts are not on Maven Central):
+```xml
+<repository>
+  <id>camunda-public</id>
+  <name>Camunda Public Repository</name>
+  <url>https://artifacts.camunda.com/artifactory/public/</url>
+</repository>
+```
+
+Then:
+- Remove all `org.camunda.bpm.*` dependencies and `camunda-bom` from `pom.xml` / `build.gradle`
+- Remove embedded-engine dependencies (H2, JDBC starter) — no longer needed without the embedded engine
+- Add the resolved starter at the resolved version; add `io.camunda:camunda-process-test-spring` at the same version in test scope if tests exist
+- Also add `org.springframework.boot:spring-boot-starter` if not already transitively available (needed for `jakarta.annotation` and common Spring Boot auto-config)
 - Replace `@EnableProcessApplication` with `@Deployment`
-- Update `application.properties` / `application.yaml` — replace `camunda.*` keys with `camunda.client.*` equivalents
+- Update `application.properties` / `application.yaml` — replace `camunda.*` keys with `camunda.client.*` equivalents (see the [properties reference](https://docs.camunda.io/docs/apis-tools/camunda-spring-boot-starter/properties-reference/))
 - Reference: "Maven dependency and configuration" section in patterns
 
 **Phase 2: Client code**

--- a/agentic-migration-skills/skills/migrate-c7-to-c8-code/SKILL.md
+++ b/agentic-migration-skills/skills/migrate-c7-to-c8-code/SKILL.md
@@ -11,7 +11,7 @@ You are a migration expert helping the user migrate a Java codebase from Camunda
 
 ## Step 1: Gather inputs
 
-Before asking anything, detect the build tool yourself: check the project root for `pom.xml` (Maven) or `build.gradle` / `build.gradle.kts` (Gradle).
+Before calling `AskUserQuestion`, pick a candidate project root (use the provided argument if present, otherwise the current working directory), then detect the build tool by checking that directory for `pom.xml` (Maven) or `build.gradle` / `build.gradle.kts` (Gradle).
 
 Then call `AskUserQuestion` **once** with the following questions (combine them in a single call — do not ask one at a time):
 
@@ -39,7 +39,7 @@ Ask the user to choose one of:
 - **B. AI only** — AI migrates everything directly without OpenRewrite. Use this when you can't run OpenRewrite (non-Maven/Gradle builds, restricted environments) or want to review every change individually.
 - **C. Assessment only** — Scan the codebase and produce a report: file inventory, complexity estimate, effort breakdown. No code changes. Use this first if you want to understand the scope before committing.
 
-**Question 4 — Build tool** (only include if approach A is plausible and detection was ambiguous)
+**Question 4 — Build tool** (include only when detection is ambiguous; relevant only if the user later chooses approach A)
 
 - If exactly one build tool was detected, do not ask — state the detection in the question text of Question 3 (e.g. "Detected Maven."). Only ask if both or neither were found.
 
@@ -163,10 +163,8 @@ Before AI cleanup, ask whether to commit the OpenRewrite result. Commit only if 
 
 **2. AI cleanup — after OpenRewrite has run**
 
-First, fetch the pattern catalog via WebFetch — this is your reference for resolving TODOs, config, tests, listeners, and JUEL. Do not rely on training knowledge for API mappings:
-```
-https://raw.githubusercontent.com/camunda/camunda-7-to-8-migration-tooling/main/code-conversion/patterns/ALL_IN_ONE.md
-```
+First, fetch the pattern catalog via WebFetch from `main` — this is your reference for resolving TODOs, config, tests, listeners, and JUEL. Do not rely on training knowledge for API mappings:
+`https://raw.githubusercontent.com/camunda/camunda-7-to-8-migration-tooling/main/code-conversion/patterns/ALL_IN_ONE.md`
 If context budget is tight, fetch only the individual pattern files you need from `code-conversion/patterns/` (same repo, same raw URL scheme) instead of the full catalog.
 
 Work through each of the following. Confirm each before moving on. Do not auto-commit; ask whether to commit after each item and commit only with explicit user approval.
@@ -183,10 +181,8 @@ Work through each of the following. Confirm each before moving on. Do not auto-c
 
 ### Approach B — AI only
 
-First, fetch the pattern catalog via WebFetch — this is your primary reference for all C7→C8 transformations. Do not rely on training knowledge for API mappings:
-```
-https://raw.githubusercontent.com/camunda/camunda-7-to-8-migration-tooling/main/code-conversion/patterns/ALL_IN_ONE.md
-```
+First, fetch the pattern catalog via WebFetch from `main` — this is your primary reference for all C7→C8 transformations. Do not rely on training knowledge for API mappings:
+`https://raw.githubusercontent.com/camunda/camunda-7-to-8-migration-tooling/main/code-conversion/patterns/ALL_IN_ONE.md`
 If context budget is tight, fetch only the individual pattern files you need from `code-conversion/patterns/` instead of the full catalog.
 
 Work through each phase sequentially. Confirm completion of each phase before moving to the next. Do not auto-commit; ask whether to commit after each phase and commit only with explicit user approval.
@@ -202,7 +198,7 @@ Detect the Spring Boot version from the existing `pom.xml` or `build.gradle`:
 - Spring Boot 3.x → use `io.camunda:camunda-spring-boot-3-starter` (supported for 8.9+; use for 8.8 too)
 - Spring Boot 4.x → use `io.camunda:camunda-spring-boot-starter`
 
-Add the Camunda public repository if not already present (artifacts are not on Maven Central):
+Add the Camunda public repository if not already present (some Camunda artifacts may not be on Maven Central):
 ```xml
 <repository>
   <id>camunda-public</id>

--- a/agentic-migration-skills/skills/migrate-c7-to-c8-code/SKILL.md
+++ b/agentic-migration-skills/skills/migrate-c7-to-c8-code/SKILL.md
@@ -42,6 +42,7 @@ Ask the user to choose one of:
 **Question 4 — Build tool** (include only when detection is ambiguous; relevant only if the user later chooses approach A)
 
 - If exactly one build tool was detected, do not ask — state the detection in the question text of Question 3 (e.g. "Detected Maven."). Only ask if both or neither were found.
+- When you do ask it, use explicit question text such as: "Which build tool should I use for the OpenRewrite step: Maven or Gradle?"
 
 ---
 
@@ -276,11 +277,11 @@ Write the full report to `MIGRATION_REPORT.md`. Then stop — make no code chang
 5. **Check for leftover business keys**: Search for `businessKey` — map to `businessId` (8.9+) or tags (8.8), don't silently drop
 6. **Run tests**: `mvn test` or `./gradlew test` — fix failures
 7. **Check common pitfalls**:
-   - **Critical naming swap**: C7 `processDefinitionKey` (the string key like `"my-process"`) becomes C8 `bpmnProcessId`/`processDefinitionId`; C7 `processDefinitionId` (the UUID) becomes C8 `processDefinitionKey` — easy to miss, causes silent runtime bugs. Same swap applies to decision definitions.
-   - Process instance IDs changed from `String` to `Long` — check all ID handling
-   - `VariableMap` usage — variables are now plain JSON, `TypedValue` API is gone
-   - `HistoryService` references — map to Orchestration Cluster search endpoints (eventually consistent — no read-after-write inside workers); historic *data* needs the History Data Migrator (8.9, RDBMS)
-   - Batch operations — available since 8.8 via the Orchestration Cluster API (cancel/resolve/migrate/modify; delete since 8.9); only *custom* batch handlers need manual design
+  - **Critical naming swap**: C7 `processDefinitionKey` (the string key like `"my-process"`) becomes C8 `bpmnProcessId`; C7 `processDefinitionId` (the UUID) becomes C8 `processDefinitionKey` — easy to miss, causes silent runtime bugs. Same swap applies to decision definitions.
+  - Process instance IDs changed from `String` to `Long` — check all ID handling
+  - `VariableMap` usage — variables are now plain JSON, `TypedValue` API is gone
+  - `HistoryService` references — map to Orchestration Cluster search endpoints (eventually consistent — no read-after-write inside workers); historic *data* needs the History Data Migrator (8.9, RDBMS)
+  - Batch operations — available since 8.8 via the Orchestration Cluster API (cancel/resolve/migrate/modify; delete since 8.9); only *custom* batch handlers need manual design
 
 Present a summary:
 ```
@@ -299,7 +300,7 @@ Record the summary in `MIGRATION_REPORT.md`. For any remaining issues, ask the u
 
 ## Behavior rules
 
-- **Always load the pattern catalog before touching any code.** Never guess API mappings. For API details not covered by the catalog, prefer the official Camunda docs (the Camunda Docs MCP server, if available, or docs.camunda.io) over training knowledge.
+- **Always load the pattern catalog before touching any code.** Never guess API mappings. For API details not covered by the catalog, prefer the official Camunda docs (`docs.camunda.io`) via `WebFetch` over training knowledge.
 - **Respect the target version.** Do not recommend 8.9 features (businessId, conditional events, global user task listeners, batch delete) to an 8.8 target, and do not send 8.9 targets down 8.8 workarounds.
 - **One phase at a time; commits are opt-in.** Confirm each phase before starting the next. Never start on a dirty working tree. Ask before each commit and proceed only when the user explicitly allows it.
 - **Keep `MIGRATION_REPORT.md` current.** Assessment, decisions, phase status, validation results.

--- a/agentic-migration-skills/skills/migrate-c7-to-c8-code/SKILL.md
+++ b/agentic-migration-skills/skills/migrate-c7-to-c8-code/SKILL.md
@@ -200,13 +200,18 @@ Detect the Spring Boot version from the existing `pom.xml` or `build.gradle`:
 - Spring Boot 4.x → use `io.camunda:camunda-spring-boot-starter`
 
 Add the Camunda public repository if not already present (some Camunda artifacts may not be on Maven Central):
-```xml
-<repository>
-  <id>camunda-public</id>
-  <name>Camunda Public Repository</name>
-  <url>https://artifacts.camunda.com/artifactory/public/</url>
-</repository>
-```
+
+- **Maven (`pom.xml`)**:
+    <repository>
+      <id>camunda-public</id>
+      <name>Camunda Public Repository</name>
+      <url>https://artifacts.camunda.com/artifactory/public/</url>
+    </repository>
+
+- **Gradle (`build.gradle` / `build.gradle.kts`)**:
+    repositories {
+      maven { url "https://artifacts.camunda.com/artifactory/public/" }
+    }
 
 Then:
 - Remove all `org.camunda.bpm.*` dependencies and `camunda-bom` from `pom.xml` / `build.gradle`

--- a/agentic-migration-skills/skills/migrate-c7-to-c8-code/SKILL.md
+++ b/agentic-migration-skills/skills/migrate-c7-to-c8-code/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: migrate-c7-to-c8-code
-description: Use this when migrating or converting a Camunda 7 / camunda-bpm Java/Spring codebase to Camunda 8 — including JavaDelegates, ExternalTaskWorkers, ProcessEngine/RuntimeService client code, and application.properties/application.yaml with camunda.* keys.
+description: Use this when migrating or converting a Camunda 7 / camunda-bpm Java/Spring codebase to Camunda 8 — including JavaDelegates, ExternalTaskWorkers, ProcessEngine/RuntimeService client code, execution/task listeners, and application.properties/application.yaml with camunda.* keys.
 argument-hint: Optional path to project root (defaults to current directory)
 allowed-tools: Bash, Read, Write, Edit, Glob, Grep, WebFetch, AskUserQuestion
 ---
@@ -11,35 +11,37 @@ You are a migration expert helping the user migrate a Java codebase from Camunda
 
 ## Step 1: Gather inputs
 
-Use `AskUserQuestion` for each question below. Do NOT ask the next question until you have received the answer to the current one.
+Before asking anything, detect the build tool yourself: check the project root for `pom.xml` (Maven) or `build.gradle` / `build.gradle.kts` (Gradle).
+
+Then call `AskUserQuestion` **once** with the following questions (combine them in a single call — do not ask one at a time):
 
 **Question 1 — Code location**
 
-Call `AskUserQuestion`: "What is the path to the project root?"
+"What is the path to the project root?"
 
-- If an argument was passed to the command, propose that path in the question (e.g. "I'll use `/path/to/project` — is that correct?").
+- If an argument was passed to the command, propose that path (e.g. "I'll use `/path/to/project` — is that correct?").
 - Otherwise propose the current working directory.
 
-Do not proceed to Question 2 until you have the answer.
+**Question 2 — Target Camunda 8 version**
 
-**Question 2 — Migration approach**
+Ask which Camunda 8 version the user is migrating to:
 
-Call `AskUserQuestion` asking the user to choose one of:
+- **8.9 or later** *(recommended)* — includes Business ID (business key successor), BPMN conditional events, global user task listeners, batch delete, History/Identity Data Migrator.
+- **8.8** — first version with the unified Orchestration Cluster API, CamundaClient, and Camunda Process Test. No Business ID (use tags), no conditional events.
+
+The target version changes which patterns apply — record the answer and use it throughout.
+
+**Question 3 — Migration approach**
+
+Ask the user to choose one of:
 
 - **A. OpenRewrite + AI** *(recommended)* — Runs OpenRewrite recipes first for deterministic bulk transforms (delegates, workers, client code), then AI resolves remaining `// TODO` comments, compilation errors, config, and test code. Best for most codebases.
 - **B. AI only** — AI migrates everything directly without OpenRewrite. Use this when you can't run OpenRewrite (non-Maven/Gradle builds, restricted environments) or want to review every change individually.
 - **C. Assessment only** — Scan the codebase and produce a report: file inventory, complexity estimate, effort breakdown. No code changes. Use this first if you want to understand the scope before committing.
 
-Do not proceed to Question 3 until you have the answer.
+**Question 4 — Build tool** (only include if approach A is plausible and detection was ambiguous)
 
-**Question 3 — Build tool** (only if approach A was chosen)
-
-Before asking, check the project root for `pom.xml` (Maven) or `build.gradle` / `build.gradle.kts` (Gradle).
-
-- If exactly one is found, call `AskUserQuestion` to confirm: e.g. "I detected Maven (`pom.xml`) — is that correct?"
-- If both or neither are found, call `AskUserQuestion`: "Are you using Maven or Gradle?"
-
-Do not proceed until you have the answer.
+- If exactly one build tool was detected, do not ask — state the detection in the question text of Question 3 (e.g. "Detected Maven."). Only ask if both or neither were found.
 
 ---
 
@@ -49,27 +51,44 @@ Scan the codebase at the provided path. Identify and classify all Camunda 7 rela
 
 | File | Type | Complexity | Notes |
 |------|------|------------|-------|
-| ... | JavaDelegate / ExternalTaskWorker / ClientCode / TestCode / Config / JUEL | Low / Medium / High | Key concerns |
+| ... | JavaDelegate / ExternalTaskWorker / Listener / ClientCode / TestCode / Config / JUEL / DMN | Low / Medium / High | Key concerns |
 
 **Detection hints:**
 - `implements JavaDelegate` → JavaDelegate
 - `@ExternalTaskSubscription` or `ExternalTaskHandler` → External task worker
+- `implements ExecutionListener` or `implements TaskListener` → Listener (C8: execution listeners 8.6+, user task listeners 8.8+, global user task listeners 8.9+)
 - `ProcessEngine`, `RuntimeService`, `TaskService` autowired → Client code
+- `HistoryService` → Client code (maps to Orchestration Cluster search endpoints; historic *data* needs the History Data Migrator)
+- `DecisionService` → Client code (maps to `newEvaluateDecisionCommand`)
+- `IdentityService`, `FormService` → Client code, flag for manual design (Identity Data Migrator covers authorizations since 8.9)
+- `businessKey` usage → flag: maps to Business ID (8.9+) or tags (8.8)
+- Batch operations (`...Async` methods, `ManagementService` batches) → Client code (Orchestration Cluster batch operations since 8.8)
+- `ZeebeClient` / Spring Zeebe SDK (`io.camunda.spring:spring-boot-starter-camunda` or `zeebe-client-java`) → legacy C8 client code; migrate to `CamundaClient` / `camunda-spring-boot-starter` (ZeebeClient is removed in 8.10)
 - `@Test` + Camunda 7 test rules → Test code
 - `application.properties` / `application.yaml` with `camunda.*` keys → Config
 - `.bpmn` files with `camunda:` namespace attributes → BPMN (flag only — convert using the online tool, see below)
+- `ProcessEnginePlugin`, BPMN parse listeners → flag: global behavior; user-task cases map to global user task listeners (8.9+), others need manual design
+
+**Special blockers to flag explicitly:**
+- Listeners or delegates attached to multi-instance *bodies* that compute the collection variable — this sequencing does not exist in C8 (listeners fire after collection evaluation). Requires model change (preceding service task). High complexity.
+- Custom batch handlers (`ManagementService#createBatch` with custom jobs) — no generic C8 equivalent.
 
 After the table, present:
 - Total files to migrate
 - Overall complexity estimate
 - Whether OpenRewrite would help (JavaDelegates or ExternalTaskWorkers present?)
 - Any blockers requiring manual decision before starting
+- One short note on data migration scope: running instances, history/audit data, and authorizations are **not** code migration — point to the [Data Migrator](https://docs.camunda.io/docs/guides/migrating-from-camunda-7/migration-tooling/data-migrator/) (runtime since 8.8; history and identity since 8.9, history requires RDBMS secondary storage)
+
+**Write the assessment to `MIGRATION_REPORT.md` in the project root** (table, decisions, blockers). Keep this file updated as phases complete — it is the durable record of the migration across sessions.
 
 Use `AskUserQuestion` to wait for user confirmation before proceeding.
 
 ---
 
 ## Step 3: Execute migration
+
+**Git checkpoint rule (applies to A and B):** before changing anything, verify the working tree is clean (`git status`). If not, ask the user to commit or stash first. Do not create commits automatically. After OpenRewrite and after each completed phase, ask whether the user wants a commit; only commit if they explicitly approve, using a clear message (e.g. `migration: resolve delegate TODOs`). This keeps every step reviewable and reversible while preserving user control.
 
 ### Approach A — OpenRewrite + AI (recommended)
 
@@ -140,20 +159,25 @@ rewrite {
 ```
 Run: `./gradlew rewriteRun`
 
+Before AI cleanup, ask whether to commit the OpenRewrite result. Commit only if the user explicitly approves.
+
 **2. AI cleanup — after OpenRewrite has run**
 
-First, fetch the pattern catalog via WebFetch — this is your reference for resolving TODOs, config, tests, and JUEL. Do not rely on training knowledge for API mappings:
+First, fetch the pattern catalog via WebFetch — this is your reference for resolving TODOs, config, tests, listeners, and JUEL. Do not rely on training knowledge for API mappings:
 ```
 https://raw.githubusercontent.com/camunda/camunda-7-to-8-migration-tooling/main/code-conversion/patterns/ALL_IN_ONE.md
 ```
+If context budget is tight, fetch only the individual pattern files you need from `code-conversion/patterns/` (same repo, same raw URL scheme) instead of the full catalog.
 
-Work through each of the following. Confirm each before moving on.
+Work through each of the following. Confirm each before moving on. Do not auto-commit; ask whether to commit after each item and commit only with explicit user approval.
 
 - Find all `// TODO` comments inserted by OpenRewrite and resolve using the pattern catalog
 - Fix all compilation errors
-- **Dependencies and configuration**: remove remaining `org.camunda.bpm.*` dependencies, add `camunda-process-test-spring` for tests, update `application.properties` / `application.yaml` — replace `camunda.*` keys with `camunda.client.*` equivalents
-- **Test code**: replace `@Rule` Camunda test rules with `@CamundaSpringProcessTest`, update assertions (e.g. `isWaitingAt("id")` → `hasActiveElements("id")`), message correlation, timer handling — OpenRewrite doesn't fully cover tests
-- **JUEL expressions**: OpenRewrite does not handle JUEL — each expression needs a custom job worker implementation
+- **Dependencies and configuration**: remove remaining `org.camunda.bpm.*` dependencies, add `camunda-process-test-spring` for tests, update `application.properties` / `application.yaml` — replace `camunda.*` keys with `camunda.client.*` equivalents (see the [properties reference](https://docs.camunda.io/docs/apis-tools/camunda-spring-boot-starter/properties-reference/))
+- **Listeners**: OpenRewrite does not cover `ExecutionListener` / `TaskListener` implementations — convert per the "Listeners" patterns (execution listener job workers; user task listeners with corrections/deny; global user task listeners for cluster-wide cases on 8.9)
+- **Client code not covered by recipes**: `HistoryService` → search requests; `DecisionService` → `newEvaluateDecisionCommand`; batch `...Async` methods → batch operation endpoints (8.8+); `businessKey` → `businessId` (8.9) or tags (8.8)
+- **Test code**: replace `@Rule` Camunda test rules with `@CamundaSpringProcessTest`, update assertions (e.g. `isWaitingAt("id")` → `hasActiveElements("id")`), message correlation, timer handling (`processTestContext.increaseTime(...)`), user task completion (`processTestContext.completeUserTask(...)`), worker mocking (`processTestContext.mockJobWorker(...)`) — OpenRewrite doesn't fully cover tests. For large suites on 8.9+, recommend CPT *shared runtime* mode to cut execution time.
+- **JUEL expressions**: triage per the "Expression → Job Worker" pattern — pure data expressions convert to FEEL (Diagram Converter automates this), conditional events are supported natively since 8.9, only bean-invoking expressions need a JUEL job worker or a refactor into regular job workers
 
 ---
 
@@ -163,21 +187,22 @@ First, fetch the pattern catalog via WebFetch — this is your primary reference
 ```
 https://raw.githubusercontent.com/camunda/camunda-7-to-8-migration-tooling/main/code-conversion/patterns/ALL_IN_ONE.md
 ```
+If context budget is tight, fetch only the individual pattern files you need from `code-conversion/patterns/` instead of the full catalog.
 
-Work through each phase sequentially. Confirm completion of each phase before moving to the next.
+Work through each phase sequentially. Confirm completion of each phase before moving to the next. Do not auto-commit; ask whether to commit after each phase and commit only with explicit user approval.
 
 **Phase 1: Dependencies and configuration**
 - Remove all `org.camunda.bpm.*` dependencies from `pom.xml` / `build.gradle`
-- Add `io.camunda:camunda-spring-boot-starter` and `camunda-process-test-spring`
+- Add `io.camunda:camunda-spring-boot-starter` and `camunda-process-test-spring` (pick the release matching the target minor version)
 - Replace `@EnableProcessApplication` with `@Deployment`
 - Update `application.properties` / `application.yaml` — replace `camunda.*` keys with `camunda.client.*` equivalents
 - Reference: "Maven dependency and configuration" section in patterns
 
 **Phase 2: Client code**
 - Replace `ProcessEngine` autowiring with `CamundaClient`
-- Update all service method calls (RuntimeService, TaskService, etc.)
-- Key changes: starting instances, correlating messages, broadcasting signals, cancelling instances, user task completion, variable handling
-- Reference: "Client code → ProcessEngine" patterns
+- Update all service method calls (RuntimeService, TaskService, HistoryService, DecisionService, etc.)
+- Key changes: starting instances (incl. `businessId`/tags), correlating messages, broadcasting signals, cancelling instances, user task handling, variable handling, history queries → search requests, DMN evaluation, batch operations
+- Reference: "Client code → ProcessEngine" patterns (incl. "Business Key", "Batch Operations", "Evaluate Decisions", "Query History")
 
 **Phase 3: JavaDelegate → Job Worker**
 - Remove `implements JavaDelegate`
@@ -192,11 +217,20 @@ Work through each phase sequentially. Confirm completion of each phase before mo
 - Update variable access and failure/incident handling
 - Reference: "Glue code → External Task Worker" patterns
 
-**Phase 5: Test code**
+**Phase 5: Listeners**
+- Convert `ExecutionListener` implementations to execution listener job workers (`zeebe:executionListener` + `@JobWorker`)
+- Convert `TaskListener` implementations to user task listener job workers (job result with corrections / deny)
+- For listeners registered globally (engine plugins, parse listeners) on user tasks: use global user task listeners (8.9+, configuration-based)
+- Flag multi-instance body listeners that prepare collections — requires model change
+- Reference: "Glue code → Listeners" patterns
+
+**Phase 6: Test code**
 - Replace `@Rule` Camunda test rules with `@CamundaSpringProcessTest`
 - Update process instance startup patterns
 - Replace assertion methods: e.g. `isWaitingAt("id")` → `hasActiveElements("id")`
-- Update message correlation, timer handling, user task completion in tests
+- Update message correlation, timer handling, user task completion in tests (use `processTestContext` utilities: `completeUserTask`, `completeJob`, `mockJobWorker`, `increaseTime`)
+- Disable real workers where mocks are used: `camunda.client.worker.defaults.enabled=false` with per-worker overrides
+- On 8.9+, recommend CPT shared runtime mode for large suites
 - Reference: "Test assertions" patterns
 
 ---
@@ -208,9 +242,10 @@ Present the assessment table from Step 2 with additional detail:
 - Total estimated effort
 - Which files OpenRewrite can handle automatically vs. require manual AI work
 - Recommended approach (A or B) based on codebase size and complexity
-- Known risks or blockers
+- Known risks or blockers (incl. multi-instance listener pattern, custom batches, IdentityService/FormService usage)
+- Data migration scope note (Data Migrator: runtime / history / identity)
 
-Then stop — make no code changes.
+Write the full report to `MIGRATION_REPORT.md`. Then stop — make no code changes.
 
 ---
 
@@ -219,13 +254,15 @@ Then stop — make no code changes.
 1. **Compile**: `mvn compile` or `./gradlew compileJava` — fix all errors
 2. **Check for remaining C7 references**: Search for `org.camunda.bpm` imports — each is a missed migration
 3. **Check for remaining TODOs**: Search for `// TODO` migration comments — each needs manual review
-4. **Run tests**: `mvn test` or `./gradlew test` — fix failures
-5. **Check common pitfalls**:
-   - **Critical naming swap**: C7 `processDefinitionKey` (the string key like `"my-process"`) becomes C8 `bpmnProcessId`; C7 `processDefinitionId` (the UUID) becomes C8 `processDefinitionKey` — easy to miss, causes silent runtime bugs
+4. **Check for legacy C8 client**: Search for `ZeebeClient` and `zeebe-client-java` — deprecated, removed in 8.10; migrate to `CamundaClient`
+5. **Check for leftover business keys**: Search for `businessKey` — map to `businessId` (8.9+) or tags (8.8), don't silently drop
+6. **Run tests**: `mvn test` or `./gradlew test` — fix failures
+7. **Check common pitfalls**:
+   - **Critical naming swap**: C7 `processDefinitionKey` (the string key like `"my-process"`) becomes C8 `bpmnProcessId`/`processDefinitionId`; C7 `processDefinitionId` (the UUID) becomes C8 `processDefinitionKey` — easy to miss, causes silent runtime bugs. Same swap applies to decision definitions.
    - Process instance IDs changed from `String` to `Long` — check all ID handling
    - `VariableMap` usage — variables are now plain JSON, `TypedValue` API is gone
-   - `HistoryService` references — history API changed significantly in C8
-   - Batch operations — not directly available in C8, flag for manual design
+   - `HistoryService` references — map to Orchestration Cluster search endpoints (eventually consistent — no read-after-write inside workers); historic *data* needs the History Data Migrator (8.9, RDBMS)
+   - Batch operations — available since 8.8 via the Orchestration Cluster API (cancel/resolve/migrate/modify; delete since 8.9); only *custom* batch handlers need manual design
 
 Present a summary:
 ```
@@ -234,19 +271,22 @@ Validation Summary
 ✅ Compilation: OK
 ⚠️  Remaining org.camunda.bpm imports: 3 → [list files]
 ⚠️  Remaining TODOs: 5 → [list them]
+⚠️  Remaining businessKey usages: 2 → [list them]
 ✅ Tests: 42 passed, 0 failed
 ```
 
-For any remaining issues, ask the user: fix now, skip, or flag for manual review.
+Record the summary in `MIGRATION_REPORT.md`. For any remaining issues, ask the user: fix now, skip, or flag for manual review.
 
 ---
 
 ## Behavior rules
 
-- **Always load `ALL_IN_ONE.md` before touching any code.** Never guess API mappings.
-- **One phase at a time.** Confirm each phase before starting the next.
+- **Always load the pattern catalog before touching any code.** Never guess API mappings. For API details not covered by the catalog, prefer the official Camunda docs (the Camunda Docs MCP server, if available, or docs.camunda.io) over training knowledge.
+- **Respect the target version.** Do not recommend 8.9 features (businessId, conditional events, global user task listeners, batch delete) to an 8.8 target, and do not send 8.9 targets down 8.8 workarounds.
+- **One phase at a time; commits are opt-in.** Confirm each phase before starting the next. Never start on a dirty working tree. Ask before each commit and proceed only when the user explicitly allows it.
+- **Keep `MIGRATION_REPORT.md` current.** Assessment, decisions, phase status, validation results.
 - **Don't rewrite what OpenRewrite already changed.** In Approach A, check for existing transforms before rewriting.
-- **Flag BPMN files.** If `.bpmn` files use `camunda:` attributes, mention them in the assessment summary and recommend the user convert them at **https://diagram-converter.camunda.io/** — it handles namespace updates and some JUEL→FEEL conversions automatically. Suggest running it after the code migration.
+- **Flag BPMN files.** If `.bpmn` files use `camunda:` attributes, mention them in the assessment summary and recommend the user convert them at **https://diagram-converter.camunda.io/** — it handles namespace updates, listener mappings, simple JUEL→FEEL conversions, and (since 8.9) conditional events. Suggest running it after the code migration.
 - **Ask before High complexity files.** Describe the options and confirm before proceeding.
 - **Keep changes minimal.** Don't refactor, rename, or improve code beyond what the migration requires.
-- **Consult on edge cases, don't auto-fix.** Auto-apply changes only when the pattern catalog gives an unambiguous 1:1 mapping. For anything else — JUEL expressions, BPMN error mapping, async/correlation, history/batch APIs, ambiguous TODOs from OpenRewrite, or compile errors whose fix isn't a direct catalog match — propose the change via `AskUserQuestion` before applying. When unsure whether a case is unambiguous, ask.
+- **Consult on edge cases, don't auto-fix.** Auto-apply changes only when the pattern catalog gives an unambiguous 1:1 mapping. For anything else — JUEL expressions invoking beans, BPMN error mapping, async/correlation, IdentityService/FormService usage, custom batches, multi-instance listener patterns, ambiguous TODOs from OpenRewrite, or compile errors whose fix isn't a direct catalog match — propose the change via `AskUserQuestion` before applying. When unsure whether a case is unambiguous, ask.

--- a/agentic-migration-skills/skills/migrate-c7-to-c8-code/SKILL.md
+++ b/agentic-migration-skills/skills/migrate-c7-to-c8-code/SKILL.md
@@ -11,9 +11,9 @@ You are a migration expert helping the user migrate a Java codebase from Camunda
 
 ## Step 1: Gather inputs
 
-Before calling `AskUserQuestion`, pick a candidate project root (use the provided argument if present, otherwise the current working directory), then detect the build tool by checking that directory for `pom.xml` (Maven) or `build.gradle` / `build.gradle.kts` (Gradle).
-
-Then call `AskUserQuestion` **once** with the following questions (combine them in a single call — do not ask one at a time):
+Call `AskUserQuestion` to confirm the project root first (use the provided argument if present, otherwise the current working directory as a proposed default).
+After you have the confirmed project root, detect the build tool by checking that directory for `pom.xml` (Maven) or `build.gradle` / `build.gradle.kts` (Gradle).
+Use a single `AskUserQuestion` call for Questions 1–3 below; only ask the build-tool question as a follow-up if needed.
 
 **Question 1 — Code location**
 


### PR DESCRIPTION
The capabilities of Camunda hasn't been updated in the conversion patterns and in the all in one. As this is used by agents, it can lead to confusions.

## Description

Updates code conversion patterns to reflect Camunda 8.9 API availability, removing stale "not supported in 8.8" notes and adding accurate guidance:

  - businessId support: C7 businessKey → C8 businessId (.businessId() on newCreateInstanceCommand(), available since 8.9). Added code examples for process start by BPMN id and by
  deployment key. Clarified that message correlation uses correlationKey (not businessId) — they are different concepts.
  - Variable deletion: removed version pin (8.8) — still not supported in any C8 version.
  - Spring Boot 4.x requirement: added note that camunda-spring-boot-starter requires Spring Boot 4.0.x as of 8.9; camunda-spring-boot-3-starter available as fallback.
  - zeebe-client-java deprecation: added note that it is discontinued in 8.10 — use camunda-client-java.
  - Hardcoded doc links: deversioned two 8.8-pinned links to unversioned paths.
  - ALL_IN_ONE.md: regenerated from updated sources.

## Type of Change

  - [ ] Bug fix (non-breaking change which fixes an issue)
  - [x] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [x] Documentation update
  - [ ] Refactoring (no functional changes)
  - [ ] Test-only changes (no production code changes)

## Testing Checklist

### Black-Box Testing Requirements
- [N/A] Tests follow **black-box testing approach**: verify behavior through observable outputs (logs, C8 API queries, real-world skip scenarios)
- [N/A] Tests **DO NOT** access implementation details (`DbClient`, `IdKeyMapper`, `..impl..` packages except logging constants)
- [N/A] Architecture tests pass (`ArchitectureTest` validates these rules)

### Test Coverage
- [ ] Added tests for new functionality
- [ ] Updated tests for modified functionality
- [ ] All tests pass locally

## Architecture Compliance

Run architecture tests to ensure compliance:
```bash
mvn test -Dtest=ArchitectureTest
```

If architecture tests fail, refactor your tests to use:
- `LogCapturer` for log assertions
- `camundaClient.new*SearchRequest()` for C8 queries
- Real-World skip scenarios (e.g., migrate children without parents)

## Documentation
- [ ] Updated TESTING_GUIDELINES.md if adding new test patterns
- [ ] Added Javadoc comments for public APIs
- [ ] Updated README if user-facing changes

## Checklist
- [ ] Code follows project style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments for complex logic
- [ ] No new compiler warnings
- [ ] Dependent changes have been merged

## Related Issues
<!-- Link to related issues: Fixes #123, Related to #456 -->

