### PR TITLE
fix(ci): add Harbor login to code-conversion jobs to prevent Docker Hub pull failures (backport #1598 to maintenance/0.2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,8 @@ jobs:
           secrets: |
             secret/data/products/cambpm/ci/nexus USER | NEXUS_APP_CAMUNDA_COM_USR;
             secret/data/products/cambpm/ci/nexus PASSWORD | NEXUS_APP_CAMUNDA_COM_PSW;
+            secret/data/products/cambpm/ci/harbor username | HARBOR_USERNAME;
+            secret/data/products/cambpm/ci/harbor password | HARBOR_PASSWORD;
 
       - name: Setup Maven
         uses: ./.github/actions/setup-maven
@@ -90,6 +92,13 @@ jobs:
           vault-address: ${{ secrets.VAULT_ADDR }}
           vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+
+      - name: Login to Camunda Registry
+        uses: docker/login-action@v4
+        with:
+          registry: registry.camunda.cloud
+          username: ${{ steps.secrets.outputs.HARBOR_USERNAME }}
+          password: ${{ steps.secrets.outputs.HARBOR_PASSWORD }}
 
       - name: Build code-conversion module
         working-directory: code-conversion

--- a/code-conversion/patterns/code-examples/camunda-8/src/test/resources/camunda-container-runtime.properties
+++ b/code-conversion/patterns/code-examples/camunda-8/src/test/resources/camunda-container-runtime.properties
@@ -1,0 +1,6 @@
+# Override the default Docker Hub image name to pull through the authenticated Camunda Harbor
+# proxy cache instead of docker.io. This avoids Docker Hub rate-limiting failures in CI
+# (see GitHub issue #1595). registry.camunda.cloud/camunda/* is the pull-through proxy for
+# Docker Hub camunda/* images, so this resolves to Docker Hub camunda/camunda but authenticated
+# and cached via Harbor.
+camundaDockerImageName=registry.camunda.cloud/camunda/camunda


### PR DESCRIPTION
Backport of #1598 to `maintenance/0.2`.

Cherry-pick of 344e790d. Conflict resolved: maintenance/0.2 does not have `code-conversion-previous-version` job, so that hunk was dropped; Harbor login for the `code-conversion` job applied cleanly.