### PR TITLE
ci: run Linux H2 integration jobs on push to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -285,11 +285,13 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 70
     if: |
+      github.event_name == 'push' ||
+      github.event_name == 'schedule' ||
+      github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'pull_request' && (
         contains(github.event.pull_request.labels.*.name, 'ci:runtime') ||
         (!contains(github.event.pull_request.labels.*.name, 'ci:runtime') && !contains(github.event.pull_request.labels.*.name, 'ci:history') && !contains(github.event.pull_request.labels.*.name, 'ci:identity'))
-      )) ||
-      github.event_name == 'workflow_dispatch'
+      ))
     steps:
       - name: Checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
@@ -323,11 +325,13 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 70
     if: |
+      github.event_name == 'push' ||
+      github.event_name == 'schedule' ||
+      github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'pull_request' && (
         contains(github.event.pull_request.labels.*.name, 'ci:history') ||
         (!contains(github.event.pull_request.labels.*.name, 'ci:runtime') && !contains(github.event.pull_request.labels.*.name, 'ci:history') && !contains(github.event.pull_request.labels.*.name, 'ci:identity'))
-      )) ||
-      github.event_name == 'workflow_dispatch'
+      ))
     steps:
       - name: Checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
@@ -531,11 +535,13 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 70
     if: |
+      github.event_name == 'push' ||
+      github.event_name == 'schedule' ||
+      github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'pull_request' && (
         contains(github.event.pull_request.labels.*.name, 'ci:identity') ||
         (!contains(github.event.pull_request.labels.*.name, 'ci:runtime') && !contains(github.event.pull_request.labels.*.name, 'ci:history') && !contains(github.event.pull_request.labels.*.name, 'ci:identity'))
-      )) ||
-      github.event_name == 'workflow_dispatch'
+      ))
     steps:
       - name: Checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7


### PR DESCRIPTION
## Summary

- The Linux H2 integration jobs `it-runtime-h2`, `it-history-h2`, and `it-identity-h2` had `if:` conditions of `pull_request || workflow_dispatch` only — **no `push` branch**. On pushes/merges to `main` (and `maintenance/*`) they were always **skipped**.
- That left main-push protection for these suites resting solely on `it-history-h2-windows` (the only history job whose `if:` includes `push`/`schedule`). The Linux suites — faster and the primary dev target — never gated `main`.
- This adds `push`, `schedule`, and top-level `workflow_dispatch` to all three jobs' `if:`, mirroring `it-history-h2-windows`. The PR-label logic for selective PR runs is preserved unchanged.

## Test plan

- [ ] On this PR (no `ci:*` label): the three Linux H2 jobs run as before (PR fall-through branch still matches).
- [ ] After merge: confirm `it-runtime-h2`, `it-history-h2`, `it-identity-h2` run on the `push` to `main` (previously skipped).
- [ ] Scheduled run picks up the three jobs.

Closes #1516

🤖 Generated with [Claude Code](https://claude.com/claude-code)
