### PR TITLE
fix(security): bump logback to 1.5.37 (CVE-2026-13006)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,7 @@
     <camunda8.docker.image>camunda/camunda:${version.camunda-8}</camunda8.docker.image>
     <version.elasticsearch>8.19.6</version.elasticsearch>
     <version.spring-boot>4.1.0</version.spring-boot>
+    <logback.version>1.5.37</logback.version>
     <version.netty>4.2.15.Final</version.netty>
     <version.assertj>3.27.7</version.assertj>
     <version.junit.jupiter>6.0.3</version.junit.jupiter>


### PR DESCRIPTION
## Summary

- Pins `logback.version` to `1.5.37` in root pom, overriding the Spring Boot BOM default (`1.5.34`)
- Affects `logback-classic` and `logback-core` across all modules

## Security context

CVE-2026-13006 is an ACE in logback-core ≤ 1.5.35 that requires the Janino library on the classpath to exploit the conditional config processing path. Janino is absent from all modules in this repo, so this fix is **hygiene only** (silences SCA scanner alerts) — not an active security incident.

## Test plan

- [ ] CI build passes on all modules
- [ ] `mvn dependency:tree -Dincludes=ch.qos.logback` confirms 1.5.37 resolves across all modules

🤖 Generated with [Claude Code](https://claude.com/claude-code)