### PR TITLE
fix(e2e): pin Camunda 8 Docker image via POM

### DIFF
--- a/data-migrator/qa/e2e-tests/src/main/resources/docker-compose.yml.template
+++ b/data-migrator/qa/e2e-tests/src/main/resources/docker-compose.yml.template
@@ -112,7 +112,7 @@ services:
       - e2e-network
 
   camunda8: # Consolidated Zeebe + Operate + Tasklist - https://docs.camunda.io/docs/self-managed/setup/deploy/other/docker/#zeebe
-    image: camunda/camunda:SNAPSHOT
+    image: ${camunda8.docker.image}
     container_name: camunda8
     ports:
       - "26500:26500"

--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,7 @@
 
     <version.camunda-7>7.24.6-ee</version.camunda-7>
     <version.camunda-8>8.9.9</version.camunda-8>
+    <camunda8.docker.image>camunda/camunda:${version.camunda-8}</camunda8.docker.image>
     <version.elasticsearch>8.19.6</version.elasticsearch>
     <version.spring-boot>4.1.0</version.spring-boot>
     <version.netty>4.2.15.Final</version.netty>


### PR DESCRIPTION
## Summary

- Add a `camunda8.docker.image` Maven property on `maintenance/0.3`, derived from `version.camunda-8`
- Use that property in the e2e Docker compose template instead of the moving `camunda/camunda:SNAPSHOT` tag
- Align e2e Docker runtime with the pinned Camunda 8 Maven version for release validation

## Context

`main` parameterized the e2e Camunda 8 Docker image in `aca3e720` as part of the dual-version CI work. The full commit does not cherry-pick cleanly to `maintenance/0.3` because it also changes the CI workflow substantially, so this PR applies the relevant POM/template part for the maintenance branch.

## Validation

- `mvn process-resources -pl data-migrator/qa/e2e-tests -Pe2e --batch-mode`
- Verified generated compose resolves to `image: camunda/camunda:8.9.9`

related to #1199