### PR TITLE
feat(recipes): extend user task migration and detect job-based workers

### DIFF
--- a/code-conversion/recipes/src/main/java/io/camunda/migration/code/recipes/client/DetectJobBasedUserTaskWorkerRecipe.java
+++ b/code-conversion/recipes/src/main/java/io/camunda/migration/code/recipes/client/DetectJobBasedUserTaskWorkerRecipe.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.migration.code.recipes.client;
+
+import java.util.stream.Stream;
+import io.camunda.migration.code.recipes.utils.RecipeUtils;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Preconditions;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.search.UsesType;
+import org.openrewrite.java.tree.Comment;
+import org.openrewrite.java.tree.Expression;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JavaType;
+import org.openrewrite.java.tree.TextComment;
+import org.openrewrite.java.tree.TypeUtils;
+
+/**
+ * Flags job-based user task workers so they can be migrated to Camunda user tasks.
+ *
+ * <p>Job-based user tasks are handled by a {@code @JobWorker} that activates the built-in {@code
+ * io.camunda.zeebe:userTask} job type. They are deprecated in Camunda 8.8 and removed in 8.10.
+ * There is no code equivalent for a Camunda user task - they are managed through the User Task API
+ * / Tasklist rather than a job worker - so this recipe only attaches a {@code TODO} to the worker
+ * instead of rewriting it.
+ */
+public class DetectJobBasedUserTaskWorkerRecipe extends Recipe {
+
+  static final String USER_TASK_JOB_TYPE = "io.camunda.zeebe:userTask";
+
+  static final String MIGRATION_HINT =
+      " TODO: job-based user tasks are deprecated (removed in Camunda 8.10). This @JobWorker handles"
+          + " the built-in \""
+          + USER_TASK_JOB_TYPE
+          + "\" job type. Migrate to Camunda user tasks: remove this worker and manage the task via"
+          + " the User Task API / Tasklist. See"
+          + " https://docs.camunda.io/docs/apis-tools/migration-manuals/migrate-to-camunda-user-tasks/";
+
+  public DetectJobBasedUserTaskWorkerRecipe() {}
+
+  @Override
+  public String getDisplayName() {
+    return "Detects job-based user task workers";
+  }
+
+  @Override
+  public String getDescription() {
+    return "Flags @JobWorker methods that activate the built-in \"io.camunda.zeebe:userTask\" job "
+        + "type with a TODO, because job-based user tasks are deprecated and must be migrated to "
+        + "Camunda user tasks before Camunda 8.10.";
+  }
+
+  @Override
+  public TreeVisitor<?, ExecutionContext> getVisitor() {
+    return Preconditions.check(
+        Preconditions.or(
+            new UsesType<>("io.camunda.client.annotation.JobWorker", true),
+            new UsesType<>("io.camunda.spring.client.annotation.JobWorker", true)),
+        new JavaIsoVisitor<ExecutionContext>() {
+          @Override
+          public J.MethodDeclaration visitMethodDeclaration(
+              J.MethodDeclaration method, ExecutionContext ctx) {
+            J.MethodDeclaration m = super.visitMethodDeclaration(method, ctx);
+
+            boolean handlesUserTaskJob =
+                m.getLeadingAnnotations().stream()
+                    .anyMatch(a -> isJobWorkerAnnotation(a) && targetsUserTaskJobType(a));
+            if (!handlesUserTaskJob) {
+              return m;
+            }
+
+            // avoid appending the hint again on repeated visits
+            boolean alreadyFlagged =
+                m.getComments().stream()
+                    .anyMatch(
+                        c -> c instanceof TextComment tc && tc.getText().contains(USER_TASK_JOB_TYPE));
+            if (alreadyFlagged) {
+              return m;
+            }
+
+            Comment hint = RecipeUtils.createSimpleComment(m, MIGRATION_HINT);
+            return m.withComments(
+                Stream.concat(m.getComments().stream(), Stream.of(hint)).toList());
+          }
+        });
+  }
+
+  private static boolean isJobWorkerAnnotation(J.Annotation annotation) {
+    JavaType.FullyQualified type = TypeUtils.asFullyQualified(annotation.getType());
+    if (type != null) {
+      return type.getFullyQualifiedName().endsWith(".JobWorker");
+    }
+    // fall back to the simple name when the annotation type could not be attributed
+    return "JobWorker".equals(annotation.getSimpleName());
+  }
+
+  private static boolean targetsUserTaskJobType(J.Annotation annotation) {
+    if (annotation.getArguments() == null) {
+      return false;
+    }
+    for (Expression argument : annotation.getArguments()) {
+      if (argument instanceof J.Assignment assignment
+          && assignment.getVariable() instanceof J.Identifier name
+          && "type".equals(name.getSimpleName())
+          && assignment.getAssignment() instanceof J.Literal literal
+          && USER_TASK_JOB_TYPE.equals(literal.getValue())) {
+        return true;
+      }
+    }
+    return false;
+  }
+}

