### PR TITLE
[Backport 0.3] Fix error message for Camunda 8 DMN files to include filename

### DIFF
--- a/diagram-converter/cli/src/main/java/io/camunda/migration/diagram/converter/cli/AbstractConvertCommand.java
+++ b/diagram-converter/cli/src/main/java/io/camunda/migration/diagram/converter/cli/AbstractConvertCommand.java
@@ -188,19 +188,24 @@ public abstract class AbstractConvertCommand implements Callable<Integer> {
   }
 
   private DiagramCheckResult checkModel(Entry<File, ModelInstance> modelInstance) {
+    String modelIdentifier = modelIdentifier(modelInstance.getKey());
     try {
       return converter.check(
-          modelInstance.getKey().getPath(),
+          modelIdentifier,
           modelInstance.getValue(),
           ConverterPropertiesFactory.getInstance().merge(converterProperties()));
     } catch (Exception e) {
-      LOG_CLI.error("Problem while converting: {}", createMessage(e));
+      LOG_CLI.error("Problem while converting {}: {}", modelIdentifier, createMessage(e));
       returnCode = 1;
       return null;
     }
   }
 
   protected abstract Map<File, ModelInstance> modelInstances();
+
+  protected String modelIdentifier(File modelFile) {
+    return modelFile.getAbsolutePath();
+  }
 
   protected DefaultConverterProperties converterProperties() {
     DefaultConverterProperties properties = new DefaultConverterProperties();

--- a/diagram-converter/cli/src/main/java/io/camunda/migration/diagram/converter/cli/ConvertLocalCommand.java
+++ b/diagram-converter/cli/src/main/java/io/camunda/migration/diagram/converter/cli/ConvertLocalCommand.java
@@ -61,6 +61,20 @@ public class ConvertLocalCommand extends AbstractConvertCommand {
   }
 
   @Override
+  protected String modelIdentifier(File modelFile) {
+    Path absoluteModelPath = modelFile.toPath().toAbsolutePath().normalize();
+    Path absoluteInputRoot =
+        (file.isDirectory() ? file.toPath() : file.getAbsoluteFile().getParentFile().toPath())
+            .toAbsolutePath()
+            .normalize();
+
+    if (absoluteModelPath.startsWith(absoluteInputRoot)) {
+      return absoluteInputRoot.relativize(absoluteModelPath).toString();
+    }
+    return absoluteModelPath.toString();
+  }
+
+  @Override
   protected Map<File, ModelInstance> modelInstances() {
     if (!file.exists()) {
       LOG_CLI.error("File {} does not exist", file.getAbsolutePath());

--- a/diagram-converter/cli/src/test/java/io/camunda/migration/diagram/converter/cli/ConvertLocalCommandTest.java
+++ b/diagram-converter/cli/src/test/java/io/camunda/migration/diagram/converter/cli/ConvertLocalCommandTest.java
@@ -11,6 +11,9 @@ import static java.nio.file.StandardCopyOption.*;
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
 
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -18,6 +21,7 @@ import java.nio.file.Files;
 import java.util.Objects;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.slf4j.LoggerFactory;
 
 public class ConvertLocalCommandTest {
   private void setupDir(String filename, File tempDir) {
@@ -107,5 +111,62 @@ public class ConvertLocalCommandTest {
     Integer call = command.call();
     assertEquals(0, call);
     assertThat(tempDir.listFiles()).hasSize(1).anyMatch(file -> file.getName().equals("c7.bpmn"));
+  }
+
+  @Test
+  void shouldReturnErrorCodeForAlreadyCamunda8Dmn(@TempDir File tempDir) {
+    setupDir("c8.dmn", tempDir);
+    ConvertLocalCommand command = new ConvertLocalCommand();
+    command.file = tempDir;
+    Integer call = command.call();
+    assertEquals(1, call);
+  }
+
+  @Test
+  void shouldIncludeFilenameInErrorForAlreadyCamunda8Dmn(@TempDir File tempDir) {
+    setupDir("c8.dmn", tempDir);
+    String expectedPath = "c8.dmn";
+    Logger cliLogger = (Logger) LoggerFactory.getLogger("cli");
+    ListAppender<ILoggingEvent> listAppender = new ListAppender<>();
+    listAppender.start();
+    cliLogger.addAppender(listAppender);
+    try {
+      ConvertLocalCommand command = new ConvertLocalCommand();
+      command.file = tempDir;
+      Integer call = command.call();
+      assertEquals(1, call);
+      assertThat(listAppender.list)
+          .anyMatch(
+              event ->
+                  event.getFormattedMessage().contains(expectedPath)
+                      && event.getFormattedMessage().contains("Problem while converting"));
+    } finally {
+      cliLogger.detachAppender(listAppender);
+      listAppender.stop();
+    }
+  }
+
+  @Test
+  void shouldIncludeFilenameInErrorForAlreadyCamunda8Bpmn(@TempDir File tempDir) {
+    setupDir("c8.bpmn", tempDir);
+    String expectedPath = "c8.bpmn";
+    Logger cliLogger = (Logger) LoggerFactory.getLogger("cli");
+    ListAppender<ILoggingEvent> listAppender = new ListAppender<>();
+    listAppender.start();
+    cliLogger.addAppender(listAppender);
+    try {
+      ConvertLocalCommand command = new ConvertLocalCommand();
+      command.file = tempDir;
+      Integer call = command.call();
+      assertEquals(1, call);
+      assertThat(listAppender.list)
+          .anyMatch(
+              event ->
+                  event.getFormattedMessage().contains(expectedPath)
+                      && event.getFormattedMessage().contains("Problem while converting"));
+    } finally {
+      cliLogger.detachAppender(listAppender);
+      listAppender.stop();
+    }
   }
 }

--- a/diagram-converter/cli/src/test/resources/c8.dmn
+++ b/diagram-converter/cli/src/test/resources/c8.dmn
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_c8dmn" name="DRD" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="5.15.2" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.3.0">
+  <decision id="Decision_1" name="Decision 1">
+    <decisionTable id="DecisionTable_1">
+      <input id="Input_1">
+        <inputExpression id="InputExpression_1" typeRef="string">
+          <text>input</text>
+        </inputExpression>
+      </input>
+      <output id="Output_1" typeRef="string" />
+    </decisionTable>
+  </decision>
+  <dmndi:DMNDI>
+    <dmndi:DMNDiagram>
+      <dmndi:DMNShape dmnElementRef="Decision_1">
+        <dc:Bounds height="80" width="180" x="160" y="100" />
+      </dmndi:DMNShape>
+    </dmndi:DMNDiagram>
+  </dmndi:DMNDI>
+</definitions>


### PR DESCRIPTION
Backport of #1433 to `maintenance/0.3`.

Cherry-picked cleanly with no conflicts.

## Summary
- Includes filename in error message when converting DMN/BPMN files already on Camunda 8
- Adds `modelIdentifier()` method to `AbstractConvertCommand` returning absolute path
- `ConvertLocalCommand` overrides it to return input-root-relative path
- Adds test resource `c8.dmn` and three new test cases

Closes #680 (backport)