### PR TITLE
fix(runtime): relax Awaitility waits for CI stability (backport #1599 to maintenance/0.2)

### DIFF
--- a/data-migrator/qa/integration-tests/pom.xml
+++ b/data-migrator/qa/integration-tests/pom.xml
@@ -161,6 +161,10 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <version>3.5.6</version>
+        <configuration>
+          <forkedProcessTimeoutInSeconds>3900</forkedProcessTimeoutInSeconds>
+          <forkedProcessExitTimeoutInSeconds>300</forkedProcessExitTimeoutInSeconds>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/runtime/RuntimeMigrationAbstractTest.java
+++ b/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/runtime/RuntimeMigrationAbstractTest.java
@@ -18,9 +18,8 @@ import io.camunda.migration.data.RuntimeMigrator;
 import io.camunda.migration.data.impl.clients.DbClient;
 import io.camunda.migration.data.qa.AbstractMigratorTest;
 import io.camunda.process.test.api.CamundaSpringProcessTest;
-
+import java.time.Duration;
 import java.util.List;
-
 import java.util.Optional;
 import org.awaitility.Awaitility;
 import org.camunda.bpm.engine.RepositoryService;
@@ -32,6 +31,19 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 @CamundaSpringProcessTest
 public abstract class RuntimeMigrationAbstractTest extends AbstractMigratorTest {
+
+  /**
+    * Set generous Awaitility defaults so that this module's own {@code await()} calls without
+    * an explicit {@code .atMost()} inherit a CI-safe timeout after the Spring/CPT context has
+    * started.
+   *
+    * <p>These defaults do not override CPT's explicit cluster readiness timeout, but they keep
+    * post-startup assertions from relying on Awaitility's short default timeout.
+   */
+  static {
+    Awaitility.setDefaultTimeout(Duration.ofSeconds(120));
+    Awaitility.setDefaultPollInterval(Duration.ofSeconds(2));
+  }
 
   // Migrator ---------------------------------------
 


### PR DESCRIPTION
Backport of #1599 to `maintenance/0.2`.

## Changes applied

- `RuntimeMigrationAbstractTest.java`: configure global Awaitility timeout defaults (120s timeout, 2s poll interval)
- `data-migrator/qa/integration-tests/pom.xml`: add Surefire fork timeout bounds (`forkedProcessTimeoutInSeconds=3900`, `forkedProcessExitTimeoutInSeconds=300`)

## Conflict resolution

`GroupMigrationTest.java`, `IdentityTestHelper.java`, and `UserMigrationTest.java` do not exist in `maintenance/0.2` — those changes were omitted from this backport.