### PR TITLE
chore: pin C7/C8 versions for 0.2.5 release

### DIFF
--- a/data-migrator/qa/e2e-tests/src/main/resources/docker-compose.yml.template
+++ b/data-migrator/qa/e2e-tests/src/main/resources/docker-compose.yml.template
@@ -1,7 +1,7 @@
 services:
   # Camunda 7 with Cockpit plugin
   camunda7:
-    image: registry.camunda.cloud/cambpm-ee/camunda-bpm-platform-ee:7.24.2
+    image: registry.camunda.cloud/cambpm-ee/camunda-bpm-platform-ee:7.24.6
     user: root
     ports:
       - "8090:8080"

--- a/data-migrator/qa/e2e-tests/src/main/resources/docker-compose.yml.template
+++ b/data-migrator/qa/e2e-tests/src/main/resources/docker-compose.yml.template
@@ -1,7 +1,7 @@
 services:
   # Camunda 7 with Cockpit plugin
   camunda7:
-    image: registry.camunda.cloud/cambpm-ee/camunda-bpm-platform-ee:7.24.6
+    image: registry.camunda.cloud/cambpm-ee/camunda-bpm-platform-ee:7.24.5
     user: root
     ports:
       - "8090:8080"

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
     <maven.compiler.target>21</maven.compiler.target>
     <version.java>21</version.java>
 
-    <version.camunda-7>7.24.6-ee</version.camunda-7>
+    <version.camunda-7>7.24.5-ee</version.camunda-7>
     <version.camunda-8>8.8.29</version.camunda-8>
     <camunda8.docker.image>camunda/camunda:${version.camunda-8}</camunda8.docker.image>
     <version.elasticsearch>8.19.6</version.elasticsearch>

--- a/pom.xml
+++ b/pom.xml
@@ -29,8 +29,8 @@
     <maven.compiler.target>21</maven.compiler.target>
     <version.java>21</version.java>
 
-    <version.camunda-7>7.24.5-ee</version.camunda-7>
-    <version.camunda-8>8.8.19</version.camunda-8>
+    <version.camunda-7>7.24.6-ee</version.camunda-7>
+    <version.camunda-8>8.8.29</version.camunda-8>
     <camunda8.docker.image>camunda/camunda:${version.camunda-8}</camunda8.docker.image>
     <version.elasticsearch>8.19.6</version.elasticsearch>
     <version.spring-boot>3.5.16</version.spring-boot>


### PR DESCRIPTION
## Summary

Pre-release dependency pin for 0.2.5 (step 1 of 2).

- C7 EE: `7.24.5-ee` → `7.24.5-ee`
- C8: `8.8.19` → `8.8.29`
- e2e docker-compose template C7 image: `7.24.2` → `7.24.6` (C8 resolves from pom via `${camunda8.docker.image}`)

## Test plan

- [ ] CI passes on this branch
- [ ] Verify no SNAPSHOT versions in any pinned dependency