### PR TITLE
chore(deps): update Camunda 7 to 7.24.5 (maintenance/0.2)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
     <maven.compiler.target>21</maven.compiler.target>
     <version.java>21</version.java>
 
-    <version.camunda-7>7.24.3-ee</version.camunda-7>
+    <version.camunda-7>7.24.5-ee</version.camunda-7>
     <version.camunda-8>8.8.19</version.camunda-8>
     <camunda8.docker.image>camunda/camunda:${version.camunda-8}</camunda8.docker.image>
     <version.elasticsearch>8.19.6</version.elasticsearch>


### PR DESCRIPTION
Maintenance/0.2-specific follow-up for #1500.

The original 7.24.9-ee backport is not valid on maintenance/0.2: this branch depends on org.camunda.bpm:camunda-engine-spring-6, and that artifact is published through 7.24.5-ee but not for 7.24.6-ee or newer. Using 7.24.9-ee caused the data-migrator CI jobs to fail during dependency resolution.

This updates version.camunda-7 from 7.24.3-ee to the latest resolvable patch for the maintenance/0.2 dependency line: 7.24.5-ee.

Validation:
- mvn -q dependency:get -Dartifact=org.camunda.bpm:camunda-engine-spring-6:7.24.5-ee -Dtransitive=false
- mvn -q dependency:get -Dartifact=org.camunda.bpm:camunda-engine-spring-6:7.24.9-ee -Dtransitive=false (fails; artifact is missing)
- mvn -f .worktree/maintenance-0.2-backport-1500/pom.xml -pl data-migrator/core -am -DskipTests compile
- mvn -f .worktree/maintenance-0.2-backport-1500/pom.xml -pl data-migrator/distro -am -DskipTests package