### PR TITLE
feat: retry C8Client.activateJobs on transient timeout, log only on exhaustion

### DIFF
--- a/data-migrator/core/pom.xml
+++ b/data-migrator/core/pom.xml
@@ -259,6 +259,18 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/data-migrator/core/src/main/java/io/camunda/migration/data/impl/clients/C8Client.java
+++ b/data-migrator/core/src/main/java/io/camunda/migration/data/impl/clients/C8Client.java
@@ -8,6 +8,7 @@
 package io.camunda.migration.data.impl.clients;
 
 import static io.camunda.migration.data.constants.MigratorConstants.C8_DEFAULT_TENANT;
+import static io.camunda.migration.data.impl.logging.C8ClientLogs.ACTIVATE_JOBS_TIMEOUT_RETRY;
 import static io.camunda.migration.data.impl.logging.C8ClientLogs.FAILED_TO_ACTIVATE_JOBS;
 import static io.camunda.migration.data.impl.logging.C8ClientLogs.FAILED_TO_CREATE_GROUP_MEMBERSHIP;
 import static io.camunda.migration.data.impl.logging.C8ClientLogs.FAILED_TO_CREATE_PROCESS_INSTANCE;
@@ -119,13 +120,17 @@ import io.camunda.search.entities.ProcessDefinitionEntity;
 import io.camunda.search.entities.ProcessInstanceEntity;
 import io.camunda.search.filter.DecisionRequirementsFilter;
 import io.camunda.search.filter.FlowNodeInstanceFilter;
