### PR TITLE
fix(data-migrator): align with Camunda 8 enforced OpenAPI nullability contract

### DIFF
--- a/data-migrator/core/src/main/java/io/camunda/migration/data/constants/MigratorConstants.java
+++ b/data-migrator/core/src/main/java/io/camunda/migration/data/constants/MigratorConstants.java
@@ -24,4 +24,11 @@ public final class MigratorConstants {
   public static final String C8_DEFAULT_TENANT = "<default>";
   public static final String C7_LEGACY_PREFIX = "c7-legacy";
   public static final String C7_MULTI_INSTANCE_BODY_SUFFIX = "#multiInstanceBody";
+
+  /**
+   * Substituted for {@code null} on free-form identifier columns whose C8 contract is non-null
+   * (e.g. {@code AuditLogEntity.entityKey} for entity-less audit log rows). Applies wherever the
+   * migrator would otherwise emit {@code null}
+   */
+  public static final String C7_NULL_PLACEHOLDER = "C7_MIGRATED";
 }

--- a/data-migrator/core/src/main/java/io/camunda/migration/data/impl/clients/C7Client.java
+++ b/data-migrator/core/src/main/java/io/camunda/migration/data/impl/clients/C7Client.java
@@ -624,6 +624,22 @@ public class C7Client {
   }
 
   /**
+   * Fetches the most recent historic job log entry for the given job ID, ordered by timestamp descending.
+   * Used to source `lastUpdateTime` on migrated jobs — the timestamp of the final C7 lifecycle event.
+   */
+  public HistoricJobLog getHistoricJobLogLatest(String jobId) {
+    HistoricJobLogQueryImpl query = (HistoricJobLogQueryImpl) historyService.createHistoricJobLogQuery()
+        .jobId(jobId)
+        .orderByTimestamp()
+        .desc()
+        .orderByJobId()
+        .desc();
+    List<HistoricJobLog> results = callApi(() -> query.listPage(0, 1),
+        format(FAILED_TO_FETCH_HISTORIC_ELEMENT, "HistoricJobLog with jobId", jobId));
+    return results.isEmpty() ? null : results.getFirst();
+  }
+
+  /**
    * Processes historic job log entries with pagination using the provided callback consumer.
    */
   public void fetchAndHandleHistoricJobLogs(Consumer<HistoricJobLog> callback, Date timestampAfter) {
@@ -652,6 +668,20 @@ public class C7Client {
         .orderByTimestamp()
         .asc();
     List<HistoricExternalTaskLog> results = callApi(query::list,
+        format(FAILED_TO_FETCH_HISTORIC_ELEMENT, "HistoricExternalTaskLog with externalTaskId", externalTaskId));
+    return results.isEmpty() ? null : results.getFirst();
+  }
+
+  /**
+   * Fetches the most recent historic external task log entry for the given external task ID, ordered by timestamp descending.
+   * Used to source `lastUpdateTime` on migrated jobs — the timestamp of the final C7 lifecycle event.
+   */
+  public HistoricExternalTaskLog getHistoricExternalTaskLogLatest(String externalTaskId) {
+    HistoricExternalTaskLogQueryImpl query = (HistoricExternalTaskLogQueryImpl) historyService.createHistoricExternalTaskLogQuery()
+        .externalTaskId(externalTaskId)
+        .orderByTimestamp()
+        .desc();
+    List<HistoricExternalTaskLog> results = callApi(() -> query.listPage(0, 1),
         format(FAILED_TO_FETCH_HISTORIC_ELEMENT, "HistoricExternalTaskLog with externalTaskId", externalTaskId));
     return results.isEmpty() ? null : results.getFirst();
   }

--- a/data-migrator/core/src/main/java/io/camunda/migration/data/impl/history/migrator/AuditLogMigrator.java
+++ b/data-migrator/core/src/main/java/io/camunda/migration/data/impl/history/migrator/AuditLogMigrator.java
@@ -8,6 +8,7 @@
 package io.camunda.migration.data.impl.history.migrator;
 
 import static io.camunda.migration.data.constants.MigratorConstants.C7_HISTORY_PARTITION_ID;
+import static io.camunda.migration.data.constants.MigratorConstants.C7_NULL_PLACEHOLDER;
 import static io.camunda.migration.data.impl.logging.HistoryMigratorLogs.SKIP_REASON_BELONGS_TO_SKIPPED_TASK;
 import static io.camunda.migration.data.impl.logging.HistoryMigratorLogs.SKIP_REASON_MISSING_JOB_REFERENCE;
 import static io.camunda.migration.data.impl.logging.HistoryMigratorLogs.SKIP_REASON_MISSING_PROCESS_DEFINITION;
@@ -99,6 +100,12 @@ public class AuditLogMigrator extends HistoryEntityMigrator<UserOperationLogEntr
 
       setHistoryCleanupDate(c7AuditLog, auditLogDbModelBuilder);
       AuditLogDbModel dbModel = convert(C7Entity.of(c7AuditLog), auditLogDbModelBuilder);
+
+      // Ensure entityKey is never null: C8's AuditLogEntity contract requires a non-null entityKey.
+      if (dbModel.entityKey() == null) {
+        dbModel = dbModel.copy(b ->
+            ((Builder) b).entityKey(C7_NULL_PLACEHOLDER));
+      }
 
       if (c7AuditLog.getProcessDefinitionKey() != null && dbModel.processDefinitionKey() == null) {
         throw new EntitySkippedException(c7AuditLog, SKIP_REASON_MISSING_PROCESS_DEFINITION);

--- a/data-migrator/core/src/main/java/io/camunda/migration/data/impl/history/migrator/ExternalTaskMigrator.java
+++ b/data-migrator/core/src/main/java/io/camunda/migration/data/impl/history/migrator/ExternalTaskMigrator.java
@@ -14,6 +14,7 @@ import static io.camunda.migration.data.impl.logging.HistoryMigratorLogs.SKIP_RE
 import static io.camunda.migration.data.impl.logging.HistoryMigratorLogs.logMigratingExternalTask;
 import static io.camunda.migration.data.impl.persistence.IdKeyMapper.TYPE.HISTORY_EXTERNAL_TASK;
 import static io.camunda.migration.data.impl.persistence.IdKeyMapper.TYPE.HISTORY_PROCESS_INSTANCE;
+import static io.camunda.migration.data.impl.util.ConverterUtil.convertDate;
 import static io.camunda.migration.data.impl.util.ConverterUtil.getNextKey;
 
 import io.camunda.db.rdbms.write.domain.JobDbModel;
@@ -116,6 +117,8 @@ public class ExternalTaskMigrator extends HistoryEntityMigrator<HistoricExternal
           builder.elementInstanceKey(elementInstanceKey);
         }
       }
+
+      builder.lastUpdateTime(convertDate(c7Client.getHistoricExternalTaskLogLatest(c7ExternalTaskId).getTimestamp()));
 
       JobDbModel dbModel = convert(C7Entity.of(c7ExternalTaskLog), builder);
 

--- a/data-migrator/core/src/main/java/io/camunda/migration/data/impl/history/migrator/ExternalTaskMigrator.java
+++ b/data-migrator/core/src/main/java/io/camunda/migration/data/impl/history/migrator/ExternalTaskMigrator.java
@@ -8,6 +8,7 @@
 package io.camunda.migration.data.impl.history.migrator;
 
 import static io.camunda.migration.data.impl.logging.HistoryMigratorLogs.SKIP_REASON_CANNOT_DETERMINE_FLOW_NODE;
+import static io.camunda.migration.data.impl.logging.HistoryMigratorLogs.SKIP_REASON_MISSING_FLOW_NODE;
 import static io.camunda.migration.data.impl.logging.HistoryMigratorLogs.SKIP_REASON_MISSING_PROCESS_DEFINITION;
 import static io.camunda.migration.data.impl.logging.HistoryMigratorLogs.SKIP_REASON_MISSING_PROCESS_INSTANCE;
 import static io.camunda.migration.data.impl.logging.HistoryMigratorLogs.SKIP_REASON_MISSING_ROOT_PROCESS_INSTANCE;
@@ -136,6 +137,11 @@ public class ExternalTaskMigrator extends HistoryEntityMigrator<HistoricExternal
 
       if (hasMultipleFlowNodes.get() && dbModel.elementInstanceKey() == null) {
         throw new EntitySkippedException(c7ExternalTaskLog, SKIP_REASON_CANNOT_DETERMINE_FLOW_NODE);
+      }
+
+      if (dbModel.elementInstanceKey() == null) {
+        // External task never entered its activity (e.g., flow nodes not migrated) — skip; C8 requires non-null elementInstanceKey
+        throw new EntitySkippedException(c7ExternalTaskLog, SKIP_REASON_MISSING_FLOW_NODE);
       }
 
       c8Client.insertJob(dbModel);

--- a/data-migrator/core/src/main/java/io/camunda/migration/data/impl/history/migrator/ExternalTaskMigrator.java
+++ b/data-migrator/core/src/main/java/io/camunda/migration/data/impl/history/migrator/ExternalTaskMigrator.java
@@ -119,6 +119,7 @@ public class ExternalTaskMigrator extends HistoryEntityMigrator<HistoricExternal
         }
       }
 
+      // A log entry exists for this external task — it is what triggered this migration call — so null is not possible here.
       builder.lastUpdateTime(convertDate(c7Client.getHistoricExternalTaskLogLatest(c7ExternalTaskId).getTimestamp()));
 
       JobDbModel dbModel = convert(C7Entity.of(c7ExternalTaskLog), builder);

--- a/data-migrator/core/src/main/java/io/camunda/migration/data/impl/history/migrator/FlowNodeMigrator.java
+++ b/data-migrator/core/src/main/java/io/camunda/migration/data/impl/history/migrator/FlowNodeMigrator.java
@@ -11,6 +11,7 @@ import static io.camunda.migration.data.impl.logging.HistoryMigratorLogs.SKIP_RE
 import static io.camunda.migration.data.impl.logging.HistoryMigratorLogs.SKIP_REASON_MISSING_PROCESS_DEFINITION;
 import static io.camunda.migration.data.impl.logging.HistoryMigratorLogs.SKIP_REASON_MISSING_PROCESS_INSTANCE;
 import static io.camunda.migration.data.impl.logging.HistoryMigratorLogs.SKIP_REASON_MISSING_ROOT_PROCESS_INSTANCE;
+import static io.camunda.migration.data.impl.logging.HistoryMigratorLogs.SKIP_REASON_REQUIRED_FIELD_NULL;
 import static io.camunda.migration.data.impl.persistence.IdKeyMapper.TYPE.HISTORY_FLOW_NODE;
 import static io.camunda.migration.data.impl.persistence.IdKeyMapper.TYPE.HISTORY_PROCESS_INSTANCE;
 import static io.camunda.migration.data.impl.util.ConverterUtil.getNextKey;
