### PR TITLE
fix(deps): pin spring-framework-bom 7.0.8 across all modules

### DIFF
--- a/code-conversion/patterns/code-examples/camunda-7/pom.xml
+++ b/code-conversion/patterns/code-examples/camunda-7/pom.xml
@@ -22,6 +22,13 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
+        <groupId>org.springframework</groupId>
+        <artifactId>spring-framework-bom</artifactId>
+        <version>${version.spring-framework}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-dependencies</artifactId>
         <version>${version.spring-boot}</version>

--- a/code-conversion/patterns/code-examples/camunda-8/pom.xml
+++ b/code-conversion/patterns/code-examples/camunda-8/pom.xml
@@ -17,6 +17,13 @@
 	<dependencyManagement>
 		<dependencies>
 			<dependency>
+				<groupId>org.springframework</groupId>
+				<artifactId>spring-framework-bom</artifactId>
+				<version>${version.spring-framework}</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+			<dependency>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-dependencies</artifactId>
 				<version>${version.spring-boot}</version>

--- a/code-conversion/recipes/pom.xml
+++ b/code-conversion/recipes/pom.xml
@@ -32,6 +32,13 @@
         <scope>import</scope>
       </dependency>
       <dependency>
+        <groupId>org.springframework</groupId>
+        <artifactId>spring-framework-bom</artifactId>
+        <version>${version.spring-framework}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-dependencies</artifactId>
         <version>${version.spring-boot}</version>

--- a/data-migrator/core/pom.xml
+++ b/data-migrator/core/pom.xml
@@ -18,6 +18,13 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
+        <groupId>org.springframework</groupId>
+        <artifactId>spring-framework-bom</artifactId>
+        <version>${version.spring-framework}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-dependencies</artifactId>
         <version>${version.spring-boot}</version>

--- a/data-migrator/distro/pom.xml
+++ b/data-migrator/distro/pom.xml
@@ -18,6 +18,13 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
+        <groupId>org.springframework</groupId>
+        <artifactId>spring-framework-bom</artifactId>
+        <version>${version.spring-framework}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-dependencies</artifactId>
         <version>${version.spring-boot}</version>

--- a/data-migrator/pom.xml
+++ b/data-migrator/pom.xml
@@ -21,7 +21,7 @@
       <dependency>
         <groupId>org.springframework</groupId>
         <artifactId>spring-framework-bom</artifactId>
-        <version>7.0.8</version>
+        <version>${version.spring-framework}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/diagram-converter/pom.xml
+++ b/diagram-converter/pom.xml
@@ -59,6 +59,13 @@
         <version>${version.camunda-8}</version>
       </dependency>
       <dependency>
+        <groupId>org.springframework</groupId>
+        <artifactId>spring-framework-bom</artifactId>
+        <version>${version.spring-framework}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-dependencies</artifactId>
         <version>${version.spring-boot}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,7 @@
     <camunda8.docker.image>camunda/camunda:SNAPSHOT</camunda8.docker.image>
     <version.elasticsearch>8.19.6</version.elasticsearch>
     <version.spring-boot>4.0.6</version.spring-boot>
+    <version.spring-framework>7.0.8</version.spring-framework>
     <version.assertj>3.27.7</version.assertj>
     <version.junit.jupiter>6.1.0</version.junit.jupiter>
     <version.h2>2.4.240</version.h2>
@@ -98,6 +99,13 @@
 
   <dependencyManagement>
     <dependencies>
+      <dependency>
+        <groupId>org.springframework</groupId>
+        <artifactId>spring-framework-bom</artifactId>
+        <version>${version.spring-framework}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
       <dependency>
         <groupId>org.junit</groupId>
         <artifactId>junit-bom</artifactId>


### PR DESCRIPTION
## Summary

Spring Boot 4.0.6 manages Spring Framework 7.0.7, which contains a CVE fixed in 7.0.8. The previous fix (#1463, maintenance/0.3) patched only `data-migrator` with a hardcoded version. This PR makes it a proper project-wide solution.

**Root cause**: Spring Boot 4.0.6 resolves `spring-webmvc`/`spring-web`/`spring-context` to 7.0.7. Modules that import `spring-boot-dependencies` in their own `dependencyManagement` get the vulnerable version because child `dependencyManagement` overrides parent.

**Fix**:
- Add `version.spring-framework=7.0.8` property to root `pom.xml`
- Import `spring-framework-bom` before `spring-boot-dependencies` in every module with its own `dependencyManagement` (`data-migrator`, `data-migrator/core`, `data-migrator/distro`, `diagram-converter`, `code-conversion/recipes`, `code-conversion/patterns/camunda-7`, `code-conversion/patterns/camunda-8`)
- Add `spring-framework-bom` to root `pom.xml` `dependencyManagement` as catch-all for modules without their own

**Verified**: `mvn dependency:tree` across all 20 modules — no `7.0.7` anywhere, all Spring artifacts resolve to `7.0.8`.

## Related

- Closes the project-wide gap left open after #1463 (maintenance/0.3 hotfix)
- Supersedes the approach in #1458

## Test plan

- [ ] CI passes (build + tests)
- [ ] `mvn dependency:tree -Dincludes=org.springframework:spring-webmvc` shows `7.0.8` in `diagram-converter/webapp`, `data-migrator/core`, `code-conversion/recipes`

🤖 Generated with [Claude Code](https://claude.com/claude-code)