### PR TITLE
fix(e2e): pin Camunda 8 Docker image via POM

### DIFF
--- a/data-migrator/qa/e2e-tests/src/main/resources/docker-compose.yml.template
+++ b/data-migrator/qa/e2e-tests/src/main/resources/docker-compose.yml.template
@@ -95,7 +95,7 @@ services:
       - e2e-network
 
   camunda8: # Consolidated Zeebe + Operate + Tasklist - https://docs.camunda.io/docs/self-managed/setup/deploy/other/docker/#zeebe
-    image: camunda/camunda:8.8.14
+    image: ${camunda8.docker.image}
     container_name: camunda8
     ports:
       - "26500:26500"

--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,7 @@
 
     <version.camunda-7>7.24.3-ee</version.camunda-7>
     <version.camunda-8>8.8.19</version.camunda-8>
+    <camunda8.docker.image>camunda/camunda:${version.camunda-8}</camunda8.docker.image>
     <version.elasticsearch>8.19.6</version.elasticsearch>
     <version.spring-boot>3.5.15</version.spring-boot>
     <version.assertj>3.27.7</version.assertj>


### PR DESCRIPTION
## Summary
- Add `camunda8.docker.image` derived from `${version.camunda-8}`
- Use the property in the E2E Docker Compose template for the Camunda 8 image

## Validation
- `mvn -N validate`
- `mvn -N help:evaluate -Dexpression=camunda8.docker.image -q -DforceStdout` -> `camunda/camunda:8.8.19`
- `git diff --check`

Note: `mvn process-resources -DskipTests` in `data-migrator/qa/e2e-tests` is blocked on this branch by missing local artifact `io.camunda:camunda-7-to-8-data-migrator:zip:0.2.5-SNAPSHOT`.