### PR TITLE
fix(deps): upgrade Spring Framework to 7.0.8 across all modules

### DIFF
--- a/code-conversion/patterns/code-examples/camunda-7/pom.xml
+++ b/code-conversion/patterns/code-examples/camunda-7/pom.xml
@@ -22,6 +22,13 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
+        <groupId>org.springframework</groupId>
+        <artifactId>spring-framework-bom</artifactId>
+        <version>${version.spring-framework}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-dependencies</artifactId>
         <version>${version.spring-boot}</version>

--- a/code-conversion/patterns/code-examples/camunda-8/pom.xml
+++ b/code-conversion/patterns/code-examples/camunda-8/pom.xml
@@ -17,6 +17,13 @@
 	<dependencyManagement>
 		<dependencies>
 			<dependency>
+				<groupId>org.springframework</groupId>
+				<artifactId>spring-framework-bom</artifactId>
+				<version>${version.spring-framework}</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+			<dependency>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-dependencies</artifactId>
 				<version>${version.spring-boot}</version>

--- a/code-conversion/pom.xml
+++ b/code-conversion/pom.xml
@@ -13,6 +13,18 @@
   <packaging>pom</packaging>
   <name>Camunda 7 to 8 Migration Tooling - Code</name>
 
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.springframework</groupId>
+        <artifactId>spring-framework-bom</artifactId>
+        <version>${version.spring-framework}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <profiles>
     <profile>
       <id>distro</id>

--- a/code-conversion/recipes/pom.xml
+++ b/code-conversion/recipes/pom.xml
@@ -32,6 +32,13 @@
         <scope>import</scope>
       </dependency>
       <dependency>
+        <groupId>org.springframework</groupId>
+        <artifactId>spring-framework-bom</artifactId>
+        <version>${version.spring-framework}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-dependencies</artifactId>
         <version>${version.spring-boot}</version>

--- a/data-migrator/core/pom.xml
+++ b/data-migrator/core/pom.xml
@@ -18,6 +18,13 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
+        <groupId>org.springframework</groupId>
+        <artifactId>spring-framework-bom</artifactId>
+        <version>${version.spring-framework}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-dependencies</artifactId>
         <version>${version.spring-boot}</version>

--- a/data-migrator/distro/pom.xml
+++ b/data-migrator/distro/pom.xml
@@ -18,6 +18,13 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
+        <groupId>org.springframework</groupId>
+        <artifactId>spring-framework-bom</artifactId>
+        <version>${version.spring-framework}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-dependencies</artifactId>
         <version>${version.spring-boot}</version>

--- a/data-migrator/pom.xml
+++ b/data-migrator/pom.xml
@@ -16,12 +16,10 @@
 
   <dependencyManagement>
     <dependencies>
-      <!-- as long as there is no official engine-spring artifact for spring 7,
-      we need to override transitive spring libs -->
       <dependency>
         <groupId>org.springframework</groupId>
         <artifactId>spring-framework-bom</artifactId>
-        <version>7.0.8</version>
+        <version>${version.spring-framework}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/diagram-converter/pom.xml
+++ b/diagram-converter/pom.xml
@@ -59,6 +59,13 @@
         <version>${version.camunda-8}</version>
       </dependency>
       <dependency>
+        <groupId>org.springframework</groupId>
+        <artifactId>spring-framework-bom</artifactId>
+        <version>${version.spring-framework}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-dependencies</artifactId>
         <version>${version.spring-boot}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,7 @@
     <camunda8.docker.image>camunda/camunda:SNAPSHOT</camunda8.docker.image>
     <version.elasticsearch>8.19.6</version.elasticsearch>
     <version.spring-boot>4.0.6</version.spring-boot>
+    <version.spring-framework>7.0.8</version.spring-framework>
     <version.assertj>3.27.7</version.assertj>
     <version.junit.jupiter>6.1.0</version.junit.jupiter>
     <version.h2>2.4.240</version.h2>


### PR DESCRIPTION
## Summary

- Pins `spring-framework.version` to **7.0.8** across all modules via `version.spring-framework` property in the root pom and explicit `spring-framework-bom` imports in every `<dependencyManagement>` block that also imports `spring-boot-dependencies`
- Removes the previously ineffective `spring-framework-bom` override from `data-migrator/pom.xml` and replaces it with a working pattern
- Adds parent-level `spring-framework-bom` entries to `data-migrator/pom.xml` and `code-conversion/pom.xml` for modules with no own BOM imports (assembly, examples, process-solution-camunda-7)

## Context

**CVE-2026-41840** (Spring WebFlux multipart DoS) affects Spring Framework 7.0.0–7.0.7. This repo does not use Spring WebFlux and is **not exploitable**, but all modules were resolving Spring Framework 7.0.7 and SCA scanners will flag it.

### Root cause of the old failed override

`data-migrator/pom.xml` imported `spring-framework-bom:7.0.8` at the parent level, but child modules imported `spring-boot-dependencies:4.0.6` in their own `<dependencyManagement>`. Maven gives child-module BOM imports higher precedence than parent-level entries — so the parent's 7.0.8 pin was silently overridden by Spring Boot's managed 7.0.7.

### Fix

In each of the 6 poms that own a `spring-boot-dependencies` BOM import, `spring-framework-bom:7.0.8` is now inserted **before** it in the same `<dependencyManagement>` block. Within a single block, the first declaration of a given artifact wins, so 7.0.8 takes precedence.

## Test plan

- [ ] `mvn dependency:tree -Dincludes=org.springframework:spring-core` shows only `7.0.8` across all modules
- [ ] `mvn clean install -DskipTests` passes (BUILD SUCCESS)
- [ ] No regression in existing tests (`mvn clean install`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)