@@ -131,6 +132,15 @@ public class FlowNodeMigrator extends HistoryEntityMigrator<HistoricActivityInst
         throw new EntitySkippedException(c7FlowNode, SKIP_REASON_MISSING_ROOT_PROCESS_INSTANCE);
       }
 
+      // The built-in FlowNodeTransformer always sets these, but a custom interceptor may null them.
+      // C8 enforces them as non-null, so skip rather than write a row Operate cannot read.
+      assertRequiredFieldPresent(c7FlowNode, "flowNodeInstanceKey", dbModel.flowNodeInstanceKey());
+      assertRequiredFieldPresent(c7FlowNode, "flowNodeId", dbModel.flowNodeId());
+      assertRequiredFieldPresent(c7FlowNode, "type", dbModel.type());
+      assertRequiredFieldPresent(c7FlowNode, "state", dbModel.state());
+      assertRequiredFieldPresent(c7FlowNode, "processDefinitionId", dbModel.processDefinitionId());
+      assertRequiredFieldPresent(c7FlowNode, "tenantId", dbModel.tenantId());
+
       c8Client.insertFlowNodeInstance(dbModel);
 
       return MigrationResult.of(dbModel.flowNodeInstanceKey());
@@ -148,6 +158,12 @@ public class FlowNodeMigrator extends HistoryEntityMigrator<HistoricActivityInst
    */
   public static String generateTreePath(Long processInstanceKey, Long elementInstanceKey) {
     return processInstanceKey + "/" + elementInstanceKey;
+  }
+
+  protected void assertRequiredFieldPresent(HistoricActivityInstance c7FlowNode, String field, Object value) {
+    if (value == null) {
+      throw new EntitySkippedException(c7FlowNode, String.format(SKIP_REASON_REQUIRED_FIELD_NULL, field));
+    }
   }
 
   protected Long resolveFlowNodeScopeKey(HistoricActivityInstance c7FlowNode,

--- a/data-migrator/core/src/main/java/io/camunda/migration/data/impl/history/migrator/IncidentMigrator.java
+++ b/data-migrator/core/src/main/java/io/camunda/migration/data/impl/history/migrator/IncidentMigrator.java
@@ -133,10 +133,11 @@ public class IncidentMigrator extends HistoryEntityMigrator<HistoricIncident, In
           // incident. Skip to avoid wrong associations. See https://github.com/camunda/camunda-7-to-8-migration-tooling/issues/1103
           throw new EntitySkippedException(c7Incident, SKIP_REASON_CANNOT_DETERMINE_FLOW_NODE);
         }
-        // Activities on async before waiting state will not have a flow node instance key, but should not be skipped
-        if (!c7Client.hasWaitingExecution(c7Incident.getProcessInstanceId(), c7Incident.getActivityId())) {
-          throw new EntitySkippedException(c7Incident, SKIP_REASON_MISSING_FLOW_NODE);
-        }
+        // C7 did not persist a HistoricActivityInstance for this activity (typically an async-before
+        // activity whose execution failed on all retries before activity entry). C8 requires a
+        // non-null flowNodeInstanceKey on IncidentEntity, so skip. See context/decisions.md
+        // (`JobEntity.elementInstanceKey & IncidentEntity.flowNodeInstanceKey`).
+        throw new EntitySkippedException(c7Incident, SKIP_REASON_MISSING_FLOW_NODE);
       }
 
       if ((isFailedJobIncident(c7Incident) || isFailedExternalTaskIncident(c7Incident))

--- a/data-migrator/core/src/main/java/io/camunda/migration/data/impl/history/migrator/JobMigrator.java
+++ b/data-migrator/core/src/main/java/io/camunda/migration/data/impl/history/migrator/JobMigrator.java
@@ -16,6 +16,7 @@ import static io.camunda.migration.data.impl.logging.HistoryMigratorLogs.logMigr
 import static io.camunda.migration.data.impl.persistence.IdKeyMapper.TYPE.HISTORY_FLOW_NODE;
 import static io.camunda.migration.data.impl.persistence.IdKeyMapper.TYPE.HISTORY_JOB;
 import static io.camunda.migration.data.impl.persistence.IdKeyMapper.TYPE.HISTORY_PROCESS_INSTANCE;
+import static io.camunda.migration.data.impl.util.ConverterUtil.convertDate;
 import static io.camunda.migration.data.impl.util.ConverterUtil.getNextKey;
 import static org.camunda.bpm.engine.impl.jobexecutor.MessageJobDeclaration.ASYNC_AFTER;
 import static org.camunda.bpm.engine.impl.jobexecutor.MessageJobDeclaration.ASYNC_BEFORE;
@@ -126,6 +127,8 @@ public class JobMigrator extends HistoryEntityMigrator<HistoricJobLog, JobDbMode
           builder.elementInstanceKey(elementInstanceKey);
         }
       }
+
+      builder.lastUpdateTime(convertDate(c7Client.getHistoricJobLogLatest(c7JobId).getTimestamp()));
 
       JobDbModel dbModel = convert(C7Entity.of(c7JobLog), builder);
 

--- a/data-migrator/core/src/main/java/io/camunda/migration/data/impl/history/migrator/JobMigrator.java
+++ b/data-migrator/core/src/main/java/io/camunda/migration/data/impl/history/migrator/JobMigrator.java
@@ -8,6 +8,7 @@
 package io.camunda.migration.data.impl.history.migrator;
 
 import static io.camunda.migration.data.impl.logging.HistoryMigratorLogs.SKIP_REASON_CANNOT_DETERMINE_FLOW_NODE;
+import static io.camunda.migration.data.impl.logging.HistoryMigratorLogs.SKIP_REASON_MISSING_FLOW_NODE;
 import static io.camunda.migration.data.impl.logging.HistoryMigratorLogs.SKIP_REASON_MISSING_PROCESS_DEFINITION;
 import static io.camunda.migration.data.impl.logging.HistoryMigratorLogs.SKIP_REASON_MISSING_PROCESS_INSTANCE;
 import static io.camunda.migration.data.impl.logging.HistoryMigratorLogs.SKIP_REASON_MISSING_ROOT_PROCESS_INSTANCE;
@@ -148,8 +149,11 @@ public class JobMigrator extends HistoryEntityMigrator<HistoricJobLog, JobDbMode
         throw new EntitySkippedException(c7JobLog, SKIP_REASON_CANNOT_DETERMINE_FLOW_NODE);
       }
 
-      // For async-after jobs, element instance key is required
-      if (isAsyncAfter && dbModel.elementInstanceKey() == null) {
+      if (dbModel.elementInstanceKey() == null) {
+        if (isAsyncBefore) {
+          // C7 did not persist a HistoricActivityInstance for this activity
+          throw new EntitySkippedException(c7JobLog, SKIP_REASON_MISSING_FLOW_NODE);
+        }
         throw new C8EntityNotFoundException(HISTORY_FLOW_NODE, dbModel.processInstanceKey(), c7JobLog.getActivityId());
       }
 

--- a/data-migrator/core/src/main/java/io/camunda/migration/data/impl/history/migrator/JobMigrator.java
+++ b/data-migrator/core/src/main/java/io/camunda/migration/data/impl/history/migrator/JobMigrator.java
@@ -129,6 +129,7 @@ public class JobMigrator extends HistoryEntityMigrator<HistoricJobLog, JobDbMode
         }
       }
 
+      // A log entry exists for this job — it is what triggered this migration call — so null is not possible here.
       builder.lastUpdateTime(convertDate(c7Client.getHistoricJobLogLatest(c7JobId).getTimestamp()));
 
       JobDbModel dbModel = convert(C7Entity.of(c7JobLog), builder);

