### PR TITLE
test(core): make C7TablePrefixTest self-contained to avoid test-context coupling

### DIFF
--- a/data-migrator/core/src/test/java/io/camunda/migration/data/C7TablePrefixTest.java
+++ b/data-migrator/core/src/test/java/io/camunda/migration/data/C7TablePrefixTest.java
@@ -18,13 +18,17 @@ import org.springframework.test.context.TestContext;
 import org.springframework.test.context.TestExecutionListener;
 import org.springframework.test.context.TestExecutionListeners;
 import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.support.DirtiesContextTestExecutionListener;
 
 @TestPropertySource(properties = {
     "camunda.migrator.c7.data-source.jdbc-url=jdbc:h2:mem:migrator-prefix;DB_CLOSE_DELAY=-1",
     "camunda.migrator.c7.data-source.table-prefix=MY_PREFIX_"
 })
 @SpringBootTest
-@TestExecutionListeners(CustomTestExecutionListener.class)
+@TestExecutionListeners({
+    CustomTestExecutionListener.class,
+    DirtiesContextTestExecutionListener.class
+})
 public class C7TablePrefixTest {
 
   /**

--- a/data-migrator/core/src/test/java/io/camunda/migration/data/C7TablePrefixTest.java
+++ b/data-migrator/core/src/test/java/io/camunda/migration/data/C7TablePrefixTest.java
@@ -8,58 +8,35 @@
 
 package io.camunda.migration.data;
 
-import static io.camunda.migration.data.C7TablePrefixTest.*;
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.h2.jdbc.JdbcSQLSyntaxErrorException;
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.TestContext;
-import org.springframework.test.context.TestExecutionListener;
-import org.springframework.test.context.TestExecutionListeners;
-import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.support.DirtiesContextTestExecutionListener;
+import org.springframework.boot.WebApplicationType;
+import org.springframework.boot.builder.SpringApplicationBuilder;
 
-@TestPropertySource(properties = {
-    "camunda.migrator.c7.data-source.jdbc-url=jdbc:h2:mem:migrator-prefix;DB_CLOSE_DELAY=-1",
-    "camunda.migrator.c7.data-source.table-prefix=MY_PREFIX_"
-})
-@SpringBootTest
-@TestExecutionListeners({
-    CustomTestExecutionListener.class,
-    DirtiesContextTestExecutionListener.class
-})
 public class C7TablePrefixTest {
 
   /**
-   * This test verifies that engine tables are prefix with `MY_PREFIX_`. See `CustomTestExecutionListener` for validation logic.
+   * Verifies that the configured C7 table prefix (`MY_PREFIX_`) is applied to the engine tables:
+   * with the prefix set the engine looks up `MY_PREFIX_ACT_GE_PROPERTY`, which does not exist, so
+   * application startup fails.
+   *
+   * <p>The application is started in a self-contained way (rather than via {@code @SpringBootTest})
+   * so the intentionally-failing context never enters Spring's test context cache and cannot leak
+   * into other tests in the same JVM.
    */
   @Test
-  public void shouldThrowExceptionSincePrefixedTableIsNotFound() {
-  }
-
-  static class CustomTestExecutionListener implements TestExecutionListener {
-
-    @Override
-    public void beforeTestClass(TestContext testContext) {
-      try {
-        // Attempt to load application context
-        testContext.getApplicationContext();
-      } catch (IllegalStateException e) {
-        Throwable nestedCause = findNestedCause(e, JdbcSQLSyntaxErrorException.class);
-        assertThat(nestedCause).isNotNull();
-        assertThat(nestedCause).hasMessageContaining("Table \"MY_PREFIX_ACT_GE_PROPERTY\" not found");
-      }
-    }
-
-    protected Throwable findNestedCause(Throwable throwable, Class<? extends Throwable> targetType) {
-      Throwable current = throwable;
-      while (current != null && !targetType.isInstance(current)) {
-        current = current.getCause();
-      }
-      return targetType.isInstance(current) ? current : null;
-    }
-
+  public void shouldFailStartupSincePrefixedTableIsNotFound() {
+    assertThatThrownBy(() -> new SpringApplicationBuilder(TestApp.class)
+        .web(WebApplicationType.NONE)
+        .properties(
+            "camunda.migrator.c7.data-source.jdbc-url=jdbc:h2:mem:migrator-prefix",
+            "camunda.migrator.c7.data-source.table-prefix=MY_PREFIX_")
+        .run())
+        .rootCause()
+        .isInstanceOf(JdbcSQLSyntaxErrorException.class)
+        .hasMessageContaining("Table \"MY_PREFIX_ACT_GE_PROPERTY\" not found");
   }
 
 }


### PR DESCRIPTION
## Description

`C7TablePrefixTest` intentionally provokes a Spring context startup failure (the `MY_PREFIX_` table prefix makes the C7 engine look up `MY_PREFIX_ACT_GE_PROPERTY`, which doesn't exist) and asserts on it. It did this via `@SpringBootTest` plus a custom `TestExecutionListener` that swallowed the failure in `beforeTestClass`.

The first attempt at this fix added `DirtiesContextTestExecutionListener` to invalidate the failed context. As the Copilot review pointed out, that listener is a no-op without `@DirtiesContext`. On closer inspection the cache-invalidation premise doesn't hold at all:

- A Spring context that **fails to load is never cached** — Spring only records a failure count (threshold 1 in Spring 7). So there's nothing in the test context cache to invalidate.
- `mergeMode = MERGE_WITH_DEFAULTS` (the issue's suggested fix) **breaks the test**: `DependencyInjectionTestExecutionListener` re-triggers the load, trips the failure threshold, and throws `IllegalStateException` uncaught.
- Reviewing the CI runs cited in #1594, the actual job-failing tests were `VariablesTest` (`Cluster is unhealthy` — a Zeebe testcontainer health-check timeout) and the Oracle jobs (`ORA-12516`, container not ready). The `MY_PREFIX_ACT_GE_PROPERTY not found` lines are this test's own intentional, caught failure and never failed the build.

**Fix**: rewrite the test to be self-contained. It starts the application directly via `SpringApplicationBuilder(...).web(NONE).run()` wrapped in `assertThatThrownBy`, and asserts the root cause is the expected `JdbcSQLSyntaxErrorException`. The intentionally-failing context never enters the test context cache, so it cannot couple to other `@SpringBootTest` classes in the same JVM, and the custom listener is removed entirely.

## Type of Change
- [x] Test-only changes (no production code changes)

## Testing Checklist
- [x] `mvn test -pl data-migrator/core` — 102 tests, 0 failures, in both default and `alphabetical` run order (`-Dsurefire.runOrder=alphabetical`, which runs `C7TablePrefixTest` first)
- [x] Architecture tests unaffected (no production code changed)

## Related Issues
Relates to #1594 (see note above — the CI failures cited there are the Zeebe cluster-health timeout tracked separately, plus Oracle container flakiness, not context pollution).

🤖 Generated with [Claude Code](https://claude.com/claude-code)