### PR TITLE
fix(cockpit): bundle @babel/runtime so the plugin loads in-browser (backport #1531 to maintenance/0.2)

### DIFF
--- a/data-migrator/plugins/cockpit/frontend/package-lock.json
+++ b/data-migrator/plugins/cockpit/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "camunda-7-to-8-data-migrator-cockpit-plugin",
       "version": "0.0.1",
       "dependencies": {
+        "@babel/runtime": "~7.27.0",
         "@tanstack/react-table": "^8.21.3",
         "react": "~18.3.1",
         "react-dom": "~18.3.1"
@@ -1595,7 +1596,6 @@
       "version": "7.27.0",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.0.tgz",
       "integrity": "sha512-VtPOkrdPHZsKc/clNqyi9WUA8TINkZ4cGk63UUE3u4pmB2k+ZMQRDuIOagv8UVd6j7k0T3+RRIb7beKTebNbcw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "regenerator-runtime": "^0.14.0"

--- a/data-migrator/plugins/cockpit/frontend/package.json
+++ b/data-migrator/plugins/cockpit/frontend/package.json
@@ -13,6 +13,7 @@
   },
   "type": "module",
   "dependencies": {
+    "@babel/runtime": "~7.27.0",
     "@tanstack/react-table": "^8.21.3",
     "react": "~18.3.1",
     "react-dom": "~18.3.1"

--- a/data-migrator/qa/e2e-tests/tests/cockpit-plugin.spec.ts
+++ b/data-migrator/qa/e2e-tests/tests/cockpit-plugin.spec.ts
@@ -6,11 +6,11 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import { test, expect } from '@playwright/test';
+import { test, expect, Page } from '@playwright/test';
 
 /**
  * E2E smoke test for the Cockpit plugin
- * 
+ *
  * This test validates that:
  * 1. Camunda 7 starts successfully with the plugin deployed
  * 2. The Cockpit UI is accessible
@@ -18,133 +18,124 @@ import { test, expect } from '@playwright/test';
  * 4. The plugin can interact with migrated/skipped entities
  */
 
-test.describe('Cockpit Plugin E2E', () => {
-  
-  test.beforeEach(async ({ page }) => {
-    // Navigate to Camunda Cockpit and login
-    await page.goto('/camunda/app/cockpit/default/');
-    
-    // Wait for the login page to load
-    await page.waitForLoadState('networkidle');
-    
-    // Check if we're on a login page (some Camunda instances might auto-login)
-    const isLoginPage = await page.locator('input[ng-model="username"]').isVisible().catch(() => false);
-    
-    if (isLoginPage) {
-      // Fill in login credentials - Camunda 7 default demo user
-      const usernameInput = page.locator('input[ng-model="username"]');
-      const passwordInput = page.locator('input[ng-model="password"]');
-      const submitButton = page.locator('button[type="submit"]');
-      
-      // Wait for inputs to be visible
-      await usernameInput.waitFor({ state: 'visible', timeout: 10000 });
-      
-      await usernameInput.fill('demo');
-      await passwordInput.fill('demo');
-      
-      // Take screenshot before login
-      await page.screenshot({ path: 'test-results/before-login.png', fullPage: true });
-      
-      await submitButton.click();
-      
-      // Wait a bit for the login to process
-      await page.waitForTimeout(2000);
-      
-      // Take screenshot after clicking login
-      await page.screenshot({ path: 'test-results/after-login-click.png', fullPage: true });
-      
-      // Wait for the dashboard to load with a longer timeout
-      // The URL might redirect through several pages
-      await page.waitForURL('**/cockpit/default/#/dashboard', { timeout: 30000 });
-    }
-  });
+// The Cockpit navbar renders the "Processes" link more than once (a visible
+// desktop bar plus a collapsed responsive copy share the same href), so a bare
+// a[href="#/processes"] locator matches multiple elements and trips Playwright's
+// strict mode. Scope to the visible match so the choice is deterministic
+// regardless of DOM order (the hidden responsive copy may come first).
+const processesLink = (page: Page) => page.locator('a[href="#/processes"]:visible').first();
 
+// Navigate from the dashboard to the plugin's processes page.
+async function openProcessesPage(page: Page) {
+  await processesLink(page).click();
+  await page.waitForURL(/#\/processes/, { timeout: 15000 });
+}
+
+test.describe('Cockpit Plugin E2E', () => {
+  test.describe.configure({ mode: 'serial' });
+  // Cold CI containers need time for the login round-trip plus the Angular
+  // bootstrap; give each test a generous budget.
+  test.setTimeout(90000);
+
+  test.beforeEach(async ({ page }) => {
+    // Playwright's default `page` fixture is function-scoped: every test gets a
+    // fresh, cookie-less context, so we authenticate from scratch each time.
+    await page.goto('/camunda/app/cockpit/default/');
+
+    // Log in with the Camunda 7 demo user. The login form is served by the same
+    // Angular app, so wait for it explicitly rather than racing isVisible().
+    const usernameInput = page.locator('input[ng-model="username"]');
+    await usernameInput.waitFor({ state: 'visible', timeout: 30000 });
+    await usernameInput.fill('demo');
+    await page.fill('input[ng-model="password"]', 'demo');
+    await page.click('button[type="submit"]');
+
+    // Readiness gate: the Cockpit SPA must finish bootstrapping and render its
+    // navigation before any test interacts with it. If a plugin bundle fails to
+    // load (e.g. an unresolved bare module specifier), the SPA hangs on its
+    // loading spinner and this wait fails fast with a clear, actionable signal
+    // instead of a vague mid-test click timeout.
+    await processesLink(page).waitFor({ state: 'visible', timeout: 60000 });
+  });
   test('should load Camunda Cockpit successfully', async ({ page }) => {
-    // Take a screenshot after login for debugging
     await page.screenshot({ path: 'test-results/after-login.png', fullPage: true });
-    
-    // Verify we're on the Cockpit dashboard
-    await expect(page).toHaveURL(/.*cockpit.*dashboard/);
-    
-    // Verify the page title
+
+    // Cockpit URL may or may not include #/dashboard depending on version/timing
+    await expect(page).toHaveURL(/\/camunda\/app\/cockpit\//);
     await expect(page).toHaveTitle(/Cockpit/);
+
+    // The static <title> is present even on the login page; asserting the nav
+    // rendered is what actually proves the SPA bootstrapped successfully.
+    await expect(processesLink(page)).toBeVisible();
   });
 
   test('should display the migrator plugin on processes page', async ({ page }) => {
-    // Navigate to processes page
-    await page.click('a[href="#/processes"]');
-    await page.waitForURL('**/#/processes?pdSearchQuery=%5B%5D');
-    
+    await openProcessesPage(page);
+
     // Wait for the plugin to load - look for the plugin title
     const pluginTitle = page.locator('h1.section-title:has-text("Camunda 7 to 8 Data Migrator")');
     await pluginTitle.waitFor({ timeout: 10000 });
-    
+
     // Verify the plugin title is visible
     await expect(pluginTitle).toBeVisible();
-    
+
     // Take a screenshot for verification
     await page.screenshot({ path: 'test-results/plugin-on-processes-page.png', fullPage: true });
   });
 
   test('should display migrated and skipped entity tabs', async ({ page }) => {
-    // Navigate to processes page
-    await page.click('a[href="#/processes"]');
-    await page.waitForURL('**/#/processes?pdSearchQuery=%5B%5D');
-    
+    await openProcessesPage(page);
+
     // Wait for the plugin to render
     await page.waitForTimeout(2000); // Give React time to render
-    
+
     // Look for the radio buttons for skipped/migrated
     const skippedRadio = page.locator('input[type="radio"][value="skipped"]');
     const migratedRadio = page.locator('input[type="radio"][value="migrated"]');
-    
+
     // Verify both radio buttons are visible
     await expect(skippedRadio).toBeVisible();
     await expect(migratedRadio).toBeVisible();
-    
+
     // Verify the labels are present
     await expect(page.locator('text=Skipped')).toBeVisible();
     await expect(page.locator('text=Migrated')).toBeVisible();
-    
+
     // Take a screenshot
     await page.screenshot({ path: 'test-results/plugin-tabs.png', fullPage: true });
   });
 
   test('should be able to switch between entity types', async ({ page }) => {
-    // Navigate to processes page
-    await page.click('a[href="#/processes"]');
-    await page.waitForURL('**/#/processes?pdSearchQuery=%5B%5D');
-    
+    await openProcessesPage(page);
+
     // Wait for plugin to load
     await page.waitForTimeout(2000);
-    
+
     // Switch to History mode to access the entity type selector
     const historyRadio = page.locator('input[type="radio"][value="history"]');
     await historyRadio.click();
-    
+
     // Wait for the dropdown to appear
     await page.waitForTimeout(500);
-    
+
     // Look for the entity type selector dropdown
     const entityTypeSelector = page.locator('select#type-selector');
-    
+
     // Verify the selector is visible
     await expect(entityTypeSelector).toBeVisible();
-    
+
     // Take screenshot of the dropdown
     await page.screenshot({ path: 'test-results/entity-type-selector.png', fullPage: true });
-    
+
     // Verify we can see options
     const options = entityTypeSelector.locator('option');
     const optionsCount = await options.count();
-    
+
     expect(optionsCount).toBeGreaterThan(0);
   });
 
   test('should display 6 skipped process instances with correct columns and data', async ({ page }) => {
-    // Navigate to processes page
-    await page.click('a[href="#/processes"]');
-    await page.waitForURL('**/#/processes?pdSearchQuery=%5B%5D');
+    await openProcessesPage(page);
 
     // Wait for plugin to load
     await page.waitForTimeout(2000);
@@ -205,31 +196,29 @@ test.describe('Cockpit Plugin E2E', () => {
         errors.push(msg.text());
       }
     });
-    
-    // Navigate to processes page  
-    await page.click('a[href="#/processes"]');
-    await page.waitForURL('**/#/processes?pdSearchQuery=%5B%5D');
-    
+
+    await openProcessesPage(page);
+
     // Wait for plugin to fully render
     await page.locator('h1:has-text("Camunda 7 to 8 Data Migrator")').waitFor({ timeout: 10000 });
     await page.waitForTimeout(2000);
-    
+
     // Take final screenshot
     await page.screenshot({ path: 'test-results/plugin-loaded.png', fullPage: true });
-    
+
     // Verify no React errors or critical JavaScript errors
-    const hasReactErrors = errors.some(err => 
-      err.includes('React') || 
+    const hasReactErrors = errors.some(err =>
+      err.includes('React') ||
       err.includes('TypeError') ||
       err.includes('ReferenceError') ||
       err.includes('is not a function')
     );
-    
+
     // Log errors for debugging if any exist
     if (errors.length > 0) {
       console.log('Console errors detected:', errors);
     }
-    
+
     expect(hasReactErrors).toBeFalsy();
   });
 });


### PR DESCRIPTION
Backport of #1531 to `maintenance/0.2`.

**Conflict resolution:** `@babel/runtime` was already a transitive dep at 7.27.0 on this branch (babel monorepo not yet bumped to 7.29.x). Used `~7.27.0` in `package.json` and lockfile to stay consistent with the rest of the babel toolchain on this branch. The critical fix — declaring `@babel/runtime` as an explicit dependency so Rollup bundles it — is intact.

The `cockpit-plugin.spec.ts` conflict was resolved by taking the cherry-pick's version (added `test.describe.configure` + `test.setTimeout(90000)` which were missing on this branch).

---

Original PR description:

The cockpit plugin ships a broken bundle — `@babel/runtime` was never declared as a dependency, so `@rollup/plugin-node-resolve` left bare `@babel/runtime/helpers/*` specifiers in `dist/plugin.js`. The browser's native ES module loader can't resolve bare specifiers, so loading the plugin threw and broke Cockpit's bootstrap, leaving the SPA stuck on its loading spinner.