### PR TITLE
ci: split runtime integration tests into 4 parallel shards (maintenance/0.3)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,37 @@ on:
     - cron: "0 5 * * 1-5"  # Weekday mornings for general CI
 
 jobs:
+  # Detects whether data-migrator source changed so downstream jobs can skip
+  # expensive tests on PRs that only touch other modules. For non-PR events
+  # (push to main, schedule, workflow_dispatch) we always consider it changed.
+  detect-changes:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      data-migrator: ${{ steps.filter.outputs.data-migrator }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          fetch-depth: 0
+
+      - name: Check for data-migrator changes
+        id: filter
+        env:
+          BASE_REF: ${{ github.base_ref }}
+          EVENT: ${{ github.event_name }}
+        run: |
+          if [[ "$EVENT" != "pull_request" ]]; then
+            echo "data-migrator=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          git fetch origin "${BASE_REF}" --depth=1
+          if git diff --name-only "origin/${BASE_REF}...HEAD" | grep -qE '^(data-migrator/|pom\.xml$)'; then
+            echo "data-migrator=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "data-migrator=false" >> "$GITHUB_OUTPUT"
+          fi
+
   distro:
     runs-on: ubuntu-latest
     timeout-minutes: 70
@@ -274,13 +305,31 @@ jobs:
         run: mvn verify -Ppostgresql,integration,history-only
 
   it-runtime-h2:
+    needs: [detect-changes]
     runs-on: ubuntu-latest
-    timeout-minutes: 70
+    timeout-minutes: 30
+    # Split the runtime suite into 4 parallel shards (was 1 serial job, ~53 min).
+    # Each shard name matches its Maven profile (runtime-<shard>) and describes
+    # the sub-set of test packages it covers.
+    strategy:
+      fail-fast: false
+      matrix:
+        shard:
+          - core          # runtime root + persistence + distribution (catch-all for new packages)
+          - element       # runtime.element + runtime.datasource
+          - jobtype       # runtime.jobtype + runtime.tenant
+          - variables     # runtime.variables
     if: |
-      (github.event_name == 'pull_request' && (
-        contains(github.event.pull_request.labels.*.name, 'ci:runtime') ||
-        (!contains(github.event.pull_request.labels.*.name, 'ci:runtime') && !contains(github.event.pull_request.labels.*.name, 'ci:history') && !contains(github.event.pull_request.labels.*.name, 'ci:identity'))
-      )) ||
+      (github.event_name == 'pull_request' &&
+       (
+         contains(github.event.pull_request.labels.*.name, 'ci:runtime') ||
+         (
+           needs.detect-changes.outputs.data-migrator == 'true' &&
+           !contains(github.event.pull_request.labels.*.name, 'ci:history') &&
+           !contains(github.event.pull_request.labels.*.name, 'ci:identity')
+         )
+       )
+      ) ||
       github.event_name == 'workflow_dispatch'
     steps:
       - name: Checkout code
@@ -307,9 +356,9 @@ jobs:
           vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
 
-      - name: Run runtime tests with H2
+      - name: Run ${{ matrix.shard }} runtime tests with H2
         working-directory: data-migrator
-        run: mvn verify -Pintegration,runtime-only
+        run: mvn verify -Pintegration,runtime-${{ matrix.shard }}
 
   it-history-h2:
     runs-on: ubuntu-latest

--- a/data-migrator/AGENTS.md
+++ b/data-migrator/AGENTS.md
@@ -46,8 +46,16 @@ The `qa/integration-tests` and `qa/e2e-tests` modules are **not included in the 
 # All integration tests (runtime + history + identity) on H2
 mvn verify -Pintegration
 
-# Runtime integration tests only
+# Runtime integration tests only (full suite, ~53 min)
 mvn verify -Pintegration,runtime-only
+
+# Runtime integration tests — individual CI shards (~20 min each, run in parallel)
+mvn verify -Pintegration,runtime-core       # runtime root + persistence + distribution (catch-all)
+mvn verify -Pintegration,runtime-element    # runtime.element + runtime.datasource
+mvn verify -Pintegration,runtime-jobtype    # runtime.jobtype + runtime.tenant
+mvn verify -Pintegration,runtime-variables  # runtime.variables
+# Note: new sub-packages under runtime/ go to runtime-core automatically (catch-all).
+# Once a new package is large enough, move it to its own shard in pom.xml.
 
 # History integration tests only
 mvn verify -Pintegration,history-only

--- a/data-migrator/qa/integration-tests/pom.xml
+++ b/data-migrator/qa/integration-tests/pom.xml
@@ -392,6 +392,108 @@
         </plugins>
       </build>
     </profile>
+    <!--
+      Runtime test shards for parallel CI execution.
+
+      The runtime-only suite takes ~53 minutes serially. These four named shards
+      split it into parallel jobs, each targeting ~20 minutes. ArchitectureTest
+      runs in every shard so structural regressions are caught regardless of
+      which shard fails first.
+
+      Shard assignment by package:
+        runtime-core      –  runtime root + persistence + distribution (CATCH-ALL)
+        runtime-element   –  runtime.element, runtime.datasource
+        runtime-jobtype   –  runtime.jobtype, runtime.tenant
+        runtime-variables –  runtime.variables
+
+      runtime-core is intentionally a catch-all: new sub-packages under runtime/
+      that are not assigned to another shard are automatically picked up here via
+      the exclude-based filter. When a new package grows large, move it to its
+      own shard by adding it to the excludes list below and creating a new profile.
+    -->
+    <profile>
+      <id>runtime-core</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+              <!--
+                Broad include so new runtime sub-packages are never silently dropped.
+                Packages assigned to other shards are excluded below.
+              -->
+              <includes>
+                <include>**/runtime/**/*Test.java</include>
+                <include>**/persistence/**/*Test.java</include>
+                <include>**/distribution/**/*Test.java</include>
+                <include>**/ArchitectureTest.java</include>
+              </includes>
+              <excludes>
+                <exclude>**/runtime/element/**</exclude>
+                <exclude>**/runtime/datasource/**</exclude>
+                <exclude>**/runtime/jobtype/**</exclude>
+                <exclude>**/runtime/tenant/**</exclude>
+                <exclude>**/runtime/variables/**</exclude>
+              </excludes>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>runtime-element</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+              <includes>
+                <include>**/runtime/element/**/*Test.java</include>
+                <include>**/runtime/datasource/**/*Test.java</include>
+                <include>**/ArchitectureTest.java</include>
+              </includes>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>runtime-jobtype</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+              <includes>
+                <include>**/runtime/jobtype/**/*Test.java</include>
+                <include>**/runtime/tenant/**/*Test.java</include>
+                <include>**/ArchitectureTest.java</include>
+              </includes>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>runtime-variables</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+              <includes>
+                <include>**/runtime/variables/**/*Test.java</include>
+                <include>**/ArchitectureTest.java</include>
+              </includes>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
     <profile>
       <id>history-only</id>
       <build>


### PR DESCRIPTION
Backport of #1627 to `maintenance/0.3`.

## Summary

- Adds `detect-changes` job — skips `it-runtime-h2` on PRs that don't touch `data-migrator/` or `pom.xml`
- Splits `it-runtime-h2` into 4 parallel shards (`core`, `element`, `jobtype`, `variables`), timeout 70→30 min
- Adds 4 Maven profiles (`runtime-core`, `runtime-element`, `runtime-jobtype`, `runtime-variables`) to `pom.xml`
- Updates `data-migrator/AGENTS.md` with shard command docs

## Why cherry-pick failed

The cherry-pick commit had `read-versions` as surrounding context (exists on `main`, not on `maintenance/0.3`), causing a conflict.

## Test plan

- [ ] A data-migrator PR shows 4 parallel `it-runtime-h2` jobs each finishing ≤ 30 min
- [ ] A non-data-migrator PR shows `it-runtime-h2` skipped