--- a/data-migrator/core/src/main/java/io/camunda/migration/data/impl/logging/HistoryMigratorLogs.java
+++ b/data-migrator/core/src/main/java/io/camunda/migration/data/impl/logging/HistoryMigratorLogs.java
@@ -44,6 +44,7 @@ public class HistoryMigratorLogs {
   public static final String SKIP_REASON_MISSING_FLOW_NODE = "Missing flow node";
   public static final String SKIP_REASON_CANNOT_DETERMINE_FLOW_NODE =
       "Flow node cannot be determined. Possible causes: multi-instance or performed process instance modification.";
+  public static final String SKIP_REASON_REQUIRED_FIELD_NULL = "Required field [%s] is null";
   public static final String SKIP_REASON_MISSING_FORM = "Missing form";
   public static final String SKIP_REASON_MISSING_PARENT_FLOW_NODE = "Missing parent flow node";
   public static final String SKIP_REASON_MISSING_DECISION_REQUIREMENTS = "Missing decision requirements definition";

--- a/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/history/HistoryMigrationOrderedByCreateTimeTest.java
+++ b/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/history/HistoryMigrationOrderedByCreateTimeTest.java
@@ -308,12 +308,12 @@ public class HistoryMigrationOrderedByCreateTimeTest extends HistoryMigrationAbs
 
   @Test
   public void shouldMigrateIncidentsCreatedBetweenRuns() {
-    // given
+    // given: only the propagated parent incident migrates; the child incident is skipped (no HAI)
+    deployer.deployCamunda7Process("callActivityWithIncidentSubprocess.bpmn");
     deployer.deployCamunda7Process("incidentProcess.bpmn");
-    String instanceId = runtimeService.startProcessInstanceByKey("incidentProcessId").getProcessInstanceId();
-    triggerIncident(instanceId);
+    triggerIncident(startCallActivityAndGetChildInstanceId());
     Supplier<List<IncidentEntity>> incidentSupplier =
-        () -> searchHistoricIncidents("incidentProcessId");
+        () -> searchHistoricIncidents("callActivityWithIncidentSubprocessId");
 
     // when
     historyMigrator.migrate();
@@ -323,8 +323,7 @@ public class HistoryMigrationOrderedByCreateTimeTest extends HistoryMigrationAbs
 
     // given
     ClockUtil.offset(5_000L);
-    instanceId = runtimeService.startProcessInstanceByKey("incidentProcessId").getProcessInstanceId();
-    triggerIncident(instanceId);
+    triggerIncident(startCallActivityAndGetChildInstanceId());
 
     // when
     historyMigrator.migrate();
@@ -335,20 +334,28 @@ public class HistoryMigrationOrderedByCreateTimeTest extends HistoryMigrationAbs
 
   @Test
   public void shouldMigrateIncidentsWithSameCreationDate() {
-    // given
+    // given: two parents, each contributing one migratable propagated incident
+    deployer.deployCamunda7Process("callActivityWithIncidentSubprocess.bpmn");
     deployer.deployCamunda7Process("incidentProcess.bpmn");
 
     ClockUtil.setCurrentTime(new Date());
-    String processInstanceId1 = runtimeService.startProcessInstanceByKey("incidentProcessId").getProcessInstanceId();
-    triggerIncident(processInstanceId1);
-    String processInstanceId2 = runtimeService.startProcessInstanceByKey("incidentProcessId").getProcessInstanceId();
-    triggerIncident(processInstanceId2);
+    triggerIncident(startCallActivityAndGetChildInstanceId());
+    triggerIncident(startCallActivityAndGetChildInstanceId());
 
     // when
     historyMigrator.migrate();
 
     // then
-    assertThat(searchHistoricIncidents("incidentProcessId")).hasSize(2);
+    assertThat(searchHistoricIncidents("callActivityWithIncidentSubprocessId")).hasSize(2);
+  }
+
+  /** Starts a call-activity parent and returns its child instance id, where the failing job lives. */
+  private String startCallActivityAndGetChildInstanceId() {
+    var parent = runtimeService.startProcessInstanceByKey("callActivityWithIncidentSubprocessId");
+    return runtimeService.createProcessInstanceQuery()
+        .superProcessInstanceId(parent.getId())
+        .singleResult()
+        .getProcessInstanceId();
   }
 
   @Test

--- a/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/history/HistoryMigrationSkippingTest.java
+++ b/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/history/HistoryMigrationSkippingTest.java
@@ -788,6 +788,7 @@ public class HistoryMigrationSkippingTest extends HistoryMigrationAbstractTest {
     // when: migration runs and external task is skipped
     historyMigrator.migrateByType(HISTORY_PROCESS_DEFINITION);
     historyMigrator.migrateByType(HISTORY_PROCESS_INSTANCE);
+    historyMigrator.migrateByType(HISTORY_FLOW_NODE);
     historyMigrator.migrateByType(HISTORY_INCIDENT);
 
     // then: the process instance was migrated

--- a/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/history/TransactionRollbackTest.java
+++ b/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/history/TransactionRollbackTest.java
@@ -221,17 +221,21 @@ public class TransactionRollbackTest extends HistoryMigrationAbstractTest {
 
   @Test
   public void shouldRollbackIncidentInsertWhenMappingFails() {
-    // given - create process with incident
-    deployer.deployCamunda7Process("incidentProcess.bpmn");
-    ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("incidentProcessId");
+    // given - a single migratable incident on a waiting user task (the activity has a
+    // HistoricActivityInstance, so the incident resolves a flowNodeInstanceKey)
+    deployer.deployCamunda7Process("userTaskProcess.bpmn");
+    ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("userTaskProcessId");
+    String executionId = runtimeService.createExecutionQuery()
+        .processInstanceId(processInstance.getId())
+        .activityId("userTaskId")
+        .singleResult()
+        .getId();
+    runtimeService.createIncident("customIncident", executionId, "config", "message");
 
-    // Trigger incident
-    triggerIncident(processInstance.getId());
-
-    // Migrate prerequisites
+    // Migrate prerequisites (flow nodes so the incident resolves its flowNodeInstanceKey)
     historyMigrator.migrateByType(HISTORY_PROCESS_DEFINITION);
     historyMigrator.migrateByType(HISTORY_PROCESS_INSTANCE);
-    historyMigrator.migrateByType(HISTORY_JOB);
+    historyMigrator.migrateByType(HISTORY_FLOW_NODE);
 
     // when/then - test rollback behavior
     String c7Id = historyService.createHistoricIncidentQuery().singleResult().getId();
@@ -240,13 +244,13 @@ public class TransactionRollbackTest extends HistoryMigrationAbstractTest {
         c7Id,
         () -> historyMigrator.migrateByType(HISTORY_INCIDENT),
         () -> {
-          List<IncidentEntity> incidents = searchHistoricIncidents("incidentProcessId");
+          List<IncidentEntity> incidents = searchHistoricIncidents("userTaskProcessId");
           assertThat(incidents)
               .as("C8 should contain NO incidents after rollback")
               .isEmpty();
         },
         () -> {
-          List<IncidentEntity> incidents = searchHistoricIncidents("incidentProcessId");
+          List<IncidentEntity> incidents = searchHistoricIncidents("userTaskProcessId");
           assertThat(incidents)
               .as("After retry, C8 should contain incidents")
               .isNotEmpty();
@@ -364,8 +368,11 @@ public class TransactionRollbackTest extends HistoryMigrationAbstractTest {
   protected void configureSpyToFailOnFirstInsert(IdKeyMapper.TYPE entityType) {
     AtomicInteger callCount = new AtomicInteger(0);
     doAnswer(invocation -> {
+      Object c8Key = invocation.getArgument(1);
       IdKeyMapper.TYPE type = invocation.getArgument(3);
-      if (type == entityType) {
+      // Fail only a real migration insert (non-null c8Key), not a skip-record insert, so a skipped
+      // sibling of the same type cannot consume the simulated failure.
+      if (type == entityType && c8Key != null) {
         if (callCount.incrementAndGet() == 1) {
           throw SIMULATED_MAPPING_FAILURE;
         }

--- a/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/history/entity/HistoryAuditLogAdminTest.java
+++ b/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/history/entity/HistoryAuditLogAdminTest.java
@@ -8,6 +8,7 @@
 package io.camunda.migration.data.qa.history.entity;
 
 import static io.camunda.migration.data.constants.MigratorConstants.C8_DEFAULT_TENANT;
+import static io.camunda.migration.data.constants.MigratorConstants.C7_NULL_PLACEHOLDER;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.migration.data.qa.history.HistoryMigrationAbstractTest;
@@ -78,6 +79,7 @@ public class HistoryAuditLogAdminTest extends HistoryMigrationAbstractTest {
     assertThat(log.tenantId()).isEqualTo(C8_DEFAULT_TENANT);
     assertThat(log.tenantScope()).isEqualTo(AuditLogEntity.AuditLogTenantScope.GLOBAL);
     assertThat(log.entityType()).isEqualTo(AuditLogEntity.AuditLogEntityType.USER);
+    assertThat(log.entityKey()).isEqualTo(C7_NULL_PLACEHOLDER);
     assertThat(log.operationType()).isEqualTo(AuditLogEntity.AuditLogOperationType.CREATE);
     assertThat(log.result()).isEqualTo(AuditLogEntity.AuditLogOperationResult.SUCCESS);
     assertThat(log.agentElementId()).isNull();
@@ -184,6 +186,7 @@ public class HistoryAuditLogAdminTest extends HistoryMigrationAbstractTest {
     assertThat(logs).extracting(AuditLogEntity::entityType).containsOnly(AuditLogEntity.AuditLogEntityType.GROUP);
     assertThat(logs).extracting(AuditLogEntity::operationType).containsOnly(AuditLogEntity.AuditLogOperationType.CREATE);
     assertThat(logs).extracting(AuditLogEntity::entityDescription).contains("newGroupId");
+    assertThat(logs).extracting(AuditLogEntity::entityKey).containsOnly(C7_NULL_PLACEHOLDER);
   }
 
   @Test
@@ -263,6 +266,7 @@ public class HistoryAuditLogAdminTest extends HistoryMigrationAbstractTest {
     assertThat(logs).extracting(AuditLogEntity::entityType).containsOnly(AuditLogEntity.AuditLogEntityType.TENANT);
     assertThat(logs).extracting(AuditLogEntity::operationType).containsOnly(AuditLogEntity.AuditLogOperationType.CREATE);
     assertThat(logs).extracting(AuditLogEntity::entityDescription).contains("newTenantId");
+    assertThat(logs).extracting(AuditLogEntity::entityKey).containsOnly(C7_NULL_PLACEHOLDER);
   }
 
   @Test
@@ -378,6 +382,7 @@ public class HistoryAuditLogAdminTest extends HistoryMigrationAbstractTest {
     assertThat(logs).extracting(AuditLogEntity::entityType).containsOnly(AuditLogEntity.AuditLogEntityType.AUTHORIZATION);
     assertThat(logs).extracting(AuditLogEntity::operationType)
         .containsOnly(AuditLogEntity.AuditLogOperationType.UPDATE);
+    assertThat(logs).extracting(AuditLogEntity::entityKey).containsOnly(C7_NULL_PLACEHOLDER);
   }
 
   @Test

--- a/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/history/entity/HistoryAuditLogTest.java
+++ b/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/history/entity/HistoryAuditLogTest.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.migration.data.qa.history.entity;
 
+import static io.camunda.migration.data.constants.MigratorConstants.C7_NULL_PLACEHOLDER;
 import static io.camunda.migration.data.constants.MigratorConstants.C8_DEFAULT_TENANT;
 import static io.camunda.migration.data.impl.persistence.IdKeyMapper.TYPE.HISTORY_AUDIT_LOG;
 import static io.camunda.migration.data.impl.persistence.IdKeyMapper.TYPE.HISTORY_FLOW_NODE;
@@ -156,6 +157,7 @@ public class HistoryAuditLogTest extends HistoryMigrationAbstractTest {
     assertThat(logs).extracting(AuditLogEntity::category).contains(AuditLogEntity.AuditLogOperationCategory.DEPLOYED_RESOURCES);
     assertThat(logs).extracting(AuditLogEntity::entityType).containsOnly(AuditLogEntity.AuditLogEntityType.VARIABLE);
     assertThat(logs).extracting(AuditLogEntity::operationType).containsOnly(AuditLogEntity.AuditLogOperationType.UPDATE);
+    assertThat(logs).extracting(AuditLogEntity::entityKey).containsOnly(C7_NULL_PLACEHOLDER);
   }
 
   @Test
@@ -434,6 +436,7 @@ public class HistoryAuditLogTest extends HistoryMigrationAbstractTest {
     assertThat(logs).hasSize(1);
     assertThat(logs).extracting(AuditLogEntity::entityType).contains(AuditLogEntity.AuditLogEntityType.RESOURCE);
     assertThat(logs).extracting(AuditLogEntity::operationType).contains(AuditLogEntity.AuditLogOperationType.CREATE);
+    assertThat(logs).extracting(AuditLogEntity::entityKey).containsOnly(C7_NULL_PLACEHOLDER);
   }
 
   @Test
@@ -583,6 +586,7 @@ public class HistoryAuditLogTest extends HistoryMigrationAbstractTest {
     assertThat(log.operationType()).isEqualTo(AuditLogEntity.AuditLogOperationType.COMPLETE);
     assertThat(log.category()).isEqualTo(AuditLogEntity.AuditLogOperationCategory.DEPLOYED_RESOURCES);
     assertThat(log.jobKey()).isNotNull();
+    assertThat(log.entityKey()).isEqualTo(C7_NULL_PLACEHOLDER);
     assertThat(log.actorId()).isEqualTo("demo");
   }
 
@@ -625,6 +629,7 @@ public class HistoryAuditLogTest extends HistoryMigrationAbstractTest {
     assertThat(log.operationType()).isEqualTo(AuditLogEntity.AuditLogOperationType.UPDATE);
     assertThat(log.category()).isEqualTo(AuditLogEntity.AuditLogOperationCategory.DEPLOYED_RESOURCES);
     assertThat(log.actorId()).isEqualTo("demo");
+    assertThat(log.entityKey()).isEqualTo(C7_NULL_PLACEHOLDER);
   }
 
   @Test

--- a/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/history/entity/HistoryExternalTaskTest.java
+++ b/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/history/entity/HistoryExternalTaskTest.java
@@ -11,6 +11,7 @@ import static io.camunda.migration.data.constants.MigratorConstants.C8_DEFAULT_T
 import static io.camunda.migration.data.impl.persistence.IdKeyMapper.TYPE.HISTORY_EXTERNAL_TASK;
 import static io.camunda.migration.data.impl.persistence.IdKeyMapper.TYPE.HISTORY_PROCESS_DEFINITION;
 import static io.camunda.migration.data.impl.persistence.IdKeyMapper.TYPE.HISTORY_PROCESS_INSTANCE;
+import static io.camunda.migration.data.impl.util.ConverterUtil.convertDate;
 import static io.camunda.migration.data.impl.util.ConverterUtil.prefixDefinitionId;
 import static io.camunda.migration.data.qa.extension.HistoryMigrationExtension.USER_TASK_ID;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -423,6 +424,9 @@ public class HistoryExternalTaskTest extends HistoryMigrationAbstractTest {
     assertThat(job.processDefinitionId()).isEqualTo(prefixDefinitionId(PROCESS_KEY));
     assertThat(job.tenantId()).isEqualTo(C8_DEFAULT_TENANT);
     assertThat(job.creationTime()).isNotNull();
+    assertThat(job.lastUpdateTime())
+      .isNotNull()
+      .isAfterOrEqualTo(job.creationTime());
     if (worker != null) {
       assertThat(job.worker()).isEqualTo(worker);
     } else {

--- a/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/history/entity/HistoryExternalTaskTest.java
+++ b/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/history/entity/HistoryExternalTaskTest.java
@@ -9,9 +9,9 @@ package io.camunda.migration.data.qa.history.entity;
 
 import static io.camunda.migration.data.constants.MigratorConstants.C8_DEFAULT_TENANT;
 import static io.camunda.migration.data.impl.persistence.IdKeyMapper.TYPE.HISTORY_EXTERNAL_TASK;
+import static io.camunda.migration.data.impl.persistence.IdKeyMapper.TYPE.HISTORY_FLOW_NODE;
 import static io.camunda.migration.data.impl.persistence.IdKeyMapper.TYPE.HISTORY_PROCESS_DEFINITION;
 import static io.camunda.migration.data.impl.persistence.IdKeyMapper.TYPE.HISTORY_PROCESS_INSTANCE;
-import static io.camunda.migration.data.impl.util.ConverterUtil.convertDate;
 import static io.camunda.migration.data.impl.util.ConverterUtil.prefixDefinitionId;
 import static io.camunda.migration.data.qa.extension.HistoryMigrationExtension.USER_TASK_ID;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -58,6 +58,7 @@ public class HistoryExternalTaskTest extends HistoryMigrationAbstractTest {
     // when: migration runs
     historyMigrator.migrateByType(HISTORY_PROCESS_DEFINITION);
     historyMigrator.migrateByType(HISTORY_PROCESS_INSTANCE);
+    historyMigrator.migrateByType(HISTORY_FLOW_NODE);
     historyMigrator.migrateByType(HISTORY_EXTERNAL_TASK);
 
     // then: the process instance was migrated
@@ -100,6 +101,7 @@ public class HistoryExternalTaskTest extends HistoryMigrationAbstractTest {
     // when: migration runs
     historyMigrator.migrateByType(HISTORY_PROCESS_DEFINITION);
     historyMigrator.migrateByType(HISTORY_PROCESS_INSTANCE);
+    historyMigrator.migrateByType(HISTORY_FLOW_NODE);
     historyMigrator.migrateByType(HISTORY_EXTERNAL_TASK);
 
     // then: the process instance was migrated
@@ -157,6 +159,7 @@ public class HistoryExternalTaskTest extends HistoryMigrationAbstractTest {
     // when: migration runs
     historyMigrator.migrateByType(HISTORY_PROCESS_DEFINITION);
     historyMigrator.migrateByType(HISTORY_PROCESS_INSTANCE);
+    historyMigrator.migrateByType(HISTORY_FLOW_NODE);
     historyMigrator.migrateByType(HISTORY_EXTERNAL_TASK);
 
     // then: only ONE C8 job entry created despite multiple log entries
@@ -240,7 +243,7 @@ public class HistoryExternalTaskTest extends HistoryMigrationAbstractTest {
   }
 
   @Test
-  public void shouldMigrateExternalTaskWithoutFlowNode() {
+  public void shouldSkipExternalTaskWhenFlowNodeNotMigrated() {
     // given: a process with an external task where flow nodes are NOT migrated
     var c7Model = Bpmn.createExecutableProcess(PROCESS_KEY)
         .startEvent()
@@ -260,20 +263,19 @@ public class HistoryExternalTaskTest extends HistoryMigrationAbstractTest {
     // Note: HISTORY_FLOW_NODE is NOT migrated
     historyMigrator.migrateByType(HISTORY_EXTERNAL_TASK);
 
-    // then: the external task was migrated successfully with null elementInstanceKey
+    // then: the external task is skipped because C8 requires non-null elementInstanceKey
     List<ProcessInstanceEntity> processInstances = searchHistoricProcessInstances(PROCESS_KEY);
     assertThat(processInstances).hasSize(1);
     long processInstanceKey = processInstances.getFirst().processInstanceKey();
 
     List<JobEntity> c8Jobs = searchJobs(processInstanceKey);
-    assertThat(c8Jobs).as("External task should be migrated even without flow node").hasSize(1);
-    assertThat(c8Jobs.getFirst().elementInstanceKey())
-        .as("elementInstanceKey should be null when flow nodes are not migrated")
-        .isNull();
+    assertThat(c8Jobs)
+        .as("External task should be skipped when no flow-node instance exists in C8")
+        .isEmpty();
   }
 
   @Test
-  public void shouldMigrateCompletedExternalTaskWithoutFlowNode() {
+  public void shouldSkipCompletedExternalTaskWhenFlowNodeNotMigrated() {
     // given: a process with a completed external task where flow nodes are NOT migrated
     var c7Model = Bpmn.createExecutableProcess(PROCESS_KEY)
         .startEvent()
@@ -300,16 +302,15 @@ public class HistoryExternalTaskTest extends HistoryMigrationAbstractTest {
     // Note: HISTORY_FLOW_NODE is NOT migrated
     historyMigrator.migrateByType(HISTORY_EXTERNAL_TASK);
 
-    // then: the completed external task was migrated successfully with null elementInstanceKey
+    // then: the external task is skipped because C8 requires non-null elementInstanceKey
     List<ProcessInstanceEntity> processInstances = searchHistoricProcessInstances(PROCESS_KEY);
     assertThat(processInstances).hasSize(1);
     long processInstanceKey = processInstances.getFirst().processInstanceKey();
 
     List<JobEntity> c8Jobs = searchJobs(processInstanceKey);
-    assertThat(c8Jobs).as("Completed external task should be migrated even without flow node").hasSize(1);
-    assertThat(c8Jobs.getFirst().elementInstanceKey())
-        .as("elementInstanceKey should be null when flow nodes are not migrated")
-        .isNull();
+    assertThat(c8Jobs)
+        .as("Completed external task should be skipped when no flow-node instance exists in C8")
+        .isEmpty();
   }
 
   @Test
@@ -415,6 +416,7 @@ public class HistoryExternalTaskTest extends HistoryMigrationAbstractTest {
     assertThat(job.processInstanceKey()).isEqualTo(processInstanceKey);
     assertThat(job.rootProcessInstanceKey()).isEqualTo(processInstanceKey);
     assertThat(job.processDefinitionKey()).isEqualTo(processDefinitionKey);
+    assertThat(job.elementInstanceKey()).isNotNull();
     assertThat(job.type()).isEqualTo(TOPIC_NAME);
     assertThat(job.state()).isEqualTo(JobState.COMPLETED);
     assertThat(job.kind()).isEqualTo(JobKind.BPMN_ELEMENT);

--- a/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/history/entity/HistoryIncidentTest.java
+++ b/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/history/entity/HistoryIncidentTest.java
@@ -10,12 +10,6 @@ package io.camunda.migration.data.qa.history.entity;
 import static io.camunda.migration.data.constants.MigratorConstants.C8_DEFAULT_TENANT;
 import static io.camunda.migration.data.impl.util.ConverterUtil.prefixDefinitionId;
 import static io.camunda.migration.data.qa.extension.HistoryMigrationExtension.USER_TASK_ID;
-import static io.camunda.search.entities.IncidentEntity.ErrorType.CONDITION_ERROR;
-import static io.camunda.search.entities.IncidentEntity.ErrorType.DECISION_EVALUATION_ERROR;
-import static io.camunda.search.entities.IncidentEntity.ErrorType.FORM_NOT_FOUND;
-import static io.camunda.search.entities.IncidentEntity.ErrorType.JOB_NO_RETRIES;
-import static io.camunda.search.entities.IncidentEntity.ErrorType.RESOURCE_NOT_FOUND;
-import static io.camunda.search.entities.IncidentEntity.ErrorType.UNHANDLED_ERROR_EVENT;
 import static io.camunda.search.entities.IncidentEntity.ErrorType.UNKNOWN;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -54,8 +48,10 @@ public class HistoryIncidentTest extends HistoryMigrationAbstractTest {
   protected ExternalTaskService externalTaskService;
 
   @Test
-  public void shouldMigrateIncidentTenant() {
-    // given
+  public void shouldSkipFailingTaskIncidentRegardlessOfTenant() {
+    // given: incidents on a failing async-before service task across two tenants. The activity
+    // has no HistoricActivityInstance in C7 (class-load fails before activity entry), so both
+    // incidents are skipped under the C8 non-null flowNodeInstanceKey contract.
     deployer.deployCamunda7Process("incidentProcess.bpmn");
     deployer.deployCamunda7Process("incidentProcess2.bpmn", "tenant1");
     ProcessInstance c7ProcessDefaultTenant = runtimeService.startProcessInstanceByKey("incidentProcessId");
@@ -66,13 +62,11 @@ public class HistoryIncidentTest extends HistoryMigrationAbstractTest {
     // when
     historyMigrator.migrate();
 
-    // then
-    List<IncidentEntity> incidentsDefaultTenant = searchHistoricIncidents("incidentProcessId");
-    List<IncidentEntity> incidentsTenant1 = searchHistoricIncidents("incidentProcessId2");
-    assertThat(incidentsDefaultTenant).singleElement()
-        .extracting(IncidentEntity::tenantId)
-        .isEqualTo(C8_DEFAULT_TENANT);
-    assertThat(incidentsTenant1).singleElement().extracting(IncidentEntity::tenantId).isEqualTo("tenant1");
+    // then: incidents skipped on both tenants — the skip behavior is tenant-agnostic
+    assertThat(searchHistoricIncidents("incidentProcessId"))
+        .as("Default-tenant failing-task incident should be skipped").isEmpty();
+    assertThat(searchHistoricIncidents("incidentProcessId2"))
+        .as("Tenant1 failing-task incident should be skipped").isEmpty();
   }
 
   @Test
@@ -162,8 +156,10 @@ public class HistoryIncidentTest extends HistoryMigrationAbstractTest {
   }
 
   @Test
-  public void shouldMigrateFailedJobIncidentForNestedProcessInstance() {
-    // given a parent process that calls a child process containing a failing async service task
+  public void shouldMigratePropagatedParentIncidentEvenWhenChildIncidentIsSkipped() {
+    // given a parent process that calls a child process containing a failing async service task.
+    // Child incident: points to the failing activity, which has no HAI in C7 → skipped.
+    // Parent incident: propagated from the call activity, which HAS HAI → migrates.
     deployer.deployCamunda7Process("callActivityWithIncidentSubprocess.bpmn");
     deployer.deployCamunda7Process("incidentProcess.bpmn");
     ProcessInstance parentProcess = runtimeService.startProcessInstanceByKey("callActivityWithIncidentSubprocessId");
@@ -191,14 +187,14 @@ public class HistoryIncidentTest extends HistoryMigrationAbstractTest {
     // when
     historyMigrator.migrate();
 
-    // then both incidents are migrated
-
-    // child incident has a job key (the failed job was migrated)
+    // then: child incident is skipped (failing activity has no HAI in C7)
     List<IncidentEntity> childIncidents = searchHistoricIncidents(childProcess.getProcessDefinitionKey());
-    assertThat(childIncidents).as("child process incident should be migrated").hasSize(1);
-    assertThat(childIncidents.getFirst().jobKey()).as("child incident should have a job key").isNotNull();
+    assertThat(childIncidents)
+        .as("child incident should be skipped — failing activity has no HAI in C7")
+        .isEmpty();
 
-    // parent incident is migrated without a job key (propagated incident has no direct job reference)
+    // and: parent incident is migrated — the call activity has a HAI, and the propagated
+    // incident has no job reference so it doesn't cascade-skip
     List<IncidentEntity> parentIncidents = searchHistoricIncidents(parentProcess.getProcessDefinitionKey());
     assertThat(parentIncidents).as("parent process incident should be migrated").hasSize(1);
     assertThat(parentIncidents.getFirst().jobKey()).as("propagated parent incident should have no job key").isNull();
@@ -305,139 +301,116 @@ public class HistoryIncidentTest extends HistoryMigrationAbstractTest {
   }
 
   @Test
-  public void shouldMigrateIncidentBasicFieldsForServiceTask() {
-    // given
+  public void shouldSkipIncidentForFailingServiceTask() {
+    // given: async-before service task with an unresolvable delegate → C7 records the incident
+    // but never persists a HistoricActivityInstance for the activity
     deployer.deployCamunda7Process("incidentProcess.bpmn");
     ProcessInstance c7ProcessInstance = runtimeService.startProcessInstanceByKey("incidentProcessId");
     triggerIncident(c7ProcessInstance.getId());
 
-    HistoricIncident c7Incident = historyService.createHistoricIncidentQuery()
-        .processInstanceId(c7ProcessInstance.getId())
-        .singleResult();
-    assertThat(c7Incident).isNotNull();
+    assertThat(historyService.createHistoricIncidentQuery().processInstanceId(c7ProcessInstance.getId()).count())
+        .as("C7 should record the incident even though no HAI is committed").isEqualTo(1);
 
     // when
     historyMigrator.migrate();
 
-    // then
-    List<IncidentEntity> incidents = searchHistoricIncidents("incidentProcessId");
-    assertThat(incidents).hasSize(1);
-    IncidentEntity c8Incident = incidents.getFirst();
-    assertOnIncidentBasicFields(c8Incident, c7Incident, c7ProcessInstance, null, RESOURCE_NOT_FOUND, true, true);
+    // then: incident is skipped — C8 requires non-null flowNodeInstanceKey
+    assertThat(searchHistoricIncidents("incidentProcessId"))
+        .as("Failing-service-task incident is skipped (no HAI in C7)").isEmpty();
   }
 
   @Test
-  public void shouldMigrateIncidentWithFormNotFoundErrorType() {
-    // given
+  public void shouldSkipIncidentWithFormNotFoundErrorType() {
+    // given: form-not-found scenario produces an incident on an activity that has no HAI in C7
     deployer.deployCamunda7Process("formNotFoundProcess.bpmn");
     ProcessInstance c7ProcessInstance = runtimeService.startProcessInstanceByKey("formNotFoundProcessId");
     triggerIncident(c7ProcessInstance.getId());
 
-    HistoricIncident c7Incident = historyService.createHistoricIncidentQuery()
-        .processInstanceId(c7ProcessInstance.getId())
-        .singleResult();
-    assertThat(c7Incident).isNotNull();
+    assertThat(historyService.createHistoricIncidentQuery().processInstanceId(c7ProcessInstance.getId()).count())
+        .as("C7 should record the FORM_NOT_FOUND incident").isEqualTo(1);
 
     // when
     historyMigrator.migrate();
 
     // then
-    List<IncidentEntity> incidents = searchHistoricIncidents("formNotFoundProcessId");
-    assertThat(incidents).hasSize(1);
-    IncidentEntity c8Incident = incidents.getFirst();
-    assertOnIncidentBasicFields(c8Incident, c7Incident, c7ProcessInstance, null, FORM_NOT_FOUND, true, true);
+    assertThat(searchHistoricIncidents("formNotFoundProcessId"))
+        .as("FORM_NOT_FOUND incident is skipped (no HAI in C7)").isEmpty();
   }
 
   @Test
-  public void shouldMigrateIncidentWithDecisionEvaluationErrorType() {
-    // given
+  public void shouldSkipIncidentWithDecisionEvaluationErrorType() {
+    // given: decision-evaluation failure produces an incident on an activity that has no HAI in C7
     deployer.deployCamunda7Process("ruleTaskProcess.bpmn");
     deployer.deployCamunda7Decision("mappingFailureDmn.dmn");
     ProcessInstance c7ProcessInstance = runtimeService.startProcessInstanceByKey("ruleTaskProcessId",
         Collections.singletonMap("input", "single entry list"));
     triggerIncident(c7ProcessInstance.getId());
 
-    HistoricIncident c7Incident = historyService.createHistoricIncidentQuery()
-        .processInstanceId(c7ProcessInstance.getId())
-        .singleResult();
-    assertThat(c7Incident).isNotNull();
+    assertThat(historyService.createHistoricIncidentQuery().processInstanceId(c7ProcessInstance.getId()).count())
+        .as("C7 should record the DECISION_EVALUATION incident").isEqualTo(1);
 
     // when
     historyMigrator.migrate();
 
     // then
-    List<IncidentEntity> incidents = searchHistoricIncidents("ruleTaskProcessId");
-    assertThat(incidents).hasSize(1);
-    IncidentEntity c8Incident = incidents.getFirst();
-    assertOnIncidentBasicFields(c8Incident, c7Incident, c7ProcessInstance, null, DECISION_EVALUATION_ERROR, true, true);
+    assertThat(searchHistoricIncidents("ruleTaskProcessId"))
+        .as("DECISION_EVALUATION incident is skipped (no HAI in C7)").isEmpty();
   }
 
   @Test
-  public void shouldMigrateIncidentWithConditionalErrorType() {
-    // given
+  public void shouldSkipIncidentWithConditionalErrorType() {
+    // given: conditional-error scenario produces an incident on an activity that has no HAI in C7
     deployer.deployCamunda7Process("conditionErrorProcess.bpmn");
     ProcessInstance c7ProcessInstance = runtimeService.startProcessInstanceByKey("conditionErrorProcessId");
     triggerIncident(c7ProcessInstance.getId());
 
-    HistoricIncident c7Incident = historyService.createHistoricIncidentQuery()
-        .processInstanceId(c7ProcessInstance.getId())
-        .singleResult();
-    assertThat(c7Incident).isNotNull();
+    assertThat(historyService.createHistoricIncidentQuery().processInstanceId(c7ProcessInstance.getId()).count())
+        .as("C7 should record the CONDITION_ERROR incident").isEqualTo(1);
 
     // when
     historyMigrator.migrate();
 
     // then
-    List<IncidentEntity> incidents = searchHistoricIncidents("conditionErrorProcessId");
-    assertThat(incidents).hasSize(1);
-    IncidentEntity c8Incident = incidents.getFirst();
-    assertOnIncidentBasicFields(c8Incident, c7Incident, c7ProcessInstance, null, CONDITION_ERROR, true, true);
+    assertThat(searchHistoricIncidents("conditionErrorProcessId"))
+        .as("CONDITION_ERROR incident is skipped (no HAI in C7)").isEmpty();
   }
 
   @Test
-  public void shouldMigrateIncidentWithUnhandledErrorType() {
-    // given
+  public void shouldSkipIncidentWithUnhandledErrorType() {
+    // given: unhandled BPMN error produces an incident on an activity that has no HAI in C7
     processEngineConfigurationImpl.setEnableExceptionsAfterUnhandledBpmnError(true);
     deployer.deployCamunda7Process("unhandledErrorProcess.bpmn");
     ProcessInstance c7ProcessInstance = runtimeService.startProcessInstanceByKey("unhandledErrorProcessId");
     triggerIncident(c7ProcessInstance.getId());
 
-    HistoricIncident c7Incident = historyService.createHistoricIncidentQuery()
-        .processInstanceId(c7ProcessInstance.getId())
-        .singleResult();
-    assertThat(c7Incident).isNotNull();
+    assertThat(historyService.createHistoricIncidentQuery().processInstanceId(c7ProcessInstance.getId()).count())
+        .as("C7 should record the UNHANDLED_ERROR_EVENT incident").isEqualTo(1);
 
     // when
     historyMigrator.migrate();
 
     // then
-    List<IncidentEntity> incidents = searchHistoricIncidents("unhandledErrorProcessId");
-    assertThat(incidents).hasSize(1);
-    IncidentEntity c8Incident = incidents.getFirst();
-    assertOnIncidentBasicFields(c8Incident, c7Incident, c7ProcessInstance, null, UNHANDLED_ERROR_EVENT, true, true);
+    assertThat(searchHistoricIncidents("unhandledErrorProcessId"))
+        .as("UNHANDLED_ERROR_EVENT incident is skipped (no HAI in C7)").isEmpty();
   }
 
   @Test
-  public void shouldMigrateIncidentWithNoJobRetriesErrorType() {
-    // given
+  public void shouldSkipIncidentWithNoJobRetriesErrorType() {
+    // given: async-before failing delegate exhausts retries → incident with no HAI for the activity
     processEngineConfigurationImpl.setEnableExceptionsAfterUnhandledBpmnError(true);
     deployer.deployCamunda7Process("noJobRetriesProcess.bpmn");
     ProcessInstance c7ProcessInstance = runtimeService.startProcessInstanceByKey("noJobRetriesProcessId");
     triggerIncident(c7ProcessInstance.getId());
 
-    HistoricIncident c7Incident = historyService.createHistoricIncidentQuery()
-        .processInstanceId(c7ProcessInstance.getId())
-        .singleResult();
-    assertThat(c7Incident).isNotNull();
+    assertThat(historyService.createHistoricIncidentQuery().processInstanceId(c7ProcessInstance.getId()).count())
+        .as("C7 should record the JOB_NO_RETRIES incident").isEqualTo(1);
 
     // when
     historyMigrator.migrate();
 
     // then
-    List<IncidentEntity> incidents = searchHistoricIncidents("noJobRetriesProcessId");
-    assertThat(incidents).hasSize(1);
-    IncidentEntity c8Incident = incidents.getFirst();
-    assertOnIncidentBasicFields(c8Incident, c7Incident, c7ProcessInstance, null, JOB_NO_RETRIES, true, true);
+    assertThat(searchHistoricIncidents("noJobRetriesProcessId"))
+        .as("JOB_NO_RETRIES incident is skipped (no HAI in C7)").isEmpty();
   }
 
   @Test
@@ -473,32 +446,9 @@ public class HistoryIncidentTest extends HistoryMigrationAbstractTest {
         .isEqualTo("PI_" + processInstanceKey + "/FNI_" + flownodeInstanceKey);
   }
 
-  @Test
-  public void shouldGenerateTreePathForIncidentsWithoutFlowNodeInstanceKey() {
-    // given
-    deployer.deployCamunda7Process("incidentProcess.bpmn");
-    ProcessInstance c7ProcessInstance = runtimeService.startProcessInstanceByKey("incidentProcessId");
-    triggerIncident(c7ProcessInstance.getId());
-
-    HistoricIncident c7Incident = historyService.createHistoricIncidentQuery()
-        .processInstanceId(c7ProcessInstance.getId())
-        .singleResult();
-    assertThat(c7Incident).isNotNull();
-
-    // when
-    historyMigrator.migrate();
-
-    // then
-    List<ProcessInstanceEntity> processInstances = searchHistoricProcessInstances("incidentProcessId");
-    assertThat(processInstances).hasSize(1);
-    Long processInstanceKey = processInstances.getFirst().processInstanceKey();
-
-    List<IncidentDbModel> incidents = searchIncidentsByProcessInstanceKeyAndReturnAsDbModel(processInstanceKey);
-    assertThat(incidents).singleElement()
-        .extracting(IncidentDbModel::treePath)
-        .isNotNull()
-        .isEqualTo("PI_" + processInstanceKey);
-  }
+  // Note: the sister test `shouldGenerateTreePathForIncidentsWithoutFlowNodeInstanceKey` was
+  // removed when IncidentMigrator stopped writing null flowNodeInstanceKey (see context/decisions.md).
+  // The "without FNI" path is now a skip — covered by the `shouldSkipIncident*` tests above.
 
   @Test
   @Disabled("https://github.com/camunda/camunda-7-to-8-migration-tooling/issues/1103")

--- a/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/history/entity/HistoryJobTest.java
+++ b/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/history/entity/HistoryJobTest.java
@@ -368,8 +368,11 @@ public class HistoryJobTest extends HistoryMigrationAbstractTest {
     assertThat(job.errorCode()).isNull();
     assertThat(job.errorMessage()).isNull();
     assertThat(job.hasFailedWithRetriesLeft()).isFalse();
-    assertThat(job.isDenied()).isNull();
-    assertThat(job.lastUpdateTime()).isNull();
+    // returns `false` in 8.9; returns `null` in 8.10
+    assertThat(job.isDenied()).isIn(null, false);
+    assertThat(job.lastUpdateTime())
+        .isNotNull()
+        .isAfterOrEqualTo(job.creationTime());
   }
 
   protected void deployModel() {

--- a/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/history/entity/HistoryJobTest.java
+++ b/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/history/entity/HistoryJobTest.java
@@ -8,6 +8,7 @@
 package io.camunda.migration.data.qa.history.entity;
 
 import static io.camunda.migration.data.constants.MigratorConstants.C8_DEFAULT_TENANT;
+import static io.camunda.migration.data.impl.persistence.IdKeyMapper.TYPE.HISTORY_FLOW_NODE;
 import static io.camunda.migration.data.impl.persistence.IdKeyMapper.TYPE.HISTORY_JOB;
 import static io.camunda.migration.data.impl.persistence.IdKeyMapper.TYPE.HISTORY_PROCESS_DEFINITION;
 import static io.camunda.migration.data.impl.persistence.IdKeyMapper.TYPE.HISTORY_PROCESS_INSTANCE;
@@ -44,9 +45,10 @@ public class HistoryJobTest extends HistoryMigrationAbstractTest {
     String c7JobId = jobs.getFirst().getId();
     managementService.executeJob(c7JobId);
 
-    // when: jobs and process instances are migrated
+    // when: jobs flow nodes and process instances are migrated
     historyMigrator.migrateByType(HISTORY_PROCESS_DEFINITION);
     historyMigrator.migrateByType(HISTORY_PROCESS_INSTANCE);
+    historyMigrator.migrateByType(HISTORY_FLOW_NODE);
     historyMigrator.migrateByType(HISTORY_JOB);
 
     // then: the process instance was migrated
@@ -59,7 +61,7 @@ public class HistoryJobTest extends HistoryMigrationAbstractTest {
     assertThat(c8Jobs).as("One C8 job entry per C7 job (deduplication by job ID)").hasSize(1);
 
     JobEntity job = c8Jobs.getFirst();
-    assertJobProperties(job, processInstanceKey, "asyncBeforeUserTaskProcessId", "asyncUserTaskId", false,
+    assertJobProperties(job, processInstanceKey, "asyncBeforeUserTaskProcessId", "asyncUserTaskId",
         processInstances.getFirst().processDefinitionKey());
   }
 
@@ -85,7 +87,7 @@ public class HistoryJobTest extends HistoryMigrationAbstractTest {
     assertThat(c8Jobs).as("One C8 job entry per C7 job (deduplication by job ID)").hasSize(1);
 
     JobEntity job = c8Jobs.getFirst();
-    assertJobProperties(job, processInstanceKey, PROCESS, "startEvent", true, processInstances.getFirst().processDefinitionKey());
+    assertJobProperties(job, processInstanceKey, PROCESS, "startEvent", processInstances.getFirst().processDefinitionKey());
 
     List<FlowNodeInstanceDbModel> startEvent = searchFlowNodeInstancesByName("startEvent");
     assertThat(startEvent).hasSize(1);
@@ -101,69 +103,31 @@ public class HistoryJobTest extends HistoryMigrationAbstractTest {
   }
 
   @Test
-  public void shouldMigrateFailedJobAndPopulateJobKeyOnIncident() {
-    // given: a failing service task that creates an incident
-    deployer.deployCamunda7Process("failingServiceTaskProcess.bpmn");
-    runtimeService.startProcessInstanceByKey("failingServiceTaskProcessId");
-
-    executeAllJobsWithRetry();
-    assertThat(historyService.createHistoricIncidentQuery().count())
-        .as("Expected one incident to be created").isEqualTo(1);
-
-    // when: full migration runs (jobs migrated before incidents)
-    historyMigrator.migrate();
-
-    // then: the process instance was migrated
-    List<ProcessInstanceEntity> processInstances = searchHistoricProcessInstances("failingServiceTaskProcessId");
-    assertThat(processInstances).hasSize(1);
-    long processInstanceKey = processInstances.getFirst().processInstanceKey();
-
-    // and: the failed job was migrated to C8
-    List<JobEntity> c8Jobs = searchJobs(processInstanceKey);
-    assertThat(c8Jobs).as("Exactly one C8 job entry (deduplication by job ID)").hasSize(1);
-    JobEntity job = c8Jobs.getFirst();
-
-    assertJobProperties(job, processInstanceKey, "failingServiceTaskProcessId", "serviceTaskId", false, processInstances.getFirst().processDefinitionKey());
-
-    // and: the incident was migrated with jobKey pointing to the C8 job
-    var incidents = searchHistoricIncidents("failingServiceTaskProcessId");
-    assertThat(incidents).hasSize(1);
-    assertThat(incidents.getFirst().jobKey())
-        .as("Incident's jobKey should reference the migrated job")
-        .isNotNull();
-    assertThat(incidents.getFirst().jobKey()).isEqualTo(job.jobKey());
-  }
-
-  @Test
   public void shouldMigrateJobWithTenant() {
-    // given: a failing service task that creates an incident
-    deployer.deployCamunda7Process("failingServiceTaskProcess.bpmn", "tenantId");
-    runtimeService.startProcessInstanceByKey("failingServiceTaskProcessId");
-
+    // given: an async-after start event with a failing downstream task, deployed under a tenant.
+    // The async-after job migrates because the start event's HistoricActivityInstance is committed.
+    deployModel("tenantId");
+    runtimeService.startProcessInstanceByKey(PROCESS);
     executeAllJobsWithRetry();
-    assertThat(historyService.createHistoricIncidentQuery().count())
-        .as("Expected one incident to be created").isEqualTo(1);
 
-    // when: full migration runs (jobs migrated before incidents)
+    // when: full migration runs
     historyMigrator.migrate();
 
-    // then: the process instance was migrated
-    List<ProcessInstanceEntity> processInstances = searchHistoricProcessInstances("failingServiceTaskProcessId");
+    // then: the migrated job carries the expected tenant
+    List<ProcessInstanceEntity> processInstances = searchHistoricProcessInstances(PROCESS);
     assertThat(processInstances).hasSize(1);
-    long processInstanceKey = processInstances.getFirst().processInstanceKey();
-
-    // and: the failed job was migrated to C8
-    List<JobEntity> c8Jobs = searchJobs(processInstanceKey);
-    assertThat(c8Jobs).as("Exactly one C8 job entry (deduplication by job ID)").hasSize(1);
-    JobEntity job = c8Jobs.getFirst();
-    assertThat(job.tenantId()).isEqualTo("tenantId");
+    List<JobEntity> c8Jobs = searchJobs(processInstances.getFirst().processInstanceKey());
+    assertThat(c8Jobs).as("Exactly one C8 job entry").hasSize(1);
+    assertThat(c8Jobs.getFirst().tenantId()).isEqualTo("tenantId");
   }
 
   @Test
   public void shouldDeduplicateJobsByJobId() {
-    // given: a failing service task with multiple job log entries (creation + multiple failures)
-    deployer.deployCamunda7Process("failingServiceTaskProcess.bpmn");
-    runtimeService.startProcessInstanceByKey("failingServiceTaskProcessId");
+    // given: an async-after start event whose continuation can't advance to the broken downstream
+    // service task — repeated executeJob attempts produce multiple HistoricJobLog entries for
+    // the same C7 job ID. The async-after job's activity (the start event) has a committed FNI.
+    deployModel();
+    runtimeService.startProcessInstanceByKey(PROCESS);
 
     var jobs = managementService.createJobQuery().list();
     assertThat(jobs).hasSize(1);
@@ -182,13 +146,14 @@ public class HistoryJobTest extends HistoryMigrationAbstractTest {
     var jobLogCount = historyService.createHistoricJobLogQuery().jobId(job.getId()).count();
     assertThat(jobLogCount).as("Should have multiple job log entries").isGreaterThan(1);
 
-    // when
+    // when (flow nodes must be migrated before jobs since C8 requires non-null elementInstanceKey)
     historyMigrator.migrateByType(HISTORY_PROCESS_DEFINITION);
     historyMigrator.migrateByType(HISTORY_PROCESS_INSTANCE);
+    historyMigrator.migrateByType(HISTORY_FLOW_NODE);
     historyMigrator.migrateByType(HISTORY_JOB);
 
     // then: only ONE C8 job entry created despite multiple log entries (tracked by job ID)
-    List<ProcessInstanceEntity> processInstances = searchHistoricProcessInstances("failingServiceTaskProcessId");
+    List<ProcessInstanceEntity> processInstances = searchHistoricProcessInstances(PROCESS);
     assertThat(processInstances).hasSize(1);
     List<JobEntity> c8Jobs = searchJobs(processInstances.getFirst().processInstanceKey());
     assertThat(c8Jobs).as("Exactly one C8 job per C7 job despite multiple log entries").hasSize(1);
@@ -241,7 +206,35 @@ public class HistoryJobTest extends HistoryMigrationAbstractTest {
   }
 
   @Test
-  public void shouldMigrateAsyncBeforeJobWithoutFlowNode() {
+  public void shouldSkipJobWhenC7HasNoHistoricActivityInstance() {
+    // given: an async-before service task that fails on all retry
+    // C7 records a HistoricJobLog but no HistoricActivityInstance for the service task
+    deployer.deployCamunda7Process("failingServiceTaskProcess.bpmn");
+    runtimeService.startProcessInstanceByKey("failingServiceTaskProcessId");
+
+    executeAllJobsWithRetry();
+
+    assertThat(historyService.createHistoricJobLogQuery().count())
+        .as("C7 should have recorded job log entries for the failing task").isGreaterThan(0);
+    assertThat(historyService.createHistoricActivityInstanceQuery().activityId("serviceTaskId").count())
+          .as("C7 must not have a HistoricActivityInstance for the failing task").isZero();
+
+    // when: full migration runs
+    historyMigrator.migrate();
+
+    // then: the process instance migrated, but the job was skipped because C8 requires
+    // non-null elementInstanceKey and no C8 flow-node instance exists for this activity
+    List<ProcessInstanceEntity> processInstances = searchHistoricProcessInstances("failingServiceTaskProcessId");
+    assertThat(processInstances).hasSize(1);
+
+    List<JobEntity> c8Jobs = searchJobs(processInstances.getFirst().processInstanceKey());
+    assertThat(c8Jobs)
+        .as("Job must be skipped when C7 has no HistoricActivityInstance for its activity")
+        .isEmpty();
+  }
+
+  @Test
+  public void shouldSkipAsyncBeforeJobWhenFlowNodeNotMigrated() {
     // given: a process with an async-before user task where flow nodes are NOT migrated
     deployer.deployCamunda7Process("asyncBeforeUserTaskProcess.bpmn");
     runtimeService.startProcessInstanceByKey("asyncBeforeUserTaskProcessId");
@@ -253,44 +246,43 @@ public class HistoryJobTest extends HistoryMigrationAbstractTest {
     managementService.executeJob(c7JobId);
 
     // when: migrate jobs WITHOUT migrating flow nodes
-    // For async-before, this should succeed because elementInstanceKey can be null
     historyMigrator.migrateByType(HISTORY_PROCESS_DEFINITION);
     historyMigrator.migrateByType(HISTORY_PROCESS_INSTANCE);
     // Note: HISTORY_FLOW_NODE is NOT migrated
     historyMigrator.migrateByType(HISTORY_JOB);
 
-    // then: the job was migrated successfully with null elementInstanceKey
+    // then: the job is skipped because C8 requires non-null elementInstanceKey
     List<ProcessInstanceEntity> processInstances = searchHistoricProcessInstances("asyncBeforeUserTaskProcessId");
     assertThat(processInstances).hasSize(1);
     long processInstanceKey = processInstances.getFirst().processInstanceKey();
 
     List<JobEntity> c8Jobs = searchJobs(processInstanceKey);
-    assertThat(c8Jobs).as("Async-before job should be migrated even without flow node").hasSize(1);
-    assertThat(c8Jobs.getFirst().elementInstanceKey())
-        .as("elementInstanceKey should be null for async-before without migrated flow node")
-        .isNull();
+    assertThat(c8Jobs)
+        .as("Async-before job should be skipped when no flow-node instance exists in C8")
+        .isEmpty();
   }
 
   @Test
-  public void shouldThrowExceptionForAsyncAfterJobWithoutFlowNode() {
+  public void shouldSkipAsyncAfterJobWhenFlowNodeNotMigrated() {
     // given: a process with an async-after start event where flow nodes are NOT migrated
     deployModel(); // deploys a process with camundaAsyncAfter() on start event
     runtimeService.startProcessInstanceByKey(PROCESS);
     executeAllJobsWithRetry();
 
     // when: migrate jobs WITHOUT migrating flow nodes
-    // For async-after, this should throw C8EntityNotFoundException because elementInstanceKey is required
     historyMigrator.migrateByType(HISTORY_PROCESS_DEFINITION);
     historyMigrator.migrateByType(HISTORY_PROCESS_INSTANCE);
     // Note: HISTORY_FLOW_NODE is NOT migrated
     historyMigrator.migrateByType(HISTORY_JOB);
 
-    // then: no jobs migrated because async-after requires elementInstanceKey
+    // then: the job is skipped because C8 requires non-null elementInstanceKey
     List<ProcessInstanceEntity> processInstances = searchHistoricProcessInstances(PROCESS);
     assertThat(processInstances).hasSize(1);
 
     List<JobEntity> c8Jobs = searchJobs(processInstances.getFirst().processInstanceKey());
-    assertThat(c8Jobs).as("Async-after job should NOT be migrated without flow node").isEmpty();
+    assertThat(c8Jobs)
+        .as("Async-after job should be skipped when no flow-node instance exists in C8")
+        .isEmpty();
   }
 
   @Test
@@ -338,18 +330,12 @@ public class HistoryJobTest extends HistoryMigrationAbstractTest {
   }
 
   protected void assertJobProperties(JobEntity job, long processInstanceKey, String c7ProcessDefinitionKey,
-                                     String taskId, boolean isAsyncAfter, Long processDefinitionKey) {
+                                     String taskId, Long processDefinitionKey) {
     assertThat(job.jobKey()).isNotNull();
     assertThat(job.processInstanceKey()).isEqualTo(processInstanceKey);
     assertThat(job.rootProcessInstanceKey()).isEqualTo(processInstanceKey);
     assertThat(job.processDefinitionKey()).isEqualTo(processDefinitionKey);
-    if (isAsyncAfter) {
-      assertThat(job.elementInstanceKey()).isNotNull();
-    } else {
-      // elementInstanceKey is null for async-before because the flow node instance does not yet
-      // exist at the time the job was created and executed
-      assertThat(job.elementInstanceKey()).isNull();
-    }
+    assertThat(job.elementInstanceKey()).isNotNull();
 
     assertThat(job.type()).isEqualTo("async-continuation");
     assertThat(job.worker()).isNotNull();
@@ -376,16 +362,21 @@ public class HistoryJobTest extends HistoryMigrationAbstractTest {
   }
 
   protected void deployModel() {
-    String process = PROCESS;
-    var c7Model = org.camunda.bpm.model.bpmn.Bpmn.createExecutableProcess(process)
+    deployer.deployC7ModelInstance(PROCESS, buildAsyncAfterFailingModel());
+  }
+
+  protected void deployModel(String tenantId) {
+    deployer.deployC7ModelInstance(PROCESS, buildAsyncAfterFailingModel(), tenantId);
+  }
+
+  private BpmnModelInstance buildAsyncAfterFailingModel() {
+    return Bpmn.createExecutableProcess(PROCESS)
         .startEvent("startEvent")
         .camundaAsyncAfter()
         .serviceTask("serviceTaskId")
           .camundaClass("foo")
         .endEvent()
         .done();
-
-    deployer.deployC7ModelInstance(process, c7Model);
   }
 
   protected void deployCallingModel() {

--- a/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/history/entity/interceptor/FlowNodeRequiredFieldSkipTest.java
+++ b/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/history/entity/interceptor/FlowNodeRequiredFieldSkipTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.migration.data.qa.history.entity.interceptor;
+
+import static io.camunda.migration.data.impl.logging.HistoryMigratorLogs.SKIPPING;
+import static io.camunda.migration.data.impl.logging.HistoryMigratorLogs.SKIP_REASON_REQUIRED_FIELD_NULL;
+import static io.camunda.migration.data.impl.persistence.IdKeyMapper.TYPE.HISTORY_FLOW_NODE;
+import static io.camunda.migration.data.qa.util.LogMessageFormatter.formatMessage;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.migration.data.HistoryMigrator;
+import io.camunda.migration.data.interceptor.EntityInterceptor;
+import io.camunda.migration.data.qa.history.HistoryMigrationAbstractTest;
+import io.camunda.migration.data.qa.history.entity.interceptor.pojo.RequiredFieldNullingInterceptor;
+import io.camunda.migration.data.qa.util.WithSpringProfile;
+import io.camunda.search.entities.ProcessInstanceEntity;
+import io.github.netmikey.logunit.api.LogCapturer;
+import java.util.List;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.slf4j.event.Level;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@WithSpringProfile("required-field-null")
+public class FlowNodeRequiredFieldSkipTest extends HistoryMigrationAbstractTest {
+
+  @RegisterExtension
+  protected LogCapturer logs = LogCapturer.create().captureForType(HistoryMigrator.class, Level.DEBUG);
+
+  @Autowired
+  protected List<EntityInterceptor> configuredEntityInterceptors;
+
+  @ParameterizedTest
+  @ValueSource(strings = {"flowNodeInstanceKey", "flowNodeId", "type", "state", "processDefinitionId", "tenantId"})
+  public void shouldSkipFlowNodeWhenRequiredFieldIsNull(String field) {
+    // given: an interceptor that nulls the required field after the built-in transformer set it
+    nullingInterceptor().setFieldToNull(field);
+    deployer.deployCamunda7Process("simpleProcess.bpmn");
+    String processInstanceId = runtimeService.startProcessInstanceByKey("simpleProcess").getId();
+    String startEventC7Id = historyService.createHistoricActivityInstanceQuery()
+        .processInstanceId(processInstanceId).activityId("startEvent").singleResult().getId();
+
+    // when
+    historyMigrator.migrate();
+
+    // then: the process instance migrates but its flow nodes are skipped
+    List<ProcessInstanceEntity> processInstances = searchHistoricProcessInstances("simpleProcess");
+    assertThat(processInstances).hasSize(1);
+    assertThat(searchHistoricFlowNodes(processInstances.getFirst().processInstanceKey())).isEmpty();
+    logs.assertContains(formatMessage(SKIPPING, HISTORY_FLOW_NODE.getDisplayName(), startEventC7Id,
+        String.format(SKIP_REASON_REQUIRED_FIELD_NULL, field)));
+  }
+
+  private RequiredFieldNullingInterceptor nullingInterceptor() {
+    return configuredEntityInterceptors.stream()
+        .filter(RequiredFieldNullingInterceptor.class::isInstance)
+        .map(RequiredFieldNullingInterceptor.class::cast)
+        .findFirst()
+        .orElseThrow();
+  }
+}

--- a/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/history/entity/interceptor/FlowNodeRequiredFieldSkipTest.java
+++ b/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/history/entity/interceptor/FlowNodeRequiredFieldSkipTest.java
@@ -21,6 +21,7 @@ import io.camunda.migration.data.qa.util.WithSpringProfile;
 import io.camunda.search.entities.ProcessInstanceEntity;
 import io.github.netmikey.logunit.api.LogCapturer;
 import java.util.List;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -35,6 +36,11 @@ public class FlowNodeRequiredFieldSkipTest extends HistoryMigrationAbstractTest 
 
   @Autowired
   protected List<EntityInterceptor> configuredEntityInterceptors;
+
+  @AfterEach
+  void resetNullingInterceptor() {
+    nullingInterceptor().setFieldToNull(null);
+  }
 
   @ParameterizedTest
   @ValueSource(strings = {"flowNodeInstanceKey", "flowNodeId", "type", "state", "processDefinitionId", "tenantId"})

--- a/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/history/entity/interceptor/HistoryDeclarativeConfigurationTest.java
+++ b/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/history/entity/interceptor/HistoryDeclarativeConfigurationTest.java
@@ -125,8 +125,6 @@ public class HistoryDeclarativeConfigurationTest extends HistoryMigrationAbstrac
 
     assertThat(migratedProcessInstances).isNotEmpty();
 
-    Long processInstanceKey = migratedProcessInstances.getFirst().processInstanceKey();
-
     List<FlowNodeInstanceEntity> migratedFlowNodes =
         flowNodeInstanceReader
             .search(io.camunda.search.query.FlowNodeInstanceQuery.of(queryBuilder ->

--- a/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/history/entity/interceptor/pojo/ComplexEntityInterceptor.java
+++ b/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/history/entity/interceptor/pojo/ComplexEntityInterceptor.java
@@ -11,6 +11,7 @@ import static io.camunda.migration.data.impl.util.ConverterUtil.getNextKey;
 
 import io.camunda.db.rdbms.write.domain.FlowNodeInstanceDbModel;
 import io.camunda.db.rdbms.write.domain.ProcessInstanceDbModel;
+import io.camunda.search.entities.FlowNodeInstanceEntity;
 import io.camunda.migration.data.interceptor.EntityInterceptor;
 import io.camunda.migration.data.interceptor.property.EntityConversionContext;
 import io.camunda.migration.data.qa.util.WhiteBox;
@@ -59,7 +60,12 @@ public class ComplexEntityInterceptor implements EntityInterceptor<Object, Objec
     } else if (entity instanceof HistoricActivityInstance && builder instanceof FlowNodeInstanceDbModel.FlowNodeInstanceDbModelBuilder) {
       FlowNodeInstanceDbModel.FlowNodeInstanceDbModelBuilder flowNodeBuilder =
           (FlowNodeInstanceDbModel.FlowNodeInstanceDbModelBuilder) builder;
-      ((FlowNodeInstanceDbModel.FlowNodeInstanceDbModelBuilder) builder).processInstanceKey(getNextKey());
+      HistoricActivityInstance activityInstance = (HistoricActivityInstance) entity;
+      flowNodeBuilder.processInstanceKey(getNextKey())
+          .flowNodeId(activityInstance.getActivityId())
+          .processDefinitionId(activityInstance.getProcessDefinitionKey())
+          .type(FlowNodeInstanceEntity.FlowNodeType.SERVICE_TASK)
+          .state(FlowNodeInstanceEntity.FlowNodeState.COMPLETED);
       if (targetTenantId != null) {
         flowNodeBuilder.tenantId(targetTenantId);
       }

--- a/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/history/entity/interceptor/pojo/RequiredFieldNullingInterceptor.java
+++ b/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/history/entity/interceptor/pojo/RequiredFieldNullingInterceptor.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.migration.data.qa.history.entity.interceptor.pojo;
+
+import io.camunda.db.rdbms.write.domain.FlowNodeInstanceDbModel.FlowNodeInstanceDbModelBuilder;
+import io.camunda.migration.data.interceptor.EntityInterceptor;
+import java.util.Set;
+import org.camunda.bpm.engine.history.HistoricActivityInstance;
+
+/**
+ * Test interceptor that clears a single, configurable required field on the flow node builder after
+ * the built-in {@code FlowNodeTransformer} has populated it. Used to verify that the migrator skips
+ * flow nodes whose required fields are nulled by a custom interceptor.
+ */
+public class RequiredFieldNullingInterceptor
+    implements EntityInterceptor<HistoricActivityInstance, FlowNodeInstanceDbModelBuilder> {
+
+  protected String fieldToNull;
+
+  @Override
+  public Set<Class<?>> getTypes() {
+    return Set.of(HistoricActivityInstance.class);
+  }
+
+  @Override
+  public void execute(HistoricActivityInstance c7Entity, FlowNodeInstanceDbModelBuilder builder) {
+    if (fieldToNull == null) {
+      return;
+    }
+    switch (fieldToNull) {
+      case "flowNodeInstanceKey" -> builder.flowNodeInstanceKey(null);
+      case "flowNodeId" -> builder.flowNodeId(null);
+      case "type" -> builder.type(null);
+      case "state" -> builder.state(null);
+      case "processDefinitionId" -> builder.processDefinitionId(null);
+      case "tenantId" -> builder.tenantId(null);
+      default -> throw new IllegalArgumentException("Unknown field: " + fieldToNull);
+    }
+  }
+
+  public void setFieldToNull(String fieldToNull) {
+    this.fieldToNull = fieldToNull;
+  }
+}

--- a/data-migrator/qa/integration-tests/src/test/resources/application-required-field-null.yml
+++ b/data-migrator/qa/integration-tests/src/test/resources/application-required-field-null.yml
@@ -1,0 +1,5 @@
+camunda.migrator:
+  interceptors:
+    # Built-in transformers stay enabled and populate all fields; this custom interceptor runs
+    # afterwards and nulls a single (test-selected) required field on the flow node.
+    - class-name: io.camunda.migration.data.qa.history.entity.interceptor.pojo.RequiredFieldNullingInterceptor


### PR DESCRIPTION
# Pull Request Template

## Description
<!-- Describe your changes in detail -->

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Test-only changes (no production code changes)

## Testing Checklist

### Black-Box Testing Requirements
- [ ] Tests follow **black-box testing approach**: verify behavior through observable outputs (logs, C8 API queries, real-world skip scenarios)
- [ ] Tests **DO NOT** access implementation details (`DbClient`, `IdKeyMapper`, `..impl..` packages except logging constants)
- [ ] Architecture tests pass (`ArchitectureTest` validates these rules)

### Test Coverage
- [ ] Added tests for new functionality
- [ ] Updated tests for modified functionality
- [ ] All tests pass locally

## Architecture Compliance

Run architecture tests to ensure compliance:
```bash
mvn test -Dtest=ArchitectureTest
```

If architecture tests fail, refactor your tests to use:
- `LogCapturer` for log assertions
- `camundaClient.new*SearchRequest()` for C8 queries
- Real-World skip scenarios (e.g., migrate children without parents)

## Documentation
- [ ] Updated TESTING_GUIDELINES.md if adding new test patterns
- [ ] Added Javadoc comments for public APIs
- [ ] Updated README if user-facing changes

## Checklist
- [ ] Code follows project style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments for complex logic
- [ ] No new compiler warnings
- [ ] Dependent changes have been merged

## Related Issues
<!-- Link to related issues: Fixes #123, Related to #456 -->

