### PR TITLE
feat(recipes): delete META-INF/processes.xml during cleanup

### DIFF
--- a/code-conversion/recipes/src/main/java/io/camunda/migration/code/recipes/client/DeleteProcessesXmlRecipe.java
+++ b/code-conversion/recipes/src/main/java/io/camunda/migration/code/recipes/client/DeleteProcessesXmlRecipe.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.migration.code.recipes.client;
+
+import java.util.HashSet;
+import java.util.Set;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.ScanningRecipe;
+import org.openrewrite.SourceFile;
+import org.openrewrite.Tree;
+import org.openrewrite.TreeVisitor;
+
+public class DeleteProcessesXmlRecipe extends ScanningRecipe<Set<String>> {
+
+  private static final String C7_SCHEMA_URI =
+      "http://www.camunda.org/schema/1.0/ProcessApplication";
+  private static final String PROCESSES_XML_SUFFIX = "META-INF/processes.xml";
+
+  @Override
+  public String getDisplayName() {
+    return "Delete META-INF/processes.xml";
+  }
+
+  @Override
+  public String getDescription() {
+    return "Removes the Camunda 7 process archive descriptor (processes.xml),"
+        + " which has no equivalent in Camunda 8.";
+  }
+
+  @Override
+  public Set<String> getInitialValue(ExecutionContext ctx) {
+    return new HashSet<>();
+  }
+
+  @Override
+  public TreeVisitor<?, ExecutionContext> getScanner(Set<String> filesToDelete) {
+    return new TreeVisitor<>() {
+      @Override
+      public Tree visit(Tree tree, ExecutionContext ctx) {
+        if (tree instanceof SourceFile sourceFile) {
+          String path = sourceFile.getSourcePath().toString();
+          if (path.endsWith(PROCESSES_XML_SUFFIX)
+              && sourceFile.printAll().contains(C7_SCHEMA_URI)) {
+            filesToDelete.add(path);
+          }
+        }
+        return tree;
+      }
+    };
+  }
+
+  @Override
+  public TreeVisitor<?, ExecutionContext> getVisitor(Set<String> filesToDelete) {
+    return new TreeVisitor<>() {
+      @Override
+      public Tree visit(Tree tree, ExecutionContext ctx) {
+        if (tree instanceof SourceFile sourceFile
+            && filesToDelete.contains(sourceFile.getSourcePath().toString())) {
+          return null;
+        }
+        return tree;
+      }
+    };
+  }
+}

--- a/code-conversion/recipes/src/main/java/io/camunda/migration/code/recipes/client/DeleteProcessesXmlRecipe.java
+++ b/code-conversion/recipes/src/main/java/io/camunda/migration/code/recipes/client/DeleteProcessesXmlRecipe.java
@@ -43,10 +43,9 @@ public class DeleteProcessesXmlRecipe extends ScanningRecipe<Set<String>> {
       @Override
       public Tree visit(Tree tree, ExecutionContext ctx) {
         if (tree instanceof SourceFile sourceFile) {
-          String path = sourceFile.getSourcePath().toString();
-          if (path.endsWith(PROCESSES_XML_SUFFIX)
+          if (sourceFile.getSourcePath().endsWith(PROCESSES_XML_SUFFIX)
               && sourceFile.printAll().contains(C7_SCHEMA_URI)) {
-            filesToDelete.add(path);
+            filesToDelete.add(sourceFile.getSourcePath().toString());
           }
         }
         return tree;

--- a/code-conversion/recipes/src/main/resources/META-INF/rewrite/clientRecipes.yml
+++ b/code-conversion/recipes/src/main/resources/META-INF/rewrite/clientRecipes.yml
@@ -47,6 +47,7 @@ displayName: Runs all delegate cleanup recipes
 description: Removes delegate code and unused imports.
 recipeList:
   - io.camunda.migration.code.recipes.client.CleanupEngineDependencyRecipe
+  - io.camunda.migration.code.recipes.client.DeleteProcessesXmlRecipe
   - org.openrewrite.java.RemoveUnusedImports
 ---
 type: specs.openrewrite.org/v1beta/recipe

--- a/code-conversion/recipes/src/test/java/io/camunda/migration/code/recipes/client/cleanup/DeleteProcessesXmlTest.java
+++ b/code-conversion/recipes/src/test/java/io/camunda/migration/code/recipes/client/cleanup/DeleteProcessesXmlTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.migration.code.recipes.client.cleanup;
+
+import static org.openrewrite.xml.Assertions.xml;
+
+import io.camunda.migration.code.recipes.client.DeleteProcessesXmlRecipe;
+import org.junit.jupiter.api.Test;
+import org.openrewrite.test.RewriteTest;
+
+class DeleteProcessesXmlTest implements RewriteTest {
+
+  private static final String C7_PROCESSES_XML =
+      """
+      <?xml version="1.0" encoding="UTF-8"?>
+      <process-application
+        xmlns="http://www.camunda.org/schema/1.0/ProcessApplication"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+        <process-archive name="default">
+          <properties>
+            <property name="isScanForProcessDefinitions">false</property>
+            <property name="isDeleteUponUndeploy">true</property>
+          </properties>
+        </process-archive>
+      </process-application>
+      """;
+
+  @Test
+  void deletesC7ProcessesXmlWithProcessApplicationSchema() {
+    rewriteRun(
+        spec -> spec.recipe(new DeleteProcessesXmlRecipe()),
+        xml(
+            C7_PROCESSES_XML,
+            spec ->
+                spec.path("src/main/resources/META-INF/processes.xml")
+                    // null return signals that the recipe should delete this file
+                    .after(s -> null)));
+  }
+
+  @Test
+  void doesNotDeleteXmlWithoutC7ProcessApplicationSchema() {
+    rewriteRun(
+        spec -> spec.recipe(new DeleteProcessesXmlRecipe()),
+        xml(
+            """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <processes xmlns="http://example.com/some-other-schema">
+              <process id="myProcess"/>
+            </processes>
+            """,
+            spec -> spec.path("src/main/resources/META-INF/processes.xml")));
+  }
+
+  @Test
+  void doesNotDeleteC7ProcessesXmlOutsideMetaInf() {
+    rewriteRun(
+        spec -> spec.recipe(new DeleteProcessesXmlRecipe()),
+        xml(
+            C7_PROCESSES_XML,
+            spec -> spec.path("src/main/resources/processes.xml")));
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `DeleteProcessesXmlRecipe` — a `ScanningRecipe` that deletes `META-INF/processes.xml` when it contains the Camunda 7 process archive schema URI (`http://www.camunda.org/schema/1.0/ProcessApplication`)
- Files without that schema URI or located outside `META-INF/` are left untouched (safe for edge cases with non-Camunda XML using the same filename)
- Recipe is registered in `AllClientCleanupRecipes`

Closes #1553

## Test plan

- [x] `deletesC7ProcessesXmlWithProcessApplicationSchema` — standard C7 `processes.xml` is deleted
- [x] `doesNotDeleteXmlWithoutC7ProcessApplicationSchema` — XML with same filename but different namespace is preserved
- [x] `doesNotDeleteC7ProcessesXmlOutsideMetaInf` — file at wrong path is preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)