+import java.net.SocketTimeoutException;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.TimeoutException;
 import java.util.function.Supplier;
 import org.apache.commons.lang3.StringUtils;
 import org.camunda.bpm.engine.identity.Tenant;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -135,6 +140,10 @@ import org.springframework.stereotype.Component;
  */
 @Component
 public class C8Client {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(C8Client.class);
+  private static final int MAX_ACTIVATE_JOBS_RETRIES = 3;
+  protected long activateJobsRetryDelayMs = 2000L;
 
   @Autowired
   protected MigratorProperties properties;
@@ -221,7 +230,8 @@ public class C8Client {
   }
 
   /**
-   * Activates jobs for the specified job type.
+   * Activates jobs for the specified job type, with up to MAX_ACTIVATE_JOBS_RETRIES retries on
+   * transient timeout failures.
    */
   public List<ActivatedJob> activateJobs(String jobType) {
     Set<String> tenantIds = properties.getTenantIds();
@@ -234,7 +244,39 @@ public class C8Client {
       tenantIdsWithDefault.add(C8_DEFAULT_TENANT);
       activateJobs = activateJobs.tenantIds(List.copyOf(tenantIdsWithDefault));
     }
-    return callApi(activateJobs::execute, FAILED_TO_ACTIVATE_JOBS + jobType).getJobs();
+
+    for (int attempt = 1; attempt <= MAX_ACTIVATE_JOBS_RETRIES; attempt++) {
+      try {
+        return callApi(activateJobs::execute, FAILED_TO_ACTIVATE_JOBS + jobType).getJobs();
+      } catch (MigratorException e) {
+        if (isCausedByTimeout(e) && attempt < MAX_ACTIVATE_JOBS_RETRIES) {
+          LOGGER.warn(ACTIVATE_JOBS_TIMEOUT_RETRY, jobType, attempt, MAX_ACTIVATE_JOBS_RETRIES);
+          sleepUninterruptibly(activateJobsRetryDelayMs * attempt);
+        } else {
+          throw e;
+        }
+      }
+    }
+    throw new IllegalStateException("Unexpected: retry loop exhausted without throwing");
+  }
+
+  protected static boolean isCausedByTimeout(Throwable t) {
+    Throwable cause = t;
+    while (cause != null) {
+      if (cause instanceof TimeoutException || cause instanceof SocketTimeoutException) {
+        return true;
+      }
+      cause = cause.getCause();
+    }
+    return false;
+  }
+
+  private void sleepUninterruptibly(long ms) {
+    try {
+      Thread.sleep(ms);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+    }
   }
 
   /**

--- a/data-migrator/core/src/main/java/io/camunda/migration/data/impl/clients/C8Client.java
+++ b/data-migrator/core/src/main/java/io/camunda/migration/data/impl/clients/C8Client.java
@@ -141,8 +141,8 @@ import org.springframework.stereotype.Component;
 @Component
 public class C8Client {
 
-  private static final Logger LOGGER = LoggerFactory.getLogger(C8Client.class);
-  private static final int MAX_ACTIVATE_JOBS_RETRIES = 3;
+  static final Logger LOGGER = LoggerFactory.getLogger(C8Client.class);
+  static final int MAX_ACTIVATE_JOBS_RETRIES = 3;
   protected long activateJobsRetryDelayMs = 2000L;
 
   @Autowired
@@ -271,7 +271,7 @@ public class C8Client {
     return false;
   }
 
-  private void sleepUninterruptibly(long ms) {
+  void sleepUninterruptibly(long ms) {
     try {
       Thread.sleep(ms);
     } catch (InterruptedException e) {

--- a/data-migrator/core/src/main/java/io/camunda/migration/data/impl/clients/C8Client.java
+++ b/data-migrator/core/src/main/java/io/camunda/migration/data/impl/clients/C8Client.java
@@ -9,7 +9,6 @@ package io.camunda.migration.data.impl.clients;
 
 import static io.camunda.migration.data.constants.MigratorConstants.C8_DEFAULT_TENANT;
 import static io.camunda.migration.data.impl.logging.C8ClientLogs.FAILED_TO_ACTIVATE_JOBS;
-import static io.camunda.migration.data.impl.logging.C8ClientLogs.retryingActivateJobs;
 import static io.camunda.migration.data.impl.logging.C8ClientLogs.FAILED_TO_CREATE_GROUP_MEMBERSHIP;
 import static io.camunda.migration.data.impl.logging.C8ClientLogs.FAILED_TO_CREATE_PROCESS_INSTANCE;
 import static io.camunda.migration.data.impl.logging.C8ClientLogs.FAILED_TO_CREATE_TENANT_GROUP_MEMBERSHIP;
@@ -57,6 +56,7 @@ import static io.camunda.migration.data.impl.util.ExceptionUtils.wrapException;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
 import io.camunda.client.CamundaClient;
+import io.camunda.client.api.command.ClientException;
 import io.camunda.client.api.command.CreateAuthorizationCommandStep1;
 import io.camunda.client.api.command.CreateGroupCommandStep1;
 import io.camunda.client.api.command.CreateTenantCommandStep1;
@@ -244,13 +244,12 @@ public class C8Client {
 
     for (int attempt = 1; attempt <= MAX_ACTIVATE_JOBS_RETRIES; attempt++) {
       try {
-        return callApi(activateJobs::execute, FAILED_TO_ACTIVATE_JOBS + jobType).getJobs();
-      } catch (MigratorException e) {
+        return activateJobs.execute().getJobs();
+      } catch (ClientException e) {
         if (isCausedByTimeout(e) && attempt < MAX_ACTIVATE_JOBS_RETRIES) {
-          retryingActivateJobs(jobType, attempt, MAX_ACTIVATE_JOBS_RETRIES);
           sleepUninterruptibly(activateJobsRetryDelayMs * attempt);
         } else {
-          throw e;
+          throw wrapException(FAILED_TO_ACTIVATE_JOBS + jobType, e);
         }
       }
     }

--- a/data-migrator/core/src/main/java/io/camunda/migration/data/impl/clients/C8Client.java
+++ b/data-migrator/core/src/main/java/io/camunda/migration/data/impl/clients/C8Client.java
@@ -56,7 +56,6 @@ import static io.camunda.migration.data.impl.util.ExceptionUtils.wrapException;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
 import io.camunda.client.CamundaClient;
-import io.camunda.client.api.command.ClientException;
 import io.camunda.client.api.command.CreateAuthorizationCommandStep1;
 import io.camunda.client.api.command.CreateGroupCommandStep1;
 import io.camunda.client.api.command.CreateTenantCommandStep1;
@@ -140,7 +139,7 @@ import org.springframework.stereotype.Component;
 public class C8Client {
 
   static final int MAX_ACTIVATE_JOBS_RETRIES = 3;
-  protected long activateJobsRetryDelayMs = 2000L;
+  long activateJobsRetryDelayMs = 2000L;
 
   @Autowired
   protected MigratorProperties properties;
@@ -227,7 +226,7 @@ public class C8Client {
   }
 
   /**
-   * Activates jobs for the specified job type, with up to MAX_ACTIVATE_JOBS_RETRIES retries on
+   * Activates jobs for the specified job type, retrying up to MAX_ACTIVATE_JOBS_RETRIES times on
    * transient timeout failures.
    */
   public List<ActivatedJob> activateJobs(String jobType) {
@@ -244,19 +243,19 @@ public class C8Client {
 
     for (int attempt = 1; attempt <= MAX_ACTIVATE_JOBS_RETRIES; attempt++) {
       try {
-        return activateJobs.execute().getJobs();
-      } catch (ClientException e) {
+        return callApi(activateJobs::execute, FAILED_TO_ACTIVATE_JOBS + jobType).getJobs();
+      } catch (MigratorException e) {
         if (isCausedByTimeout(e) && attempt < MAX_ACTIVATE_JOBS_RETRIES) {
           sleepUninterruptibly(activateJobsRetryDelayMs * attempt);
         } else {
-          throw wrapException(FAILED_TO_ACTIVATE_JOBS + jobType, e);
+          throw e;
         }
       }
     }
     throw new IllegalStateException("Unexpected: retry loop exhausted without throwing");
   }
 
-  protected static boolean isCausedByTimeout(Throwable t) {
+  static boolean isCausedByTimeout(Throwable t) {
     Throwable cause = t;
     while (cause != null) {
       if (cause instanceof TimeoutException || cause instanceof SocketTimeoutException) {

--- a/data-migrator/core/src/main/java/io/camunda/migration/data/impl/clients/C8Client.java
+++ b/data-migrator/core/src/main/java/io/camunda/migration/data/impl/clients/C8Client.java
@@ -8,8 +8,8 @@
 package io.camunda.migration.data.impl.clients;
 
 import static io.camunda.migration.data.constants.MigratorConstants.C8_DEFAULT_TENANT;
-import static io.camunda.migration.data.impl.logging.C8ClientLogs.ACTIVATE_JOBS_TIMEOUT_RETRY;
 import static io.camunda.migration.data.impl.logging.C8ClientLogs.FAILED_TO_ACTIVATE_JOBS;
+import static io.camunda.migration.data.impl.logging.C8ClientLogs.retryingActivateJobs;
 import static io.camunda.migration.data.impl.logging.C8ClientLogs.FAILED_TO_CREATE_GROUP_MEMBERSHIP;
 import static io.camunda.migration.data.impl.logging.C8ClientLogs.FAILED_TO_CREATE_PROCESS_INSTANCE;
 import static io.camunda.migration.data.impl.logging.C8ClientLogs.FAILED_TO_CREATE_TENANT_GROUP_MEMBERSHIP;
@@ -129,8 +129,6 @@ import java.util.concurrent.TimeoutException;
 import java.util.function.Supplier;
 import org.apache.commons.lang3.StringUtils;
 import org.camunda.bpm.engine.identity.Tenant;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -141,7 +139,6 @@ import org.springframework.stereotype.Component;
 @Component
 public class C8Client {
 
-  static final Logger LOGGER = LoggerFactory.getLogger(C8Client.class);
   static final int MAX_ACTIVATE_JOBS_RETRIES = 3;
   protected long activateJobsRetryDelayMs = 2000L;
 
@@ -250,7 +247,7 @@ public class C8Client {
         return callApi(activateJobs::execute, FAILED_TO_ACTIVATE_JOBS + jobType).getJobs();
       } catch (MigratorException e) {
         if (isCausedByTimeout(e) && attempt < MAX_ACTIVATE_JOBS_RETRIES) {
-          LOGGER.warn(ACTIVATE_JOBS_TIMEOUT_RETRY, jobType, attempt, MAX_ACTIVATE_JOBS_RETRIES);
+          retryingActivateJobs(jobType, attempt, MAX_ACTIVATE_JOBS_RETRIES);
           sleepUninterruptibly(activateJobsRetryDelayMs * attempt);
         } else {
           throw e;

--- a/data-migrator/core/src/main/java/io/camunda/migration/data/impl/clients/C8Client.java
+++ b/data-migrator/core/src/main/java/io/camunda/migration/data/impl/clients/C8Client.java
@@ -56,6 +56,7 @@ import static io.camunda.migration.data.impl.util.ExceptionUtils.wrapException;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
 import io.camunda.client.CamundaClient;
+import io.camunda.client.api.command.ClientException;
 import io.camunda.client.api.command.CreateAuthorizationCommandStep1;
 import io.camunda.client.api.command.CreateGroupCommandStep1;
 import io.camunda.client.api.command.CreateTenantCommandStep1;
@@ -138,7 +139,7 @@ import org.springframework.stereotype.Component;
 @Component
 public class C8Client {
 
-  static final int MAX_ACTIVATE_JOBS_RETRIES = 3;
+  static final int MAX_ACTIVATE_JOBS_ATTEMPTS = 3;
   long activateJobsRetryDelayMs = 2000L;
 
   @Autowired
@@ -226,8 +227,12 @@ public class C8Client {
   }
 
   /**
-   * Activates jobs for the specified job type, retrying up to MAX_ACTIVATE_JOBS_RETRIES times on
-   * transient timeout failures.
+   * Activates jobs for the specified job type, retrying up to {@value #MAX_ACTIVATE_JOBS_ATTEMPTS}
+   * times on transient timeout failures.
+   *
+   * <p>Calls {@code execute()} directly rather than {@code ExceptionUtils.callApi} so that the
+   * ERROR log and exception wrapping only happen once — on a non-timeout failure or after the last
+   * attempt is exhausted. Transient timeouts that recover on a later attempt produce no error log.
    */
   public List<ActivatedJob> activateJobs(String jobType) {
     Set<String> tenantIds = properties.getTenantIds();
@@ -241,14 +246,14 @@ public class C8Client {
       activateJobs = activateJobs.tenantIds(List.copyOf(tenantIdsWithDefault));
     }
 
-    for (int attempt = 1; attempt <= MAX_ACTIVATE_JOBS_RETRIES; attempt++) {
+    for (int attempt = 1; attempt <= MAX_ACTIVATE_JOBS_ATTEMPTS; attempt++) {
       try {
-        return callApi(activateJobs::execute, FAILED_TO_ACTIVATE_JOBS + jobType).getJobs();
-      } catch (MigratorException e) {
-        if (isCausedByTimeout(e) && attempt < MAX_ACTIVATE_JOBS_RETRIES) {
+        return activateJobs.execute().getJobs();
+      } catch (ClientException e) {
+        if (isCausedByTimeout(e) && attempt < MAX_ACTIVATE_JOBS_ATTEMPTS) {
           sleepUninterruptibly(activateJobsRetryDelayMs * attempt);
         } else {
-          throw e;
+          throw wrapException(FAILED_TO_ACTIVATE_JOBS + jobType, e);
         }
       }
     }

--- a/data-migrator/core/src/main/java/io/camunda/migration/data/impl/logging/C8ClientLogs.java
+++ b/data-migrator/core/src/main/java/io/camunda/migration/data/impl/logging/C8ClientLogs.java
@@ -8,11 +8,23 @@
 
 package io.camunda.migration.data.impl.logging;
 
+import io.camunda.migration.data.impl.clients.C8Client;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /**
  * Centralized logging utility for C8Client.
  * Contains all log messages and string constants used in C8Client.
  */
 public class C8ClientLogs {
+
+  protected static final Logger LOGGER = LoggerFactory.getLogger(C8Client.class);
+
+  private static final String ACTIVATE_JOBS_TIMEOUT_RETRY = "Timeout while activating jobs for type: {}. Retrying ({}/{})...";
+
+  public static void retryingActivateJobs(String jobType, int attempt, int maxRetries) {
+    LOGGER.warn(ACTIVATE_JOBS_TIMEOUT_RETRY, jobType, attempt, maxRetries);
+  }
 
   // C8 Client Error Messages
   public static final String FAILED_TO_DEPLOY_C8_RESOURCES = "Failed to deploy C8 resources: ";
@@ -51,6 +63,5 @@ public class C8ClientLogs {
   public static final String FAILED_TO_CREATE_TENANT_GROUP_MEMBERSHIP = "Failed to create tenant membership for tenant [%s] and group [%s], check logs for details";
   public static final String FAILED_TO_INSERT_JOB = "Failed to insert job";
   public static final String FAILED_TO_QUERY_TOPOLOGY = "Camunda REST API cannot be reached to query for the topology. If you want to continue in offline mode, please configure a partition count with the following config property: ";
-  public static final String ACTIVATE_JOBS_TIMEOUT_RETRY = "Timeout while activating jobs for type: {}. Retrying ({}/{})...";
 
 }

--- a/data-migrator/core/src/main/java/io/camunda/migration/data/impl/logging/C8ClientLogs.java
+++ b/data-migrator/core/src/main/java/io/camunda/migration/data/impl/logging/C8ClientLogs.java
@@ -8,23 +8,11 @@
 
 package io.camunda.migration.data.impl.logging;
 
-import io.camunda.migration.data.impl.clients.C8Client;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 /**
  * Centralized logging utility for C8Client.
  * Contains all log messages and string constants used in C8Client.
  */
 public class C8ClientLogs {
-
-  protected static final Logger LOGGER = LoggerFactory.getLogger(C8Client.class);
-
-  private static final String ACTIVATE_JOBS_TIMEOUT_RETRY = "Timeout while activating jobs for type: {}. Retrying ({}/{})...";
-
-  public static void retryingActivateJobs(String jobType, int attempt, int maxRetries) {
-    LOGGER.warn(ACTIVATE_JOBS_TIMEOUT_RETRY, jobType, attempt, maxRetries);
-  }
 
   // C8 Client Error Messages
   public static final String FAILED_TO_DEPLOY_C8_RESOURCES = "Failed to deploy C8 resources: ";

--- a/data-migrator/core/src/main/java/io/camunda/migration/data/impl/logging/C8ClientLogs.java
+++ b/data-migrator/core/src/main/java/io/camunda/migration/data/impl/logging/C8ClientLogs.java
@@ -51,5 +51,6 @@ public class C8ClientLogs {
   public static final String FAILED_TO_CREATE_TENANT_GROUP_MEMBERSHIP = "Failed to create tenant membership for tenant [%s] and group [%s], check logs for details";
   public static final String FAILED_TO_INSERT_JOB = "Failed to insert job";
   public static final String FAILED_TO_QUERY_TOPOLOGY = "Camunda REST API cannot be reached to query for the topology. If you want to continue in offline mode, please configure a partition count with the following config property: ";
+  public static final String ACTIVATE_JOBS_TIMEOUT_RETRY = "Timeout while activating jobs for type: {}. Retrying ({}/{})...";
 
 }

--- a/data-migrator/core/src/test/java/io/camunda/migration/data/impl/clients/C8ClientActivateJobsRetryTest.java
+++ b/data-migrator/core/src/test/java/io/camunda/migration/data/impl/clients/C8ClientActivateJobsRetryTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.migration.data.impl.clients;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.command.ClientException;
+import io.camunda.client.api.response.ActivateJobsResponse;
+import io.camunda.migration.data.config.property.MigratorProperties;
+import io.camunda.migration.data.exception.MigratorException;
+import java.net.SocketTimeoutException;
+import java.util.List;
+import java.util.concurrent.TimeoutException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class C8ClientActivateJobsRetryTest {
+
+  @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+  private CamundaClient camundaClient;
+
+  @Mock
+  private MigratorProperties properties;
+
+  @InjectMocks
+  private C8Client c8Client;
+
+  @BeforeEach
+  void setUp() {
+    c8Client.activateJobsRetryDelayMs = 0L;
+    when(properties.getPageSize()).thenReturn(10);
+    when(properties.getTenantIds()).thenReturn(null);
+  }
+
+  @Test
+  void retriesOnTimeoutAndSucceedsOnSecondAttempt() {
+    var cmd = camundaClient.newActivateJobsCommand().jobType("migrator").maxJobsToActivate(10);
+    var response = Mockito.mock(ActivateJobsResponse.class);
+    when(response.getJobs()).thenReturn(List.of());
+    when(cmd.execute())
+        .thenThrow(new ClientException("timeout", new SocketTimeoutException()))
+        .thenReturn(response);
+
+    List<?> result = c8Client.activateJobs("migrator");
+
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  void throwsAfterAllRetriesExhausted() {
+    var cmd = camundaClient.newActivateJobsCommand().jobType("migrator").maxJobsToActivate(10);
+    when(cmd.execute())
+        .thenThrow(new ClientException("timeout", new SocketTimeoutException()));
+
+    assertThrows(MigratorException.class, () -> c8Client.activateJobs("migrator"));
+  }
+
+  @Test
+  void doesNotRetryOnNonTimeoutException() {
+    var cmd = camundaClient.newActivateJobsCommand().jobType("migrator").maxJobsToActivate(10);
+    var response = Mockito.mock(ActivateJobsResponse.class);
+    when(cmd.execute())
+        .thenThrow(new ClientException("bad request", new RuntimeException("bad")))
+        .thenReturn(response);
+
+    assertThrows(MigratorException.class, () -> c8Client.activateJobs("migrator"));
+  }
+
+  @Test
+  void isCausedByTimeout_trueForSocketTimeoutInCauseChain() {
+    var e = new MigratorException("msg", new ClientException("msg", new SocketTimeoutException()));
+    assertTrue(C8Client.isCausedByTimeout(e));
+  }
+
+  @Test
+  void isCausedByTimeout_trueForTimeoutException() {
+    var e = new MigratorException("msg", new ClientException("msg", new TimeoutException()));
+    assertTrue(C8Client.isCausedByTimeout(e));
+  }
+
+  @Test
+  void isCausedByTimeout_falseForOtherException() {
+    var e = new MigratorException("msg", new ClientException("msg", new RuntimeException("other")));
+    assertFalse(C8Client.isCausedByTimeout(e));
+  }
+}

--- a/data-migrator/core/src/test/java/io/camunda/migration/data/impl/clients/C8ClientActivateJobsRetryTest.java
+++ b/data-migrator/core/src/test/java/io/camunda/migration/data/impl/clients/C8ClientActivateJobsRetryTest.java
@@ -11,6 +11,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.camunda.client.CamundaClient;
@@ -64,6 +66,7 @@ class C8ClientActivateJobsRetryTest {
     List<?> result = c8Client.activateJobs("migrator");
 
     assertThat(result).isEmpty();
+    verify(cmd, times(2)).execute();
   }
 
   @Test
@@ -73,17 +76,17 @@ class C8ClientActivateJobsRetryTest {
         .thenThrow(new ClientException("timeout", new SocketTimeoutException()));
 
     assertThrows(MigratorException.class, () -> c8Client.activateJobs("migrator"));
+    verify(cmd, times(3)).execute();
   }
 
   @Test
   void doesNotRetryOnNonTimeoutException() {
     var cmd = camundaClient.newActivateJobsCommand().jobType("migrator").maxJobsToActivate(10);
-    var response = Mockito.mock(ActivateJobsResponse.class);
     when(cmd.execute())
-        .thenThrow(new ClientException("bad request", new RuntimeException("bad")))
-        .thenReturn(response);
+        .thenThrow(new ClientException("bad request", new RuntimeException("bad")));
 
     assertThrows(MigratorException.class, () -> c8Client.activateJobs("migrator"));
+    verify(cmd, times(1)).execute();
   }
 
   @Test


### PR DESCRIPTION
## Summary

Closes #1487

- `C8Client.activateJobs()` retries on transient `SocketTimeoutException` / `TimeoutException` — up to 3 attempts total (2 retries), with linear backoff (`activateJobsRetryDelayMs` × attempt → 2 s, then 4 s).
- Calls `execute()` directly and only wraps + logs via `wrapException()` on a non-timeout failure or after the final attempt is exhausted. Transient timeouts that recover on a later attempt produce **no** ERROR stack trace.
- Non-timeout failures (a `ClientException` whose cause chain contains no timeout) propagate immediately on the first attempt — no retry.
- `activateJobs` is idempotent (jobs stay in the queue until explicitly completed), so retrying is safe.
- Unit test class `C8ClientActivateJobsRetryTest` verifies the exact `execute()` invocation counts (2 on recovery, 3 on exhaustion, 1 on non-timeout) plus the `isCausedByTimeout` cause-chain helper.

## Context

CI failure on the `mariadb + 8.10.0-SNAPSHOT` matrix ([related PR #1470](https://github.com/camunda/camunda-7-to-8-migration-tooling/pull/1470)) revealed that transient socket timeouts from `activateJobs` crash the migration run instead of being retried. This PR adds retry hardening to the production client. It also helps real migrations when the C8 cluster or its DB is briefly slow.

## Test plan

- [x] `C8ClientActivateJobsRetryTest` — 6 unit tests, all green; attempt counts asserted via `verify(times(...))`
- [x] Integration: `mvn verify -Pmariadb,integration -Dversion.camunda-8=8.10.0-SNAPSHOT -Dc8.api=current -Dcamunda.process-test.camunda-docker-image-version=SNAPSHOT` — all runtime tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)