### PR TITLE
fix(qa): reduce Oracle HikariCP pool sizes to prevent ORA-12516 flakiness (maintenance/0.2)

### DIFF
--- a/data-migrator/qa/integration-tests/src/test/resources/application-oracle.yml
+++ b/data-migrator/qa/integration-tests/src/test/resources/application-oracle.yml
@@ -3,7 +3,7 @@ camunda:
     auto-ddl: true
     c7:
       data-source:
-        maximum-pool-size: 1
+        maximum-pool-size: 2
         minimum-idle: 0
         auto-ddl: true
         jdbc-url: jdbc:oracle:thin:@localhost:15432/ORCLDB

--- a/data-migrator/qa/integration-tests/src/test/resources/application-oracle.yml
+++ b/data-migrator/qa/integration-tests/src/test/resources/application-oracle.yml
@@ -3,6 +3,8 @@ camunda:
     auto-ddl: true
     c7:
       data-source:
+        maximum-pool-size: 1
+        minimum-idle: 0
         auto-ddl: true
         jdbc-url: jdbc:oracle:thin:@localhost:15432/ORCLDB
         username: camunda
@@ -21,6 +23,8 @@ camunda:
     auto-ddl: true
     c8:
       data-source:
+        maximum-pool-size: 1
+        minimum-idle: 0
         auto-ddl: true
         jdbc-url: jdbc:oracle:thin:@localhost:15432/ORCLDB
         username: camunda


### PR DESCRIPTION
Backport of #1626 to `maintenance/0.2`.

## Summary

- Adds `maximum-pool-size: 1` and `minimum-idle: 0` to both c7 and c8 data sources in `application-oracle.yml`
- Fixes intermittent `ORA-12516: Cannot connect to database` failures from pool exhaustion

## Why cherry-pick failed

`maintenance/0.2` predates the pool-size keys — they were never added to this branch. Applied the same values manually.

`application-oracle-19.yml` is not backported: Oracle 19c CI (`it-runtime-oracle-19`) does not exist on `maintenance/0.2`.

## Test plan

- [ ] `it-runtime-oracle` CI job runs without ORA-12516 failures