--- a/code-conversion/recipes/src/main/java/io/camunda/migration/code/recipes/client/MigrateUserTaskMethodsRecipe.java
+++ b/code-conversion/recipes/src/main/java/io/camunda/migration/code/recipes/client/MigrateUserTaskMethodsRecipe.java
@@ -18,6 +18,35 @@ import org.openrewrite.java.search.UsesMethod;
 
 public class MigrateUserTaskMethodsRecipe extends AbstractMigrationRecipe {
 
+  /**
+   * The Camunda user task API commands ({@code newCompleteUserTaskCommand}, {@code
+   * newAssignUserTaskCommand}, ...) only work against tasks that carry the {@code <zeebe:userTask
+   * />} extension element. Against a job-based user task they fail with a 404, so migrated code
+   * gets this hint.
+   */
+  private static final String ENSURE_ZEEBE_USER_TASK_HINT =
+      " TODO: the Camunda user task API requires the BPMN user task element to declare"
+          + " <zeebe:userTask />, otherwise this command fails with a 404. Run the Diagram Converter"
+          + " to add it automatically.";
+
+  /**
+   * C7 has no dedicated {@code unclaim} on {@code TaskService}; unclaiming is done via {@code
+   * setAssignee(taskId, null)}. A {@link org.openrewrite.java.MethodMatcher} cannot tell a null
+   * assignee apart from a real one, so the assign command is emitted with this hint.
+   */
+  private static final String NULL_ASSIGNEE_UNCLAIM_HINT =
+      " TODO: if the original assignee was null (unclaim), use"
+          + " camundaClient.newUnassignUserTaskCommand(taskKey) instead.";
+
+  /**
+   * Camunda 8 has no task-scoped variables. {@code newSetVariablesCommand} expects an element
+   * instance key rather than the task key, so the generated call needs manual review.
+   */
+  private static final String NO_TASK_SCOPED_VARIABLES_HINT =
+      " TODO: Camunda 8 has no task-scoped variables. newSetVariablesCommand expects the element"
+          + " instance key (not the task key); set the variable on the process/element instance"
+          + " scope instead.";
+
   @Override
   public String getDisplayName() {
     return "Migrates user task related methods";
@@ -32,9 +61,11 @@ public class MigrateUserTaskMethodsRecipe extends AbstractMigrationRecipe {
   protected TreeVisitor<?, ExecutionContext> preconditions() {
     return Preconditions.or(
         new UsesMethod<>("org.camunda.bpm.engine.TaskService createTaskQuery()", true),
-        new UsesMethod<>("org.camunda.bpm.engine.RuntimeService claim(..)", true),
-        new UsesMethod<>("org.camunda.bpm.engine.RuntimeService complete(..)", true),
-        new UsesMethod<>("org.camunda.bpm.engine.RuntimeService getVariable(..)", true),
+        new UsesMethod<>("org.camunda.bpm.engine.TaskService claim(..)", true),
+        new UsesMethod<>("org.camunda.bpm.engine.TaskService setAssignee(..)", true),
+        new UsesMethod<>("org.camunda.bpm.engine.TaskService complete(..)", true),
+        new UsesMethod<>("org.camunda.bpm.engine.TaskService setVariable(..)", true),
+        new UsesMethod<>("org.camunda.bpm.engine.TaskService getVariable(..)", true),
         new UsesMethod<>("org.camunda.bpm.engine.task.Task getTaskDefinitionKey()", true));
   }
 
@@ -48,7 +79,7 @@ public class MigrateUserTaskMethodsRecipe extends AbstractMigrationRecipe {
             RecipeUtils.createSimpleJavaTemplate(
                 """
                 #{camundaClient:any(io.camunda.client.CamundaClient)}
-                    .newUserTaskAssignCommand(Long.valueOf(#{taskId:any(java.lang.String)}))
+                    .newAssignUserTaskCommand(Long.valueOf(#{taskId:any(java.lang.String)}))
                     .assignee(#{userId:any(java.lang.String)})
                     .send()
                     .join();
@@ -60,6 +91,25 @@ public class MigrateUserTaskMethodsRecipe extends AbstractMigrationRecipe {
                 new ReplacementUtils.SimpleReplacementSpec.NamedArg("taskId", 0),
                 new ReplacementUtils.SimpleReplacementSpec.NamedArg("userId", 1)),
             Collections.emptyList()),
+        new ReplacementUtils.SimpleReplacementSpec(
+            // "setAssignee(String taskId, String userId)" - C7 assign; unclaim passes a null userId
+            new MethodMatcher(
+                "org.camunda.bpm.engine.TaskService setAssignee(java.lang.String, java.lang.String)"),
+            RecipeUtils.createSimpleJavaTemplate(
+                """
+                #{camundaClient:any(io.camunda.client.CamundaClient)}
+                    .newAssignUserTaskCommand(Long.valueOf(#{taskId:any(java.lang.String)}))
+                    .assignee(#{userId:any(java.lang.String)})
+                    .send()
+                    .join();
+                """),
+            RecipeUtils.createSimpleIdentifier("camundaClient", "io.camunda.client.CamundaClient"),
+            "io.camunda.client.api.response.AssignUserTaskResponse",
+            ReplacementUtils.ReturnTypeStrategy.USE_SPECIFIED_TYPE,
+            List.of(
+                new ReplacementUtils.SimpleReplacementSpec.NamedArg("taskId", 0),
+                new ReplacementUtils.SimpleReplacementSpec.NamedArg("userId", 1)),
+            List.of(NULL_ASSIGNEE_UNCLAIM_HINT)),
         new ReplacementUtils.SimpleReplacementSpec(
             // "complete(String taskId)"
             new MethodMatcher("org.camunda.bpm.engine.TaskService complete(java.lang.String)"),
@@ -74,7 +124,7 @@ public class MigrateUserTaskMethodsRecipe extends AbstractMigrationRecipe {
             "io.camunda.client.api.response.CompleteUserTaskResponse",
             ReplacementUtils.ReturnTypeStrategy.USE_SPECIFIED_TYPE,
             List.of(new ReplacementUtils.SimpleReplacementSpec.NamedArg("taskId", 0)),
-            Collections.emptyList()),
+            List.of(ENSURE_ZEEBE_USER_TASK_HINT)),
         new ReplacementUtils.SimpleReplacementSpec(
             // "complete(String taskId, Map<String, Object> variables)"
             new MethodMatcher(
@@ -93,7 +143,27 @@ public class MigrateUserTaskMethodsRecipe extends AbstractMigrationRecipe {
             List.of(
                 new ReplacementUtils.SimpleReplacementSpec.NamedArg("taskId", 0),
                 new ReplacementUtils.SimpleReplacementSpec.NamedArg("variables", 1)),
-            Collections.emptyList()),
+            List.of(ENSURE_ZEEBE_USER_TASK_HINT)),
+        new ReplacementUtils.SimpleReplacementSpec(
+            // "setVariable(String taskId, String variableName, Object value)"
+            new MethodMatcher(
+                "org.camunda.bpm.engine.TaskService setVariable(java.lang.String, java.lang.String, java.lang.Object)"),
+            RecipeUtils.createSimpleJavaTemplate(
+                """
+                #{camundaClient:any(io.camunda.client.CamundaClient)}
+                    .newSetVariablesCommand(Long.valueOf(#{taskId:any(java.lang.String)}))
+                    .variables(java.util.Map.of(#{variableName:any(java.lang.String)}, #{value:any(java.lang.Object)}))
+                    .send()
+                    .join();
+                """),
+            RecipeUtils.createSimpleIdentifier("camundaClient", "io.camunda.client.CamundaClient"),
+            "io.camunda.client.api.response.SetVariablesResponse",
+            ReplacementUtils.ReturnTypeStrategy.USE_SPECIFIED_TYPE,
+            List.of(
+                new ReplacementUtils.SimpleReplacementSpec.NamedArg("taskId", 0),
+                new ReplacementUtils.SimpleReplacementSpec.NamedArg("variableName", 1),
+                new ReplacementUtils.SimpleReplacementSpec.NamedArg("value", 2)),
+            List.of(NO_TASK_SCOPED_VARIABLES_HINT)),
         new ReplacementUtils.SimpleReplacementSpec(
             // "getVariable(String taskId, String variableName)"
             new MethodMatcher(

--- a/code-conversion/recipes/src/main/java/io/camunda/migration/code/recipes/client/MigrateUserTaskMethodsRecipe.java
+++ b/code-conversion/recipes/src/main/java/io/camunda/migration/code/recipes/client/MigrateUserTaskMethodsRecipe.java
@@ -152,7 +152,7 @@ public class MigrateUserTaskMethodsRecipe extends AbstractMigrationRecipe {
                 """
                 #{camundaClient:any(io.camunda.client.CamundaClient)}
                     .newSetVariablesCommand(Long.valueOf(#{taskId:any(java.lang.String)}))
-                    .variables(java.util.Map.of(#{variableName:any(java.lang.String)}, #{value:any(java.lang.Object)}))
+                    .variables(java.util.Collections.singletonMap(#{variableName:any(java.lang.String)}, #{value:any(java.lang.Object)}))
                     .send()
                     .join();
                 """),

--- a/code-conversion/recipes/src/main/java/io/camunda/migration/code/recipes/client/MigrateUserTaskMethodsRecipe.java
+++ b/code-conversion/recipes/src/main/java/io/camunda/migration/code/recipes/client/MigrateUserTaskMethodsRecipe.java
@@ -90,7 +90,7 @@ public class MigrateUserTaskMethodsRecipe extends AbstractMigrationRecipe {
             List.of(
                 new ReplacementUtils.SimpleReplacementSpec.NamedArg("taskId", 0),
                 new ReplacementUtils.SimpleReplacementSpec.NamedArg("userId", 1)),
-            Collections.emptyList()),
+            List.of(ENSURE_ZEEBE_USER_TASK_HINT)),
         new ReplacementUtils.SimpleReplacementSpec(
             // "setAssignee(String taskId, String userId)" - C7 assign; unclaim passes a null userId
             new MethodMatcher(
@@ -109,7 +109,7 @@ public class MigrateUserTaskMethodsRecipe extends AbstractMigrationRecipe {
             List.of(
                 new ReplacementUtils.SimpleReplacementSpec.NamedArg("taskId", 0),
                 new ReplacementUtils.SimpleReplacementSpec.NamedArg("userId", 1)),
-            List.of(NULL_ASSIGNEE_UNCLAIM_HINT)),
+            List.of(ENSURE_ZEEBE_USER_TASK_HINT, NULL_ASSIGNEE_UNCLAIM_HINT)),
         new ReplacementUtils.SimpleReplacementSpec(
             // "complete(String taskId)"
             new MethodMatcher("org.camunda.bpm.engine.TaskService complete(java.lang.String)"),

--- a/code-conversion/recipes/src/main/resources/META-INF/rewrite/clientRecipes.yml
+++ b/code-conversion/recipes/src/main/resources/META-INF/rewrite/clientRecipes.yml
@@ -24,6 +24,7 @@ recipeList:
   - io.camunda.migration.code.recipes.client.MigrateStartProcessInstanceMethodsRecipe
   - io.camunda.migration.code.recipes.client.MigrateMessageMethodsRecipe
   - io.camunda.migration.code.recipes.client.MigrateUserTaskMethodsRecipe
+  - io.camunda.migration.code.recipes.client.DetectJobBasedUserTaskWorkerRecipe
   - io.camunda.migration.code.recipes.client.MigrateProcessInstanceQueryMethodsRecipe
   - io.camunda.migration.code.recipes.testing.ReplaceAssertionsRecipe
   # Match the Spring Boot 3 starter chosen above: camunda-process-test-spring defaults to

--- a/code-conversion/recipes/src/test/java/io/camunda/migration/code/recipes/client/migrate/AbstractMigrationRecipeNullReturnTypeTest.java
+++ b/code-conversion/recipes/src/test/java/io/camunda/migration/code/recipes/client/migrate/AbstractMigrationRecipeNullReturnTypeTest.java
@@ -237,6 +237,7 @@ class AbstractMigrationRecipeNullReturnTypeTest implements RewriteTest {
                         Task task = taskService.createTaskQuery()
                             .processInstanceBusinessKey(businessKey)
                             .singleResult();
+                        // TODO: the Camunda user task API requires the BPMN user task element to declare <zeebe:userTask />, otherwise this command fails with a 404. Run the Diagram Converter to add it automatically.
                         camundaClient
                                 .newCompleteUserTaskCommand(Long.valueOf(//TODO: Manual migration required - could not resolve return type for: task
                                         task.getId()))

--- a/code-conversion/recipes/src/test/java/io/camunda/migration/code/recipes/client/migrate/DetectJobBasedUserTaskWorkerTest.java
+++ b/code-conversion/recipes/src/test/java/io/camunda/migration/code/recipes/client/migrate/DetectJobBasedUserTaskWorkerTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.migration.code.recipes.client.migrate;
+
+import static org.openrewrite.java.Assertions.java;
+
+import io.camunda.migration.code.recipes.client.DetectJobBasedUserTaskWorkerRecipe;
+import org.junit.jupiter.api.Test;
+import org.openrewrite.test.RewriteTest;
+
+class DetectJobBasedUserTaskWorkerTest implements RewriteTest {
+
+  @Test
+  void flagsJobBasedUserTaskWorker() {
+    rewriteRun(
+        spec -> spec.recipe(new DetectJobBasedUserTaskWorkerRecipe()),
+        // language=java
+        java(
+"""
+package org.camunda.community.migration.example;
+
+import io.camunda.client.annotation.JobWorker;
+import io.camunda.client.api.response.ActivatedJob;
+
+public class UserTaskWorker {
+
+    @JobWorker(type = "io.camunda.zeebe:userTask")
+    public void handleUserTask(ActivatedJob job) {
+    }
+}
+""",
+"""
+package org.camunda.community.migration.example;
+
+import io.camunda.client.annotation.JobWorker;
+import io.camunda.client.api.response.ActivatedJob;
+
+public class UserTaskWorker {
+
+    // TODO: job-based user tasks are deprecated (removed in Camunda 8.10). This @JobWorker handles the built-in "io.camunda.zeebe:userTask" job type. Migrate to Camunda user tasks: remove this worker and manage the task via the User Task API / Tasklist. See https://docs.camunda.io/docs/apis-tools/migration-manuals/migrate-to-camunda-user-tasks/
+    @JobWorker(type = "io.camunda.zeebe:userTask")
+    public void handleUserTask(ActivatedJob job) {
+    }
+}
+"""));
+  }
+
+  @Test
+  void doesNotFlagOtherJobWorkers() {
+    rewriteRun(
+        spec -> spec.recipe(new DetectJobBasedUserTaskWorkerRecipe()),
+        // language=java
+        java(
+"""
+package org.camunda.community.migration.example;
+
+import io.camunda.client.annotation.JobWorker;
+import io.camunda.client.api.response.ActivatedJob;
+
+public class PaymentWorker {
+
+    @JobWorker(type = "retrievePayment")
+    public void retrievePayment(ActivatedJob job) {
+    }
+}
+"""));
+  }
+}

--- a/code-conversion/recipes/src/test/java/io/camunda/migration/code/recipes/client/migrate/ReplaceUserTaskMethodsTest.java
+++ b/code-conversion/recipes/src/test/java/io/camunda/migration/code/recipes/client/migrate/ReplaceUserTaskMethodsTest.java
@@ -335,7 +335,7 @@ public class HandleSetVariable {
         // TODO: Camunda 8 has no task-scoped variables. newSetVariablesCommand expects the element instance key (not the task key); set the variable on the process/element instance scope instead.
         camundaClient
                 .newSetVariablesCommand(Long.valueOf(taskId))
-                .variables(java.util.Map.of(variableName, value))
+                .variables(java.util.Collections.singletonMap(variableName, value))
                 .send()
                 .join();
     }

--- a/code-conversion/recipes/src/test/java/io/camunda/migration/code/recipes/client/migrate/ReplaceUserTaskMethodsTest.java
+++ b/code-conversion/recipes/src/test/java/io/camunda/migration/code/recipes/client/migrate/ReplaceUserTaskMethodsTest.java
@@ -150,6 +150,7 @@ public class HandleClaim {
     private TaskService taskService;
 
     public void claimTask(String taskId, String userId) {
+        // TODO: the Camunda user task API requires the BPMN user task element to declare <zeebe:userTask />, otherwise this command fails with a 404. Run the Diagram Converter to add it automatically.
         camundaClient
                 .newAssignUserTaskCommand(Long.valueOf(taskId))
                 .assignee(userId)
@@ -194,6 +195,7 @@ public class HandleAssign {
     private TaskService taskService;
 
     public void assignTask(String taskId, String userId) {
+        // TODO: the Camunda user task API requires the BPMN user task element to declare <zeebe:userTask />, otherwise this command fails with a 404. Run the Diagram Converter to add it automatically.
         // TODO: if the original assignee was null (unclaim), use camundaClient.newUnassignUserTaskCommand(taskKey) instead.
         camundaClient
                 .newAssignUserTaskCommand(Long.valueOf(taskId))

--- a/code-conversion/recipes/src/test/java/io/camunda/migration/code/recipes/client/migrate/ReplaceUserTaskMethodsTest.java
+++ b/code-conversion/recipes/src/test/java/io/camunda/migration/code/recipes/client/migrate/ReplaceUserTaskMethodsTest.java
@@ -115,4 +115,231 @@ public class HandleUserTasksTestClass {
 }
 """));
   }
+
+  @Test
+  void replaceClaim() {
+    rewriteRun(
+        spec -> spec.recipe(new MigrateUserTaskMethodsRecipe()),
+        // language=java
+        java(
+"""
+package org.camunda.community.migration.example;
+
+import io.camunda.client.CamundaClient;
+import org.camunda.bpm.engine.TaskService;
+
+public class HandleClaim {
+
+    private CamundaClient camundaClient;
+    private TaskService taskService;
+
+    public void claimTask(String taskId, String userId) {
+        taskService.claim(taskId, userId);
+    }
+}
+""",
+"""
+package org.camunda.community.migration.example;
+
+import io.camunda.client.CamundaClient;
+import org.camunda.bpm.engine.TaskService;
+
+public class HandleClaim {
+
+    private CamundaClient camundaClient;
+    private TaskService taskService;
+
+    public void claimTask(String taskId, String userId) {
+        camundaClient
+                .newAssignUserTaskCommand(Long.valueOf(taskId))
+                .assignee(userId)
+                .send()
+                .join();
+    }
+}
+"""));
+  }
+
+  @Test
+  void replaceSetAssignee() {
+    rewriteRun(
+        spec -> spec.recipe(new MigrateUserTaskMethodsRecipe()),
+        // language=java
+        java(
+"""
+package org.camunda.community.migration.example;
+
+import io.camunda.client.CamundaClient;
+import org.camunda.bpm.engine.TaskService;
+
+public class HandleAssign {
+
+    private CamundaClient camundaClient;
+    private TaskService taskService;
+
+    public void assignTask(String taskId, String userId) {
+        taskService.setAssignee(taskId, userId);
+    }
+}
+""",
+"""
+package org.camunda.community.migration.example;
+
+import io.camunda.client.CamundaClient;
+import org.camunda.bpm.engine.TaskService;
+
+public class HandleAssign {
+
+    private CamundaClient camundaClient;
+    private TaskService taskService;
+
+    public void assignTask(String taskId, String userId) {
+        // TODO: if the original assignee was null (unclaim), use camundaClient.newUnassignUserTaskCommand(taskKey) instead.
+        camundaClient
+                .newAssignUserTaskCommand(Long.valueOf(taskId))
+                .assignee(userId)
+                .send()
+                .join();
+    }
+}
+"""));
+  }
+
+  @Test
+  void replaceComplete() {
+    rewriteRun(
+        spec -> spec.recipe(new MigrateUserTaskMethodsRecipe()),
+        // language=java
+        java(
+"""
+package org.camunda.community.migration.example;
+
+import io.camunda.client.CamundaClient;
+import org.camunda.bpm.engine.TaskService;
+
+public class HandleComplete {
+
+    private CamundaClient camundaClient;
+    private TaskService taskService;
+
+    public void completeTask(String taskId) {
+        taskService.complete(taskId);
+    }
+}
+""",
+"""
+package org.camunda.community.migration.example;
+
+import io.camunda.client.CamundaClient;
+import org.camunda.bpm.engine.TaskService;
+
+public class HandleComplete {
+
+    private CamundaClient camundaClient;
+    private TaskService taskService;
+
+    public void completeTask(String taskId) {
+        // TODO: the Camunda user task API requires the BPMN user task element to declare <zeebe:userTask />, otherwise this command fails with a 404. Run the Diagram Converter to add it automatically.
+        camundaClient
+                .newCompleteUserTaskCommand(Long.valueOf(taskId))
+                .send()
+                .join();
+    }
+}
+"""));
+  }
+
+  @Test
+  void replaceCompleteWithVariables() {
+    rewriteRun(
+        spec -> spec.recipe(new MigrateUserTaskMethodsRecipe()),
+        // language=java
+        java(
+"""
+package org.camunda.community.migration.example;
+
+import io.camunda.client.CamundaClient;
+import org.camunda.bpm.engine.TaskService;
+
+import java.util.Map;
+
+public class HandleCompleteVariables {
+
+    private CamundaClient camundaClient;
+    private TaskService taskService;
+
+    public void completeTask(String taskId, Map<String, Object> variables) {
+        taskService.complete(taskId, variables);
+    }
+}
+""",
+"""
+package org.camunda.community.migration.example;
+
+import io.camunda.client.CamundaClient;
+import org.camunda.bpm.engine.TaskService;
+
+import java.util.Map;
+
+public class HandleCompleteVariables {
+
+    private CamundaClient camundaClient;
+    private TaskService taskService;
+
+    public void completeTask(String taskId, Map<String, Object> variables) {
+        // TODO: the Camunda user task API requires the BPMN user task element to declare <zeebe:userTask />, otherwise this command fails with a 404. Run the Diagram Converter to add it automatically.
+        camundaClient
+                .newCompleteUserTaskCommand(Long.valueOf(taskId))
+                .variables(variables)
+                .send()
+                .join();
+    }
+}
+"""));
+  }
+
+  @Test
+  void replaceSetVariable() {
+    rewriteRun(
+        spec -> spec.recipe(new MigrateUserTaskMethodsRecipe()),
+        // language=java
+        java(
+"""
+package org.camunda.community.migration.example;
+
+import io.camunda.client.CamundaClient;
+import org.camunda.bpm.engine.TaskService;
+
+public class HandleSetVariable {
+
+    private CamundaClient camundaClient;
+    private TaskService taskService;
+
+    public void setVariable(String taskId, String variableName, Object value) {
+        taskService.setVariable(taskId, variableName, value);
+    }
+}
+""",
+"""
+package org.camunda.community.migration.example;
+
+import io.camunda.client.CamundaClient;
+import org.camunda.bpm.engine.TaskService;
+
+public class HandleSetVariable {
+
+    private CamundaClient camundaClient;
+    private TaskService taskService;
+
+    public void setVariable(String taskId, String variableName, Object value) {
+        // TODO: Camunda 8 has no task-scoped variables. newSetVariablesCommand expects the element instance key (not the task key); set the variable on the process/element instance scope instead.
+        camundaClient
+                .newSetVariablesCommand(Long.valueOf(taskId))
+                .variables(java.util.Map.of(variableName, value))
+                .send()
+                .join();
+    }
+}
+"""));
+  }
 }


### PR DESCRIPTION
## Summary

- Extends `MigrateUserTaskMethodsRecipe` to cover the remaining C7 `TaskService` user task methods (`setAssignee`, `setVariable`) and fixes a broken command name in the existing `claim` migration.
- Adds `DetectJobBasedUserTaskWorkerRecipe`, which flags `@JobWorker` methods bound to the deprecated `io.camunda.zeebe:userTask` job type so they get migrated to Camunda user tasks before 8.10.
- Adds TODO hints on migrated code for the cross-cutting `<zeebe:userTask />` BPMN requirement and the C8 variable-scope difference.

## Issue API corrections

The issue text contained a few API inaccuracies; the implementation follows the real `CamundaClient` / C7 `TaskService` APIs (verified against the jars on the classpath):

- `newUserTaskCompleteCommand` → real method is `newCompleteUserTaskCommand` (existing code was already correct).
- Existing `claim` template used `newUserTaskAssignCommand`, which does not exist → fixed to **`newAssignUserTaskCommand`**.
- `taskService.unclaim(taskId)` does not exist on C7 `TaskService`. C7 unclaim is `setAssignee(taskId, null)`. A `MethodMatcher` can't distinguish a null assignee, so `setAssignee` maps to `newAssignUserTaskCommand(...).assignee(...)` with a TODO pointing to `newUnassignUserTaskCommand` for the unclaim case.
- `setVariable` has no task-scoped equivalent in C8. It maps to `newSetVariablesCommand(...)` (element-instance scope) with a TODO, since the task key is not the element instance key.
- `@JobWorker(io.camunda.zeebe:userTask)`: the issue suggested removing the annotation. The recipe instead adds a TODO and leaves the code intact — silently turning a job worker into a plain bean would break semantics, and Camunda user tasks have no job-worker equivalent to rewrite to. Flagging for manual migration is the safer, reviewable action.

## Changes

- `MigrateUserTaskMethodsRecipe` — fixed `claim` command name; corrected preconditions to target `TaskService` (were `RuntimeService`); added `setAssignee` and `setVariable` specs; added `<zeebe:userTask />` hints to both `complete` specs.
- `DetectJobBasedUserTaskWorkerRecipe` — new recipe; matches `@JobWorker` (client or spring annotation) with `type = "io.camunda.zeebe:userTask"` and attaches a migration TODO.
- `clientRecipes.yml` — registered the new recipe in `AllClientMigrateRecipes`.
- Tests — new cases in `ReplaceUserTaskMethodsTest`, new `DetectJobBasedUserTaskWorkerTest` (including a negative control), and an updated expectation in `AbstractMigrationRecipeNullReturnTypeTest`.

## Test plan

- [x] `mvn -pl code-conversion/recipes test` — all 53 tests pass
- [x] `mvn -pl code-conversion/recipes -PcheckFormat verify -DskipTests` — Spotless + license checks pass
- [x] New recipe verified against a positive case (`io.camunda.zeebe:userTask`) and a negative case (a normal `@JobWorker`)

## Baseline

Built from commit: 814e2038

related to #1556

🤖 Generated with [Claude Code](https://claude.com/claude-code)