### PR TITLE
fix(e2e): prevent DistributionSmokeTest timeout on Windows

### DIFF
--- a/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/distribution/DistributionSmokeTest.java
+++ b/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/distribution/DistributionSmokeTest.java
@@ -296,14 +296,22 @@ public class DistributionSmokeTest {
 
     for (String[] flag : validFlags) {
       ProcessBuilder processBuilder = createProcessBuilder(flag);
+      String expected = "Starting migration with flags: " + String.join(" ", flag);
 
       // when
-      process = processBuilder.start();
+      Process currentProcess = processBuilder.start();
+      try {
+        String output = readProcessOutputUntil(currentProcess, expected, 10, TimeUnit.SECONDS);
 
-      // then
-      String output = readProcessOutput(process);
-
-      assertThat(output).contains("Starting migration with flags: " + String.join(" ", flag));
+        // then
+        assertThat(output).contains(expected);
+      } finally {
+        currentProcess.destroy();
+        if (!currentProcess.waitFor(5, TimeUnit.SECONDS)) {
+          currentProcess.destroyForcibly();
+          currentProcess.waitFor(5, TimeUnit.SECONDS);
+        }
+      }
     }
   }
 
@@ -541,6 +549,57 @@ public class DistributionSmokeTest {
         output.append(line).append(System.lineSeparator());
       }
     }
+    return output.toString();
+  }
+
+  /**
+   * Reads process output until the expected string is found or the timeout elapses. Returns all
+   * output collected so far in either case. Uses a dedicated reader thread so blocking {@code
+   * readLine()} calls do not interfere with the deadline check — this is important on Windows where
+   * stream {@code ready()} is unreliable for subprocess stdout.
+   */
+  protected String readProcessOutputUntil(
+      final Process process,
+      final String expected,
+      final long timeout,
+      final TimeUnit unit)
+      throws InterruptedException {
+    final StringBuilder output = new StringBuilder();
+    final Thread readerThread =
+        new Thread(
+            () -> {
+              try (BufferedReader reader =
+                  new BufferedReader(new InputStreamReader(process.getInputStream()))) {
+                String line;
+                while ((line = reader.readLine()) != null) {
+                  synchronized (output) {
+                    output.append(line).append(System.lineSeparator());
+                    if (output.toString().contains(expected)) {
+                      return;
+                    }
+                  }
+                }
+              } catch (final IOException e) {
+                // stream closed when process is destroyed — expected
+              }
+            });
+    readerThread.setDaemon(true);
+    readerThread.start();
+
+    final long deadline = System.nanoTime() + unit.toNanos(timeout);
+    while (System.nanoTime() < deadline) {
+      synchronized (output) {
+        if (output.toString().contains(expected)) {
+          return output.toString();
+        }
+      }
+      if (!process.isAlive()) {
+        readerThread.join(1_000);
+        return output.toString();
+      }
+      Thread.sleep(50);
+    }
+    readerThread.interrupt();
     return output.toString();
   }
 }

--- a/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/distribution/DistributionSmokeTest.java
+++ b/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/distribution/DistributionSmokeTest.java
@@ -56,10 +56,8 @@ public class DistributionSmokeTest {
   }
 
   @AfterEach
-  public  void tearDown() {
-    if (process != null) {
-      process.destroyForcibly();
-    }
+  public void tearDown() {
+    destroyProcessTree(process);
   }
 
   @Test
@@ -306,11 +304,7 @@ public class DistributionSmokeTest {
         // then
         assertThat(output).contains(expected);
       } finally {
-        currentProcess.destroy();
-        if (!currentProcess.waitFor(5, TimeUnit.SECONDS)) {
-          currentProcess.destroyForcibly();
-          currentProcess.waitFor(5, TimeUnit.SECONDS);
-        }
+        destroyProcessTree(currentProcess);
       }
     }
   }
@@ -574,7 +568,7 @@ public class DistributionSmokeTest {
                 while ((line = reader.readLine()) != null) {
                   synchronized (output) {
                     output.append(line).append(System.lineSeparator());
-                    if (output.toString().contains(expected)) {
+                    if (output.indexOf(expected) >= 0) {
                       return;
                     }
                   }
@@ -589,7 +583,7 @@ public class DistributionSmokeTest {
     final long deadline = System.nanoTime() + unit.toNanos(timeout);
     while (System.nanoTime() < deadline) {
       synchronized (output) {
-        if (output.toString().contains(expected)) {
+        if (output.indexOf(expected) >= 0) {
           return output.toString();
         }
       }
@@ -601,5 +595,29 @@ public class DistributionSmokeTest {
     }
     readerThread.interrupt();
     return output.toString();
+  }
+
+  /**
+   * Terminates a process and its entire descendant tree. On Windows, {@code cmd.exe /c start.bat}
+   * spawns a child JVM that holds file locks on the extracted JARs; {@link Process#destroy()} only
+   * kills the {@code cmd.exe} parent. Descendants are destroyed first, then the parent, with a
+   * {@link Process#destroyForcibly()} fallback. {@link InterruptedException} from {@code waitFor}
+   * restores the interrupt flag and triggers an immediate forcible kill so cleanup always completes.
+   */
+  protected void destroyProcessTree(final Process proc) {
+    if (proc == null) {
+      return;
+    }
+    proc.descendants().forEach(ProcessHandle::destroyForcibly);
+    proc.destroy();
+    try {
+      if (!proc.waitFor(5, TimeUnit.SECONDS)) {
+        proc.destroyForcibly();
+        proc.waitFor(5, TimeUnit.SECONDS);
+      }
+    } catch (final InterruptedException e) {
+      Thread.currentThread().interrupt();
+      proc.destroyForcibly();
+    }
   }
 }


### PR DESCRIPTION
## Summary

- `shouldAcceptValidFlags()` was calling `readProcessOutput()` which blocks until EOF
- Valid flag combinations launch the Spring Boot app which stays alive indefinitely on Windows, hitting the 90s timeout
- Fix reads output only until the expected startup line appears, then destroys the process deterministically

## Changes

- `DistributionSmokeTest.java`: added `readProcessOutputUntil()` helper that uses a dedicated reader thread (reliable on Windows where `ready()` is not) and waits until the expected line appears or a per-iteration 10s timeout elapses; `shouldAcceptValidFlags()` now manages each spawned process in its own try/finally with graceful then forcible destroy

## Test plan

- [ ] `mvn test -pl data-migrator/qa -Pintegration -f <worktree>/pom.xml` passes on Linux
- [ ] Windows CI job `it-history-h2-windows` passes for `DistributionSmokeTest.shouldAcceptValidFlags`
- [ ] No regression in other smoke test methods (they still use `readProcessOutput` for short-lived processes)

## Baseline

Built from commit: ef928e3532a4dbd496a5834875d435a092bf65c2

closes #1616

🤖 Generated with [Claude Code](https://claude.com/claude-code)