### PR TITLE
ci: split runtime integration tests into 4 parallel shards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -326,11 +326,16 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 25
     # Split the runtime suite into 4 parallel shards (was 1 serial job, ~53 min).
-    # Each shard targets a different sub-package via the runtime-shard-N Maven profile.
+    # Each shard name matches its Maven profile (runtime-<shard>) and describes
+    # the sub-set of test packages it covers.
     strategy:
       fail-fast: false
       matrix:
-        shard: [1, 2, 3, 4]
+        shard:
+          - core          # runtime root package — basic migration scenarios
+          - element       # runtime.element + runtime.datasource
+          - jobtype       # runtime.jobtype + persistence + distribution
+          - variables     # runtime.tenant + runtime.variables
     if: |
       (github.event_name == 'pull_request' &&
        needs.detect-changes.outputs.data-migrator == 'true' &&
@@ -365,9 +370,9 @@ jobs:
           vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
 
-      - name: Run runtime shard ${{ matrix.shard }} tests with H2
+      - name: Run ${{ matrix.shard }} runtime tests with H2
         working-directory: data-migrator
-        run: mvn verify -Pintegration,runtime-shard-${{ matrix.shard }}
+        run: mvn verify -Pintegration,runtime-${{ matrix.shard }}
 
   it-history-h2:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,37 @@ jobs:
           echo "Camunda 8 current: ${CURRENT} (docker: ${CURRENT_DOCKER})"
           echo "Camunda 8 previous: ${PREVIOUS} (docker: ${PREVIOUS_DOCKER})"
 
+  # Detects whether data-migrator source changed so downstream jobs can skip
+  # expensive tests on PRs that only touch other modules. For non-PR events
+  # (push to main, schedule, workflow_dispatch) we always consider it changed.
+  detect-changes:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      data-migrator: ${{ steps.filter.outputs.data-migrator }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          fetch-depth: 0
+
+      - name: Check for data-migrator changes
+        id: filter
+        env:
+          BASE_REF: ${{ github.base_ref }}
+          EVENT: ${{ github.event_name }}
+        run: |
+          if [[ "$EVENT" != "pull_request" ]]; then
+            echo "data-migrator=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          git fetch origin "${BASE_REF}" --depth=1
+          if git diff --name-only "origin/${BASE_REF}...HEAD" | grep -qE '^(data-migrator/|pom\.xml$)'; then
+            echo "data-migrator=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "data-migrator=false" >> "$GITHUB_OUTPUT"
+          fi
+
   distro:
     runs-on: ubuntu-latest
     timeout-minutes: 70
@@ -291,13 +322,23 @@ jobs:
           --batch-mode
 
   it-runtime-h2:
+    needs: [detect-changes]
     runs-on: ubuntu-latest
-    timeout-minutes: 70
+    timeout-minutes: 25
+    # Split the runtime suite into 4 parallel shards (was 1 serial job, ~53 min).
+    # Each shard targets a different sub-package via the runtime-shard-N Maven profile.
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4]
     if: |
-      (github.event_name == 'pull_request' && (
-        contains(github.event.pull_request.labels.*.name, 'ci:runtime') ||
-        (!contains(github.event.pull_request.labels.*.name, 'ci:runtime') && !contains(github.event.pull_request.labels.*.name, 'ci:history') && !contains(github.event.pull_request.labels.*.name, 'ci:identity'))
-      )) ||
+      (github.event_name == 'pull_request' &&
+       needs.detect-changes.outputs.data-migrator == 'true' &&
+       (
+         contains(github.event.pull_request.labels.*.name, 'ci:runtime') ||
+         (!contains(github.event.pull_request.labels.*.name, 'ci:runtime') && !contains(github.event.pull_request.labels.*.name, 'ci:history') && !contains(github.event.pull_request.labels.*.name, 'ci:identity'))
+       )
+      ) ||
       github.event_name == 'workflow_dispatch'
     steps:
       - name: Checkout code
@@ -324,9 +365,9 @@ jobs:
           vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
 
-      - name: Run runtime tests with H2
+      - name: Run runtime shard ${{ matrix.shard }} tests with H2
         working-directory: data-migrator
-        run: mvn verify -Pintegration,runtime-only
+        run: mvn verify -Pintegration,runtime-shard-${{ matrix.shard }}
 
   it-history-h2:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -324,7 +324,7 @@ jobs:
   it-runtime-h2:
     needs: [detect-changes]
     runs-on: ubuntu-latest
-    timeout-minutes: 25
+    timeout-minutes: 30
     # Split the runtime suite into 4 parallel shards (was 1 serial job, ~53 min).
     # Each shard name matches its Maven profile (runtime-<shard>) and describes
     # the sub-set of test packages it covers.
@@ -332,16 +332,19 @@ jobs:
       fail-fast: false
       matrix:
         shard:
-          - core          # runtime root package — basic migration scenarios
+          - core          # runtime root + persistence + distribution (catch-all for new packages)
           - element       # runtime.element + runtime.datasource
-          - jobtype       # runtime.jobtype + persistence + distribution
-          - variables     # runtime.tenant + runtime.variables
+          - jobtype       # runtime.jobtype + runtime.tenant
+          - variables     # runtime.variables
     if: |
       (github.event_name == 'pull_request' &&
-       needs.detect-changes.outputs.data-migrator == 'true' &&
        (
          contains(github.event.pull_request.labels.*.name, 'ci:runtime') ||
-         (!contains(github.event.pull_request.labels.*.name, 'ci:runtime') && !contains(github.event.pull_request.labels.*.name, 'ci:history') && !contains(github.event.pull_request.labels.*.name, 'ci:identity'))
+         (
+           needs.detect-changes.outputs.data-migrator == 'true' &&
+           !contains(github.event.pull_request.labels.*.name, 'ci:history') &&
+           !contains(github.event.pull_request.labels.*.name, 'ci:identity')
+         )
        )
       ) ||
       github.event_name == 'workflow_dispatch'

--- a/data-migrator/AGENTS.md
+++ b/data-migrator/AGENTS.md
@@ -46,8 +46,20 @@ The `qa/integration-tests` and `qa/e2e-tests` modules are **not included in the 
 # All integration tests (runtime + history + identity) on H2
 mvn verify -Pintegration
 
-# Runtime integration tests only
+# Runtime integration tests only (full suite, ~53 min)
 mvn verify -Pintegration,runtime-only
+
+# Runtime integration tests — individual CI shards (run in parallel in CI, ~15 min each)
+# Shard 1: core runtime tests (runtime root package)
+mvn verify -Pintegration,runtime-shard-1
+# Shard 2: element and datasource tests
+mvn verify -Pintegration,runtime-shard-2
+# Shard 3: job-type, persistence, and distribution tests
+mvn verify -Pintegration,runtime-shard-3
+# Shard 4: tenancy and variable interceptor tests
+mvn verify -Pintegration,runtime-shard-4
+# Note: when adding a new test sub-package under runtime/, add it to the appropriate
+# runtime-shard-N profile in qa/integration-tests/pom.xml to avoid silent omission.
 
 # History integration tests only
 mvn verify -Pintegration,history-only

--- a/data-migrator/AGENTS.md
+++ b/data-migrator/AGENTS.md
@@ -49,13 +49,13 @@ mvn verify -Pintegration
 # Runtime integration tests only (full suite, ~53 min)
 mvn verify -Pintegration,runtime-only
 
-# Runtime integration tests — individual CI shards (run in parallel in CI, ~15 min each)
-mvn verify -Pintegration,runtime-core       # runtime root package (basic migration scenarios)
+# Runtime integration tests — individual CI shards (~20 min each, run in parallel)
+mvn verify -Pintegration,runtime-core       # runtime root + persistence + distribution (catch-all)
 mvn verify -Pintegration,runtime-element    # runtime.element + runtime.datasource
-mvn verify -Pintegration,runtime-jobtype    # runtime.jobtype + persistence + distribution
-mvn verify -Pintegration,runtime-variables  # runtime.tenant + runtime.variables
-# Note: when adding a new test sub-package under runtime/, add it to the appropriate
-# shard profile in qa/integration-tests/pom.xml to avoid silent omission.
+mvn verify -Pintegration,runtime-jobtype    # runtime.jobtype + runtime.tenant
+mvn verify -Pintegration,runtime-variables  # runtime.variables
+# Note: new sub-packages under runtime/ go to runtime-core automatically (catch-all).
+# Once a new package is large enough, move it to its own shard in pom.xml.
 
 # History integration tests only
 mvn verify -Pintegration,history-only

--- a/data-migrator/AGENTS.md
+++ b/data-migrator/AGENTS.md
@@ -50,16 +50,12 @@ mvn verify -Pintegration
 mvn verify -Pintegration,runtime-only
 
 # Runtime integration tests — individual CI shards (run in parallel in CI, ~15 min each)
-# Shard 1: core runtime tests (runtime root package)
-mvn verify -Pintegration,runtime-shard-1
-# Shard 2: element and datasource tests
-mvn verify -Pintegration,runtime-shard-2
-# Shard 3: job-type, persistence, and distribution tests
-mvn verify -Pintegration,runtime-shard-3
-# Shard 4: tenancy and variable interceptor tests
-mvn verify -Pintegration,runtime-shard-4
+mvn verify -Pintegration,runtime-core       # runtime root package (basic migration scenarios)
+mvn verify -Pintegration,runtime-element    # runtime.element + runtime.datasource
+mvn verify -Pintegration,runtime-jobtype    # runtime.jobtype + persistence + distribution
+mvn verify -Pintegration,runtime-variables  # runtime.tenant + runtime.variables
 # Note: when adding a new test sub-package under runtime/, add it to the appropriate
-# runtime-shard-N profile in qa/integration-tests/pom.xml to avoid silent omission.
+# shard profile in qa/integration-tests/pom.xml to avoid silent omission.
 
 # History integration tests only
 mvn verify -Pintegration,history-only

--- a/data-migrator/qa/integration-tests/pom.xml
+++ b/data-migrator/qa/integration-tests/pom.xml
@@ -439,6 +439,96 @@
         </plugins>
       </build>
     </profile>
+    <!--
+      Runtime test shards for parallel CI execution.
+
+      The runtime-only suite takes ~53 minutes serially. These four shards
+      split it into parallel jobs that each target ~15 minutes. Include
+      ArchitectureTest in every shard so structural regressions are caught
+      regardless of which shard fails.
+
+      Shard assignment by package:
+        shard-1  –  io.camunda.migration.data.qa.runtime (root only, no sub-packages)
+        shard-2  –  runtime.element, runtime.datasource
+        shard-3  –  runtime.jobtype, persistence, distribution
+        shard-4  –  runtime.tenant, runtime.variables
+
+      When adding a new test sub-package under runtime/, add a matching
+      <include> to the appropriate shard profile so it is not silently dropped.
+    -->
+    <profile>
+      <id>runtime-shard-1</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+              <includes>
+                <!-- Direct children of runtime/ only — sub-packages go to other shards -->
+                <include>**/runtime/*Test.java</include>
+                <include>ArchitectureTest.java</include>
+              </includes>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>runtime-shard-2</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+              <includes>
+                <include>**/runtime/element/**</include>
+                <include>**/runtime/datasource/**</include>
+                <include>ArchitectureTest.java</include>
+              </includes>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>runtime-shard-3</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+              <includes>
+                <include>**/runtime/jobtype/**</include>
+                <include>**/persistence/**</include>
+                <include>**/distribution/**</include>
+                <include>ArchitectureTest.java</include>
+              </includes>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>runtime-shard-4</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+              <includes>
+                <include>**/runtime/tenant/**</include>
+                <include>**/runtime/variables/**</include>
+                <include>ArchitectureTest.java</include>
+              </includes>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
     <profile>
       <id>history-only</id>
       <build>

--- a/data-migrator/qa/integration-tests/pom.xml
+++ b/data-migrator/qa/integration-tests/pom.xml
@@ -443,18 +443,20 @@
       Runtime test shards for parallel CI execution.
 
       The runtime-only suite takes ~53 minutes serially. These four named shards
-      split it into parallel jobs that each target ~15 minutes. Include
-      ArchitectureTest in every shard so structural regressions are caught
-      regardless of which shard fails first.
+      split it into parallel jobs, each targeting ~20 minutes. ArchitectureTest
+      runs in every shard so structural regressions are caught regardless of
+      which shard fails first.
 
       Shard assignment by package:
-        runtime-core      –  io.camunda.migration.data.qa.runtime (root, no sub-packages)
+        runtime-core      –  runtime root + persistence + distribution (CATCH-ALL)
         runtime-element   –  runtime.element, runtime.datasource
-        runtime-jobtype   –  runtime.jobtype, persistence, distribution
-        runtime-variables –  runtime.tenant, runtime.variables
+        runtime-jobtype   –  runtime.jobtype, runtime.tenant
+        runtime-variables –  runtime.variables
 
-      When adding a new test sub-package under runtime/, add a matching
-      <include> to the appropriate shard profile so it is not silently omitted.
+      runtime-core is intentionally a catch-all: new sub-packages under runtime/
+      that are not assigned to another shard are automatically picked up here via
+      the exclude-based filter. When a new package grows large, move it to its
+      own shard by adding it to the excludes list below and creating a new profile.
     -->
     <profile>
       <id>runtime-core</id>
@@ -464,11 +466,23 @@
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
+              <!--
+                Broad include so new runtime sub-packages are never silently dropped.
+                Packages assigned to other shards are excluded below.
+              -->
               <includes>
-                <!-- Direct children of runtime/ only — sub-packages go to other shards -->
-                <include>**/runtime/*Test.java</include>
-                <include>ArchitectureTest.java</include>
+                <include>**/runtime/**/*Test.java</include>
+                <include>**/persistence/**/*Test.java</include>
+                <include>**/distribution/**/*Test.java</include>
+                <include>**/ArchitectureTest.java</include>
               </includes>
+              <excludes>
+                <exclude>**/runtime/element/**</exclude>
+                <exclude>**/runtime/datasource/**</exclude>
+                <exclude>**/runtime/jobtype/**</exclude>
+                <exclude>**/runtime/tenant/**</exclude>
+                <exclude>**/runtime/variables/**</exclude>
+              </excludes>
             </configuration>
           </plugin>
         </plugins>
@@ -483,9 +497,9 @@
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
               <includes>
-                <include>**/runtime/element/**</include>
-                <include>**/runtime/datasource/**</include>
-                <include>ArchitectureTest.java</include>
+                <include>**/runtime/element/**/*Test.java</include>
+                <include>**/runtime/datasource/**/*Test.java</include>
+                <include>**/ArchitectureTest.java</include>
               </includes>
             </configuration>
           </plugin>
@@ -501,10 +515,9 @@
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
               <includes>
-                <include>**/runtime/jobtype/**</include>
-                <include>**/persistence/**</include>
-                <include>**/distribution/**</include>
-                <include>ArchitectureTest.java</include>
+                <include>**/runtime/jobtype/**/*Test.java</include>
+                <include>**/runtime/tenant/**/*Test.java</include>
+                <include>**/ArchitectureTest.java</include>
               </includes>
             </configuration>
           </plugin>
@@ -520,9 +533,8 @@
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
               <includes>
-                <include>**/runtime/tenant/**</include>
-                <include>**/runtime/variables/**</include>
-                <include>ArchitectureTest.java</include>
+                <include>**/runtime/variables/**/*Test.java</include>
+                <include>**/ArchitectureTest.java</include>
               </includes>
             </configuration>
           </plugin>

--- a/data-migrator/qa/integration-tests/pom.xml
+++ b/data-migrator/qa/integration-tests/pom.xml
@@ -442,22 +442,22 @@
     <!--
       Runtime test shards for parallel CI execution.
 
-      The runtime-only suite takes ~53 minutes serially. These four shards
+      The runtime-only suite takes ~53 minutes serially. These four named shards
       split it into parallel jobs that each target ~15 minutes. Include
       ArchitectureTest in every shard so structural regressions are caught
-      regardless of which shard fails.
+      regardless of which shard fails first.
 
       Shard assignment by package:
-        shard-1  –  io.camunda.migration.data.qa.runtime (root only, no sub-packages)
-        shard-2  –  runtime.element, runtime.datasource
-        shard-3  –  runtime.jobtype, persistence, distribution
-        shard-4  –  runtime.tenant, runtime.variables
+        runtime-core      –  io.camunda.migration.data.qa.runtime (root, no sub-packages)
+        runtime-element   –  runtime.element, runtime.datasource
+        runtime-jobtype   –  runtime.jobtype, persistence, distribution
+        runtime-variables –  runtime.tenant, runtime.variables
 
       When adding a new test sub-package under runtime/, add a matching
-      <include> to the appropriate shard profile so it is not silently dropped.
+      <include> to the appropriate shard profile so it is not silently omitted.
     -->
     <profile>
-      <id>runtime-shard-1</id>
+      <id>runtime-core</id>
       <build>
         <plugins>
           <plugin>
@@ -475,7 +475,7 @@
       </build>
     </profile>
     <profile>
-      <id>runtime-shard-2</id>
+      <id>runtime-element</id>
       <build>
         <plugins>
           <plugin>
@@ -493,7 +493,7 @@
       </build>
     </profile>
     <profile>
-      <id>runtime-shard-3</id>
+      <id>runtime-jobtype</id>
       <build>
         <plugins>
           <plugin>
@@ -512,7 +512,7 @@
       </build>
     </profile>
     <profile>
-      <id>runtime-shard-4</id>
+      <id>runtime-variables</id>
       <build>
         <plugins>
           <plugin>


### PR DESCRIPTION
## Summary

- **Short-term (immediate)**: adds a `detect-changes` job that checks git diff against the PR base. The `it-runtime-h2` matrix skips entirely when no `data-migrator/` or `pom.xml` files changed — non-data-migrator PRs (code-conversion, diagram-converter, docs) drop from ~53 min to ~16 min immediately.
- **Long-term (all data-migrator PRs)**: replaces the single serial `it-runtime-h2` job (~53 min, `runtime-only` profile) with a 4-way GitHub Actions matrix. Each shard targets a distinct sub-package via a new `runtime-shard-N` Maven profile, targeting ~15 min per shard.

## Changes

| File | What changed |
|------|-------------|
| `.github/workflows/ci.yml` | New `detect-changes` job; `it-runtime-h2` → matrix with `shard: [1,2,3,4]`, path-filter `if`, timeout 70→25 min |
| `data-migrator/qa/integration-tests/pom.xml` | 4 new `runtime-shard-N` profiles with package-based `<include>` patterns |
| `data-migrator/AGENTS.md` | Documents shard profiles and convention for new packages |

## Shard breakdown

| Shard | Profiles covers | Test classes |
|-------|----------------|-------------|
| 1 | `runtime` root package | 10 (BusinessKey, MigrationOrdered, SkipAndRetry, …) |
| 2 | `runtime.element`, `runtime.datasource` | 10 (element migrations + table prefix) |
| 3 | `runtime.jobtype`, `persistence`, `distribution` | 10 (job types + schema + smoke) |
| 4 | `runtime.tenant`, `runtime.variables` | 9 (multi-tenancy + variable interceptors) |

`ArchitectureTest` runs in every shard (fast, ~1 s, always validates package structure).

## Test plan

- [ ] `mvn verify -Pintegration,runtime-shard-1` passes locally
- [ ] `mvn verify -Pintegration,runtime-shard-2` passes locally
- [ ] `mvn verify -Pintegration,runtime-shard-3` passes locally
- [ ] `mvn verify -Pintegration,runtime-shard-4` passes locally
- [ ] CI run shows 4 parallel `it-runtime-h2` jobs each finishing ≤ 15 min
- [ ] A code-conversion-only PR shows `it-runtime-h2` skipped

## Baseline

Built from commit: `344e790d6cbee293803d47d174c0a2a0f25ba389`

closes #1607

🤖 Generated with [Claude Code](https://claude.com/claude-code)