### PR TITLE
fix(ci): add Harbor login to code-conversion jobs to prevent Docker Hub pull failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,6 +130,8 @@ jobs:
           secrets: |
             secret/data/products/cambpm/ci/nexus USER | NEXUS_APP_CAMUNDA_COM_USR;
             secret/data/products/cambpm/ci/nexus PASSWORD | NEXUS_APP_CAMUNDA_COM_PSW;
+            secret/data/products/cambpm/ci/harbor username | HARBOR_USERNAME;
+            secret/data/products/cambpm/ci/harbor password | HARBOR_PASSWORD;
 
       - name: Setup Maven
         uses: ./.github/actions/setup-maven
@@ -137,6 +139,13 @@ jobs:
           vault-address: ${{ secrets.VAULT_ADDR }}
           vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+
+      - name: Login to Camunda Registry
+        uses: docker/login-action@v4
+        with:
+          registry: registry.camunda.cloud
+          username: ${{ steps.secrets.outputs.HARBOR_USERNAME }}
+          password: ${{ steps.secrets.outputs.HARBOR_PASSWORD }}
 
       - name: Build code-conversion module
         working-directory: code-conversion
@@ -695,6 +704,8 @@ jobs:
           secrets: |
             secret/data/products/cambpm/ci/nexus USER | NEXUS_APP_CAMUNDA_COM_USR;
             secret/data/products/cambpm/ci/nexus PASSWORD | NEXUS_APP_CAMUNDA_COM_PSW;
+            secret/data/products/cambpm/ci/harbor username | HARBOR_USERNAME;
+            secret/data/products/cambpm/ci/harbor password | HARBOR_PASSWORD;
 
       - name: Setup Maven
         uses: ./.github/actions/setup-maven
@@ -702,6 +713,13 @@ jobs:
           vault-address: ${{ secrets.VAULT_ADDR }}
           vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+
+      - name: Login to Camunda Registry
+        uses: docker/login-action@v4
+        with:
+          registry: registry.camunda.cloud
+          username: ${{ steps.secrets.outputs.HARBOR_USERNAME }}
+          password: ${{ steps.secrets.outputs.HARBOR_PASSWORD }}
 
       - name: Build code-conversion module against previous Camunda 8 version
         working-directory: code-conversion

--- a/code-conversion/patterns/code-examples/camunda-8/src/test/resources/camunda-container-runtime.properties
+++ b/code-conversion/patterns/code-examples/camunda-8/src/test/resources/camunda-container-runtime.properties
@@ -1,0 +1,3 @@
+# Override the default Docker Hub image name to use the authenticated Camunda Harbor registry.
+# This prevents Docker Hub rate-limiting failures in CI (see GitHub issue #1595).
+camundaDockerImageName=registry.camunda.cloud/camunda-docker/camunda

--- a/code-conversion/patterns/code-examples/camunda-8/src/test/resources/camunda-container-runtime.properties
+++ b/code-conversion/patterns/code-examples/camunda-8/src/test/resources/camunda-container-runtime.properties
@@ -1,3 +1,6 @@
-# Override the default Docker Hub image name to use the authenticated Camunda Harbor registry.
-# This prevents Docker Hub rate-limiting failures in CI (see GitHub issue #1595).
-camundaDockerImageName=registry.camunda.cloud/camunda-docker/camunda
+# Override the default Docker Hub image name to pull through the authenticated Camunda Harbor
+# proxy cache instead of docker.io. This avoids Docker Hub rate-limiting failures in CI
+# (see GitHub issue #1595). registry.camunda.cloud/camunda/* is the pull-through proxy for
+# Docker Hub camunda/* images, so this resolves to Docker Hub camunda/camunda but authenticated
+# and cached via Harbor.
+camundaDockerImageName=registry.camunda.cloud/camunda/camunda


### PR DESCRIPTION
## Summary

- `code-conversion` and `code-conversion-previous-version` CI jobs pulled the Camunda 8 test container from Docker Hub (`camunda/camunda:SNAPSHOT`) with no authentication and no fallback. When Docker Hub was rate-limited (HTTP 429) or unreachable, the pull failed after minutes of retries and failed the whole job.
- Fix routes the pull through Camunda's authenticated Harbor **pull-through proxy** instead of anonymous Docker Hub, which is the sanctioned workaround for the Docker Hub rate-limit failures.

## Changes

- `.github/workflows/ci.yml`: import Harbor credentials from Vault and add a `Login to Camunda Registry` step (`registry.camunda.cloud`) to both `code-conversion` and `code-conversion-previous-version` jobs, mirroring the existing `e2e` jobs.
- `code-conversion/patterns/code-examples/camunda-8/src/test/resources/camunda-container-runtime.properties`: override `camundaDockerImageName` to `registry.camunda.cloud/camunda/camunda` — the documented Docker Hub pull-through proxy short URI. It resolves to Docker Hub `camunda/camunda:SNAPSHOT`, but authenticated and cached via Harbor.

## Fix history

The first attempt (`a0a01ce`) pointed the image at `registry.camunda.cloud/camunda-docker/camunda`. That path is wrong: the `camunda-docker` project does not exist on Harbor, and Harbor's nginx ingress returns **404 for any unlisted image name**. Testcontainers retried the 404 until its 2-minute awaitility timeout and threw `ContainerFetchException`, failing the job ([run](https://github.com/camunda/camunda-7-to-8-migration-tooling/actions/runs/28582836850/job/84759077673)).

The correct path is the `dockerhub-camunda` proxy-cache project, which proxies **all** `camunda/*` Docker Hub images and is exposed via the recommended short URI `registry.camunda.cloud/camunda/<image>` (per Camunda's [Harbor registry docs](https://github.com/camunda/infra-core/blob/main/docs/artifact-storages/harbor-registry.md)). Commit `4473b01` switches to `registry.camunda.cloud/camunda/camunda`.

## Test plan

- [ ] `code-conversion` job passes on CI (previously failed with `ContainerFetchException`)
- [ ] No `registry-1.docker.io` pull errors and no `camunda-docker` 404s in job logs

## Note on local tests

The `code-conversion/recipes` tests fail locally with the same 47 failures on both `main` and this branch — pre-existing, unrelated to this fix. The Docker image override only affects the `patterns/code-examples/camunda-8` Testcontainers tests, which need a running Docker daemon.

closes #1595

🤖 Generated with [Claude Code](https://claude.com/claude-code)