### PR TITLE
fix(diagram-converter): backport #1428 to maintenance/0.3 — JUEL fallback keeps ${...}

### DIFF
--- a/diagram-converter/core/src/main/java/io/camunda/migration/diagram/converter/expression/ExpressionTransformationResult.java
+++ b/diagram-converter/core/src/main/java/io/camunda/migration/diagram/converter/expression/ExpressionTransformationResult.java
@@ -12,4 +12,11 @@ public record ExpressionTransformationResult(
     String juelExpression,
     String result,
     Boolean hasMethodInvocation,
-    Boolean hasExecutionOnly) {}
+    Boolean hasExecutionOnly) {
+
+  public boolean isExpressionValue() {
+    return (result != null && result.startsWith("="))
+        || Boolean.TRUE.equals(hasMethodInvocation)
+        || Boolean.TRUE.equals(hasExecutionOnly);
+  }
+}

--- a/diagram-converter/core/src/main/java/io/camunda/migration/diagram/converter/expression/ExpressionTransformationResultMessageFactory.java
+++ b/diagram-converter/core/src/main/java/io/camunda/migration/diagram/converter/expression/ExpressionTransformationResultMessageFactory.java
@@ -14,20 +14,14 @@ import java.util.Objects;
 public class ExpressionTransformationResultMessageFactory {
   public static Message getMessage(
       ExpressionTransformationResult transformationResult, String link) {
-    // no transformation has happened (because the expression is not an expression)
-    if (Objects.equals(transformationResult.result(), transformationResult.juelExpression())) {
-      return MessageFactory.noExpressionTransformation();
-    }
     // check for execution reference
-
     if (transformationResult.hasExecutionOnly()) {
       return MessageFactory.expressionExecutionNotAvailable(
           transformationResult.context(),
           transformationResult.juelExpression(),
           transformationResult.result(),
           link);
-
-    } else
+    }
     // check for method invocation
     if (transformationResult.hasMethodInvocation()) {
       return MessageFactory.expressionMethodNotPossible(
@@ -35,13 +29,16 @@ public class ExpressionTransformationResultMessageFactory {
           transformationResult.juelExpression(),
           transformationResult.result(),
           link);
-    } else {
-      // if all is good, just give the default message
-      return MessageFactory.expression(
-          transformationResult.context(),
-          transformationResult.juelExpression(),
-          transformationResult.result(),
-          link);
     }
+    // no transformation has happened (because the expression is not an expression)
+    if (Objects.equals(transformationResult.result(), transformationResult.juelExpression())) {
+      return MessageFactory.noExpressionTransformation();
+    }
+    // if all is good, just give the default message
+    return MessageFactory.expression(
+        transformationResult.context(),
+        transformationResult.juelExpression(),
+        transformationResult.result(),
+        link);
   }
 }

--- a/diagram-converter/core/src/main/java/io/camunda/migration/diagram/converter/expression/ExpressionTransformer.java
+++ b/diagram-converter/core/src/main/java/io/camunda/migration/diagram/converter/expression/ExpressionTransformer.java
@@ -56,8 +56,11 @@ public class ExpressionTransformer {
       return null;
     }
     String transform = INSTANCE.doTransform(juelExpression, false);
-    boolean hasMethodInvocation = INSTANCE.hasMethodInvocation(juelExpression);
-    boolean hasExecutionOnly = INSTANCE.hasExecutionOnly(juelExpression);
+    boolean hasMethodInvocation = transform != null && INSTANCE.hasMethodInvocation(transform);
+    boolean hasExecutionOnly = transform != null && INSTANCE.hasExecutionOnly(transform);
+    if (hasMethodInvocation || hasExecutionOnly) {
+      transform = juelExpression;
+    }
     return new ExpressionTransformationResult(
         context, juelExpression, transform, hasMethodInvocation, hasExecutionOnly);
   }
@@ -68,8 +71,11 @@ public class ExpressionTransformer {
       return null;
     }
     String transform = INSTANCE.doTransform(juelExpression, true);
-    boolean hasMethodInvocation = INSTANCE.hasMethodInvocation(juelExpression);
-    boolean hasExecutionOnly = INSTANCE.hasExecutionOnly(juelExpression);
+    boolean hasMethodInvocation = transform != null && INSTANCE.hasMethodInvocation(transform);
+    boolean hasExecutionOnly = transform != null && INSTANCE.hasExecutionOnly(transform);
+    if (hasMethodInvocation || hasExecutionOnly) {
+      transform = juelExpression;
+    }
     return new ExpressionTransformationResult(
         context, juelExpression, transform, hasMethodInvocation, hasExecutionOnly);
   }

--- a/diagram-converter/core/src/main/java/io/camunda/migration/diagram/converter/message/MessageFactory.java
+++ b/diagram-converter/core/src/main/java/io/camunda/migration/diagram/converter/message/MessageFactory.java
@@ -471,14 +471,6 @@ public class MessageFactory {
     return INSTANCE.staticMessage("escalation-code-no-expression");
   }
 
