### PR TITLE
fix(runtime): relax Awaitility waits for CI stability

### DIFF
--- a/data-migrator/qa/integration-tests/pom.xml
+++ b/data-migrator/qa/integration-tests/pom.xml
@@ -221,6 +221,10 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <version>3.5.6</version>
+        <configuration>
+          <forkedProcessTimeoutInSeconds>3900</forkedProcessTimeoutInSeconds>
+          <forkedProcessExitTimeoutInSeconds>300</forkedProcessExitTimeoutInSeconds>
+        </configuration>
       </plugin>
       <plugin>
         <groupId>org.codehaus.mojo</groupId>

--- a/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/identity/GroupMigrationTest.java
+++ b/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/identity/GroupMigrationTest.java
@@ -142,7 +142,7 @@ public class GroupMigrationTest extends IdentityMigrationAbstractTest {
     testHelper.assertThatGroupsContain(List.of(group1), groups);
 
     // and 2 group memberships are migrated
-    await().timeout(3, TimeUnit.SECONDS).untilAsserted(() -> testHelper.assertThatUsersForGroupContainExactly(group1.getId(), "userId1", "userId2"));
+    await().timeout(30, TimeUnit.SECONDS).untilAsserted(() -> testHelper.assertThatUsersForGroupContainExactly(group1.getId(), "userId1", "userId2"));
 
     // and 1 group membership could not be migrated
     logs.assertContains(formatMessage(FAILED_TO_CREATE_GROUP_MEMBERSHIP, group1.getId(), "userId0"));
@@ -166,7 +166,7 @@ public class GroupMigrationTest extends IdentityMigrationAbstractTest {
       identityMigrator.start();
 
       // then no groups were migrated
-      await().pollDelay(Duration.ofSeconds(2)).timeout(Duration.ofSeconds(5)).untilAsserted(() -> {
+      await().pollDelay(Duration.ofSeconds(2)).timeout(Duration.ofSeconds(30)).untilAsserted(() -> {
         var currentGroups = camundaClient.newGroupsSearchRequest().execute().items();
         assertThat(currentGroups).hasSize(0);
       });

--- a/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/identity/IdentityTestHelper.java
+++ b/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/identity/IdentityTestHelper.java
@@ -120,7 +120,7 @@ public class IdentityTestHelper {
         .execute();
 
     // Because of eventual consistency, wait until tenant is visible
-    await().timeout(5, TimeUnit.SECONDS).until(() -> camundaClient.newTenantsSearchRequest().filter(t -> t.tenantId(tenantId)).execute().items().size() == 1);
+    await().timeout(30, TimeUnit.SECONDS).until(() -> camundaClient.newTenantsSearchRequest().filter(t -> t.tenantId(tenantId)).execute().items().size() == 1);
   }
 
   protected void createGroupInC8(String groupId, String groupName) {
@@ -130,7 +130,7 @@ public class IdentityTestHelper {
         .execute();
 
     // Because of eventual consistency, wait until group is visible
-    await().timeout(5, TimeUnit.SECONDS).until(() -> camundaClient.newGroupsSearchRequest().filter(g -> g.groupId(groupId)).execute().items().size() == 1);
+    await().timeout(30, TimeUnit.SECONDS).until(() -> camundaClient.newGroupsSearchRequest().filter(g -> g.groupId(groupId)).execute().items().size() == 1);
   }
 
   protected void createUserInC8(String username, String firstName, String lastName) {
@@ -141,7 +141,7 @@ public class IdentityTestHelper {
         .execute();
 
     // Because of eventual consistency, wait until user is visible
-    await().timeout(5, TimeUnit.SECONDS).until(() -> camundaClient.newUsersSearchRequest().filter(f -> f.username(username)).execute().items().size() == 1);
+    await().timeout(30, TimeUnit.SECONDS).until(() -> camundaClient.newUsersSearchRequest().filter(f -> f.username(username)).execute().items().size() == 1);
   }
 
   /*
@@ -156,19 +156,19 @@ public class IdentityTestHelper {
 
   protected List<io.camunda.client.api.search.response.User> awaitUserCountAndGet(int expectedSize) {
     var request = camundaClient.newUsersSearchRequest();
-    await().timeout(5, TimeUnit.SECONDS).until(() -> request.execute().items().size() == expectedSize);
+    await().timeout(30, TimeUnit.SECONDS).until(() -> request.execute().items().size() == expectedSize);
     return request.execute().items();
   }
 
   protected List<io.camunda.client.api.search.response.Group> awaitGroupsCountAndGet(int expectedSize) {
     var request = camundaClient.newGroupsSearchRequest();
-    await().timeout(5, TimeUnit.SECONDS).until(() -> request.execute().items().size() == expectedSize);
+    await().timeout(30, TimeUnit.SECONDS).until(() -> request.execute().items().size() == expectedSize);
     return request.execute().items();
   }
 
   protected List<io.camunda.client.api.search.response.Tenant> awaitTenantsCountAndGet(int expectedSize) {
     TenantsSearchRequest request = camundaClient.newTenantsSearchRequest();
-    await().timeout(5, TimeUnit.SECONDS).until(() -> request.execute().items().size() == expectedSize + 1) ; // +1 for default tenant
+    await().timeout(30, TimeUnit.SECONDS).until(() -> request.execute().items().size() == expectedSize + 1) ; // +1 for default tenant
     return request.execute().items();
   }
 
@@ -234,21 +234,21 @@ public class IdentityTestHelper {
   }
 
   protected void assertThatUsersForTenantContainExactly(String tenantId, String... usernames) {
-    await().timeout(5, TimeUnit.SECONDS).untilAsserted(() -> {
+    await().timeout(30, TimeUnit.SECONDS).untilAsserted(() -> {
       List<TenantUser> usersForTenant = camundaClient.newUsersByTenantSearchRequest(tenantId).execute().items();
       assertThat(usersForTenant).extracting(TenantUser::getUsername).containsExactlyInAnyOrder(usernames);
     });
   }
 
   protected void assertThatUsersForGroupContainExactly(String groupId, String... usernames) {
-    await().timeout(5, TimeUnit.SECONDS).untilAsserted(() -> {
+    await().timeout(30, TimeUnit.SECONDS).untilAsserted(() -> {
       List<GroupUser> usersForGroup = camundaClient.newUsersByGroupSearchRequest(groupId).execute().items();
       assertThat(usersForGroup).extracting(GroupUser::getUsername).containsExactlyInAnyOrder(usernames);
     });
   }
 
   protected void assertThatGroupsForTenantContainExactly(String tenantId, String... groupIds) {
-    await().timeout(5, TimeUnit.SECONDS).untilAsserted(() -> {
+    await().timeout(30, TimeUnit.SECONDS).untilAsserted(() -> {
       List<TenantGroup> groupsForTenant = camundaClient.newGroupsByTenantSearchRequest(tenantId).execute().items();
       assertThat(groupsForTenant).extracting(TenantGroup::getGroupId).containsExactlyInAnyOrder(groupIds);
     });

--- a/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/identity/UserMigrationTest.java
+++ b/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/identity/UserMigrationTest.java
@@ -98,7 +98,7 @@ public class UserMigrationTest extends IdentityMigrationAbstractTest {
       identityMigrator.start();
 
       // then no users were migrated
-      await().pollDelay(Duration.ofSeconds(2)).timeout(Duration.ofSeconds(5)).untilAsserted(() -> {
+      await().pollDelay(Duration.ofSeconds(2)).timeout(Duration.ofSeconds(30)).untilAsserted(() -> {
         var currentUsers = camundaClient.newUsersSearchRequest().execute().items();
         assertThat(currentUsers).hasSize(0);
       });

--- a/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/runtime/RuntimeMigrationAbstractTest.java
+++ b/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/runtime/RuntimeMigrationAbstractTest.java
@@ -35,15 +35,12 @@ import org.springframework.beans.factory.annotation.Autowired;
 public abstract class RuntimeMigrationAbstractTest extends AbstractMigratorTest {
 
   /**
-   * Set generous Awaitility defaults so that all {@code await()} calls without an explicit
-   * {@code .atMost()} inherit a CI-safe timeout.
+    * Set generous Awaitility defaults so that this module's own {@code await()} calls without
+    * an explicit {@code .atMost()} inherit a CI-safe timeout after the Spring/CPT context has
+    * started.
    *
-   * <p>Background: CPT's {@code CamundaProcessTestExecutionListener} waits only 10 seconds
-   * for the Camunda 8 cluster to become ready after container start. On a loaded CI runner
-   * (multiple parallel jobs, Docker image pull, JVM warm-up) that window is too small and
-   * causes intermittent {@code ConditionTimeoutException: 'Wait for cluster to be ready'}.
-   * Setting the global default to 120 s covers the full start-up window without requiring
-   * per-call timeouts everywhere.
+    * <p>These defaults do not override CPT's explicit cluster readiness timeout, but they keep
+    * post-startup assertions from relying on Awaitility's short default timeout.
    */
   static {
     Awaitility.setDefaultTimeout(Duration.ofSeconds(120));

--- a/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/runtime/RuntimeMigrationAbstractTest.java
+++ b/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/runtime/RuntimeMigrationAbstractTest.java
@@ -20,9 +20,8 @@ import io.camunda.migration.data.RuntimeMigrator;
 import io.camunda.migration.data.impl.clients.DbClient;
 import io.camunda.migration.data.qa.AbstractMigratorTest;
 import io.camunda.process.test.api.CamundaSpringProcessTest;
-
+import java.time.Duration;
 import java.util.List;
-
 import java.util.Optional;
 import org.awaitility.Awaitility;
 import org.camunda.bpm.engine.RepositoryService;
@@ -30,10 +29,28 @@ import org.camunda.bpm.engine.RuntimeService;
 import org.camunda.bpm.engine.TaskService;
 import org.camunda.bpm.engine.impl.util.ClockUtil;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.springframework.beans.factory.annotation.Autowired;
 
 @CamundaSpringProcessTest
 public abstract class RuntimeMigrationAbstractTest extends AbstractMigratorTest {
+
+  /**
+   * Set generous Awaitility defaults so that all {@code await()} calls without an explicit
+   * {@code .atMost()} inherit a CI-safe timeout.
+   *
+   * <p>Background: CPT's {@code CamundaProcessTestExecutionListener} waits only 10 seconds
+   * for the Camunda 8 cluster to become ready after container start. On a loaded CI runner
+   * (multiple parallel jobs, Docker image pull, JVM warm-up) that window is too small and
+   * causes intermittent {@code ConditionTimeoutException: 'Wait for cluster to be ready'}.
+   * Setting the global default to 120 s covers the full start-up window without requiring
+   * per-call timeouts everywhere.
+   */
+  @BeforeAll
+  static void configureAwaitility() {
+    Awaitility.setDefaultTimeout(Duration.ofSeconds(120));
+    Awaitility.setDefaultPollInterval(Duration.ofSeconds(2));
+  }
 
   // Migrator ---------------------------------------
 

--- a/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/runtime/RuntimeMigrationAbstractTest.java
+++ b/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/runtime/RuntimeMigrationAbstractTest.java
@@ -29,7 +29,6 @@ import org.camunda.bpm.engine.RuntimeService;
 import org.camunda.bpm.engine.TaskService;
 import org.camunda.bpm.engine.impl.util.ClockUtil;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeAll;
 import org.springframework.beans.factory.annotation.Autowired;
 
 @CamundaSpringProcessTest
@@ -46,8 +45,7 @@ public abstract class RuntimeMigrationAbstractTest extends AbstractMigratorTest 
    * Setting the global default to 120 s covers the full start-up window without requiring
    * per-call timeouts everywhere.
    */
-  @BeforeAll
-  static void configureAwaitility() {
+  static {
     Awaitility.setDefaultTimeout(Duration.ofSeconds(120));
     Awaitility.setDefaultPollInterval(Duration.ofSeconds(2));
   }


### PR DESCRIPTION
## Description

`BusinessKeyMigrationTest` failed intermittently on CI with timeout symptoms while waiting on Camunda 8/Testcontainers-backed state. The original investigation found that CPT's startup readiness check uses an explicit 10-second duration:

- `CamundaProcessTestExecutionListener.beforeTestClass()` calls `runtime.waitUntilClusterReady(Duration.ofSeconds(10))`
- That explicit duration is not affected by global Awaitility defaults
- No managed-runtime CPT configuration property for that readiness timeout was found in the current dependency surface

**Fix:** Harden the waits this repository controls. Runtime migration tests now set Awaitility defaults from a static initializer in `RuntimeMigrationAbstractTest`, so this module's own `Awaitility.await()` calls without explicit `.atMost()` inherit a CI-safe timeout after the Spring/CPT context has started. Identity tests also replace unjustifiably tight 3-5 second explicit Awaitility timeouts with 30 seconds.

This does not override CPT's explicit cluster readiness timeout; if that startup wait remains flaky, the fix likely belongs in CPT or requires a supported CPT configuration hook.

To avoid silent CI hangs, the data-migrator integration-test Surefire fork is now bounded below the `it-runtime-h2` job timeout:

- `forkedProcessTimeoutInSeconds=3900` (65 minutes): long enough for observed healthy runtime H2 jobs (~56-58 minutes), but short enough for Surefire/Maven to report a stuck fork before GitHub Actions kills the 70-minute job.
- `forkedProcessExitTimeoutInSeconds=300` (5 minutes): gives Testcontainers/Camunda cleanup room to shut down after tests finish, while still bounding stuck non-daemon threads.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Test-only changes (no production code changes)

## Testing Checklist

### Black-Box Testing Requirements
- [x] Tests follow **black-box testing approach**: verify behavior through observable outputs (logs, C8 API queries, real-world skip scenarios)
- [x] Tests **DO NOT** access implementation details (`DbClient`, `IdKeyMapper`, `..impl..` packages except logging constants)
- [x] No structural changes; architecture rules are not affected

### Test Coverage
- [x] Updated tests for modified timeout behavior
- [x] All default-build tests pass locally

Validation run after Docker was started:

```bash
JAVA_HOME=/opt/homebrew/opt/openjdk@21 mvn clean install -f .claude/worktrees/1596-fix-cluster-health-timeout/pom.xml
```

Result: `BUILD SUCCESS` in `03:35 min`.

Focused validations after review updates:

```bash
JAVA_HOME=/opt/homebrew/opt/openjdk@21 mvn test -pl :camunda-7-to-8-data-migrator-integration-tests -am -Pintegration -DskipTests -f .claude/worktrees/1596-fix-cluster-health-timeout/pom.xml
```

Result: `BUILD SUCCESS`.

```bash
TERM=dumb JAVA_HOME=/opt/homebrew/opt/openjdk@21 mvn verify -pl :camunda-7-to-8-data-migrator-integration-tests -am -Pintegration,runtime-only -Dtest=SpinVariablesTest -Dsurefire.failIfNoSpecifiedTests=false -f .claude/worktrees/1596-fix-cluster-health-timeout/pom.xml
```

Result: `BUILD SUCCESS`.

## Architecture Compliance

No structural changes — only timeout constants, Surefire test-fork bounds, and explanatory comments changed.

## Changes

- `RuntimeMigrationAbstractTest.java`: configure global Awaitility timeout defaults from a static initializer, setting default timeout to 120s and poll interval to 2s for this module's own post-startup awaits
- `GroupMigrationTest.java`: increased 5s -> 30s and 3s -> 30s explicit Awaitility timeouts
- `UserMigrationTest.java`: increased 5s -> 30s explicit Awaitility timeout
- `IdentityTestHelper.java`: increased all 5s timeouts to 30s (eventual-consistency waits for user/group/tenant visibility)
- `data-migrator/qa/integration-tests/pom.xml`: add Surefire fork timeout bounds for integration-test hangs

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed the code
- [x] Added comments for non-obvious timing behavior
- [x] No new compiler warnings
- [x] Dependent changes have been merged

## Related Issues
Fixes #1596

Built from baseline commit: ef928e3532a4dbd496a5834875d435a092bf65c2

🤖 Generated with [Claude Code](https://claude.com/claude-code)