### PR TITLE
chore(deps): update Camunda 7 to 7.24.9 (maintenance/0.3)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
     <maven.compiler.target>21</maven.compiler.target>
     <version.java>21</version.java>
 
-    <version.camunda-7>7.24.6-ee</version.camunda-7>
+    <version.camunda-7>7.24.9-ee</version.camunda-7>
     <version.camunda-8>8.9.9</version.camunda-8>
     <camunda8.docker.image>camunda/camunda:${version.camunda-8}</camunda8.docker.image>
     <version.elasticsearch>8.19.6</version.elasticsearch>


### PR DESCRIPTION
Backport of #1500 to maintenance/0.3.

The automatic cherry-pick conflicted because the neighboring Camunda 8 properties differ on the maintenance branch. This keeps the maintenance/0.3 Camunda 8 settings intact and only updates version.camunda-7 to 7.24.9-ee.

Validation:
- mvn -N validate -f .worktree/maintenance-0.3-backport-1500/pom.xml