-  public static Message timerExpressionMapped(String juelExpression, String feelExpression) {
-    return INSTANCE.composeMessage(
-        "timer-expression-mapped",
-        ContextBuilder.builder()
-            .context(expressionTransformationResult(juelExpression, feelExpression))
-            .build());
-  }
-
   public static Message timerExpressionNotSupported(
       String timerType, String timerExpression, String eventType, String semanticVersion) {
     return INSTANCE.composeMessage(

--- a/diagram-converter/core/src/main/java/io/camunda/migration/diagram/converter/visitor/AbstractTimerExpressionVisitor.java
+++ b/diagram-converter/core/src/main/java/io/camunda/migration/diagram/converter/visitor/AbstractTimerExpressionVisitor.java
@@ -12,13 +12,16 @@ import static io.camunda.migration.diagram.converter.NamespaceUri.*;
 import io.camunda.migration.diagram.converter.DomElementVisitorContext;
 import io.camunda.migration.diagram.converter.convertible.AbstractCatchEventConvertible;
 import io.camunda.migration.diagram.converter.expression.ExpressionTransformationResult;
+import io.camunda.migration.diagram.converter.expression.ExpressionTransformationResultMessageFactory;
 import io.camunda.migration.diagram.converter.expression.ExpressionTransformer;
 import io.camunda.migration.diagram.converter.message.Message;
 import io.camunda.migration.diagram.converter.message.MessageFactory;
-import java.util.Objects;
 import org.camunda.bpm.model.xml.instance.DomElement;
 
 public abstract class AbstractTimerExpressionVisitor extends AbstractBpmnElementVisitor {
+
+  private static final String LINK =
+      "https://docs.camunda.io/docs/components/modeler/bpmn/timer-events/";
 
   @Override
   protected final void visitBpmnElement(DomElementVisitorContext context) {
@@ -27,10 +30,10 @@ public abstract class AbstractTimerExpressionVisitor extends AbstractBpmnElement
       context.addConversion(
           AbstractCatchEventConvertible.class,
           con -> setNewExpression(con, transformationResult.result()));
-      if (!Objects.equals(transformationResult.result(), transformationResult.juelExpression())) {
-        context.addMessage(
-            MessageFactory.timerExpressionMapped(
-                transformationResult.juelExpression(), transformationResult.result()));
+      Message message =
+          ExpressionTransformationResultMessageFactory.getMessage(transformationResult, LINK);
+      if (!message.getId().isEmpty()) {
+        context.addMessage(message);
       }
     }
   }

--- a/diagram-converter/core/src/main/java/io/camunda/migration/diagram/converter/visitor/impl/element/InputOutputParameterVisitor.java
+++ b/diagram-converter/core/src/main/java/io/camunda/migration/diagram/converter/visitor/impl/element/InputOutputParameterVisitor.java
@@ -45,9 +45,10 @@ public abstract class InputOutputParameterVisitor extends AbstractCamundaElement
     ExpressionTransformationResult transformationResult =
         ExpressionTransformer.transformToFeel(
             direction.getName() + " parameter '" + name + "'", expression);
-    // Zeebe I/O mapping source must be a FEEL expression (prefixed with '=')
+    // Zeebe I/O mapping source is normally FEEL (prefixed with '='). For expressions that cannot
+    // be converted to FEEL, keep the original JUEL wrapper (${...}/#{...}) for manual follow-up.
     String source = transformationResult.result();
-    if (source != null && !source.startsWith("=")) {
+    if (shouldPrefixFeelMarker(source, transformationResult)) {
       source = "=" + source;
     }
     String finalSource = source;
@@ -58,6 +59,15 @@ public abstract class InputOutputParameterVisitor extends AbstractCamundaElement
     return ExpressionTransformationResultMessageFactory.getMessage(
         transformationResult,
         "https://docs.camunda.io/docs/components/concepts/variables/#inputoutput-variable-mappings");
+  }
+
+  private boolean shouldPrefixFeelMarker(
+      String source, ExpressionTransformationResult transformationResult) {
+    if (source == null || source.startsWith("=")) {
+      return false;
+    }
+    // Keep original JUEL wrapper intact for unconvertible expressions to support manual follow-up.
+    return !(transformationResult.hasMethodInvocation() || transformationResult.hasExecutionOnly());
   }
 
   private boolean isScript(DomElement element) {

--- a/diagram-converter/core/src/main/java/io/camunda/migration/diagram/converter/visitor/impl/eventReference/ErrorVisitor.java
+++ b/diagram-converter/core/src/main/java/io/camunda/migration/diagram/converter/visitor/impl/eventReference/ErrorVisitor.java
@@ -42,7 +42,7 @@ public class ErrorVisitor extends AbstractEventReferenceVisitor {
     }
     ExpressionTransformationResult expressionTransformationResult =
         ExpressionTransformer.transformToFeel("Error", errorCode);
-    if (expressionTransformationResult.result().startsWith("=")) {
+    if (expressionTransformationResult.isExpressionValue()) {
       context.addMessage(MessageFactory.errorCodeNoExpression());
     }
     context.addConversion(

--- a/diagram-converter/core/src/main/java/io/camunda/migration/diagram/converter/visitor/impl/eventReference/EscalationVisitor.java
+++ b/diagram-converter/core/src/main/java/io/camunda/migration/diagram/converter/visitor/impl/eventReference/EscalationVisitor.java
@@ -43,8 +43,7 @@ public class EscalationVisitor extends AbstractEventReferenceVisitor {
       context.addConversion(
           EscalationConvertible.class,
           c -> c.setEscalationCode(expressionTransformationResult.result()));
-      if (expressionTransformationResult != null
-          && expressionTransformationResult.result().startsWith("=")) {
+      if (expressionTransformationResult.isExpressionValue()) {
         context.addMessage(MessageFactory.escalationCodeNoExpression());
       }
     }

--- a/diagram-converter/core/src/main/resources/message-templates.properties
+++ b/diagram-converter/core/src/main/resources/message-templates.properties
@@ -214,9 +214,6 @@ internal-script.severity=INFO
 timer-expression-not-supported.message=Timer of type '{{ timerType }}' with value '{{ timerExpression }}' is not supported for event type '{{ eventType }}' in Zeebe version '{{ semanticVersion }}'.
 timer-expression-not-supported.severity=WARNING
 #
-timer-expression-mapped.message=Timer expression was transformed: {{ templates.expression-transformation-result }}
-timer-expression-mapped.severity=REVIEW
-#
 resource-on-conditional-flow.message=Please translate the content from '{{ resource }}' to a valid FEEL expression.
 resource-on-conditional-flow.severity=TASK
 #

--- a/diagram-converter/core/src/test/java/io/camunda/migration/diagram/converter/DiagramConverterTest.java
+++ b/diagram-converter/core/src/test/java/io/camunda/migration/diagram/converter/DiagramConverterTest.java
@@ -280,11 +280,72 @@ public class DiagramConverterTest {
   }
 
   @Test
+  void testUnconvertibleTimerExpressionsKeepFallbackValueAndEmitTaskMessages() {
+    DiagramCheckResult result = loadAndCheck("flexible-timer-event.bpmn");
+
+    assertThat(result.getResult("MethodDateEvent").getMessages())
+        .extracting(ElementCheckMessage::getMessage)
+        .anyMatch(message -> message.contains("Method invocation is not possible in FEEL."));
+    assertThat(result.getResult("ExecutionDurationEvent").getMessages())
+        .extracting(ElementCheckMessage::getMessage)
+        .anyMatch(message -> message.contains("'execution' is not available in FEEL."));
+    assertThat(result.getResult("MethodCycleBoundaryEvent").getMessages())
+        .extracting(ElementCheckMessage::getMessage)
+        .anyMatch(message -> message.contains("Method invocation is not possible in FEEL."));
+
+    BpmnModelInstance modelInstance = loadAndConvert("flexible-timer-event.bpmn");
+
+    assertThat(timerExpression(modelInstance, "MethodDateEvent")).isEqualTo("${myBean.calc()}");
+    assertThat(timerExpression(modelInstance, "ExecutionDurationEvent"))
+        .isEqualTo("${execution.hasVariable('whatever')}");
+    assertThat(timerExpression(modelInstance, "MethodCycleBoundaryEvent"))
+        .isEqualTo("${execution.getVariable(\"a\").size()}");
+  }
+
+  @Test
   void testEscalationCode() {
     BpmnModelInstance modelInstance = loadAndConvert("escalation-code.bpmn");
     DomElement escalation = modelInstance.getDocument().getElementById("Escalation_2ja61hj");
     assertThat(escalation.getAttribute(BPMN, "name")).isEqualTo("EscalationName");
     assertThat(escalation.getAttribute(BPMN, "escalationCode")).isEqualTo("EscalationCode");
+  }
+
+  private String timerExpression(BpmnModelInstance modelInstance, String elementId) {
+    return modelInstance
+        .getDocument()
+        .getElementById(elementId)
+        .getChildElementsByNameNs(BPMN, "timerEventDefinition")
+        .get(0)
+        .getChildElements()
+        .get(0)
+        .getTextContent();
+  }
+
+  @Test
+  void testExpressionCodesShouldKeepWarningsAndFallbackValue() {
+    DiagramCheckResult result = loadAndCheck("error-escalation-expression-codes.bpmn");
+    List<String> messages =
+        result.getResults().stream()
+            .flatMap(r -> r.getMessages().stream())
+            .map(ElementCheckMessage::getMessage)
+            .collect(Collectors.toList());
+    assertThat(messages)
+        .contains("Error code cannot be an expression.")
+        .contains("Escalation code cannot be an expression.");
+
+    BpmnModelInstance modelInstance = loadAndConvert("error-escalation-expression-codes.bpmn");
+    assertThat(
+            modelInstance
+                .getDocument()
+                .getElementById("Error_16zktjx")
+                .getAttribute(BPMN, "errorCode"))
+        .isEqualTo("${execution.hasVariable('whatever')}");
+    assertThat(
+            modelInstance
+                .getDocument()
+                .getElementById("Escalation_2ja61hj")
+                .getAttribute(BPMN, "escalationCode"))
+        .isEqualTo("${execution.hasVariable('whatever')}");
   }
 
   @Test
@@ -468,6 +529,72 @@ public class DiagramConverterTest {
             .findFirst()
             .orElseThrow();
     assertThat(output.getAttribute(ZEEBE, "source")).isEqualTo("=\"outputValue\"");
+  }
+
+  @Test
+  void testInputOutputWithMethodInvocationShouldPreserveFallbackJuel() {
+    BpmnModelInstance modelInstance = loadAndConvert("input-output-with-method-invocation.bpmn");
+    DomElement serviceTask =
+        modelInstance.getDocument().getElementById("ServiceTaskWithMethodInvocation");
+    assertThat(serviceTask).isNotNull();
+    DomElement extensionElements =
+        serviceTask.getChildElementsByNameNs(BPMN, "extensionElements").get(0);
+    assertThat(extensionElements).isNotNull();
+    DomElement ioMapping = extensionElements.getChildElementsByNameNs(ZEEBE, "ioMapping").get(0);
+    assertThat(ioMapping).isNotNull();
+
+    // Verify convertible expression gets = prefix
+    DomElement simpleVarInput =
+        ioMapping.getChildElementsByNameNs(ZEEBE, "input").stream()
+            .filter(e -> e.getAttribute(ZEEBE, "target").equals("simpleVar"))
+            .findFirst()
+            .orElseThrow();
+    assertThat(simpleVarInput.getAttribute(ZEEBE, "source"))
+        .as("Convertible expression should have = prefix")
+        .isEqualTo("=myVariable");
+
+    // Verify unconvertible expression with method invocation preserves JUEL wrapper without =
+    // prefix
+    DomElement methodResultInput =
+        ioMapping.getChildElementsByNameNs(ZEEBE, "input").stream()
+            .filter(e -> e.getAttribute(ZEEBE, "target").equals("methodResult"))
+            .findFirst()
+            .orElseThrow();
+    assertThat(methodResultInput.getAttribute(ZEEBE, "source"))
+        .as("Unconvertible expression with method invocation should preserve JUEL wrapper")
+        .isEqualTo("${order.getPriority()}");
+
+    // Verify chained method call after execution.getVariable preserves JUEL wrapper
+    DomElement variableSizeInput =
+        ioMapping.getChildElementsByNameNs(ZEEBE, "input").stream()
+            .filter(e -> e.getAttribute(ZEEBE, "target").equals("variableSize"))
+            .findFirst()
+            .orElseThrow();
+    assertThat(variableSizeInput.getAttribute(ZEEBE, "source"))
+        .as(
+            "Unconvertible expression with chained method invocation after execution.getVariable should preserve JUEL wrapper")
+        .isEqualTo("${execution.getVariable(\"a\").size()}");
+
+    // Verify unconvertible expression with execution reference preserves JUEL wrapper without =
+    // prefix
+    DomElement processIdInput =
+        ioMapping.getChildElementsByNameNs(ZEEBE, "input").stream()
+            .filter(e -> e.getAttribute(ZEEBE, "target").equals("processId"))
+            .findFirst()
+            .orElseThrow();
+    assertThat(processIdInput.getAttribute(ZEEBE, "source"))
+        .as("Unconvertible expression with execution reference should preserve JUEL wrapper")
+        .isEqualTo("${execution.getProcessInstanceId()}");
+
+    // Verify output parameter with method invocation also preserves JUEL wrapper
+    DomElement priorityOutput =
+        ioMapping.getChildElementsByNameNs(ZEEBE, "output").stream()
+            .filter(e -> e.getAttribute(ZEEBE, "target").equals("priority"))
+            .findFirst()
+            .orElseThrow();
+    assertThat(priorityOutput.getAttribute(ZEEBE, "source"))
+        .as("Output parameter with method invocation should preserve JUEL wrapper")
+        .isEqualTo("${resultSet.getCount()}");
   }
 
   @Test

--- a/diagram-converter/core/src/test/java/io/camunda/migration/diagram/converter/ExpressionTransformationResultMessageFactoryTest.java
+++ b/diagram-converter/core/src/test/java/io/camunda/migration/diagram/converter/ExpressionTransformationResultMessageFactoryTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.migration.diagram.converter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.migration.diagram.converter.expression.ExpressionTransformationResult;
+import io.camunda.migration.diagram.converter.expression.ExpressionTransformationResultMessageFactory;
+import io.camunda.migration.diagram.converter.message.Message;
+import org.junit.jupiter.api.Test;
+
+class ExpressionTransformationResultMessageFactoryTest {
+
+  @Test
+  void shouldReturnExecutionMessageWhenExpressionReferencesExecution() {
+    ExpressionTransformationResult result =
+        new ExpressionTransformationResult(
+            "Job priority",
+            "${execution.getProcessInstanceId()}",
+            "${execution.getProcessInstanceId()}",
+            false,
+            true);
+
+    Message message =
+        ExpressionTransformationResultMessageFactory.getMessage(result, "https://example.test");
+
+    assertThat(message.getId()).isEqualTo("expression-execution-not-available");
+  }
+
+  @Test
+  void shouldReturnMethodMessageWhenExpressionHasMethodInvocation() {
+    ExpressionTransformationResult result =
+        new ExpressionTransformationResult(
+            "Job priority", "${order.getPriority()}", "${order.getPriority()}", true, false);
+
+    Message message =
+        ExpressionTransformationResultMessageFactory.getMessage(result, "https://example.test");
+
+    assertThat(message.getId()).isEqualTo("expression-method-not-possible");
+  }
+
+  @Test
+  void shouldPreferExecutionMessageWhenBothFlagsAreSet() {
+    ExpressionTransformationResult result =
+        new ExpressionTransformationResult(
+            "Job priority",
+            "${execution.order.getPriority()}",
+            "${execution.order.getPriority()}",
+            true,
+            true);
+
+    Message message =
+        ExpressionTransformationResultMessageFactory.getMessage(result, "https://example.test");
+
+    assertThat(message.getId()).isEqualTo("expression-execution-not-available");
+  }
+
+  @Test
+  void shouldReturnEmptyMessageForStaticExpressionWithoutTransformation() {
+    ExpressionTransformationResult result =
+        new ExpressionTransformationResult(
+            "Job priority", "static-value", "static-value", false, false);
+
+    Message message =
+        ExpressionTransformationResultMessageFactory.getMessage(result, "https://example.test");
+
+    assertThat(message.getId()).isEmpty();
+  }
+
+  @Test
+  void shouldReturnReviewExpressionMessageWhenTransformationSucceeds() {
+    ExpressionTransformationResult result =
+        new ExpressionTransformationResult(
+            "Job priority", "${jobPriority}", "=jobPriority", false, false);
+
+    Message message =
+        ExpressionTransformationResultMessageFactory.getMessage(result, "https://example.test");
+
+    assertThat(message.getId()).isEqualTo("expression");
+  }
+}

--- a/diagram-converter/core/src/test/java/io/camunda/migration/diagram/converter/ExpressionTransformerTest.java
+++ b/diagram-converter/core/src/test/java/io/camunda/migration/diagram/converter/ExpressionTransformerTest.java
@@ -24,6 +24,10 @@ public class ExpressionTransformerTest {
     return new ExpressionTestBuilder(expression, TransformationType.feel);
   }
 
+  private static ExpressionTestBuilder expressionToFeelDmn(String expression) {
+    return new ExpressionTestBuilder(expression, TransformationType.feelDmn);
+  }
+
   private static ExpressionTestBuilder expressionToJobType(String expression) {
     return new ExpressionTestBuilder(expression, TransformationType.jobType);
   }
@@ -74,11 +78,43 @@ public class ExpressionTransformerTest {
             expressionToFeel("${not(empty donut || coffee)}")
                 .isMappedTo("=not(donut=null or coffee)"),
             expressionToFeel("${execution.getVariable(\"a\")}").isMappedTo("=a"),
-            expressionToFeel("${execution.getProcessInstanceId()}").hasUsedExecution(true),
-            expressionToFeel("${myexecutionContext.isSpecial()}").hasUsedExecution(false),
-            expressionToFeel("${var.getSomething()}").hasMethodInvocation(true),
-            expressionToFeel("${!dauerbuchungVoat21Ids.isEmpty()}").hasMethodInvocation(true),
+            expressionToFeel("${execution.getVariable(\"a\").size()}")
+                .isMappedTo("${execution.getVariable(\"a\").size()}")
+                .hasMethodInvocation(true),
+            expressionToFeel("#{execution.getVariable(\"a\").size()}")
+                .isMappedTo("#{execution.getVariable(\"a\").size()}")
+                .hasMethodInvocation(true),
+            expressionToFeel("size: ${execution.getVariable(\"a\").size()}")
+                .isMappedTo("size: ${execution.getVariable(\"a\").size()}")
+                .hasMethodInvocation(true),
+            expressionToFeel("${execution.getProcessInstanceId()}")
+                .isMappedTo("${execution.getProcessInstanceId()}")
+                .hasUsedExecution(true)
+                .hasMethodInvocation(true),
+            expressionToFeel("${execution.hasVariable('whatever')}")
+                .isMappedTo("${execution.hasVariable('whatever')}")
+                .hasUsedExecution(true),
+            expressionToFeel("#{execution.hasVariable('whatever')}")
+                .isMappedTo("#{execution.hasVariable('whatever')}")
+                .hasUsedExecution(true),
+            expressionToFeel("${myexecutionContext.isSpecial()}")
+                .isMappedTo("${myexecutionContext.isSpecial()}")
+                .hasUsedExecution(false)
+                .hasMethodInvocation(true),
+            expressionToFeel("#{order.getPriority()}")
+                .isMappedTo("#{order.getPriority()}")
+                .hasMethodInvocation(true),
+            expressionToFeel("Priority: ${order.getPriority()}")
+                .isMappedTo("Priority: ${order.getPriority()}")
+                .hasMethodInvocation(true),
+            expressionToFeel("${var.getSomething()}")
+                .isMappedTo("${var.getSomething()}")
+                .hasMethodInvocation(true),
+            expressionToFeel("${!dauerbuchungVoat21Ids.isEmpty()}")
+                .isMappedTo("${!dauerbuchungVoat21Ids.isEmpty()}")
+                .hasMethodInvocation(true),
             expressionToFeel("${!dauerbuchungVoat21Ids.contains(\"someText\")}")
+                .isMappedTo("${!dauerbuchungVoat21Ids.contains(\"someText\")}")
                 .hasMethodInvocation(true),
             expressionToFeel("${input > 5.5}").hasMethodInvocation(false),
             expressionToFeel("${input != ''}").isMappedTo("=input != \"\""),
@@ -101,8 +137,37 @@ public class ExpressionTransformerTest {
                     data.getTests()));
   }
 
+  @TestFactory
+  public Stream<DynamicContainer> shouldResolveExpressionForDmnMode() {
+    return Stream.of(
+            expressionToFeelDmn("").isMappedTo(null),
+            expressionToFeelDmn("${someVariable}").isMappedTo("someVariable"),
+            expressionToFeelDmn("${execution.getVariable(\"a\")}").isMappedTo("a"),
+            expressionToFeelDmn("${execution.getVariable(\"a\").size()}")
+                .isMappedTo("${execution.getVariable(\"a\").size()}")
+                .hasMethodInvocation(true),
+            expressionToFeelDmn("#{execution.getVariable(\"a\").size()}")
+                .isMappedTo("#{execution.getVariable(\"a\").size()}")
+                .hasMethodInvocation(true),
+            expressionToFeelDmn("${execution.getProcessInstanceId()}")
+                .isMappedTo("${execution.getProcessInstanceId()}")
+                .hasUsedExecution(true),
+            expressionToFeelDmn("#{order.getPriority()}")
+                .isMappedTo("#{order.getPriority()}")
+                .hasMethodInvocation(true))
+        .map(
+            data ->
+                DynamicContainer.dynamicContainer(
+                    "Expression to "
+                        + data.getTransformationType()
+                        + ": "
+                        + data.getResult().juelExpression(),
+                    data.getTests()));
+  }
+
   private enum TransformationType {
     feel,
+    feelDmn,
     jobType
   }
 
@@ -116,6 +181,7 @@ public class ExpressionTransformerTest {
       this.result =
           switch (type) {
             case feel -> ExpressionTransformer.transformToFeel("Test", expression);
+            case feelDmn -> ExpressionTransformer.transformToFeelDmn("Test", expression);
             case jobType -> ExpressionTransformer.transformToJobType(expression);
           };
     }

--- a/diagram-converter/core/src/test/java/io/camunda/migration/diagram/converter/message/MessageFactoryTest.java
+++ b/diagram-converter/core/src/test/java/io/camunda/migration/diagram/converter/message/MessageFactoryTest.java
@@ -383,21 +383,6 @@ public class MessageFactoryTest {
   }
 
   @Test
-  void shouldBuildTimerExpressionMappedMessage() {
-    String juelExpression = random();
-    String feelExpression = random();
-    Message message = timerExpressionMapped(juelExpression, feelExpression);
-    assertNotNull(message);
-    assertNotNull(message.getMessage());
-    assertNotNull(message.getSeverity());
-    assertThat(message.getMessage())
-        .isEqualTo(
-            String.format(
-                "Timer expression was transformed: Please review transformed expression: '%s' -> '%s'.",
-                juelExpression, feelExpression));
-  }
-
-  @Test
   void shouldBuildTimerExpressionNotSupported() {
     String timerType = random();
     String timerValue = random();

--- a/diagram-converter/core/src/test/resources/BPMN_CONVERSION.yaml
+++ b/diagram-converter/core/src/test/resources/BPMN_CONVERSION.yaml
@@ -580,23 +580,23 @@ categories:
             <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=input != null and input &gt; 5</bpmn:conditionExpression>
           </bpmn:sequenceFlow>
           <bpmn:sequenceFlow id="MethodInvocationIsUsedSequenceFlow" name="Method invocation is used" sourceRef="someGateway" targetRef="someTask">
-            <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=objectVar.getAddress().getStreet() != "main street"</bpmn:conditionExpression>
+            <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${objectVar.getAddress().getStreet() != "main street"}</bpmn:conditionExpression>
           </bpmn:sequenceFlow>
           <bpmn:serviceTask completionQuantity="1" id="TaskWithInMappingsServiceTask" implementation="##WebService" isForCompensation="false" name="Task with in mappings" startQuantity="1">
             <bpmn:extensionElements>
               <zeebe:ioMapping>
-                <zeebe:input source="=myObject.getAddress().getStreet()" target="taskForMethodExpected"/>
+                <zeebe:input source="${myObject.getAddress().getStreet()}" target="taskForMethodExpected"/>
                 <zeebe:input source="=justAnotherVariable" target="reviewExpected"/>
-                <zeebe:input source="=execution.getProcessEngineServices()" target="taskForExecutionExpected"/>
+                <zeebe:input source="${execution.getProcessEngineServices()}" target="taskForExecutionExpected"/>
               </zeebe:ioMapping>
             </bpmn:extensionElements>
           </bpmn:serviceTask>
           <bpmn:serviceTask completionQuantity="1" id="TaskWithOutMappingsServiceTask" implementation="##WebService" isForCompensation="false" name="Task with out mappings" startQuantity="1">
             <bpmn:extensionElements>
               <zeebe:ioMapping>
-                <zeebe:output source="=anotherObject.getCustomerName()" target="taskForMethodExpected"/>
+                <zeebe:output source="${anotherObject.getCustomerName()}" target="taskForMethodExpected"/>
                 <zeebe:output source="=aNewVariable" target="reviewExpected"/>
-                <zeebe:output source="=execution.getProcessInstanceId()" target="taskForExecutionExpected"/>
+                <zeebe:output source="${execution.getProcessInstanceId()}" target="taskForExecutionExpected"/>
               </zeebe:ioMapping>
             </bpmn:extensionElements>
           </bpmn:serviceTask>
@@ -615,29 +615,29 @@ categories:
             <bpmn:multiInstanceLoopCharacteristics behavior="All" isSequential="true">
               <documentation/>
               <extensionElements>
-                <zeebe:loopCharacteristics inputCollection="=myInput.getAdresses().getAll()" inputElement="myElement"/>
+                <zeebe:loopCharacteristics inputCollection="${myInput.getAdresses().getAll()}" inputElement="myElement"/>
               </extensionElements>
-              <bpmn:completionCondition xsi:type="bpmn:tFormalExpression">=myInput.getComplete()</bpmn:completionCondition>
+              <bpmn:completionCondition xsi:type="bpmn:tFormalExpression">${myInput.getComplete()}</bpmn:completionCondition>
             </bpmn:multiInstanceLoopCharacteristics>
           </bpmn:serviceTask>
           <bpmn:task completionQuantity="1" id="someTask" isForCompensation="false" startQuantity="1"/>
         expectedMessages: |
           <conversion:message severity="REVIEW">Condition expression: Please review transformed expression: '${input &gt; 3}' -&gt; '=input &gt; 3'.</conversion:message>
           <conversion:message severity="REVIEW">Condition expression: Please review transformed expression: '${execution.getVariable("input") != null &amp;&amp; input &gt; 5}' -&gt; '=input != null and input &gt; 5'.</conversion:message>
-          <conversion:message severity="TASK">Condition expression: Transformed expression: '${objectVar.getAddress().getStreet() != "main street"}' -&gt; '=objectVar.getAddress().getStreet() != "main street"'. Method invocation is not possible in FEEL.</conversion:message>               
-          <conversion:message severity="TASK">Input parameter 'taskForMethodExpected': Transformed expression: '${myObject.getAddress().getStreet()}' -&gt; '=myObject.getAddress().getStreet()'. Method invocation is not possible in FEEL.</conversion:message>
-          <conversion:message severity="TASK">Input parameter 'taskForExecutionExpected': Transformed expression: '${execution.getProcessEngineServices()}' -&gt; '=execution.getProcessEngineServices()'. 'execution' is not available in FEEL.</conversion:message>
+          <conversion:message severity="TASK">Condition expression: Transformed expression: '${objectVar.getAddress().getStreet() != "main street"}' -&gt; '${objectVar.getAddress().getStreet() != "main street"}'. Method invocation is not possible in FEEL.</conversion:message>
+          <conversion:message severity="TASK">Input parameter 'taskForMethodExpected': Transformed expression: '${myObject.getAddress().getStreet()}' -&gt; '${myObject.getAddress().getStreet()}'. Method invocation is not possible in FEEL.</conversion:message>
+          <conversion:message severity="TASK">Input parameter 'taskForExecutionExpected': Transformed expression: '${execution.getProcessEngineServices()}' -&gt; '${execution.getProcessEngineServices()}'. 'execution' is not available in FEEL.</conversion:message>
           <conversion:message severity="REVIEW">Input parameter 'reviewExpected': Please review transformed expression: '${justAnotherVariable}' -&gt; '=justAnotherVariable'.</conversion:message>
-          <conversion:message severity="TASK">Output parameter 'taskForMethodExpected': Transformed expression: '${anotherObject.getCustomerName()}' -&gt; '=anotherObject.getCustomerName()'. Method invocation is not possible in FEEL.</conversion:message>
-          <conversion:message severity="TASK">Output parameter 'taskForExecutionExpected': Transformed expression: '${execution.getProcessInstanceId()}' -&gt; '=execution.getProcessInstanceId()'. 'execution' is not available in FEEL.</conversion:message>
+          <conversion:message severity="TASK">Output parameter 'taskForMethodExpected': Transformed expression: '${anotherObject.getCustomerName()}' -&gt; '${anotherObject.getCustomerName()}'. Method invocation is not possible in FEEL.</conversion:message>
+          <conversion:message severity="TASK">Output parameter 'taskForExecutionExpected': Transformed expression: '${execution.getProcessInstanceId()}' -&gt; '${execution.getProcessInstanceId()}'. 'execution' is not available in FEEL.</conversion:message>
           <conversion:message severity="REVIEW">Output parameter 'reviewExpected': Please review transformed expression: '${aNewVariable}' -&gt; '=aNewVariable'.</conversion:message>
           <conversion:message severity="TASK">Collecting results in a multi instance is now natively possible with Zeebe. Please review.</conversion:message>
           <conversion:message severity="REVIEW">Collection: Please review transformed expression: '${execution.getVariable("myList")}' -&gt; '=myList'.</conversion:message>
           <conversion:message severity="REVIEW">Completion condition: Please review transformed expression: '${execution.getVariable("complete") == true}' -&gt; '=complete = true'.</conversion:message>
           <conversion:message severity="INFO">Attribute 'elementVariable' on 'multiInstanceLoopCharacteristics' was mapped. Is set to Zeebe input element.</conversion:message>
           <conversion:message severity="TASK">Collecting results in a multi instance is now natively possible with Zeebe. Please review.</conversion:message>
-          <conversion:message severity="TASK">Collection: Transformed expression: '${myInput.getAdresses().getAll()}' -&gt; '=myInput.getAdresses().getAll()'. Method invocation is not possible in FEEL.</conversion:message>
-          <conversion:message severity="TASK">Completion condition: Transformed expression: '${myInput.getComplete()}' -&gt; '=myInput.getComplete()'. Method invocation is not possible in FEEL.</conversion:message>
+          <conversion:message severity="TASK">Collection: Transformed expression: '${myInput.getAdresses().getAll()}' -&gt; '${myInput.getAdresses().getAll()}'. Method invocation is not possible in FEEL.</conversion:message>
+          <conversion:message severity="TASK">Completion condition: Transformed expression: '${myInput.getComplete()}' -&gt; '${myInput.getComplete()}'. Method invocation is not possible in FEEL.</conversion:message>
           <conversion:message severity="INFO">Attribute 'elementVariable' on 'multiInstanceLoopCharacteristics' was mapped. Is set to Zeebe input element.</conversion:message>
   - category: Conditional events
     cases:

--- a/diagram-converter/core/src/test/resources/error-escalation-expression-codes.bpmn
+++ b/diagram-converter/core/src/test/resources/error-escalation-expression-codes.bpmn
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1gbx4qr" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.23.0" modeler:executionPlatform="Camunda Platform" modeler:executionPlatformVersion="7.19.0">
+  <bpmn:process id="TransactionTestProcess" name="Transaction Test" isExecutable="true">
+    <bpmn:startEvent id="Event_1i3htun" name="Expression code conversion should be tested">
+      <bpmn:outgoing>Flow_0we8gbc</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_0we8gbc" sourceRef="Event_1i3htun" targetRef="Activity_1h3hatw" />
+    <bpmn:serviceTask id="Activity_1h3hatw" name="Throw error">
+      <bpmn:incoming>Flow_0we8gbc</bpmn:incoming>
+      <bpmn:outgoing>Flow_0y3k84c</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:endEvent id="Event_09a497u" name="Expression code conversion done">
+      <bpmn:incoming>Flow_0y3k84c</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_0y3k84c" sourceRef="Activity_1h3hatw" targetRef="Event_09a497u" />
+    <bpmn:endEvent id="Event_1ey9c8f" name="Error handled">
+      <bpmn:incoming>Flow_03nn2dd</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_03nn2dd" sourceRef="Event_0apc6gw" targetRef="Event_1ey9c8f" />
+    <bpmn:boundaryEvent id="Event_0apc6gw" name="Escalation thrown" attachedToRef="Activity_1h3hatw">
+      <bpmn:outgoing>Flow_03nn2dd</bpmn:outgoing>
+      <bpmn:escalationEventDefinition id="EscalationEventDefinition_075vn24" escalationRef="Escalation_2ja61hj" />
+    </bpmn:boundaryEvent>
+  </bpmn:process>
+  <bpmn:error id="Error_16zktjx" name="SomeName" errorCode="${execution.hasVariable('whatever')}" />
+  <bpmn:escalation id="Escalation_2ja61hj" name="EscalationName" escalationCode="${execution.hasVariable('whatever')}" />
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="TransactionTestProcess">
+      <bpmndi:BPMNShape id="Event_1i3htun_di" bpmnElement="Event_1i3htun">
+        <dc:Bounds x="142" y="202" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="116" y="245" width="89" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_10af0py_di" bpmnElement="Activity_1h3hatw">
+        <dc:Bounds x="230" y="180" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_09a497u_di" bpmnElement="Event_09a497u">
+        <dc:Bounds x="382" y="202" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="360" y="245" width="81" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1ey9c8f_di" bpmnElement="Event_1ey9c8f">
+        <dc:Bounds x="362" y="322" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="347" y="365" width="67" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1w7mpnk_di" bpmnElement="Event_0apc6gw">
+        <dc:Bounds x="272" y="242" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="248" y="285" width="87" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0we8gbc_di" bpmnElement="Flow_0we8gbc">
+        <di:waypoint x="178" y="220" />
+        <di:waypoint x="230" y="220" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0y3k84c_di" bpmnElement="Flow_0y3k84c">
+        <di:waypoint x="330" y="220" />
+        <di:waypoint x="382" y="220" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_03nn2dd_di" bpmnElement="Flow_03nn2dd">
+        <di:waypoint x="290" y="278" />
+        <di:waypoint x="290" y="340" />
+        <di:waypoint x="362" y="340" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/diagram-converter/core/src/test/resources/flexible-timer-event.bpmn
+++ b/diagram-converter/core/src/test/resources/flexible-timer-event.bpmn
@@ -215,6 +215,21 @@
         <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">${boundaryCycle}</bpmn:timeCycle>
       </bpmn:timerEventDefinition>
     </bpmn:boundaryEvent>
+    <bpmn:intermediateCatchEvent id="MethodDateEvent" name="Method date">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_1uwvrq4">
+        <bpmn:timeDate xsi:type="bpmn:tFormalExpression">${myBean.calc()}</bpmn:timeDate>
+      </bpmn:timerEventDefinition>
+    </bpmn:intermediateCatchEvent>
+    <bpmn:intermediateCatchEvent id="ExecutionDurationEvent" name="Execution duration">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_1vwvrq4">
+        <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">${execution.hasVariable('whatever')}</bpmn:timeDuration>
+      </bpmn:timerEventDefinition>
+    </bpmn:intermediateCatchEvent>
+    <bpmn:boundaryEvent id="MethodCycleBoundaryEvent" name="Method cycle boundary" cancelActivity="false" attachedToRef="TaskTask">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_1xwvrq4">
+        <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">${execution.getVariable("a").size()}</bpmn:timeCycle>
+      </bpmn:timerEventDefinition>
+    </bpmn:boundaryEvent>
     <bpmn:sequenceFlow id="Flow_12cl7jz" sourceRef="CycleNonInterruptingBoundaryEvent" targetRef="TimerConversionTestedEndEvent" />
     <bpmn:sequenceFlow id="Flow_10k0b0x" sourceRef="DateNonInterruptingBoundaryEvent" targetRef="TimerConversionTestedEndEvent" />
     <bpmn:sequenceFlow id="Flow_0kngvsj" sourceRef="DurationNonInterruptingBoundaryEvent" targetRef="TimerConversionTestedEndEvent" />

--- a/diagram-converter/core/src/test/resources/input-output-with-method-invocation.bpmn
+++ b/diagram-converter/core/src/test/resources/input-output-with-method-invocation.bpmn
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions
+  xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+  xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI"
+  xmlns:dc="http://www.omg.org/spec/DD/20100524/DC"
+  xmlns:camunda="http://camunda.org/schema/1.0/bpmn"
+  xmlns:di="http://www.omg.org/spec/DD/20100524/DI"
+  xmlns:modeler="http://camunda.org/schema/modeler/1.0"
+  id="Definitions_methodInvocation"
+  targetNamespace="http://bpmn.io/schema/bpmn"
+  exporter="Camunda Modeler"
+  exporterVersion="5.10.0"
+  modeler:executionPlatform="Camunda Platform"
+  modeler:executionPlatformVersion="7.19.0">
+  <bpmn:process id="Process_methodInvocation" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:serviceTask id="ServiceTaskWithMethodInvocation" name="Service Task with Method Call">
+      <bpmn:extensionElements>
+        <camunda:inputOutput>
+          <camunda:inputParameter name="simpleVar">${myVariable}</camunda:inputParameter>
+          <camunda:inputParameter name="methodResult">${order.getPriority()}</camunda:inputParameter>
+          <camunda:inputParameter name="variableSize">${execution.getVariable("a").size()}</camunda:inputParameter>
+          <camunda:inputParameter name="processId">${execution.getProcessInstanceId()}</camunda:inputParameter>
+          <camunda:outputParameter name="priority">${resultSet.getCount()}</camunda:outputParameter>
+        </camunda:inputOutput>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1</bpmn:incoming>
+      <bpmn:outgoing>Flow_2</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:endEvent id="EndEvent_1">
+      <bpmn:incoming>Flow_2</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1" sourceRef="StartEvent_1" targetRef="ServiceTaskWithMethodInvocation" />
+    <bpmn:sequenceFlow id="Flow_2" sourceRef="ServiceTaskWithMethodInvocation" targetRef="EndEvent_1" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_methodInvocation">
+      <bpmndi:BPMNShape id="StartEvent_1_di" bpmnElement="StartEvent_1">
+        <dc:Bounds x="152" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="ServiceTaskWithMethodInvocation_di" bpmnElement="ServiceTaskWithMethodInvocation">
+        <dc:Bounds x="240" y="80" width="180" height="80" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="252" y="167" width="156" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_1_di" bpmnElement="EndEvent_1">
+        <dc:Bounds x="492" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1_di" bpmnElement="Flow_1">
+        <di:waypoint x="188" y="120" />
+        <di:waypoint x="240" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_2_di" bpmnElement="Flow_2">
+        <di:waypoint x="420" y="120" />
+        <di:waypoint x="492" y="120" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>


### PR DESCRIPTION
Backport of #1428 to `maintenance/0.3`.

## What

Cherry-pick of b7921779 with two conflict resolutions:

- **`JobPriorityWriter.java` dropped** — the job priority feature (`#1...`, commit `348e5e52`) was never backported to `0.3`, so the file doesn't exist on this branch. The 3-line guard added in #1428 is moot here.
- **`BPMN_CONVERSION.yaml` Job Priority test category dropped** — same reason; tests for a feature not present on `0.3`.

All 16 other files (core expression transformer, timer visitor, message factory, new JUEL fallback tests) applied cleanly. 382 tests pass on `0.3`.

## Test plan

- [x] `mvn test -pl diagram-converter/core -am` passes (382 tests, 0 failures)
- [ ] CI green