### PR TITLE
feat(security): include npm manifests in JAR artifacts for vulnerability scanning

### DIFF
--- a/data-migrator/plugins/cockpit/pom.xml
+++ b/data-migrator/plugins/cockpit/pom.xml
@@ -157,6 +157,26 @@
               </resources>
             </configuration>
           </execution>
+          <execution>
+            <id>Copy frontend manifests to JAR</id>
+            <phase>process-resources</phase>
+            <goals>
+              <goal>copy-resources</goal>
+            </goals>
+            <configuration>
+              <outputDirectory>${basedir}/target/classes</outputDirectory>
+              <resources>
+                <resource>
+                  <directory>${basedir}/${frontend.working.directory}</directory>
+                  <includes>
+                    <include>package.json</include>
+                    <include>package-lock.json</include>
+                  </includes>
+                  <filtering>false</filtering>
+                </resource>
+              </resources>
+            </configuration>
+          </execution>
         </executions>
       </plugin>
       <plugin>

--- a/data-migrator/plugins/cockpit/pom.xml
+++ b/data-migrator/plugins/cockpit/pom.xml
@@ -164,7 +164,7 @@
               <goal>copy-resources</goal>
             </goals>
             <configuration>
-              <outputDirectory>${basedir}/target/classes</outputDirectory>
+              <outputDirectory>${project.build.outputDirectory}</outputDirectory>
               <resources>
                 <resource>
                   <directory>${basedir}/${frontend.working.directory}</directory>

--- a/diagram-converter/webapp/pom.xml
+++ b/diagram-converter/webapp/pom.xml
@@ -98,6 +98,32 @@
         </executions>
       </plugin>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-resources-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>Copy frontend manifests to JAR</id>
+            <goals>
+              <goal>copy-resources</goal>
+            </goals>
+            <phase>process-resources</phase>
+            <configuration>
+              <outputDirectory>${basedir}/target/classes</outputDirectory>
+              <resources>
+                <resource>
+                  <directory>${basedir}/src/main/javascript</directory>
+                  <includes>
+                    <include>package.json</include>
+                    <include>package-lock.json</include>
+                  </includes>
+                  <filtering>false</filtering>
+                </resource>
+              </resources>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-maven-plugin</artifactId>
         <configuration>

--- a/diagram-converter/webapp/pom.xml
+++ b/diagram-converter/webapp/pom.xml
@@ -108,7 +108,7 @@
             </goals>
             <phase>process-resources</phase>
             <configuration>
-              <outputDirectory>${basedir}/target/classes</outputDirectory>
+              <outputDirectory>${project.build.outputDirectory}</outputDirectory>
               <resources>
                 <resource>
                   <directory>${basedir}/src/main/javascript</directory>


### PR DESCRIPTION
## Summary

Adds `package.json` and `package-lock.json` to the built JAR artifacts so the InfoSec vulnerability scanner can detect frontend npm CVEs. This is the standard Camunda pattern for frontend security scanning coverage.

- `camunda-7-to-8-data-migrator-cockpit-plugin` — new `maven-resources-plugin` execution copies files from `frontend/` to JAR root
- `camunda-7-to-8-diagram-converter-webapp` — new `maven-resources-plugin` execution copies files from `src/main/javascript/` to `BOOT-INF/classes/`

Both files verified present in the built JARs:
```
# cockpit plugin
package.json
package-lock.json

# diagram-converter webapp
BOOT-INF/classes/package.json
BOOT-INF/classes/package-lock.json
```

Closes #1568

## Context

Identified as part of the frontend security scanning gap analysis — see #1565, #1566, and #1569 for related fixes.

## Test plan

- [x] `mvn clean install -DskipTests` succeeds for both modules
- [x] `jar tf` confirms `package.json` and `package-lock.json` present in both JARs
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)