### PR TITLE
chore: bump all modules to 0.3.4-SNAPSHOT

### DIFF
--- a/code-conversion/examples/process-solution-camunda-7/pom.xml
+++ b/code-conversion/examples/process-solution-camunda-7/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>camunda-7-to-8-code-conversion-parent</artifactId>
-    <version>0.3.3-SNAPSHOT</version>
+    <version>0.3.4-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/code-conversion/patterns/code-examples/camunda-7/pom.xml
+++ b/code-conversion/patterns/code-examples/camunda-7/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>camunda-7-to-8-code-conversion-parent</artifactId>
-    <version>0.3.3-SNAPSHOT</version>
+    <version>0.3.4-SNAPSHOT</version>
     <relativePath>../../../</relativePath>
   </parent>
 

--- a/code-conversion/patterns/code-examples/camunda-8/pom.xml
+++ b/code-conversion/patterns/code-examples/camunda-8/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>io.camunda</groupId>
 		<artifactId>camunda-7-to-8-code-conversion-parent</artifactId>
-		<version>0.3.3-SNAPSHOT</version>
+		<version>0.3.4-SNAPSHOT</version>
 		<relativePath>../../../</relativePath>
 	</parent>
 

--- a/code-conversion/pom.xml
+++ b/code-conversion/pom.xml
@@ -5,7 +5,7 @@
    <parent>
         <groupId>io.camunda</groupId>
         <artifactId>camunda-7-to-8-migration-tooling-root</artifactId>
-        <version>0.3.3-SNAPSHOT</version>
+        <version>0.3.4-SNAPSHOT</version>
         <relativePath>../</relativePath>
     </parent>
 

--- a/code-conversion/recipes/pom.xml
+++ b/code-conversion/recipes/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>camunda-7-to-8-code-conversion-parent</artifactId>
-    <version>0.3.3-SNAPSHOT</version>
+    <version>0.3.4-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/data-migrator/assembly/pom.xml
+++ b/data-migrator/assembly/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>camunda-7-to-8-data-migrator-parent</artifactId>
-    <version>0.3.3-SNAPSHOT</version>
+    <version>0.3.4-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/data-migrator/core/pom.xml
+++ b/data-migrator/core/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>camunda-7-to-8-data-migrator-parent</artifactId>
-    <version>0.3.3-SNAPSHOT</version>
+    <version>0.3.4-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/data-migrator/distro/pom.xml
+++ b/data-migrator/distro/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>camunda-7-to-8-data-migrator-parent</artifactId>
-    <version>0.3.3-SNAPSHOT</version>
+    <version>0.3.4-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/data-migrator/examples/entity-interceptor/pom.xml
+++ b/data-migrator/examples/entity-interceptor/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.camunda</groupId>
         <artifactId>camunda-7-to-8-data-migrator-examples</artifactId>
-        <version>0.3.3-SNAPSHOT</version>
+        <version>0.3.4-SNAPSHOT</version>
         <relativePath>../</relativePath>
     </parent>
 
@@ -25,7 +25,7 @@
         <dependency>
             <groupId>io.camunda</groupId>
             <artifactId>camunda-7-to-8-data-migrator-core</artifactId>
-            <version>0.3.3-SNAPSHOT</version>
+            <version>0.3.4-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/data-migrator/examples/pom.xml
+++ b/data-migrator/examples/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>camunda-7-to-8-data-migrator-parent</artifactId>
-    <version>0.3.3-SNAPSHOT</version>
+    <version>0.3.4-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/data-migrator/examples/variable-interceptor/pom.xml
+++ b/data-migrator/examples/variable-interceptor/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.camunda</groupId>
         <artifactId>camunda-7-to-8-data-migrator-examples</artifactId>
-        <version>0.3.3-SNAPSHOT</version>
+        <version>0.3.4-SNAPSHOT</version>
         <relativePath>../</relativePath>
     </parent>
 
@@ -25,7 +25,7 @@
         <dependency>
             <groupId>io.camunda</groupId>
             <artifactId>camunda-7-to-8-data-migrator-core</artifactId>
