### PR TITLE
feat: migrate C7 business key to C8 business ID during runtime migration [backport 0.3]

### DIFF
--- a/data-migrator/core/src/main/java/io/camunda/migration/data/RuntimeMigrator.java
+++ b/data-migrator/core/src/main/java/io/camunda/migration/data/RuntimeMigrator.java
@@ -178,7 +178,8 @@ public class RuntimeMigrator {
       // Ensure all variables are fetched and can be transformed before starting the new instance
       Map<String, Object> globalVariables = variableService.getGlobalVariables(c7ProcessInstanceId);
 
-      return c8Client.createProcessInstance(bpmnProcessId, processInstance.getTenantId(), globalVariables)
+      return c8Client.createProcessInstance(bpmnProcessId, processInstance.getTenantId(), globalVariables,
+          processInstance.getBusinessKey())
           .getProcessInstanceKey();
     } else {
       RuntimeMigratorLogs.processInstanceNotExists(c7ProcessInstanceId);

--- a/data-migrator/core/src/main/java/io/camunda/migration/data/impl/clients/C8Client.java
+++ b/data-migrator/core/src/main/java/io/camunda/migration/data/impl/clients/C8Client.java
@@ -181,16 +181,20 @@ public class C8Client {
   protected JobMapper jobMapper;
 
   /**
-   * Creates a new process instance with the given BPMN process ID and variables.
+   * Creates a new process instance with the given BPMN process ID, tenant ID, variables, and
+   * optional business ID (mapped from the Camunda 7 business key). Null business IDs are ignored.
    */
   public ProcessInstanceEvent createProcessInstance(String bpmnProcessId, String tenantId,
-                                                    Map<String, Object> variables) {
+                                                    Map<String, Object> variables, String businessId) {
     var createProcessInstance = camundaClient.newCreateInstanceCommand()
         .bpmnProcessId(bpmnProcessId)
         .latestVersion()
         .variables(variables)
         .tenantId(getTenantId(tenantId));
 
+    if (businessId != null) {
+      createProcessInstance = createProcessInstance.businessId(businessId);
+    }
 
     return callApi(createProcessInstance::execute, FAILED_TO_CREATE_PROCESS_INSTANCE + bpmnProcessId);
   }

--- a/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/runtime/BusinessKeyMigrationTest.java
+++ b/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/runtime/BusinessKeyMigrationTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.migration.data.qa.runtime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.client.api.command.ClientException;
+import io.camunda.client.api.search.response.ProcessInstance;
+import java.util.List;
+import java.util.stream.Stream;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.api.Test;
+
+class BusinessKeyMigrationTest extends RuntimeMigrationAbstractTest {
+
+  static Stream<Arguments> businessKeyScenarios() {
+    return Stream.of(
+        Arguments.of(null, null, true),
+      Arguments.of("", null, false),
+        Arguments.of("myBusinessKey", "myBusinessKey", false));
+  }
+
+  @ParameterizedTest
+  @MethodSource("businessKeyScenarios")
+  public void shouldMigrateProcessInstanceWithBusinessKey(String businessKey,
+                                                           String expectedBusinessId,
+                                                           boolean startWithoutBusinessKey) {
+    // given
+    deployer.deployProcessInC7AndC8("simpleProcess.bpmn");
+
+    if (startWithoutBusinessKey) {
+      runtimeService.startProcessInstanceByKey("simpleProcess");
+    } else {
+      runtimeService.startProcessInstanceByKey("simpleProcess", businessKey);
+    }
+
+    // when
+    runtimeMigrator.start();
+
+    // then
+    Awaitility.await().ignoreException(ClientException.class).untilAsserted(() -> {
+      List<ProcessInstance> c8Instances = camundaClient.newProcessInstanceSearchRequest().execute().items();
+      assertThat(c8Instances).hasSize(1);
+      assertThat(c8Instances.getFirst().getBusinessId()).isEqualTo(expectedBusinessId);
+    });
+  }
+}


### PR DESCRIPTION
Backport of #1360 to `maintenance/0.3`.

## Changes

- `C8Client.createProcessInstance()` now accepts optional `businessId` param; conditionally calls `.businessId()` only when non-null
- `RuntimeMigrator.startNewProcessInstance()` reads `processInstance.getBusinessKey()` and forwards it as C8 business ID
- Integration test `BusinessKeyMigrationTest` covers null, empty, and present business key cases
