### PR TITLE
fix(ci): add Harbor login to code-conversion jobs to prevent Docker Hub pull failures (backport #1598 to maintenance/0.3)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,8 @@ jobs:
           secrets: |
             secret/data/products/cambpm/ci/nexus USER | NEXUS_APP_CAMUNDA_COM_USR;
             secret/data/products/cambpm/ci/nexus PASSWORD | NEXUS_APP_CAMUNDA_COM_PSW;
+            secret/data/products/cambpm/ci/harbor username | HARBOR_USERNAME;
+            secret/data/products/cambpm/ci/harbor password | HARBOR_PASSWORD;
 
       - name: Setup Maven
         uses: ./.github/actions/setup-maven
@@ -86,6 +88,13 @@ jobs:
           vault-address: ${{ secrets.VAULT_ADDR }}
           vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+
+      - name: Login to Camunda Registry
+        uses: docker/login-action@v4
+        with:
+          registry: registry.camunda.cloud
+          username: ${{ steps.secrets.outputs.HARBOR_USERNAME }}
+          password: ${{ steps.secrets.outputs.HARBOR_PASSWORD }}
 
       - name: Build code-conversion module
         working-directory: code-conversion

--- a/code-conversion/patterns/code-examples/camunda-8/src/test/resources/camunda-container-runtime.properties
+++ b/code-conversion/patterns/code-examples/camunda-8/src/test/resources/camunda-container-runtime.properties
@@ -1,0 +1,6 @@
+# Override the default Docker Hub image name to pull through the authenticated Camunda Harbor
+# proxy cache instead of docker.io. This avoids Docker Hub rate-limiting failures in CI
+# (see GitHub issue #1595). registry.camunda.cloud/camunda/* is the pull-through proxy for
+# Docker Hub camunda/* images, so this resolves to Docker Hub camunda/camunda but authenticated
+# and cached via Harbor.
+camundaDockerImageName=registry.camunda.cloud/camunda/camunda

--- a/code-conversion/patterns/code-examples/camunda-8/src/test/resources/camunda-container-runtime.properties
+++ b/code-conversion/patterns/code-examples/camunda-8/src/test/resources/camunda-container-runtime.properties
@@ -1,6 +1,0 @@
-# Override the default Docker Hub image name to pull through the authenticated Camunda Harbor
-# proxy cache instead of docker.io. This avoids Docker Hub rate-limiting failures in CI
-# (see GitHub issue #1595). registry.camunda.cloud/camunda/* is the pull-through proxy for
-# Docker Hub camunda/* images, so this resolves to Docker Hub camunda/camunda but authenticated
-# and cached via Harbor.
-camundaDockerImageName=registry.camunda.cloud/camunda/camunda


### PR DESCRIPTION
## Summary

- Backport keeps the Harbor login setup for the `code-conversion` CI job on `maintenance/0.3`.
- The Camunda 8 image-name override from `main` was removed for this maintenance branch because `registry.camunda.cloud/camunda/camunda:8.9.11` is not available in Harbor, while Docker Hub `camunda/camunda:8.9.11` exists.

## Changes

- `.github/workflows/ci.yml`: imports Harbor credentials from Vault and logs in to `registry.camunda.cloud` before running the `code-conversion` job.
- Removed `code-conversion/patterns/code-examples/camunda-8/src/test/resources/camunda-container-runtime.properties` from the backport so Camunda Process Test uses the valid maintenance release image `camunda/camunda:8.9.11`.

## Investigation

The previous PR head failed in `code-conversion` with:

```text
manifest for registry.camunda.cloud/camunda/camunda:8.9.11 not found: manifest unknown
```

Local image checks confirmed:

```text
docker manifest inspect camunda/camunda:8.9.11 -> ok
docker manifest inspect registry.camunda.cloud/camunda/camunda:8.9.11 -> no such manifest
```

## Test plan

- [x] `mvn verify -PcheckFormat --batch-mode -pl code-conversion/patterns/code-examples/camunda-8 -am`
- [ ] `code-conversion` job passes on CI
- [ ] `it-history-h2-windows` passes on the fresh CI run

closes #1595
