### PR TITLE
fix(cockpit): bundle @babel/runtime so the plugin loads in-browser

### DIFF
--- a/data-migrator/plugins/cockpit/frontend/package-lock.json
+++ b/data-migrator/plugins/cockpit/frontend/package-lock.json
@@ -2334,6 +2334,9 @@
         "arm"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2348,6 +2351,9 @@
         "arm"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2362,6 +2368,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2376,6 +2385,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2390,6 +2402,9 @@
         "loong64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2404,6 +2419,9 @@
         "loong64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2418,6 +2436,9 @@
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2432,6 +2453,9 @@
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2446,6 +2470,9 @@
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2460,6 +2487,9 @@
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2474,6 +2504,9 @@
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2488,6 +2521,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2502,6 +2538,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/data-migrator/plugins/cockpit/frontend/package-lock.json
+++ b/data-migrator/plugins/cockpit/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "camunda-7-to-8-data-migrator-cockpit-plugin",
       "version": "0.0.1",
       "dependencies": {
+        "@babel/runtime": "~7.29.0",
         "@tanstack/react-table": "^8.21.3",
         "react": "~19.2.0",
         "react-dom": "~19.2.0"
@@ -1657,6 +1658,15 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/template": {
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
@@ -2324,9 +2334,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2341,9 +2348,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2358,9 +2362,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2375,9 +2376,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2392,9 +2390,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2409,9 +2404,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2426,9 +2418,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2443,9 +2432,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2460,9 +2446,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2477,9 +2460,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2494,9 +2474,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2511,9 +2488,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2528,9 +2502,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/data-migrator/plugins/cockpit/frontend/package.json
+++ b/data-migrator/plugins/cockpit/frontend/package.json
@@ -13,6 +13,7 @@
   },
   "type": "module",
   "dependencies": {
+    "@babel/runtime": "~7.29.0",
     "@tanstack/react-table": "^8.21.3",
     "react": "~19.2.0",
     "react-dom": "~19.2.0"

--- a/data-migrator/qa/e2e-tests/tests/cockpit-plugin.spec.ts
+++ b/data-migrator/qa/e2e-tests/tests/cockpit-plugin.spec.ts
@@ -20,47 +20,47 @@ import { test, expect } from '@playwright/test';
 
 test.describe('Cockpit Plugin E2E', () => {
   test.describe.configure({ mode: 'serial' });
-  // Login flow in beforeEach can take ~20s on cold CI containers; each test
-  // needs a budget that covers that plus its own assertions.
+  // Login flow runs once on the first test (~20s on cold containers); give
+  // each test enough budget to cover that plus its own work.
   test.setTimeout(90000);
 
   test.beforeEach(async ({ page }) => {
-    await page.goto('/camunda/app/cockpit/default/');
-    await page.waitForLoadState('networkidle');
+    // Only navigate to cockpit if not already there — reloading triggers a
+    // full Angular re-bootstrap that can leave the page stuck on the spinner.
+    const currentUrl = page.url();
+    if (!currentUrl.includes('/camunda/app/cockpit/')) {
+      await page.goto('/camunda/app/cockpit/default/');
+      await page.waitForLoadState('networkidle');
 
-    // Login if the form appears — use waitFor with timeout instead of the racy
-    // isVisible() check which misses a form that Angular hasn't rendered yet.
-    try {
-      const usernameInput = page.locator('input[ng-model="username"]');
-      await usernameInput.waitFor({ state: 'visible', timeout: 5000 });
+      // Login if the form appears — use waitFor with timeout instead of the
+      // racy isVisible() check which misses a form that hasn't rendered yet.
+      try {
+        const usernameInput = page.locator('input[ng-model="username"]');
+        await usernameInput.waitFor({ state: 'visible', timeout: 5000 });
 
-      await page.screenshot({ path: 'test-results/before-login.png', fullPage: true });
-      await usernameInput.fill('demo');
-      await page.fill('input[ng-model="password"]', 'demo');
-      await page.click('button[type="submit"]');
-      await page.screenshot({ path: 'test-results/after-login-click.png', fullPage: true });
-    } catch (e) {
-      if (e instanceof Error && e.name !== 'TimeoutError') throw e;
-      // Login form did not appear within timeout — assume already authenticated.
+        await page.screenshot({ path: 'test-results/before-login.png', fullPage: true });
+        await usernameInput.fill('demo');
+        await page.fill('input[ng-model="password"]', 'demo');
+        await page.click('button[type="submit"]');
+        await page.screenshot({ path: 'test-results/after-login-click.png', fullPage: true });
+      } catch {
+        // Already authenticated — proceed
+      }
+
+      // Cockpit lands on /cockpit/default/ after login; #/dashboard hash is
+      // added asynchronously by Angular routing so don't require it.
+      await page.waitForURL(/\/camunda\/app\/cockpit\//, { timeout: 30000 });
     }
 
-    // Cockpit lands on /cockpit/default/ after login; the #/dashboard hash is
-    // added asynchronously by Angular routing so we cannot require it in the
-    // pattern. Ensure we're actually authenticated by waiting for the main nav.
-    await page.locator('a[href="#/processes"]').waitFor({ state: 'visible', timeout: 30000 });
-  });
-
-  test.afterEach(async ({ context }) => {
-    // Clear cookies for a clean slate on the next test, but do NOT call
-    // page.close() in serial mode — that closes the shared page object and
-    // causes subsequent tests to receive an already-closed page.
-    await context.clearCookies();
+    // Wait for Angular to fully render the cockpit navigation — this is a
+    // true readiness signal, unlike networkidle which fires before rendering.
+    await page.locator('a[href="#/processes"]').waitFor({ state: 'visible', timeout: 60000 });
   });
 
   test('should load Camunda Cockpit successfully', async ({ page }) => {
     await page.screenshot({ path: 'test-results/after-login.png', fullPage: true });
 
-    // Cockpit URL may or may not include #/dashboard depending on timing
+    // Cockpit URL may or may not include #/dashboard depending on version/timing
     await expect(page).toHaveURL(/\/camunda\/app\/cockpit\//);
 
     await expect(page).toHaveTitle(/Cockpit/);

--- a/data-migrator/qa/e2e-tests/tests/cockpit-plugin.spec.ts
+++ b/data-migrator/qa/e2e-tests/tests/cockpit-plugin.spec.ts
@@ -10,7 +10,7 @@ import { test, expect } from '@playwright/test';
 
 /**
  * E2E smoke test for the Cockpit plugin
- * 
+ *
  * This test validates that:
  * 1. Camunda 7 starts successfully with the plugin deployed
  * 2. The Cockpit UI is accessible
@@ -19,66 +19,49 @@ import { test, expect } from '@playwright/test';
  */
 
 test.describe('Cockpit Plugin E2E', () => {
-  // Configure this test suite to run in isolation
   test.describe.configure({ mode: 'serial' });
+  // Login flow in beforeEach can take ~20s on cold CI containers; each test
+  // needs a budget that covers that plus its own assertions.
+  test.setTimeout(90000);
 
-  test.beforeEach(async ({ page, context }) => {
-    // Clear cookies and storage to ensure clean state
-    await context.clearCookies();
-    await context.clearPermissions();
-
-    // Navigate to Camunda Cockpit and login
+  test.beforeEach(async ({ page }) => {
     await page.goto('/camunda/app/cockpit/default/');
-    
-    // Wait for the login page to load
     await page.waitForLoadState('networkidle');
-    
-    // Check if we're on a login page (some Camunda instances might auto-login)
-    const isLoginPage = await page.locator('input[ng-model="username"]').isVisible().catch(() => false);
-    
-    if (isLoginPage) {
-      // Fill in login credentials - Camunda 7 default demo user
+
+    // Login if the form appears — use waitFor with timeout instead of the racy
+    // isVisible() check which misses a form that Angular hasn't rendered yet.
+    try {
       const usernameInput = page.locator('input[ng-model="username"]');
-      const passwordInput = page.locator('input[ng-model="password"]');
-      const submitButton = page.locator('button[type="submit"]');
-      
-      // Wait for inputs to be visible
-      await usernameInput.waitFor({ state: 'visible', timeout: 10000 });
-      
-      await usernameInput.fill('demo');
-      await passwordInput.fill('demo');
-      
-      // Take screenshot before login
+      await usernameInput.waitFor({ state: 'visible', timeout: 5000 });
+
       await page.screenshot({ path: 'test-results/before-login.png', fullPage: true });
-      
-      await submitButton.click();
-      
-      // Wait a bit for the login to process
-      await page.waitForTimeout(2000);
-      
-      // Take screenshot after clicking login
+      await usernameInput.fill('demo');
+      await page.fill('input[ng-model="password"]', 'demo');
+      await page.click('button[type="submit"]');
       await page.screenshot({ path: 'test-results/after-login-click.png', fullPage: true });
-      
-      // Wait for the dashboard to load with a longer timeout
-      // The URL might redirect through several pages
-      await page.waitForURL('**/cockpit/default/#/dashboard', { timeout: 30000 });
+    } catch {
+      // Already authenticated — proceed
     }
+
+    // Cockpit lands on /cockpit/default/ after login; the #/dashboard hash is
+    // added asynchronously by Angular routing so we cannot require it in the
+    // pattern. 30s covers slow CI container startup; original 5s timed out.
+    await page.waitForURL(/\/camunda\/app\/cockpit\//, { timeout: 30000 });
   });
 
-  test.afterEach(async ({ page, context }) => {
-    // Clean up after each test to prevent state leakage
+  test.afterEach(async ({ context }) => {
+    // Clear cookies for a clean slate on the next test, but do NOT call
+    // page.close() in serial mode — that closes the shared page object and
+    // causes subsequent tests to receive an already-closed page.
     await context.clearCookies();
-    await page.close();
   });
 
   test('should load Camunda Cockpit successfully', async ({ page }) => {
-    // Take a screenshot after login for debugging
     await page.screenshot({ path: 'test-results/after-login.png', fullPage: true });
-    
-    // Verify we're on the Cockpit dashboard
-    await expect(page).toHaveURL(/.*cockpit.*dashboard/);
-    
-    // Verify the page title
+
+    // Cockpit URL may or may not include #/dashboard depending on timing
+    await expect(page).toHaveURL(/\/camunda\/app\/cockpit\//);
+
     await expect(page).toHaveTitle(/Cockpit/);
   });
 
@@ -86,14 +69,14 @@ test.describe('Cockpit Plugin E2E', () => {
     // Navigate to processes page
     await page.click('a[href="#/processes"]');
     await page.waitForURL('**/#/processes?pdSearchQuery=%5B%5D');
-    
+
     // Wait for the plugin to load - look for the plugin title
     const pluginTitle = page.locator('h1.section-title:has-text("Camunda 7 to 8 Data Migrator")');
     await pluginTitle.waitFor({ timeout: 10000 });
-    
+
     // Verify the plugin title is visible
     await expect(pluginTitle).toBeVisible();
-    
+
     // Take a screenshot for verification
     await page.screenshot({ path: 'test-results/plugin-on-processes-page.png', fullPage: true });
   });
@@ -102,22 +85,22 @@ test.describe('Cockpit Plugin E2E', () => {
     // Navigate to processes page
     await page.click('a[href="#/processes"]');
     await page.waitForURL('**/#/processes?pdSearchQuery=%5B%5D');
-    
+
     // Wait for the plugin to render
     await page.waitForTimeout(2000); // Give React time to render
-    
+
     // Look for the radio buttons for skipped/migrated
     const skippedRadio = page.locator('input[type="radio"][value="skipped"]');
     const migratedRadio = page.locator('input[type="radio"][value="migrated"]');
-    
+
     // Verify both radio buttons are visible
     await expect(skippedRadio).toBeVisible();
     await expect(migratedRadio).toBeVisible();
-    
+
     // Verify the labels are present
     await expect(page.locator('text=Skipped')).toBeVisible();
     await expect(page.locator('text=Migrated')).toBeVisible();
-    
+
     // Take a screenshot
     await page.screenshot({ path: 'test-results/plugin-tabs.png', fullPage: true });
   });
@@ -126,30 +109,30 @@ test.describe('Cockpit Plugin E2E', () => {
     // Navigate to processes page
     await page.click('a[href="#/processes"]');
     await page.waitForURL('**/#/processes?pdSearchQuery=%5B%5D');
-    
+
     // Wait for plugin to load
     await page.waitForTimeout(2000);
-    
+
     // Switch to History mode to access the entity type selector
     const historyRadio = page.locator('input[type="radio"][value="history"]');
     await historyRadio.click();
-    
+
     // Wait for the dropdown to appear
     await page.waitForTimeout(500);
-    
+
     // Look for the entity type selector dropdown
     const entityTypeSelector = page.locator('select#type-selector');
-    
+
     // Verify the selector is visible
     await expect(entityTypeSelector).toBeVisible();
-    
+
     // Take screenshot of the dropdown
     await page.screenshot({ path: 'test-results/entity-type-selector.png', fullPage: true });
-    
+
     // Verify we can see options
     const options = entityTypeSelector.locator('option');
     const optionsCount = await options.count();
-    
+
     expect(optionsCount).toBeGreaterThan(0);
   });
 
@@ -217,31 +200,31 @@ test.describe('Cockpit Plugin E2E', () => {
         errors.push(msg.text());
       }
     });
-    
-    // Navigate to processes page  
+
+    // Navigate to processes page
     await page.click('a[href="#/processes"]');
     await page.waitForURL('**/#/processes?pdSearchQuery=%5B%5D');
-    
+
     // Wait for plugin to fully render
     await page.locator('h1:has-text("Camunda 7 to 8 Data Migrator")').waitFor({ timeout: 10000 });
     await page.waitForTimeout(2000);
-    
+
     // Take final screenshot
     await page.screenshot({ path: 'test-results/plugin-loaded.png', fullPage: true });
-    
+
     // Verify no React errors or critical JavaScript errors
-    const hasReactErrors = errors.some(err => 
-      err.includes('React') || 
+    const hasReactErrors = errors.some(err =>
+      err.includes('React') ||
       err.includes('TypeError') ||
       err.includes('ReferenceError') ||
       err.includes('is not a function')
     );
-    
+
     // Log errors for debugging if any exist
     if (errors.length > 0) {
       console.log('Console errors detected:', errors);
     }
-    
+
     expect(hasReactErrors).toBeFalsy();
   });
 });

--- a/data-migrator/qa/e2e-tests/tests/cockpit-plugin.spec.ts
+++ b/data-migrator/qa/e2e-tests/tests/cockpit-plugin.spec.ts
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import { test, expect } from '@playwright/test';
+import { test, expect, Page } from '@playwright/test';
 
 /**
  * E2E smoke test for the Cockpit plugin
@@ -18,45 +18,43 @@ import { test, expect } from '@playwright/test';
  * 4. The plugin can interact with migrated/skipped entities
  */
 
+// The Cockpit navbar renders the "Processes" link more than once (a visible
+// desktop bar plus a collapsed responsive copy share the same href), so a bare
+// a[href="#/processes"] locator matches multiple elements and trips Playwright's
+// strict mode. Always scope to the first match.
+const processesLink = (page: Page) => page.locator('a[href="#/processes"]').first();
+
+// Navigate from the dashboard to the plugin's processes page.
+async function openProcessesPage(page: Page) {
+  await processesLink(page).click();
+  await page.waitForURL(/#\/processes/, { timeout: 15000 });
+}
+
 test.describe('Cockpit Plugin E2E', () => {
   test.describe.configure({ mode: 'serial' });
-  // Login flow runs once on the first test (~20s on cold containers); give
-  // each test enough budget to cover that plus its own work.
+  // Cold CI containers need time for the login round-trip plus the Angular
+  // bootstrap; give each test a generous budget.
   test.setTimeout(90000);
 
   test.beforeEach(async ({ page }) => {
-    // Only navigate to cockpit if not already there — reloading triggers a
-    // full Angular re-bootstrap that can leave the page stuck on the spinner.
-    const currentUrl = page.url();
-    if (!currentUrl.includes('/camunda/app/cockpit/')) {
-      await page.goto('/camunda/app/cockpit/default/');
-      await page.waitForLoadState('networkidle');
+    // Playwright's default `page` fixture is function-scoped: every test gets a
+    // fresh, cookie-less context, so we authenticate from scratch each time.
+    await page.goto('/camunda/app/cockpit/default/');
 
-      // Login if the form appears — use waitFor with timeout instead of the
-      // racy isVisible() check which misses a form that hasn't rendered yet.
-      try {
-        const usernameInput = page.locator('input[ng-model="username"]');
-        await usernameInput.waitFor({ state: 'visible', timeout: 5000 });
+    // Log in with the Camunda 7 demo user. The login form is served by the same
+    // Angular app, so wait for it explicitly rather than racing isVisible().
+    const usernameInput = page.locator('input[ng-model="username"]');
+    await usernameInput.waitFor({ state: 'visible', timeout: 30000 });
+    await usernameInput.fill('demo');
+    await page.fill('input[ng-model="password"]', 'demo');
+    await page.click('button[type="submit"]');
 
-        await page.screenshot({ path: 'test-results/before-login.png', fullPage: true });
-        await usernameInput.fill('demo');
-        await page.fill('input[ng-model="password"]', 'demo');
-        await page.click('button[type="submit"]');
-        await page.screenshot({ path: 'test-results/after-login-click.png', fullPage: true });
-      } catch (e) {
-        // Only swallow TimeoutError — the login form didn't appear, meaning we
-        // are already authenticated. Any other error (fill/click failure) is real.
-        if (!(e instanceof Error) || e.name !== 'TimeoutError') throw e;
-      }
-
-      // Cockpit lands on /cockpit/default/ after login; #/dashboard hash is
-      // added asynchronously by Angular routing so don't require it.
-      await page.waitForURL(/\/camunda\/app\/cockpit\//, { timeout: 30000 });
-    }
-
-    // Wait for Angular to fully render the cockpit navigation — this is a
-    // true readiness signal, unlike networkidle which fires before rendering.
-    await page.locator('a[href="#/processes"]').waitFor({ state: 'visible', timeout: 60000 });
+    // Readiness gate: the Cockpit SPA must finish bootstrapping and render its
+    // navigation before any test interacts with it. If a plugin bundle fails to
+    // load (e.g. an unresolved bare module specifier), the SPA hangs on its
+    // loading spinner and this wait fails fast with a clear, actionable signal
+    // instead of a vague mid-test click timeout.
+    await processesLink(page).waitFor({ state: 'visible', timeout: 60000 });
   });
 
   test('should load Camunda Cockpit successfully', async ({ page }) => {
@@ -64,14 +62,15 @@ test.describe('Cockpit Plugin E2E', () => {
 
     // Cockpit URL may or may not include #/dashboard depending on version/timing
     await expect(page).toHaveURL(/\/camunda\/app\/cockpit\//);
-
     await expect(page).toHaveTitle(/Cockpit/);
+
+    // The static <title> is present even on the login page; asserting the nav
+    // rendered is what actually proves the SPA bootstrapped successfully.
+    await expect(processesLink(page)).toBeVisible();
   });
 
   test('should display the migrator plugin on processes page', async ({ page }) => {
-    // Navigate to processes page
-    await page.click('a[href="#/processes"]');
-    await page.waitForURL('**/#/processes?pdSearchQuery=%5B%5D');
+    await openProcessesPage(page);
 
     // Wait for the plugin to load - look for the plugin title
     const pluginTitle = page.locator('h1.section-title:has-text("Camunda 7 to 8 Data Migrator")');
@@ -85,9 +84,7 @@ test.describe('Cockpit Plugin E2E', () => {
   });
 
   test('should display migrated and skipped entity tabs', async ({ page }) => {
-    // Navigate to processes page
-    await page.click('a[href="#/processes"]');
-    await page.waitForURL('**/#/processes?pdSearchQuery=%5B%5D');
+    await openProcessesPage(page);
 
     // Wait for the plugin to render
     await page.waitForTimeout(2000); // Give React time to render
@@ -109,9 +106,7 @@ test.describe('Cockpit Plugin E2E', () => {
   });
 
   test('should be able to switch between entity types', async ({ page }) => {
-    // Navigate to processes page
-    await page.click('a[href="#/processes"]');
-    await page.waitForURL('**/#/processes?pdSearchQuery=%5B%5D');
+    await openProcessesPage(page);
 
     // Wait for plugin to load
     await page.waitForTimeout(2000);
@@ -140,9 +135,7 @@ test.describe('Cockpit Plugin E2E', () => {
   });
 
   test('should display 6 skipped process instances with correct columns and data', async ({ page }) => {
-    // Navigate to processes page
-    await page.click('a[href="#/processes"]');
-    await page.waitForURL('**/#/processes?pdSearchQuery=%5B%5D');
+    await openProcessesPage(page);
 
     // Wait for plugin to load
     await page.waitForTimeout(2000);
@@ -204,9 +197,7 @@ test.describe('Cockpit Plugin E2E', () => {
       }
     });
 
-    // Navigate to processes page
-    await page.click('a[href="#/processes"]');
-    await page.waitForURL('**/#/processes?pdSearchQuery=%5B%5D');
+    await openProcessesPage(page);
 
     // Wait for plugin to fully render
     await page.locator('h1:has-text("Camunda 7 to 8 Data Migrator")').waitFor({ timeout: 10000 });

--- a/data-migrator/qa/e2e-tests/tests/cockpit-plugin.spec.ts
+++ b/data-migrator/qa/e2e-tests/tests/cockpit-plugin.spec.ts
@@ -39,14 +39,15 @@ test.describe('Cockpit Plugin E2E', () => {
       await page.fill('input[ng-model="password"]', 'demo');
       await page.click('button[type="submit"]');
       await page.screenshot({ path: 'test-results/after-login-click.png', fullPage: true });
-    } catch {
-      // Already authenticated — proceed
+    } catch (e) {
+      if (e instanceof Error && e.name !== 'TimeoutError') throw e;
+      // Login form did not appear within timeout — assume already authenticated.
     }
 
     // Cockpit lands on /cockpit/default/ after login; the #/dashboard hash is
     // added asynchronously by Angular routing so we cannot require it in the
-    // pattern. 30s covers slow CI container startup; original 5s timed out.
-    await page.waitForURL(/\/camunda\/app\/cockpit\//, { timeout: 30000 });
+    // pattern. Ensure we're actually authenticated by waiting for the main nav.
+    await page.locator('a[href="#/processes"]').waitFor({ state: 'visible', timeout: 30000 });
   });
 
   test.afterEach(async ({ context }) => {

--- a/data-migrator/qa/e2e-tests/tests/cockpit-plugin.spec.ts
+++ b/data-migrator/qa/e2e-tests/tests/cockpit-plugin.spec.ts
@@ -43,8 +43,10 @@ test.describe('Cockpit Plugin E2E', () => {
         await page.fill('input[ng-model="password"]', 'demo');
         await page.click('button[type="submit"]');
         await page.screenshot({ path: 'test-results/after-login-click.png', fullPage: true });
-      } catch {
-        // Already authenticated — proceed
+      } catch (e) {
+        // Only swallow TimeoutError — the login form didn't appear, meaning we
+        // are already authenticated. Any other error (fill/click failure) is real.
+        if (!(e instanceof Error) || e.name !== 'TimeoutError') throw e;
       }
 
       // Cockpit lands on /cockpit/default/ after login; #/dashboard hash is

--- a/data-migrator/qa/e2e-tests/tests/cockpit-plugin.spec.ts
+++ b/data-migrator/qa/e2e-tests/tests/cockpit-plugin.spec.ts
@@ -21,8 +21,9 @@ import { test, expect, Page } from '@playwright/test';
 // The Cockpit navbar renders the "Processes" link more than once (a visible
 // desktop bar plus a collapsed responsive copy share the same href), so a bare
 // a[href="#/processes"] locator matches multiple elements and trips Playwright's
-// strict mode. Always scope to the first match.
-const processesLink = (page: Page) => page.locator('a[href="#/processes"]').first();
+// strict mode. Scope to the visible match so the choice is deterministic
+// regardless of DOM order (the hidden responsive copy may come first).
+const processesLink = (page: Page) => page.locator('a[href="#/processes"]:visible').first();
 
 // Navigate from the dashboard to the plugin's processes page.
 async function openProcessesPage(page: Page) {


### PR DESCRIPTION
## Root cause

The cockpit plugin ships a **broken bundle** — this was a build bug, not a flaky test.

`data-migrator/plugins/cockpit/frontend` builds `plugin.js` with Rollup + `@babel/plugin-transform-runtime` and `babelHelpers: "runtime"`. That combination emits bare imports like `import _defineProperty from "@babel/runtime/helpers/defineProperty"` (plus `@babel/runtime/regenerator`). For Rollup to bundle those, `@babel/runtime` must be resolvable — but it was **never declared as a dependency**, so `@rollup/plugin-node-resolve` couldn't resolve it and left the bare specifiers in `dist/plugin.js` (Rollup warned: `(!) Unresolved dependencies`).

In the browser, Cockpit loads `plugin.js` as a native ES module, and a bare specifier can't be resolved by the browser loader:

```
Failed to resolve module specifier "@babel/runtime/helpers/defineProperty".
Relative references must start with either "/", "./", or "../".
```

That throw breaks Cockpit's plugin-loading bootstrap:

```
TypeError: Cannot read properties of undefined (reading 'default')
    at camunda-cockpit-bootstrap.js ... Array.reduce
```

…so the Cockpit Angular app **never finishes bootstrapping** and stays on its loading spinner forever. The nav link `a[href="#/processes"]` never renders, so every cockpit-plugin test fails — deterministically, on all 3 browsers and every retry.

Evidence (failure trace, run `28363523890`): the page snapshot at failure is just a spinner; **all** plugin JS/CSS return `200`; the only console/page errors are the two quoted above.

The earlier diagnosis (per-test re-login eating the 90s budget) was incorrect — test 1, which already includes login, completed in ~6s. No amount of timeout tuning fixes a bundle that can't load in the browser.

## What changed

**The fix** — `frontend/package.json`: declare `@babel/runtime` as a dependency. `node-resolve` now bundles the helpers + regenerator directly into `dist/plugin.js`. Verified: **0** bare `@babel/runtime` specifiers remain and the Rollup "Unresolved dependencies" warning is gone.

**Test hardening** — `cockpit-plugin.spec.ts`:
- Scope the Processes nav link to `.first()`. Cockpit renders the link twice (desktop + collapsed navbar); a bare `a[href="#/processes"]` matches 2 elements and trips Playwright strict mode once the SPA loads — so even with the bundle fixed, the previous `page.click(...)` would have thrown.
- Honest `beforeEach`: Playwright's `page` fixture is function-scoped, so every test gets a fresh, cookie-less context and logs in from scratch. Removed the dead "skip if already on cockpit" guard (it could never fire) and the error-swallowing `try/catch`.
- test 1 now asserts the nav actually rendered (a real bootstrap signal) rather than only the static `<title>`, which is present even on the login page.

## Test plan

Verified locally against the full migration stack (Camunda 7 + Camunda 8 + Postgres + real migration data), chromium:

```
Running 6 tests using 1 worker
  ✓ should load Camunda Cockpit successfully (1.3s)
  ✓ should display the migrator plugin on processes page (783ms)
  ✓ should display migrated and skipped entity tabs (2.6s)
  ✓ should be able to switch between entity types (3.1s)
  ✓ should display 6 skipped process instances with correct columns and data (4.6s)
  ✓ should render plugin UI elements without errors (2.6s)
  6 passed (1.3m)
```

- [x] `dist/plugin.js` contains no unresolved bare `@babel/runtime` imports
- [x] Cockpit mounts; migrator plugin renders on the processes page (verified against a real Camunda 7 + the rebuilt plugin jar)
- [x] Full chromium cockpit e2e green against the real migration stack
- [ ] CI `e2e` job green on all 3 browsers (pending)

🤖 Generated with [Claude Code](https://claude.com/claude-code)