### PR TITLE
feat(recipes): migrate businessKey to businessId in start-process methods

### DIFF
--- a/code-conversion/recipes/src/main/java/io/camunda/migration/code/recipes/client/MigrateStartProcessInstanceMethodsRecipe.java
+++ b/code-conversion/recipes/src/main/java/io/camunda/migration/code/recipes/client/MigrateStartProcessInstanceMethodsRecipe.java
@@ -81,14 +81,17 @@ public class MigrateStartProcessInstanceMethodsRecipe extends AbstractMigrationR
                                 .newCreateInstanceCommand()
                                 .bpmnProcessId(#{processDefinitionId:any(String)})
                                 .latestVersion()
+                                .businessId(#{businessId:any(String)})
                                 .send()
                                 .join();
                             """),
             RecipeUtils.createSimpleIdentifier("camundaClient", "io.camunda.client.CamundaClient"),
             "io.camunda.client.api.response.ProcessInstanceEvent",
             ReplacementUtils.ReturnTypeStrategy.USE_SPECIFIED_TYPE,
-            List.of(new ReplacementUtils.SimpleReplacementSpec.NamedArg("processDefinitionKey", 0)),
-            List.of(RecipeUtils.businessIdHint("businessKey"))),
+            List.of(
+                new ReplacementUtils.SimpleReplacementSpec.NamedArg("processDefinitionKey", 0),
+                new ReplacementUtils.SimpleReplacementSpec.NamedArg("businessId", 1)),
+            Collections.emptyList()),
         new ReplacementUtils.SimpleReplacementSpec(
             new MethodMatcher(
                 // "startProcessInstanceByKey(String processDefinitionKey, Map<String, Object>
@@ -122,6 +125,7 @@ public class MigrateStartProcessInstanceMethodsRecipe extends AbstractMigrationR
                                 .newCreateInstanceCommand()
                                 .bpmnProcessId(#{processDefinitionId:any(String)})
                                 .latestVersion()
+                                .businessId(#{businessId:any(String)})
                                 .variables(#{variableMap:any(java.util.Map)})
                                 .send()
                                 .join();
@@ -131,8 +135,9 @@ public class MigrateStartProcessInstanceMethodsRecipe extends AbstractMigrationR
             ReplacementUtils.ReturnTypeStrategy.USE_SPECIFIED_TYPE,
             List.of(
                 new ReplacementUtils.SimpleReplacementSpec.NamedArg("processDefinitionKey", 0),
+                new ReplacementUtils.SimpleReplacementSpec.NamedArg("businessId", 1),
                 new ReplacementUtils.SimpleReplacementSpec.NamedArg("variableMap", 2)),
-            List.of(RecipeUtils.businessIdHint("businessKey"))),
+            Collections.emptyList()),
         new ReplacementUtils.SimpleReplacementSpec(
             new MethodMatcher(
                 // "startProcessInstanceById(String processDefinitionId)"
@@ -159,14 +164,17 @@ public class MigrateStartProcessInstanceMethodsRecipe extends AbstractMigrationR
                             #{camundaClient:any(io.camunda.client.CamundaClient)}
                                 .newCreateInstanceCommand()
                                 .processDefinitionKey(Long.valueOf(#{processDefinitionId:any(String)}))
+                                .businessId(#{businessId:any(String)})
                                 .send()
                                 .join();
                             """),
             RecipeUtils.createSimpleIdentifier("camundaClient", "io.camunda.client.CamundaClient"),
             "io.camunda.client.api.response.ProcessInstanceEvent",
             ReplacementUtils.ReturnTypeStrategy.USE_SPECIFIED_TYPE,
-            List.of(new ReplacementUtils.SimpleReplacementSpec.NamedArg("processDefinitionId", 0)),
-            List.of(RecipeUtils.businessIdHint("businessKey"))),
+            List.of(
+                new ReplacementUtils.SimpleReplacementSpec.NamedArg("processDefinitionId", 0),
+                new ReplacementUtils.SimpleReplacementSpec.NamedArg("businessId", 1)),
+            Collections.emptyList()),
         new ReplacementUtils.SimpleReplacementSpec(
             new MethodMatcher(
                 // "startProcessInstanceById(String processDefinitionId, Map<String, Object>
@@ -198,6 +206,7 @@ public class MigrateStartProcessInstanceMethodsRecipe extends AbstractMigrationR
                             #{camundaClient:any(io.camunda.client.CamundaClient)}
                                 .newCreateInstanceCommand()
                                 .processDefinitionKey(Long.valueOf(#{processDefinitionId:any(String)}))
+                                .businessId(#{businessId:any(String)})
                                 .variables(#{variableMap:any(java.util.Map)})
                                 .send()
                                 .join();
@@ -207,8 +216,9 @@ public class MigrateStartProcessInstanceMethodsRecipe extends AbstractMigrationR
             ReplacementUtils.ReturnTypeStrategy.USE_SPECIFIED_TYPE,
             List.of(
                 new ReplacementUtils.SimpleReplacementSpec.NamedArg("processDefinitionId", 0),
+                new ReplacementUtils.SimpleReplacementSpec.NamedArg("businessId", 1),
                 new ReplacementUtils.SimpleReplacementSpec.NamedArg("variableMap", 2)),
-            List.of(RecipeUtils.businessIdHint("businessKey"))),
+            Collections.emptyList()),
         new ReplacementUtils.SimpleReplacementSpec(
             new MethodMatcher(
                 // "startProcessInstanceByMessage(String messageName)"

--- a/code-conversion/recipes/src/main/java/io/camunda/migration/code/recipes/utils/BuilderSpecFactory.java
+++ b/code-conversion/recipes/src/main/java/io/camunda/migration/code/recipes/utils/BuilderSpecFactory.java
@@ -60,7 +60,7 @@ public class BuilderSpecFactory {
                   ReplacementUtils.ReturnTypeStrategy.USE_SPECIFIED_TYPE,
                   Stream.concat(
                           nonExtractables.stream()
-                              .map(BuilderSpecFactory::createRemovedComment),
+                              .flatMap(name -> createRemovedComments(name).stream()),
                           additionalTextComments.stream())
                       .toList());
             })
@@ -122,7 +122,7 @@ public class BuilderSpecFactory {
                   ReplacementUtils.ReturnTypeStrategy.USE_SPECIFIED_TYPE,
                   Stream.concat(
                           nonExtractables.stream()
-                              .map(BuilderSpecFactory::createRemovedComment),
+                              .flatMap(name -> createRemovedComments(name).stream()),
                           additionalTextComments.stream())
                       .toList(),
                   Collections.emptyList(),
@@ -154,17 +154,20 @@ public class BuilderSpecFactory {
     return result;
   }
 
-  static String createRemovedComment(String methodName) {
+  static List<String> createRemovedComments(String methodName) {
     // Among the builder specs produced by this factory, `businessKey` only appears in the
-    // createProcessInstance builder (newCreateInstanceCommand), so a businessId hint is the
-    // right guidance for migrators. `processInstanceBusinessKey` in these builder specs only
-    // appears in the correlateMessage builder (newCorrelateMessageCommand), where businessId
-    // is not a replacement - keep that comment neutral.
+    // createProcessInstance builder (newCreateInstanceCommand). It is dropped here (rather than
+    // migrated to `.businessId(...)` like the plain start-process overloads) because the
+    // ProcessInstantiationBuilder.businessKey() semantics may differ from businessId - uniqueness
+    // enforcement / retry idempotency is opt-in in Camunda 8.9 - so a human should review it.
+    // We therefore emit a businessId hint plus a reminder that any businessKey propagated to a
+    // call activity must also be migrated on the diagram side.
     // Note: processInstanceBusinessKey on search/query paths is handled separately and does
     // get a businessId hint via RecipeUtils.businessIdHint() called directly from the recipe.
     if ("businessKey".equals(methodName)) {
-      return RecipeUtils.businessIdHint(methodName);
+      return List.of(
+          RecipeUtils.businessIdHint(methodName), RecipeUtils.businessIdCallActivityHint());
     }
-    return " " + methodName + " was removed";
+    return List.of(" " + methodName + " was removed");
   }
 }

--- a/code-conversion/recipes/src/main/java/io/camunda/migration/code/recipes/utils/RecipeUtils.java
+++ b/code-conversion/recipes/src/main/java/io/camunda/migration/code/recipes/utils/RecipeUtils.java
@@ -31,6 +31,21 @@ public class RecipeUtils {
     return " TODO: " + removedMethod + " was removed - use businessId (Camunda 8.9+) instead";
   }
 
+  /**
+   * Extra hint used alongside {@link #businessIdHint} on process-instance <em>creation</em> paths
+   * where a {@code businessKey} is dropped without an automatic {@code businessId} replacement.
+   *
+   * <p>If the former {@code businessKey} was also propagated to a called process via a
+   * {@code <camunda:in businessKey="..." />} mapping on a BPMN call activity, that propagation must
+   * be migrated to Business ID on the diagram side as well. This is out of scope for code recipes
+   * (handled by the diagram converter), so we only surface it as a reminder here.
+   */
+  public static String businessIdCallActivityHint() {
+    return " TODO: if this businessKey was propagated to a called process via <camunda:in"
+        + " businessKey=\"...\" /> on a BPMN call activity, migrate that propagation to businessId in"
+        + " the diagram as well (diagram converter)";
+  }
+
   public static J.Identifier createSimpleIdentifier(String simpleName, String javaType) {
     return new J.Identifier(
         Tree.randomId(),

--- a/code-conversion/recipes/src/test/java/io/camunda/migration/code/recipes/client/migrate/ReplaceStartProcessInstanceMethodsTest.java
+++ b/code-conversion/recipes/src/test/java/io/camunda/migration/code/recipes/client/migrate/ReplaceStartProcessInstanceMethodsTest.java
@@ -153,293 +153,301 @@ class ReplaceStartProcessInstanceMethodsTest implements RewriteTest {
                                 }
                                 """,
             """
-                                 package org.camunda.community.migration.example;
-                                 import io.camunda.client.api.response.CorrelateMessageResponse;
-                                 import io.camunda.client.api.response.ProcessInstanceEvent;
-                                 import org.camunda.bpm.engine.ProcessEngine;
-                                 import io.camunda.client.CamundaClient;
-                                 import org.springframework.beans.factory.annotation.Autowired;
-                                 import org.springframework.stereotype.Component;
+                package org.camunda.community.migration.example;
+                import io.camunda.client.api.response.CorrelateMessageResponse;
+                import io.camunda.client.api.response.ProcessInstanceEvent;
+                import org.camunda.bpm.engine.ProcessEngine;
+                import io.camunda.client.CamundaClient;
+                import org.springframework.beans.factory.annotation.Autowired;
+                import org.springframework.stereotype.Component;
 
-                                 import java.util.Map;
+                import java.util.Map;
 
-                                 @Component
-                                 public class CancelProcessInstanceTestClass {
+                @Component
+                public class CancelProcessInstanceTestClass {
 
-                                     @Autowired
-                                     private ProcessEngine engine;
+                    @Autowired
+                    private ProcessEngine engine;
 
-                                     @Autowired
-                                     private CamundaClient camundaClient;
+                    @Autowired
+                    private CamundaClient camundaClient;
 
-                                     public void startProcessInstance(String processDefinitionKey, String processDefinitionId, String businessKey, String tenantId, Map<String, Object> variableMap, String messageName) {
-                                         // by BPMNModelIdentifier
-                                         ProcessInstanceEvent instance1 = camundaClient
-                                                 .newCreateInstanceCommand()
-                                                 .bpmnProcessId(processDefinitionKey)
-                                                 .latestVersion()
-                                                 .send()
-                                                 .join();
-                                         String id = String.valueOf(instance1.getProcessInstanceKey());
-                                         System.out.println(String.valueOf(instance1.getProcessInstanceKey()));
+                    public void startProcessInstance(String processDefinitionKey, String processDefinitionId, String businessKey, String tenantId, Map<String, Object> variableMap, String messageName) {
+                        // by BPMNModelIdentifier
+                        ProcessInstanceEvent instance1 = camundaClient
+                                .newCreateInstanceCommand()
+                                .bpmnProcessId(processDefinitionKey)
+                                .latestVersion()
+                                .send()
+                                .join();
+                        String id = String.valueOf(instance1.getProcessInstanceKey());
+                        System.out.println(String.valueOf(instance1.getProcessInstanceKey()));
 
-                                         // TODO: businessKey was removed - use businessId (Camunda 8.9+) instead
-                                         camundaClient
-                                                 .newCreateInstanceCommand()
-                                                 .bpmnProcessId(processDefinitionKey)
-                                                 .latestVersion()
-                                                 .send()
-                                                 .join();
+                        camundaClient
+                                .newCreateInstanceCommand()
+                                .bpmnProcessId(processDefinitionKey)
+                                .latestVersion()
+                                .businessId(businessKey)
+                                .send()
+                                .join();
 
-                                         camundaClient
-                                                 .newCreateInstanceCommand()
-                                                 .bpmnProcessId(processDefinitionKey)
-                                                 .latestVersion()
-                                                 .variables(variableMap)
-                                                 .send()
-                                                 .join();
+                        camundaClient
+                                .newCreateInstanceCommand()
+                                .bpmnProcessId(processDefinitionKey)
+                                .latestVersion()
+                                .variables(variableMap)
+                                .send()
+                                .join();
 
-                                         // TODO: businessKey was removed - use businessId (Camunda 8.9+) instead
-                                         camundaClient
-                                                 .newCreateInstanceCommand()
-                                                 .bpmnProcessId(processDefinitionKey)
-                                                 .latestVersion()
-                                                 .variables(variableMap)
-                                                 .send()
-                                                 .join();
+                        camundaClient
+                                .newCreateInstanceCommand()
+                                .bpmnProcessId(processDefinitionKey)
+                                .latestVersion()
+                                .businessId(businessKey)
+                                .variables(variableMap)
+                                .send()
+                                .join();
 
-                                         camundaClient
-                                                 .newCreateInstanceCommand()
-                                                 .bpmnProcessId(processDefinitionKey)
-                                                 .latestVersion()
-                                                 .send()
-                                                 .join();
+                        camundaClient
+                                .newCreateInstanceCommand()
+                                .bpmnProcessId(processDefinitionKey)
+                                .latestVersion()
+                                .send()
+                                .join();
 
-                                         // TODO: businessKey was removed - use businessId (Camunda 8.9+) instead
-                                         camundaClient
-                                                 .newCreateInstanceCommand()
-                                                 .bpmnProcessId(processDefinitionKey)
-                                                 .latestVersion()
-                                                 .send()
-                                                 .join();
+                        // TODO: businessKey was removed - use businessId (Camunda 8.9+) instead
+                        // TODO: if this businessKey was propagated to a called process via <camunda:in businessKey="..." /> on a BPMN call activity, migrate that propagation to businessId in the diagram as well (diagram converter)
+                        camundaClient
+                                .newCreateInstanceCommand()
+                                .bpmnProcessId(processDefinitionKey)
+                                .latestVersion()
+                                .send()
+                                .join();
 
-                                         camundaClient
-                                                 .newCreateInstanceCommand()
-                                                 .bpmnProcessId(processDefinitionKey)
-                                                 .latestVersion()
-                                                 .tenantId(tenantId)
-                                                 .send()
-                                                 .join();
+                        camundaClient
+                                .newCreateInstanceCommand()
+                                .bpmnProcessId(processDefinitionKey)
+                                .latestVersion()
+                                .tenantId(tenantId)
+                                .send()
+                                .join();
 
-                                         camundaClient
-                                                 .newCreateInstanceCommand()
-                                                 .bpmnProcessId(processDefinitionKey)
-                                                 .latestVersion()
-                                                 .variables(variableMap)
-                                                 .send()
-                                                 .join();
+                        camundaClient
+                                .newCreateInstanceCommand()
+                                .bpmnProcessId(processDefinitionKey)
+                                .latestVersion()
+                                .variables(variableMap)
+                                .send()
+                                .join();
 
-                                         // TODO: businessKey was removed - use businessId (Camunda 8.9+) instead
-                                         camundaClient
-                                                 .newCreateInstanceCommand()
-                                                 .bpmnProcessId(processDefinitionKey)
-                                                 .latestVersion()
-                                                 .tenantId(tenantId)
-                                                 .send()
-                                                 .join();
+                        // TODO: businessKey was removed - use businessId (Camunda 8.9+) instead
+                        // TODO: if this businessKey was propagated to a called process via <camunda:in businessKey="..." /> on a BPMN call activity, migrate that propagation to businessId in the diagram as well (diagram converter)
+                        camundaClient
+                                .newCreateInstanceCommand()
+                                .bpmnProcessId(processDefinitionKey)
+                                .latestVersion()
+                                .tenantId(tenantId)
+                                .send()
+                                .join();
 
-                                         // TODO: businessKey was removed - use businessId (Camunda 8.9+) instead
-                                         camundaClient
-                                                 .newCreateInstanceCommand()
-                                                 .bpmnProcessId(processDefinitionKey)
-                                                 .latestVersion()
-                                                 .variables(variableMap)
-                                                 .send()
-                                                 .join();
+                        // TODO: businessKey was removed - use businessId (Camunda 8.9+) instead
+                        // TODO: if this businessKey was propagated to a called process via <camunda:in businessKey="..." /> on a BPMN call activity, migrate that propagation to businessId in the diagram as well (diagram converter)
+                        camundaClient
+                                .newCreateInstanceCommand()
+                                .bpmnProcessId(processDefinitionKey)
+                                .latestVersion()
+                                .variables(variableMap)
+                                .send()
+                                .join();
 
-                                         camundaClient
-                                                 .newCreateInstanceCommand()
-                                                 .bpmnProcessId(processDefinitionKey)
-                                                 .latestVersion()
-                                                 .variables(variableMap)
-                                                 .tenantId(tenantId)
-                                                 .send()
-                                                 .join();
+                        camundaClient
+                                .newCreateInstanceCommand()
+                                .bpmnProcessId(processDefinitionKey)
+                                .latestVersion()
+                                .variables(variableMap)
+                                .tenantId(tenantId)
+                                .send()
+                                .join();
 
-                                         // TODO: businessKey was removed - use businessId (Camunda 8.9+) instead
-                                         camundaClient
-                                                 .newCreateInstanceCommand()
-                                                 .bpmnProcessId(processDefinitionKey)
-                                                 .latestVersion()
-                                                 .variables(variableMap)
-                                                 .tenantId(tenantId)
-                                                 .send()
-                                                 .join();
+                        // TODO: businessKey was removed - use businessId (Camunda 8.9+) instead
+                        // TODO: if this businessKey was propagated to a called process via <camunda:in businessKey="..." /> on a BPMN call activity, migrate that propagation to businessId in the diagram as well (diagram converter)
+                        camundaClient
+                                .newCreateInstanceCommand()
+                                .bpmnProcessId(processDefinitionKey)
+                                .latestVersion()
+                                .variables(variableMap)
+                                .tenantId(tenantId)
+                                .send()
+                                .join();
 
-                                         // by key assigned on deployment
-                                         camundaClient
-                                                 .newCreateInstanceCommand()
-                                                 .processDefinitionKey(Long.valueOf(processDefinitionId))
-                                                 .send()
-                                                 .join();
+                        // by key assigned on deployment
+                        camundaClient
+                                .newCreateInstanceCommand()
+                                .processDefinitionKey(Long.valueOf(processDefinitionId))
+                                .send()
+                                .join();
 
-                                         // TODO: businessKey was removed - use businessId (Camunda 8.9+) instead
-                                         camundaClient
-                                                 .newCreateInstanceCommand()
-                                                 .processDefinitionKey(Long.valueOf(processDefinitionId))
-                                                 .send()
-                                                 .join();
+                        camundaClient
+                                .newCreateInstanceCommand()
+                                .processDefinitionKey(Long.valueOf(processDefinitionId))
+                                .businessId(businessKey)
+                                .send()
+                                .join();
 
-                                         camundaClient
-                                                 .newCreateInstanceCommand()
-                                                 .processDefinitionKey(Long.valueOf(processDefinitionId))
-                                                 .variables(variableMap)
-                                                 .send()
-                                                 .join();
+                        camundaClient
+                                .newCreateInstanceCommand()
+                                .processDefinitionKey(Long.valueOf(processDefinitionId))
+                                .variables(variableMap)
+                                .send()
+                                .join();
 
-                                         // TODO: businessKey was removed - use businessId (Camunda 8.9+) instead
-                                         camundaClient
-                                                 .newCreateInstanceCommand()
-                                                 .processDefinitionKey(Long.valueOf(processDefinitionId))
-                                                 .variables(variableMap)
-                                                 .send()
-                                                 .join();
+                        camundaClient
+                                .newCreateInstanceCommand()
+                                .processDefinitionKey(Long.valueOf(processDefinitionId))
+                                .businessId(businessKey)
+                                .variables(variableMap)
+                                .send()
+                                .join();
 
-                                         // TODO: businessKey was removed - use businessId (Camunda 8.9+) instead
-                                         camundaClient
-                                                 .newCreateInstanceCommand()
-                                                 .processDefinitionKey(Long.valueOf(processDefinitionId))
-                                                 .send()
-                                                 .join();
+                        // TODO: businessKey was removed - use businessId (Camunda 8.9+) instead
+                        // TODO: if this businessKey was propagated to a called process via <camunda:in businessKey="..." /> on a BPMN call activity, migrate that propagation to businessId in the diagram as well (diagram converter)
+                        camundaClient
+                                .newCreateInstanceCommand()
+                                .processDefinitionKey(Long.valueOf(processDefinitionId))
+                                .send()
+                                .join();
 
-                                         camundaClient
-                                                 .newCreateInstanceCommand()
-                                                 .processDefinitionKey(Long.valueOf(processDefinitionId))
-                                                 .tenantId(tenantId)
-                                                 .send()
-                                                 .join();
+                        camundaClient
+                                .newCreateInstanceCommand()
+                                .processDefinitionKey(Long.valueOf(processDefinitionId))
+                                .tenantId(tenantId)
+                                .send()
+                                .join();
 
-                                         camundaClient
-                                                 .newCreateInstanceCommand()
-                                                 .processDefinitionKey(Long.valueOf(processDefinitionId))
-                                                 .variables(variableMap)
-                                                 .send()
-                                                 .join();
+                        camundaClient
+                                .newCreateInstanceCommand()
+                                .processDefinitionKey(Long.valueOf(processDefinitionId))
+                                .variables(variableMap)
+                                .send()
+                                .join();
 
-                                         camundaClient
-                                                 .newCreateInstanceCommand()
-                                                 .processDefinitionKey(Long.valueOf(processDefinitionId))
-                                                 .variables(variableMap)
-                                                 .tenantId(tenantId)
-                                                 .send()
-                                                 .join();
+                        camundaClient
+                                .newCreateInstanceCommand()
+                                .processDefinitionKey(Long.valueOf(processDefinitionId))
+                                .variables(variableMap)
+                                .tenantId(tenantId)
+                                .send()
+                                .join();
 
-                                         // TODO: businessKey was removed - use businessId (Camunda 8.9+) instead
-                                         camundaClient
-                                                 .newCreateInstanceCommand()
-                                                 .processDefinitionKey(Long.valueOf(processDefinitionId))
-                                                 .variables(variableMap)
-                                                 .send()
-                                                 .join();
+                        // TODO: businessKey was removed - use businessId (Camunda 8.9+) instead
+                        // TODO: if this businessKey was propagated to a called process via <camunda:in businessKey="..." /> on a BPMN call activity, migrate that propagation to businessId in the diagram as well (diagram converter)
+                        camundaClient
+                                .newCreateInstanceCommand()
+                                .processDefinitionKey(Long.valueOf(processDefinitionId))
+                                .variables(variableMap)
+                                .send()
+                                .join();
 
-                                         // TODO: businessKey was removed - use businessId (Camunda 8.9+) instead
-                                         camundaClient
-                                                 .newCreateInstanceCommand()
-                                                 .processDefinitionKey(Long.valueOf(processDefinitionId))
-                                                 .tenantId(tenantId)
-                                                 .send()
-                                                 .join();
+                        // TODO: businessKey was removed - use businessId (Camunda 8.9+) instead
+                        // TODO: if this businessKey was propagated to a called process via <camunda:in businessKey="..." /> on a BPMN call activity, migrate that propagation to businessId in the diagram as well (diagram converter)
+                        camundaClient
+                                .newCreateInstanceCommand()
+                                .processDefinitionKey(Long.valueOf(processDefinitionId))
+                                .tenantId(tenantId)
+                                .send()
+                                .join();
 
-                                         // TODO: businessKey was removed - use businessId (Camunda 8.9+) instead
-                                         camundaClient
-                                                 .newCreateInstanceCommand()
-                                                 .processDefinitionKey(Long.valueOf(processDefinitionId))
-                                                 .variables(variableMap)
-                                                 .tenantId(tenantId)
-                                                 .send()
-                                                 .join();
+                        // TODO: businessKey was removed - use businessId (Camunda 8.9+) instead
+                        // TODO: if this businessKey was propagated to a called process via <camunda:in businessKey="..." /> on a BPMN call activity, migrate that propagation to businessId in the diagram as well (diagram converter)
+                        camundaClient
+                                .newCreateInstanceCommand()
+                                .processDefinitionKey(Long.valueOf(processDefinitionId))
+                                .variables(variableMap)
+                                .tenantId(tenantId)
+                                .send()
+                                .join();
 
-                                         // by message
-                                         // please configure you correlationKey
-                                         CorrelateMessageResponse instance2 = camundaClient
-                                                 .newCorrelateMessageCommand()
-                                                 .messageName(messageName)
-                                                 .correlationKey("add correlationKey here")
-                                                 .send()
-                                                 .join();
-                                         String id2 = String.valueOf(instance2.getProcessInstanceKey());
-                                         System.out.println(String.valueOf(instance2.getProcessInstanceKey()));
+                        // by message
+                        // please configure you correlationKey
+                        CorrelateMessageResponse instance2 = camundaClient
+                                .newCorrelateMessageCommand()
+                                .messageName(messageName)
+                                .correlationKey("add correlationKey here")
+                                .send()
+                                .join();
+                        String id2 = String.valueOf(instance2.getProcessInstanceKey());
+                        System.out.println(String.valueOf(instance2.getProcessInstanceKey()));
 
-                                         // please configure you correlationKey
-                                         // businessKey was removed
-                                         camundaClient
-                                                 .newCorrelateMessageCommand()
-                                                 .messageName(messageName)
-                                                 .correlationKey("add correlationKey here")
-                                                 .send()
-                                                 .join();
+                        // please configure you correlationKey
+                        // businessKey was removed
+                        camundaClient
+                                .newCorrelateMessageCommand()
+                                .messageName(messageName)
+                                .correlationKey("add correlationKey here")
+                                .send()
+                                .join();
 
-                                         // please configure you correlationKey
-                                         camundaClient
-                                                 .newCorrelateMessageCommand()
-                                                 .messageName(messageName)
-                                                 .correlationKey("add correlationKey here")
-                                                 .variables(variableMap)
-                                                 .send()
-                                                 .join();
+                        // please configure you correlationKey
+                        camundaClient
+                                .newCorrelateMessageCommand()
+                                .messageName(messageName)
+                                .correlationKey("add correlationKey here")
+                                .variables(variableMap)
+                                .send()
+                                .join();
 
-                                         // please configure you correlationKey
-                                         // businessKey was removed
-                                         camundaClient
-                                                 .newCorrelateMessageCommand()
-                                                 .messageName(messageName)
-                                                 .correlationKey("add correlationKey here")
-                                                 .variables(variableMap)
-                                                 .send()
-                                                 .join();
+                        // please configure you correlationKey
+                        // businessKey was removed
+                        camundaClient
+                                .newCorrelateMessageCommand()
+                                .messageName(messageName)
+                                .correlationKey("add correlationKey here")
+                                .variables(variableMap)
+                                .send()
+                                .join();
 
-                                         // please configure you correlationKey
-                                         // processDefinitionId was removed
-                                         camundaClient
-                                                 .newCorrelateMessageCommand()
-                                                 .messageName(messageName)
-                                                 .correlationKey("add correlationKey here")
-                                                 .send()
-                                                 .join();
+                        // please configure you correlationKey
+                        // processDefinitionId was removed
+                        camundaClient
+                                .newCorrelateMessageCommand()
+                                .messageName(messageName)
+                                .correlationKey("add correlationKey here")
+                                .send()
+                                .join();
 
-                                         // please configure you correlationKey
-                                         // businessKey was removed
-                                         // processDefinitionId was removed
-                                         camundaClient
-                                                 .newCorrelateMessageCommand()
-                                                 .messageName(messageName)
-                                                 .correlationKey("add correlationKey here")
-                                                 .send()
-                                                 .join();
+                        // please configure you correlationKey
+                        // businessKey was removed
+                        // processDefinitionId was removed
+                        camundaClient
+                                .newCorrelateMessageCommand()
+                                .messageName(messageName)
+                                .correlationKey("add correlationKey here")
+                                .send()
+                                .join();
 
-                                         // please configure you correlationKey
-                                         // processDefinitionId was removed
-                                         camundaClient
-                                                 .newCorrelateMessageCommand()
-                                                 .messageName(messageName)
-                                                 .correlationKey("add correlationKey here")
-                                                 .variables(variableMap)
-                                                 .send()
-                                                 .join();
+                        // please configure you correlationKey
+                        // processDefinitionId was removed
+                        camundaClient
+                                .newCorrelateMessageCommand()
+                                .messageName(messageName)
+                                .correlationKey("add correlationKey here")
+                                .variables(variableMap)
+                                .send()
+                                .join();
 
-                                         // please configure you correlationKey
-                                         // businessKey was removed
-                                         // processDefinitionId was removed
-                                         camundaClient
-                                                 .newCorrelateMessageCommand()
-                                                 .messageName(messageName)
-                                                 .correlationKey("add correlationKey here")
-                                                 .variables(variableMap)
-                                                 .send()
-                                                 .join();
-                                     }
-                                 }
-                                 """));
+                        // please configure you correlationKey
+                        // businessKey was removed
+                        // processDefinitionId was removed
+                        camundaClient
+                                .newCorrelateMessageCommand()
+                                .messageName(messageName)
+                                .correlationKey("add correlationKey here")
+                                .variables(variableMap)
+                                .send()
+                                .join();
+                    }
+                }
+                """));
   }
 
   @Test
@@ -498,6 +506,84 @@ class ReplaceStartProcessInstanceMethodsTest implements RewriteTest {
                                     .latestVersion()
                                     .send()
                                     .join();
+                        }
+                    }
+                    """));
+  }
+
+  @Test
+  void migratesBusinessKeyToBusinessIdForLiteralAndMethodCallArgs() {
+    rewriteRun(
+        spec -> spec.recipe(new MigrateStartProcessInstanceMethodsRecipe()),
+        // language=java
+        java(
+            """
+                    package org.camunda.community.migration.example;
+
+                    import io.camunda.client.CamundaClient;
+                    import org.camunda.bpm.engine.RuntimeService;
+                    import org.springframework.beans.factory.annotation.Autowired;
+                    import org.springframework.stereotype.Component;
+
+                    @Component
+                    public class BusinessKeyArgFormsTestClass {
+
+                        @Autowired
+                        private CamundaClient camundaClient;
+
+                        @Autowired
+                        private RuntimeService runtimeService;
+
+                        public void starts(Order order) {
+                            // string literal businessKey
+                            runtimeService.startProcessInstanceByKey("myProcess", "order-123");
+                            // method-call businessKey
+                            runtimeService.startProcessInstanceByKey("myProcess", order.getId());
+                        }
+
+                        interface Order {
+                            String getId();
+                        }
+                    }
+                    """,
+            """
+                    package org.camunda.community.migration.example;
+
+                    import io.camunda.client.CamundaClient;
+                    import org.camunda.bpm.engine.RuntimeService;
+                    import org.springframework.beans.factory.annotation.Autowired;
+                    import org.springframework.stereotype.Component;
+
+                    @Component
+                    public class BusinessKeyArgFormsTestClass {
+
+                        @Autowired
+                        private CamundaClient camundaClient;
+
+                        @Autowired
+                        private RuntimeService runtimeService;
+
+                        public void starts(Order order) {
+                            // string literal businessKey
+                            camundaClient
+                                    .newCreateInstanceCommand()
+                                    .bpmnProcessId("myProcess")
+                                    .latestVersion()
+                                    .businessId("order-123")
+                                    .send()
+                                    .join();
+                            // method-call businessKey
+                            camundaClient
+                                    .newCreateInstanceCommand()
+                                    .bpmnProcessId("myProcess")
+                                    .latestVersion()
+                                    .businessId(order.getId())
+                                    .send()
+                                    .join();
+                        }
+
+                        interface Order {
+                            String getId();
                         }
                     }
                     """));

--- a/code-conversion/recipes/src/test/java/io/camunda/migration/code/recipes/utils/BuilderSpecFactoryTest.java
+++ b/code-conversion/recipes/src/test/java/io/camunda/migration/code/recipes/utils/BuilderSpecFactoryTest.java
@@ -9,33 +9,39 @@ package io.camunda.migration.code.recipes.utils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.List;
 import org.junit.jupiter.api.Test;
 
 /**
- * Guards the comment-generation logic in {@link BuilderSpecFactory#createRemovedComment}.
+ * Guards the comment-generation logic in {@link BuilderSpecFactory#createRemovedComments}.
  *
  * <p>The method has one special case: {@code businessKey} in the createProcessInstance builder
- * should emit a businessId hint, while {@code processInstanceBusinessKey} in the
- * correlateMessage builder must stay neutral (businessId is not a replacement for message
- * correlation keys).
+ * should emit a businessId hint plus a reminder to migrate any BPMN call-activity propagation,
+ * while {@code processInstanceBusinessKey} in the correlateMessage builder must stay neutral
+ * (businessId is not a replacement for message correlation keys).
  */
 class BuilderSpecFactoryTest {
 
   @Test
-  void businessKeyGetsBusinessIdHint() {
-    String comment = BuilderSpecFactory.createRemovedComment("businessKey");
+  void businessKeyGetsBusinessIdHintAndCallActivityReminder() {
+    List<String> comments = BuilderSpecFactory.createRemovedComments("businessKey");
 
-    assertThat(comment)
+    assertThat(comments).hasSize(2);
+    assertThat(comments.get(0))
         .as("businessKey on the create-instance path should point to businessId")
         .contains("businessId")
         .contains("TODO");
+    assertThat(comments.get(1))
+        .as("businessKey should also flag call-activity propagation for the diagram converter")
+        .contains("call activity");
   }
 
   @Test
   void processInstanceBusinessKeyKeepsNeutralComment() {
-    String comment = BuilderSpecFactory.createRemovedComment("processInstanceBusinessKey");
+    List<String> comments = BuilderSpecFactory.createRemovedComments("processInstanceBusinessKey");
 
-    assertThat(comment)
+    assertThat(comments).hasSize(1);
+    assertThat(comments.get(0))
         .as("processInstanceBusinessKey is on the correlate-message path; businessId does not apply")
         .contains("processInstanceBusinessKey")
         .contains("was removed")
@@ -44,8 +50,8 @@ class BuilderSpecFactoryTest {
 
   @Test
   void otherRemovedMethodsGetGenericComment() {
-    String comment = BuilderSpecFactory.createRemovedComment("someOtherMethod");
+    List<String> comments = BuilderSpecFactory.createRemovedComments("someOtherMethod");
 
-    assertThat(comment).isEqualTo(" someOtherMethod was removed");
+    assertThat(comments).containsExactly(" someOtherMethod was removed");
   }
 }


### PR DESCRIPTION
## Summary

- `MigrateStartProcessInstanceMethodsRecipe` now actually migrates `businessKey` → `businessId` for the simple `startProcessInstanceByKey` / `startProcessInstanceById` overloads instead of leaving a TODO.
- The `businessKey` value is inserted as `.businessId(...)` on the C8 `newCreateInstanceCommand()` chain. The `#{businessId:any(String)}` placeholder matches any `String` expression, so **string literals, variable references, and method-call results** all migrate uniformly.
- `ProcessInstantiationBuilder.businessKey()` builder chains **keep a TODO** (per the issue's implementation note 4): `businessId` uniqueness enforcement is opt-in in Camunda 8.9 and the semantics (unique constraint, retry idempotency) may differ, so a human should review those.
- That TODO now also reminds the migrator to migrate any `businessKey` propagated to a called process via `<camunda:in businessKey="..." />` on a BPMN call activity — out of scope for code recipes, handled by the diagram converter (#1337).

## Changes

- `client/MigrateStartProcessInstanceMethodsRecipe.java` — the 4 simple overloads carrying `businessKey` (byKey/byId, ± variables map) now add `.businessId(#{businessId:any(String)})` with a `NamedArg` for the businessKey position; the `businessIdHint` TODO is removed from those specs.
- `utils/RecipeUtils.java` — new `businessIdCallActivityHint()` helper for the BPMN call-activity reminder (kept separate from the shared `businessIdHint`, which the query recipe also uses).
- `utils/BuilderSpecFactory.java` — `createRemovedComment` → `createRemovedComments` (returns `List<String>`) so the `businessKey` builder case emits both the businessId hint and the call-activity reminder.
- `test/.../ReplaceStartProcessInstanceMethodsTest.java` — updated expected output for the migrated overloads and the dual builder TODO; added a focused test asserting literal + method-call `businessKey` args migrate.
- `test/.../BuilderSpecFactoryTest.java` — updated for the new `createRemovedComments` API and the extra call-activity comment.

## Design decision

The issue's "Expected C8 output" #4 shows the builder pattern migrated, but Implementation Note 4 explicitly says to keep the TODO for `ProcessInstantiationBuilder.businessKey()`. I followed the implementation note (keep TODO for the builder; auto-migrate the simple overloads). Happy to flip the builder to auto-migrate if reviewers prefer the "Expected output" reading.

## Test plan

- [x] `mvn test -pl code-conversion/recipes` — full module green (49 tests, 0 failures)
- [x] `ReplaceStartProcessInstanceMethodsTest` — covers all overloads (variable form) + new literal/method-call test
- [x] `BuilderSpecFactoryTest` — businessKey emits businessId hint + call-activity reminder; correlate path stays neutral

## Baseline

Built from commit: `d913a87971e0b8621bf9c8cb34233ecb0f335bd8`

closes #1555

🤖 Generated with [Claude Code](https://claude.com/claude-code)