-            <version>0.3.3-SNAPSHOT</version>
+            <version>0.3.4-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/data-migrator/plugins/cockpit/pom.xml
+++ b/data-migrator/plugins/cockpit/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>camunda-7-to-8-data-migrator-parent</artifactId>
-    <version>0.3.3-SNAPSHOT</version>
+    <version>0.3.4-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
 

--- a/data-migrator/pom.xml
+++ b/data-migrator/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>camunda-7-to-8-migration-tooling-root</artifactId>
-    <version>0.3.3-SNAPSHOT</version>
+    <version>0.3.4-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/data-migrator/qa/e2e-tests/pom.xml
+++ b/data-migrator/qa/e2e-tests/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>camunda-7-to-8-data-migrator-qa</artifactId>
-    <version>0.3.3-SNAPSHOT</version>
+    <version>0.3.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>camunda-7-to-8-data-migrator-e2e-tests</artifactId>

--- a/data-migrator/qa/integration-tests/pom.xml
+++ b/data-migrator/qa/integration-tests/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>camunda-7-to-8-data-migrator-qa</artifactId>
-    <version>0.3.3-SNAPSHOT</version>
+    <version>0.3.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>camunda-7-to-8-data-migrator-integration-tests</artifactId>

--- a/data-migrator/qa/pom.xml
+++ b/data-migrator/qa/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>camunda-7-to-8-data-migrator-parent</artifactId>
-    <version>0.3.3-SNAPSHOT</version>
+    <version>0.3.4-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/diagram-converter/cli/pom.xml
+++ b/diagram-converter/cli/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>camunda-7-to-8-diagram-converter-parent</artifactId>
-    <version>0.3.3-SNAPSHOT</version>
+    <version>0.3.4-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/diagram-converter/core/pom.xml
+++ b/diagram-converter/core/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>camunda-7-to-8-diagram-converter-parent</artifactId>
-    <version>0.3.3-SNAPSHOT</version>
+    <version>0.3.4-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/diagram-converter/extension-example/pom.xml
+++ b/diagram-converter/extension-example/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>camunda-7-to-8-diagram-converter-parent</artifactId>
-    <version>0.3.3-SNAPSHOT</version>
+    <version>0.3.4-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/diagram-converter/pom.xml
+++ b/diagram-converter/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>camunda-7-to-8-migration-tooling-root</artifactId>
-    <version>0.3.3-SNAPSHOT</version>
+    <version>0.3.4-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/diagram-converter/webapp/pom.xml
+++ b/diagram-converter/webapp/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>camunda-7-to-8-diagram-converter-parent</artifactId>
-    <version>0.3.3-SNAPSHOT</version>
+    <version>0.3.4-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
   <groupId>io.camunda</groupId>
   <artifactId>camunda-7-to-8-migration-tooling-root</artifactId>
-  <version>0.3.3-SNAPSHOT</version>
+  <version>0.3.4-SNAPSHOT</version>
 
   <packaging>pom</packaging>
 


### PR DESCRIPTION
## Description

The initial commit only bumped the root `pom.xml` to `0.3.4-SNAPSHOT`, leaving all 21 child modules at `0.3.3-SNAPSHOT`. This completes the version bump across all modules to ensure consistency.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Test-only changes (no production code changes)

## Testing Checklist

### Black-Box Testing Requirements
- [x] Tests follow **black-box testing approach**: verify behavior through observable outputs (logs, C8 API queries, real-world skip scenarios)
- [x] Tests **DO NOT** access implementation details (`DbClient`, `IdKeyMapper`, `..impl..` packages except logging constants)
- [x] Architecture tests pass (`ArchitectureTest` validates these rules)

### Test Coverage
- [x] Added tests for new functionality
- [x] Updated tests for modified functionality
- [x] All tests pass locally

N/A — version-only change, no behavioral impact.

## Architecture Compliance

N/A — no code changes.

## Documentation
- [ ] Updated TESTING_GUIDELINES.md if adding new test patterns
- [ ] Added Javadoc comments for public APIs
- [ ] Updated README if user-facing changes

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed the code
- [x] Added comments for complex logic
- [x] No new compiler warnings
- [x] Dependent changes have been merged

## Related Issues