### PR TITLE
fix(qa): reduce Oracle HikariCP pool sizes to prevent ORA-12516 flakiness

### DIFF
--- a/data-migrator/qa/integration-tests/src/test/resources/application-oracle-19.yml
+++ b/data-migrator/qa/integration-tests/src/test/resources/application-oracle-19.yml
@@ -3,8 +3,8 @@ camunda:
     auto-ddl: true
     c7:
       data-source:
-        maximum-pool-size: 3
-        minimum-idle: 1
+        maximum-pool-size: 1
+        minimum-idle: 0
         auto-ddl: true
         jdbc-url: jdbc:oracle:thin:@localhost:15433/ORCLDB
         username: camunda
@@ -23,8 +23,8 @@ camunda:
     auto-ddl: true
     c8:
       data-source:
-        maximum-pool-size: 3
-        minimum-idle: 1
+        maximum-pool-size: 1
+        minimum-idle: 0
         auto-ddl: true
         jdbc-url: jdbc:oracle:thin:@localhost:15433/ORCLDB
         username: camunda

--- a/data-migrator/qa/integration-tests/src/test/resources/application-oracle.yml
+++ b/data-migrator/qa/integration-tests/src/test/resources/application-oracle.yml
@@ -3,8 +3,8 @@ camunda:
     auto-ddl: true
     c7:
       data-source:
-        maximum-pool-size: 3
-        minimum-idle: 1
+        maximum-pool-size: 1
+        minimum-idle: 0
         auto-ddl: true
         jdbc-url: jdbc:oracle:thin:@localhost:15432/ORCLDB
         username: camunda
@@ -23,8 +23,8 @@ camunda:
     auto-ddl: true
     c8:
       data-source:
-        maximum-pool-size: 3
-        minimum-idle: 1
+        maximum-pool-size: 1
+        minimum-idle: 0
         auto-ddl: true
         jdbc-url: jdbc:oracle:thin:@localhost:15432/ORCLDB
         username: camunda


### PR DESCRIPTION
## Summary

- Reduces HikariCP `maximum-pool-size` from 3 → 1 and `minimum-idle` from 1 → 0 for both C7 and C8 data sources in Oracle IT test configs
- Fixes intermittent `ORA-12516: Cannot connect to database` failures: ~37 unique Spring contexts × 2 data sources × 3 connections = ~222 peak connection attempts, exceeding Oracle Free's session limit
- `minimum-idle: 0` ensures idle connections are released immediately when a context is dirtied, preventing pool exhaustion across test classes

## Changes

- `data-migrator/qa/integration-tests/src/test/resources/application-oracle.yml` — pool size fix for Oracle 21c (port 15432)
- `data-migrator/qa/integration-tests/src/test/resources/application-oracle-19.yml` — pool size fix for Oracle 19c (port 15433)

## Test plan

- [ ] `mvn test -pl data-migrator/qa` passes (unit tests)
- [ ] `it-runtime-oracle` CI job runs without ORA-12516 failures
- [ ] `it-runtime-oracle-19` CI job runs without ORA-12516 failures

## Baseline

Built from commit: 344e790d6cbee293803d47d174c0a2a0f25ba389

closes #1614

🤖 Generated with [Claude Code](https://claude.com/claude-code)