### PR TITLE
feat(history): add configurable legacy definition ID prefix

### DIFF
--- a/data-migrator/assembly/resources/application.yml
+++ b/data-migrator/assembly/resources/application.yml
@@ -72,6 +72,15 @@ camunda:
       ## This enables "offline mode" where the migrator can run without connectivity to Camunda 8.
       ## If not set, the partition count is automatically fetched from the Camunda REST API.
       #partition-count: 1
+      #
+      ## Prefix prepended to migrated Camunda 7 historical definition IDs (process, decision and
+      ## form definitions). Prefixing avoids ID collisions between migrated history definitions and
+      ## native Camunda 8 definitions that share the same ID. Default: c7-legacy-
+      ## Warning: changing or removing the prefix can cause collisions/consistency issues if you
+      ## deploy Camunda 8 resources with the same IDs. Only change it if you understand the risk.
+      ## Allowed: starts with a letter or underscore, then letters, digits, '.', '-' or '_';
+      ## max 100 characters. A blank value is rejected - remove the property to use the default.
+      #legacy-id-prefix: c7-legacy-
 
       # ACTIVE or SUSPENDED C7 instances will be automatically canceled in C8 with end date set to migration date
       auto-cancel:

--- a/data-migrator/core/src/main/java/io/camunda/migration/data/config/MigratorAutoConfiguration.java
+++ b/data-migrator/core/src/main/java/io/camunda/migration/data/config/MigratorAutoConfiguration.java
@@ -43,6 +43,7 @@ import io.camunda.migration.data.impl.history.migrator.VariableMigrator;
 import io.camunda.migration.data.impl.identity.DefinitionLookupService;
 import io.camunda.migration.data.impl.history.PartitionSupplier;
 import io.camunda.migration.data.impl.identity.IdentitySync;
+import io.camunda.migration.data.impl.util.LegacyIdPrefixResolver;
 import liquibase.integration.spring.SpringLiquibase;
 import org.camunda.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
 import org.camunda.bpm.engine.impl.history.HistoryLevel;
@@ -91,6 +92,7 @@ import org.springframework.context.annotation.Import;
     SchemaShutdownCleaner.class,
     PartitionSupplier.class,
     DataSourceRegistry.class,
+    LegacyIdPrefixResolver.class,
     IdentitySync.class
 })
 @Configuration

--- a/data-migrator/core/src/main/java/io/camunda/migration/data/config/property/history/HistoryProperties.java
+++ b/data-migrator/core/src/main/java/io/camunda/migration/data/config/property/history/HistoryProperties.java
@@ -21,6 +21,19 @@ public class HistoryProperties {
    */
   protected Integer partitionCount;
 
+  /**
+   * Prefix prepended to Camunda 7 historical definition IDs (process, decision and form
+   * definitions) when they are migrated to Camunda 8.
+   * <p>
+   * Prefixing avoids collisions between migrated history definitions and native Camunda 8
+   * definitions that share the same ID. When {@code null} (not configured) the default
+   * {@code c7-legacy-} is used. When explicitly configured the value is validated: it must not be
+   * blank, must not exceed the maximum length and may only contain characters that keep the
+   * resulting definition IDs valid. Resolution and validation are handled by
+   * {@code io.camunda.migration.data.impl.util.LegacyIdPrefixResolver}.
+   */
+  protected String legacyIdPrefix;
+
   public AutoCancelProperties getAutoCancel() {
     return autoCancel;
   }
@@ -35,6 +48,14 @@ public class HistoryProperties {
 
   public void setPartitionCount(Integer partitionCount) {
     this.partitionCount = partitionCount;
+  }
+
+  public String getLegacyIdPrefix() {
+    return legacyIdPrefix;
+  }
+
+  public void setLegacyIdPrefix(String legacyIdPrefix) {
+    this.legacyIdPrefix = legacyIdPrefix;
   }
 
 }

--- a/data-migrator/core/src/main/java/io/camunda/migration/data/constants/MigratorConstants.java
+++ b/data-migrator/core/src/main/java/io/camunda/migration/data/constants/MigratorConstants.java
@@ -23,6 +23,14 @@ public final class MigratorConstants {
   public static final String LEGACY_ID_VAR_NAME = "legacyId";
   public static final String C8_DEFAULT_TENANT = "<default>";
   public static final String C7_LEGACY_PREFIX = "c7-legacy";
+
+  /**
+   * Default prefix prepended to Camunda 7 historical definition IDs (process, decision and form
+   * definitions) during migration to Camunda 8. Prefixing avoids collisions between migrated
+   * history definitions and native Camunda 8 definitions sharing the same ID. Configurable via
+   * {@code camunda.migrator.history.legacy-id-prefix}.
+   */
+  public static final String DEFAULT_LEGACY_ID_PREFIX = C7_LEGACY_PREFIX + "-";
   public static final String C7_MULTI_INSTANCE_BODY_SUFFIX = "#multiInstanceBody";
 
   /**

--- a/data-migrator/core/src/main/java/io/camunda/migration/data/impl/history/migrator/DecisionRequirementsMigrator.java
+++ b/data-migrator/core/src/main/java/io/camunda/migration/data/impl/history/migrator/DecisionRequirementsMigrator.java
@@ -72,9 +72,11 @@ public class DecisionRequirementsMigrator extends HistoryEntityMigrator<Decision
 
   /**
    * Migrates a synthetic DRD for a standalone C7 decision (one without a parent DRD) and returns
-   * both the C8 key and the {@code c7-legacy-<definitionsId>} id under which the synthetic DRD is
-   * stored. The id is the single source of truth for the foreign-key reference the decision row
-   * needs to point at, and is provided here so callers do not have to duplicate the prefix scheme.
+   * both the C8 key and the id under which the synthetic DRD is stored: the configured legacy id
+   * prefix ({@code camunda.migrator.history.legacy-id-prefix}, default {@code c7-legacy-}) prepended
+   * to the definitions id. The id is the single source of truth for the foreign-key reference the
+   * decision row needs to point at, and is provided here so callers do not have to duplicate the
+   * prefix scheme.
    */
   protected SyntheticDrd migrateSyntheticDrd(DecisionDefinition c7DecisionDefinition) {
     var newDrd = newDrd(c7DecisionDefinition);
@@ -87,7 +89,8 @@ public class DecisionRequirementsMigrator extends HistoryEntityMigrator<Decision
 
   /**
    * Identity of a synthetic DRD created for a standalone C7 decision: the C8 key used as the FK
-   * value and the {@code c7-legacy-<definitionsId>} string id stored on the DRD row.
+   * value and the prefixed string id stored on the DRD row (the configured legacy id prefix,
+   * default {@code c7-legacy-}, prepended to the definitions id).
    */
   public record SyntheticDrd(Long key, String id) {}
 

--- a/data-migrator/core/src/main/java/io/camunda/migration/data/impl/history/migrator/DecisionRequirementsMigrator.java
+++ b/data-migrator/core/src/main/java/io/camunda/migration/data/impl/history/migrator/DecisionRequirementsMigrator.java
@@ -9,7 +9,6 @@ package io.camunda.migration.data.impl.history.migrator;
 
 import static io.camunda.db.rdbms.write.domain.DecisionRequirementsDbModel.*;
 import static io.camunda.migration.data.impl.persistence.IdKeyMapper.TYPE.HISTORY_DECISION_REQUIREMENT;
-import static io.camunda.migration.data.impl.util.ConverterUtil.prefixDefinitionId;
 
 import io.camunda.db.rdbms.write.domain.DecisionRequirementsDbModel;
 import io.camunda.migration.data.exception.EntityInterceptorException;
@@ -83,7 +82,7 @@ public class DecisionRequirementsMigrator extends HistoryEntityMigrator<Decision
     if (result == null) {
       return null;
     }
-    return new SyntheticDrd(Long.parseLong(result.c8Key()), prefixDefinitionId(newDrd.getKey()));
+    return new SyntheticDrd(Long.parseLong(result.c8Key()), legacyIdPrefix.applyTo(newDrd.getKey()));
   }
 
   /**

--- a/data-migrator/core/src/main/java/io/camunda/migration/data/impl/history/migrator/HistoryEntityMigrator.java
+++ b/data-migrator/core/src/main/java/io/camunda/migration/data/impl/history/migrator/HistoryEntityMigrator.java
@@ -35,6 +35,7 @@ import io.camunda.migration.data.impl.history.C7Entity;
 import io.camunda.migration.data.impl.history.C8EntityNotFoundException;
 import io.camunda.migration.data.impl.history.EntitySkippedException;
 import io.camunda.migration.data.impl.history.PartitionSupplier;
+import io.camunda.migration.data.impl.util.LegacyIdPrefixResolver;
 import io.camunda.migration.data.interceptor.property.EntityConversionContext;
 import io.camunda.search.entities.ProcessInstanceEntity;
 import io.camunda.search.filter.FlowNodeInstanceFilter;
@@ -82,6 +83,9 @@ public abstract class HistoryEntityMigrator<C7, C8> {
 
   @Autowired
   protected PartitionSupplier partitionSupplier;
+
+  @Autowired
+  protected LegacyIdPrefixResolver legacyIdPrefix;
 
   protected MigratorMode mode = MIGRATE;
 

--- a/data-migrator/core/src/main/java/io/camunda/migration/data/impl/history/migrator/ProcessDefinitionMigrator.java
+++ b/data-migrator/core/src/main/java/io/camunda/migration/data/impl/history/migrator/ProcessDefinitionMigrator.java
@@ -9,7 +9,6 @@ package io.camunda.migration.data.impl.history.migrator;
 
 import static io.camunda.migration.data.impl.logging.HistoryMigratorLogs.logMigratingProcessDefinition;
 import static io.camunda.migration.data.impl.persistence.IdKeyMapper.TYPE.HISTORY_PROCESS_DEFINITION;
-import static io.camunda.migration.data.impl.util.ConverterUtil.prefixDefinitionId;
 
 import io.camunda.db.rdbms.write.domain.ProcessDefinitionDbModel;
 import io.camunda.db.rdbms.write.domain.ProcessDefinitionDbModel.ProcessDefinitionDbModelBuilder;
@@ -62,7 +61,7 @@ public class ProcessDefinitionMigrator extends HistoryEntityMigrator<ProcessDefi
       var builder = new ProcessDefinitionDbModelBuilder();
 
       String startFormId = c7Client.getStartFormId(c7ProcessDefinition);
-      builder.formId(prefixDefinitionId(startFormId));
+      builder.formId(legacyIdPrefix.applyTo(startFormId));
 
       var creationTime = c7Client.getDefinitionDeploymentTime(c7ProcessDefinition.getDeploymentId());
       var dbModel = convert(C7Entity.of(c7ProcessDefinition, creationTime), builder);

--- a/data-migrator/core/src/main/java/io/camunda/migration/data/impl/identity/AuthorizationManager.java
+++ b/data-migrator/core/src/main/java/io/camunda/migration/data/impl/identity/AuthorizationManager.java
@@ -196,7 +196,8 @@ public class AuthorizationManager {
 
   /**
    * Maps C7 definition keys to the same key and the legacy prefixed key in C8
-   * This is because when we migrate history data, to avoid collisions, we prefix all definition keys with C7_LEGACY_PREFIX
+   * This is because when we migrate history data, to avoid collisions, we prefix all definition keys
+   * with the configured legacy ID prefix (default {@code c7-legacy-}, see {@link LegacyIdPrefixResolver})
    * And we need to grant authorizations to both the original and the prefixed keys
    * @param resourceId
    * @return a set containing both the original and the prefixed key

--- a/data-migrator/core/src/main/java/io/camunda/migration/data/impl/identity/AuthorizationManager.java
+++ b/data-migrator/core/src/main/java/io/camunda/migration/data/impl/identity/AuthorizationManager.java
@@ -15,7 +15,6 @@ import static io.camunda.migration.data.impl.logging.IdentityMigratorLogs.FAILUR
 import static io.camunda.migration.data.impl.logging.IdentityMigratorLogs.FAILURE_UNSUPPORTED_RESOURCE_ID;
 import static io.camunda.migration.data.impl.logging.IdentityMigratorLogs.FAILURE_UNSUPPORTED_RESOURCE_TYPE;
 import static io.camunda.migration.data.impl.logging.IdentityMigratorLogs.FAILURE_UNSUPPORTED_SPECIFIC_RESOURCE_ID;
-import static io.camunda.migration.data.impl.util.ConverterUtil.prefixDefinitionId;
 import static io.camunda.migration.data.impl.util.ExceptionUtils.callApi;
 import static io.camunda.migration.data.impl.util.ExceptionUtils.rethrowIfC8Offline;
 import static java.lang.String.format;
@@ -32,6 +31,7 @@ import io.camunda.migration.data.exception.IdentityMigratorException;
 import io.camunda.migration.data.exception.MigratorException;
 import io.camunda.migration.data.impl.clients.C8Client;
 import io.camunda.migration.data.impl.logging.IdentityMigratorLogs;
+import io.camunda.migration.data.impl.util.LegacyIdPrefixResolver;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -57,6 +57,9 @@ public class AuthorizationManager {
 
   @Autowired
   protected DefinitionLookupService definitionLookupService;
+
+  @Autowired
+  protected LegacyIdPrefixResolver legacyIdPrefix;
 
   /**
    * Validates and maps a C7 authorization to a C8 authorization if the validation is successful.
@@ -202,7 +205,7 @@ public class AuthorizationManager {
     if (resourceId.equals(WILDCARD)) {
       return Set.of(WILDCARD);
     } else {
-      return Set.of(resourceId, prefixDefinitionId(resourceId));
+      return Set.of(resourceId, legacyIdPrefix.applyTo(resourceId));
     }
   }
 }

--- a/data-migrator/core/src/main/java/io/camunda/migration/data/impl/interceptor/history/entity/AuditLogTransformer.java
+++ b/data-migrator/core/src/main/java/io/camunda/migration/data/impl/interceptor/history/entity/AuditLogTransformer.java
@@ -11,7 +11,6 @@ import static io.camunda.migration.data.constants.MigratorConstants.C7_AUDIT_LOG
 import static io.camunda.migration.data.constants.MigratorConstants.C8_DEFAULT_TENANT;
 import static io.camunda.migration.data.impl.logging.HistoryMigratorLogs.UNSUPPORTED_AUDIT_LOG_ENTITY_TYPE;
 import static io.camunda.migration.data.impl.util.ConverterUtil.getTenantId;
-import static io.camunda.migration.data.impl.util.ConverterUtil.prefixDefinitionId;
 import static org.camunda.bpm.engine.EntityTypes.*;
 import static org.camunda.bpm.engine.history.UserOperationLogEntry.*;
 
@@ -19,11 +18,13 @@ import io.camunda.db.rdbms.write.domain.AuditLogDbModel;
 import io.camunda.db.rdbms.write.domain.AuditLogDbModel.Builder;
 import io.camunda.migration.data.exception.EntityInterceptorException;
 import io.camunda.migration.data.impl.logging.HistoryMigratorLogs;
+import io.camunda.migration.data.impl.util.LegacyIdPrefixResolver;
 import io.camunda.migration.data.interceptor.EntityInterceptor;
 import io.camunda.search.entities.AuditLogEntity;
 import java.util.Set;
 import org.camunda.bpm.engine.history.UserOperationLogEntry;
 import org.jspecify.annotations.NonNull;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
 
@@ -38,6 +39,9 @@ import org.springframework.stereotype.Component;
 @Order(12)
 @Component
 public class AuditLogTransformer implements EntityInterceptor<UserOperationLogEntry, AuditLogDbModel.Builder> {
+
+  @Autowired
+  protected LegacyIdPrefixResolver legacyIdPrefix;
 
   @Override
   public Set<Class<?>> getTypes() {
@@ -73,7 +77,7 @@ public class AuditLogTransformer implements EntityInterceptor<UserOperationLogEn
         .entityVersion(C7_AUDIT_LOG_ENTITY_VERSION)
         .actorId(userOperationLog.getUserId())
         .actorType(AuditLogEntity.AuditLogActorType.USER)
-        .processDefinitionId(prefixDefinitionId(userOperationLog.getProcessDefinitionKey()))
+        .processDefinitionId(legacyIdPrefix.applyTo(userOperationLog.getProcessDefinitionKey()))
         .tenantId(tenantId)
         .tenantScope(getAuditLogTenantScope(tenantId))
         .category(convertCategory(userOperationLog.getCategory()))

--- a/data-migrator/core/src/main/java/io/camunda/migration/data/impl/interceptor/history/entity/DecisionDefinitionTransformer.java
+++ b/data-migrator/core/src/main/java/io/camunda/migration/data/impl/interceptor/history/entity/DecisionDefinitionTransformer.java
@@ -10,17 +10,21 @@ package io.camunda.migration.data.impl.interceptor.history.entity;
 import static io.camunda.db.rdbms.write.domain.DecisionDefinitionDbModel.*;
 import static io.camunda.migration.data.impl.util.ConverterUtil.getNextKey;
 import static io.camunda.migration.data.impl.util.ConverterUtil.getTenantId;
-import static io.camunda.migration.data.impl.util.ConverterUtil.prefixDefinitionId;
 
+import io.camunda.migration.data.impl.util.LegacyIdPrefixResolver;
 import io.camunda.migration.data.interceptor.EntityInterceptor;
 import java.util.Set;
 import org.camunda.bpm.engine.repository.DecisionDefinition;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
 
 @Order(10)
 @Component
 public class DecisionDefinitionTransformer implements EntityInterceptor<DecisionDefinition, DecisionDefinitionDbModelBuilder> {
+
+  @Autowired
+  protected LegacyIdPrefixResolver legacyIdPrefix;
 
   @Override
   public Set<Class<?>> getTypes() {
@@ -31,7 +35,7 @@ public class DecisionDefinitionTransformer implements EntityInterceptor<Decision
   public void execute(DecisionDefinition entity, DecisionDefinitionDbModelBuilder builder) {
     builder.decisionDefinitionKey(getNextKey())
         .name(entity.getName())
-        .decisionDefinitionId(prefixDefinitionId(entity.getKey()))
+        .decisionDefinitionId(legacyIdPrefix.applyTo(entity.getKey()))
         .tenantId(getTenantId(entity.getTenantId()))
         .version(entity.getVersion());
     // Only set decisionRequirementsId from the C7 source when the parent DRD exists. For
@@ -39,7 +43,7 @@ public class DecisionDefinitionTransformer implements EntityInterceptor<Decision
     // skipping the set here preserves that value and keeps the field non-null on the C8 row.
     String c7DrdKey = entity.getDecisionRequirementsDefinitionKey();
     if (c7DrdKey != null) {
-      builder.decisionRequirementsId(prefixDefinitionId(c7DrdKey));
+      builder.decisionRequirementsId(legacyIdPrefix.applyTo(c7DrdKey));
     }
     // Note: decisionRequirementsKey is set externally
   }

--- a/data-migrator/core/src/main/java/io/camunda/migration/data/impl/interceptor/history/entity/DecisionInstanceTransformer.java
+++ b/data-migrator/core/src/main/java/io/camunda/migration/data/impl/interceptor/history/entity/DecisionInstanceTransformer.java
@@ -11,7 +11,6 @@ package io.camunda.migration.data.impl.interceptor.history.entity;
 import static io.camunda.db.rdbms.write.domain.DecisionInstanceDbModel.*;
 import static io.camunda.migration.data.impl.util.ConverterUtil.convertDate;
 import static io.camunda.migration.data.impl.util.ConverterUtil.getTenantId;
-import static io.camunda.migration.data.impl.util.ConverterUtil.prefixDefinitionId;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -19,6 +18,7 @@ import io.camunda.migration.data.exception.EntityInterceptorException;
 import io.camunda.migration.data.impl.VariableService;
 import io.camunda.migration.data.impl.clients.C7Client;
 import io.camunda.migration.data.impl.logging.HistoryMigratorLogs;
+import io.camunda.migration.data.impl.util.LegacyIdPrefixResolver;
 import io.camunda.migration.data.interceptor.EntityInterceptor;
 import io.camunda.search.entities.DecisionInstanceEntity;
 import java.util.ArrayList;
@@ -52,6 +52,9 @@ public class DecisionInstanceTransformer implements EntityInterceptor<HistoricDe
   @Autowired
   protected ObjectMapper objectMapper;
 
+  @Autowired
+  protected LegacyIdPrefixResolver legacyIdPrefix;
+
   @Override
   public Set<Class<?>> getTypes() {
     return Set.of(HistoricDecisionInstance.class);
@@ -73,9 +76,9 @@ public class DecisionInstanceTransformer implements EntityInterceptor<HistoricDe
         .evaluationDate(convertDate(entity.getEvaluationTime()))
         .evaluationFailure(null) // not stored in HistoricDecisionInstance
         .evaluationFailureMessage(null) // not stored in HistoricDecisionInstance
-        .processDefinitionId(prefixDefinitionId(entity.getProcessDefinitionKey()))
-        .decisionDefinitionId(prefixDefinitionId(entity.getDecisionDefinitionKey()))
-        .decisionRequirementsId(prefixDefinitionId(entity.getDecisionRequirementsDefinitionKey()))
+        .processDefinitionId(legacyIdPrefix.applyTo(entity.getProcessDefinitionKey()))
+        .decisionDefinitionId(legacyIdPrefix.applyTo(entity.getDecisionDefinitionKey()))
+        .decisionRequirementsId(legacyIdPrefix.applyTo(entity.getDecisionRequirementsDefinitionKey()))
         .result(resultJsonString)
         .tenantId(getTenantId(entity.getTenantId()))
         .evaluatedInputs(mapInputs(entity.getId(), entity.getInputs()))

--- a/data-migrator/core/src/main/java/io/camunda/migration/data/impl/interceptor/history/entity/DecisionRequirementsDefinitionTransformer.java
+++ b/data-migrator/core/src/main/java/io/camunda/migration/data/impl/interceptor/history/entity/DecisionRequirementsDefinitionTransformer.java
@@ -7,13 +7,12 @@
  */
 package io.camunda.migration.data.impl.interceptor.history.entity;
 
-import static io.camunda.migration.data.constants.MigratorConstants.C7_LEGACY_PREFIX;
 import static io.camunda.migration.data.impl.util.ConverterUtil.getNextKey;
 import static io.camunda.migration.data.impl.util.ConverterUtil.getTenantId;
-import static io.camunda.migration.data.impl.util.ConverterUtil.prefixDefinitionId;
 
 import io.camunda.db.rdbms.write.domain.DecisionRequirementsDbModel.Builder;
 import io.camunda.migration.data.impl.clients.C7Client;
+import io.camunda.migration.data.impl.util.LegacyIdPrefixResolver;
 import io.camunda.migration.data.interceptor.EntityInterceptor;
 import java.io.InputStream;
 import java.nio.charset.Charset;
@@ -44,6 +43,9 @@ public class DecisionRequirementsDefinitionTransformer implements EntityIntercep
   @Autowired
   protected C7Client c7Client;
 
+  @Autowired
+  protected LegacyIdPrefixResolver legacyIdPrefix;
+
   @Override
   public Set<Class<?>> getTypes() {
     return Set.of(DecisionRequirementsDefinition.class);
@@ -62,7 +64,7 @@ public class DecisionRequirementsDefinitionTransformer implements EntityIntercep
     var dmnXml = prefixDecisionIdsInDmn(resourceAsStream);
 
     builder.decisionRequirementsKey(getNextKey())
-        .decisionRequirementsId(prefixDefinitionId(entity.getKey()))
+        .decisionRequirementsId(legacyIdPrefix.applyTo(entity.getKey()))
         .name(entity.getName())
         .resourceName(resourceName)
         .version(entity.getVersion())
@@ -106,8 +108,8 @@ public class DecisionRequirementsDefinitionTransformer implements EntityIntercep
     // Check if this is a decision element
     if (DECISION.equals(element.getLocalName())) {
       String id = element.getAttribute(ID);
-      if (id != null && !id.isEmpty() && !id.startsWith(C7_LEGACY_PREFIX)) {
-        element.setAttribute(ID, prefixDefinitionId(id));
+      if (id != null && !id.isEmpty() && !id.startsWith(legacyIdPrefix.getPrefix())) {
+        element.setAttribute(ID, legacyIdPrefix.applyTo(id));
       }
     }
 
@@ -126,8 +128,8 @@ public class DecisionRequirementsDefinitionTransformer implements EntityIntercep
       String href = element.getAttribute(HREF);
       if (href != null && !href.isEmpty()) {
         // href typically looks like "#decisionId", so we need to preserve the "#" prefix
-        if (href.startsWith(HASH) && !href.startsWith(HASH + C7_LEGACY_PREFIX)) {
-          element.setAttribute(HREF, HASH + prefixDefinitionId(href.substring(1)));
+        if (href.startsWith(HASH) && !href.startsWith(HASH + legacyIdPrefix.getPrefix())) {
+          element.setAttribute(HREF, HASH + legacyIdPrefix.applyTo(href.substring(1)));
         }
       }
     }
@@ -146,9 +148,9 @@ public class DecisionRequirementsDefinitionTransformer implements EntityIntercep
     // Only process dmnElementRef for DMNShape elements, not DMNEdge
     if (DI_DMN_SHAPE.equals(element.getLocalName())) {
       String dmnElementRef = element.getAttribute(DI_DMN_ELEMENT_REF);
-      if (dmnElementRef != null && !dmnElementRef.isEmpty() && !dmnElementRef.startsWith(C7_LEGACY_PREFIX)) {
+      if (dmnElementRef != null && !dmnElementRef.isEmpty() && !dmnElementRef.startsWith(legacyIdPrefix.getPrefix())) {
         // dmnElementRef directly references the decision ID without "#" prefix
-        element.setAttribute(DI_DMN_ELEMENT_REF, prefixDefinitionId(dmnElementRef));
+        element.setAttribute(DI_DMN_ELEMENT_REF, legacyIdPrefix.applyTo(dmnElementRef));
       }
     }
 

--- a/data-migrator/core/src/main/java/io/camunda/migration/data/impl/interceptor/history/entity/ExternalTaskTransformer.java
+++ b/data-migrator/core/src/main/java/io/camunda/migration/data/impl/interceptor/history/entity/ExternalTaskTransformer.java
@@ -10,16 +10,17 @@ package io.camunda.migration.data.impl.interceptor.history.entity;
 import static io.camunda.migration.data.constants.MigratorConstants.C7_NULL_PLACEHOLDER;
 import static io.camunda.migration.data.impl.util.ConverterUtil.convertDate;
 import static io.camunda.migration.data.impl.util.ConverterUtil.getTenantId;
-import static io.camunda.migration.data.impl.util.ConverterUtil.prefixDefinitionId;
 import static io.camunda.migration.data.impl.util.ConverterUtil.sanitizeFlowNodeId;
 
 import io.camunda.db.rdbms.write.domain.JobDbModel;
+import io.camunda.migration.data.impl.util.LegacyIdPrefixResolver;
 import io.camunda.migration.data.interceptor.EntityInterceptor;
 import io.camunda.search.entities.JobEntity.JobKind;
 import io.camunda.search.entities.JobEntity.JobState;
 import io.camunda.search.entities.JobEntity.ListenerEventType;
 import java.util.Set;
 import org.camunda.bpm.engine.history.HistoricExternalTaskLog;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
 
@@ -40,6 +41,9 @@ import org.springframework.stereotype.Component;
 @Order(14)
 @Component
 public class ExternalTaskTransformer implements EntityInterceptor<HistoricExternalTaskLog, JobDbModel.Builder> {
+
+  @Autowired
+  protected LegacyIdPrefixResolver legacyIdPrefix;
 
   @Override
   public Set<Class<?>> getTypes() {
@@ -64,7 +68,7 @@ public class ExternalTaskTransformer implements EntityInterceptor<HistoricExtern
         .listenerEventType(ListenerEventType.UNSPECIFIED)
         .retries(0)
         .worker(C7_NULL_PLACEHOLDER)
-        .processDefinitionId(prefixDefinitionId(entity.getProcessDefinitionKey()))
+        .processDefinitionId(legacyIdPrefix.applyTo(entity.getProcessDefinitionKey()))
         .elementId(sanitizeFlowNodeId(entity.getActivityId()))
         .tenantId(getTenantId(entity.getTenantId()));
     // Note: partitionId is set externally by ExternalTaskMigrator to match the parent process instance

--- a/data-migrator/core/src/main/java/io/camunda/migration/data/impl/interceptor/history/entity/FlowNodeTransformer.java
+++ b/data-migrator/core/src/main/java/io/camunda/migration/data/impl/interceptor/history/entity/FlowNodeTransformer.java
@@ -10,21 +10,25 @@ package io.camunda.migration.data.impl.interceptor.history.entity;
 import static io.camunda.db.rdbms.write.domain.FlowNodeInstanceDbModel.FlowNodeInstanceDbModelBuilder;
 import static io.camunda.migration.data.impl.util.ConverterUtil.convertDate;
 import static io.camunda.migration.data.impl.util.ConverterUtil.getTenantId;
-import static io.camunda.migration.data.impl.util.ConverterUtil.prefixDefinitionId;
 import static io.camunda.migration.data.impl.util.ConverterUtil.sanitizeFlowNodeId;
 import static io.camunda.search.entities.FlowNodeInstanceEntity.FlowNodeType;
 
+import io.camunda.migration.data.impl.util.LegacyIdPrefixResolver;
 import io.camunda.migration.data.interceptor.EntityInterceptor;
 import io.camunda.search.entities.FlowNodeInstanceEntity;
 import java.util.Set;
 import org.camunda.bpm.engine.ActivityTypes;
 import org.camunda.bpm.engine.history.HistoricActivityInstance;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
 
 @Order(3)
 @Component
 public class FlowNodeTransformer implements EntityInterceptor<HistoricActivityInstance, FlowNodeInstanceDbModelBuilder> {
+
+  @Autowired
+  protected LegacyIdPrefixResolver legacyIdPrefix;
 
   @Override
   public Set<Class<?>> getTypes() {
@@ -36,7 +40,7 @@ public class FlowNodeTransformer implements EntityInterceptor<HistoricActivityIn
     builder
         .flowNodeId(sanitizeFlowNodeId(entity.getActivityId()))
         .flowNodeName(entity.getActivityName())
-        .processDefinitionId(prefixDefinitionId(entity.getProcessDefinitionKey()))
+        .processDefinitionId(legacyIdPrefix.applyTo(entity.getProcessDefinitionKey()))
         .startDate(convertDate(entity.getStartTime()))
         .type(convertType(entity.getActivityType()))
         .tenantId(getTenantId(entity.getTenantId()))

--- a/data-migrator/core/src/main/java/io/camunda/migration/data/impl/interceptor/history/entity/FormTransformer.java
+++ b/data-migrator/core/src/main/java/io/camunda/migration/data/impl/interceptor/history/entity/FormTransformer.java
@@ -9,10 +9,10 @@ package io.camunda.migration.data.impl.interceptor.history.entity;
 
 import static io.camunda.migration.data.impl.util.ConverterUtil.getNextKey;
 import static io.camunda.migration.data.impl.util.ConverterUtil.getTenantId;
-import static io.camunda.migration.data.impl.util.ConverterUtil.prefixDefinitionId;
 
 import io.camunda.db.rdbms.write.domain.FormDbModel;
 import io.camunda.migration.data.impl.clients.C7Client;
+import io.camunda.migration.data.impl.util.LegacyIdPrefixResolver;
 import io.camunda.migration.data.interceptor.EntityInterceptor;
 import java.util.Set;
 import org.camunda.bpm.engine.impl.persistence.entity.CamundaFormDefinitionEntity;
@@ -25,6 +25,9 @@ public class FormTransformer implements EntityInterceptor<CamundaFormDefinition,
 
   @Autowired
   protected C7Client c7Client;
+
+  @Autowired
+  protected LegacyIdPrefixResolver legacyIdPrefix;
 
   @Override
   public Set<Class<?>> getTypes() {
@@ -41,7 +44,7 @@ public class FormTransformer implements EntityInterceptor<CamundaFormDefinition,
 
     builder
         .formKey(getNextKey())
-        .formId(prefixDefinitionId(entity.getKey()))
+        .formId(legacyIdPrefix.applyTo(entity.getKey()))
         .tenantId(getTenantId(entity.getTenantId()))
         .version((long) entity.getVersion())
         .isDeleted(false);

--- a/data-migrator/core/src/main/java/io/camunda/migration/data/impl/interceptor/history/entity/IncidentTransformer.java
+++ b/data-migrator/core/src/main/java/io/camunda/migration/data/impl/interceptor/history/entity/IncidentTransformer.java
@@ -12,7 +12,6 @@ import static io.camunda.migration.data.constants.MigratorConstants.C7_NO_MESSAG
 import static io.camunda.migration.data.impl.util.ConverterUtil.convertDate;
 import static io.camunda.migration.data.impl.util.ConverterUtil.getNextKey;
 import static io.camunda.migration.data.impl.util.ConverterUtil.getTenantId;
-import static io.camunda.migration.data.impl.util.ConverterUtil.prefixDefinitionId;
 import static io.camunda.migration.data.impl.util.ConverterUtil.sanitizeFlowNodeId;
 import static io.camunda.search.entities.IncidentEntity.ErrorType.CONDITION_ERROR;
 import static io.camunda.search.entities.IncidentEntity.ErrorType.DECISION_EVALUATION_ERROR;
@@ -22,18 +21,23 @@ import static io.camunda.search.entities.IncidentEntity.ErrorType.RESOURCE_NOT_F
 import static io.camunda.search.entities.IncidentEntity.ErrorType.UNHANDLED_ERROR_EVENT;
 import static io.camunda.search.entities.IncidentEntity.ErrorType.UNKNOWN;
 
+import io.camunda.migration.data.impl.util.LegacyIdPrefixResolver;
 import io.camunda.migration.data.interceptor.EntityInterceptor;
 import io.camunda.search.entities.IncidentEntity;
 import org.camunda.bpm.engine.history.HistoricIncident;
 
 import java.util.Set;
 import org.camunda.bpm.engine.runtime.Incident;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
 
 @Order(7)
 @Component
 public class IncidentTransformer implements EntityInterceptor<HistoricIncident, Builder> {
+
+  @Autowired
+  protected LegacyIdPrefixResolver legacyIdPrefix;
 
   @Override
   public Set<Class<?>> getTypes() {
@@ -44,7 +48,7 @@ public class IncidentTransformer implements EntityInterceptor<HistoricIncident, 
   public void execute(HistoricIncident entity, Builder builder) {
     var incidentMessage = entity.getIncidentMessage();
     builder.incidentKey(getNextKey())
-        .processDefinitionId(prefixDefinitionId(entity.getProcessDefinitionKey()))
+        .processDefinitionId(legacyIdPrefix.applyTo(entity.getProcessDefinitionKey()))
         .flowNodeId(sanitizeFlowNodeId(entity.getActivityId()))
         .errorType(determineErrorType(entity))
         .errorMessage(incidentMessage != null ? incidentMessage : C7_NO_MESSAGE)

--- a/data-migrator/core/src/main/java/io/camunda/migration/data/impl/interceptor/history/entity/JobTransformer.java
+++ b/data-migrator/core/src/main/java/io/camunda/migration/data/impl/interceptor/history/entity/JobTransformer.java
@@ -10,16 +10,17 @@ package io.camunda.migration.data.impl.interceptor.history.entity;
 import static io.camunda.migration.data.constants.MigratorConstants.C7_NULL_PLACEHOLDER;
 import static io.camunda.migration.data.impl.util.ConverterUtil.convertDate;
 import static io.camunda.migration.data.impl.util.ConverterUtil.getTenantId;
-import static io.camunda.migration.data.impl.util.ConverterUtil.prefixDefinitionId;
 import static io.camunda.migration.data.impl.util.ConverterUtil.sanitizeFlowNodeId;
 
 import io.camunda.db.rdbms.write.domain.JobDbModel;
+import io.camunda.migration.data.impl.util.LegacyIdPrefixResolver;
 import io.camunda.migration.data.interceptor.EntityInterceptor;
 import io.camunda.search.entities.JobEntity.JobKind;
 import io.camunda.search.entities.JobEntity.JobState;
 import io.camunda.search.entities.JobEntity.ListenerEventType;
 import java.util.Set;
 import org.camunda.bpm.engine.history.HistoricJobLog;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
 
@@ -38,6 +39,9 @@ import org.springframework.stereotype.Component;
 @Order(13)
 @Component
 public class JobTransformer implements EntityInterceptor<HistoricJobLog, JobDbModel.Builder> {
+
+  @Autowired
+  protected LegacyIdPrefixResolver legacyIdPrefix;
 
   @Override
   public Set<Class<?>> getTypes() {
@@ -62,7 +66,7 @@ public class JobTransformer implements EntityInterceptor<HistoricJobLog, JobDbMo
         .kind(JobKind.BPMN_ELEMENT)
         .listenerEventType(ListenerEventType.UNSPECIFIED)
         .retries(0)
-        .processDefinitionId(prefixDefinitionId(historicJobLog.getProcessDefinitionKey()))
+        .processDefinitionId(legacyIdPrefix.applyTo(historicJobLog.getProcessDefinitionKey()))
         .elementId(sanitizeFlowNodeId(historicJobLog.getActivityId()))
         .tenantId(getTenantId(historicJobLog.getTenantId()))
         .creationTime(creationTime);

--- a/data-migrator/core/src/main/java/io/camunda/migration/data/impl/interceptor/history/entity/ProcessDefinitionTransformer.java
+++ b/data-migrator/core/src/main/java/io/camunda/migration/data/impl/interceptor/history/entity/ProcessDefinitionTransformer.java
@@ -10,9 +10,9 @@ package io.camunda.migration.data.impl.interceptor.history.entity;
 import static io.camunda.db.rdbms.write.domain.ProcessDefinitionDbModel.*;
 import static io.camunda.migration.data.impl.util.ConverterUtil.getNextKey;
 import static io.camunda.migration.data.impl.util.ConverterUtil.getTenantId;
-import static io.camunda.migration.data.impl.util.ConverterUtil.prefixDefinitionId;
 
 import io.camunda.migration.data.impl.clients.C7Client;
+import io.camunda.migration.data.impl.util.LegacyIdPrefixResolver;
 import io.camunda.migration.data.interceptor.EntityInterceptor;
 import java.util.Set;
 import org.camunda.bpm.engine.repository.ProcessDefinition;
@@ -27,6 +27,9 @@ public class ProcessDefinitionTransformer implements EntityInterceptor<ProcessDe
   @Autowired
   protected C7Client c7Client;
 
+  @Autowired
+  protected LegacyIdPrefixResolver legacyIdPrefix;
+
   @Override
   public Set<Class<?>> getTypes() {
     return Set.of(ProcessDefinition.class);
@@ -39,7 +42,7 @@ public class ProcessDefinitionTransformer implements EntityInterceptor<ProcessDe
     var bpmnXml = c7Client.getResourceAsString(deploymentId, resourceName);
 
     builder.processDefinitionKey(getNextKey())
-        .processDefinitionId(prefixDefinitionId(entity.getKey()))
+        .processDefinitionId(legacyIdPrefix.applyTo(entity.getKey()))
         .resourceName(resourceName)
         .name(entity.getName())
         .tenantId(getTenantId(entity.getTenantId()))

--- a/data-migrator/core/src/main/java/io/camunda/migration/data/impl/interceptor/history/entity/ProcessInstanceTransformer.java
+++ b/data-migrator/core/src/main/java/io/camunda/migration/data/impl/interceptor/history/entity/ProcessInstanceTransformer.java
@@ -11,20 +11,24 @@ import static io.camunda.db.rdbms.write.domain.ProcessInstanceDbModel.ProcessIns
 import static io.camunda.migration.data.constants.MigratorConstants.C7_LEGACY_PREFIX;
 import static io.camunda.migration.data.impl.util.ConverterUtil.convertDate;
 import static io.camunda.migration.data.impl.util.ConverterUtil.getTenantId;
-import static io.camunda.migration.data.impl.util.ConverterUtil.prefixDefinitionId;
 import static io.camunda.search.entities.ProcessInstanceEntity.ProcessInstanceState;
 
+import io.camunda.migration.data.impl.util.LegacyIdPrefixResolver;
 import io.camunda.migration.data.interceptor.EntityInterceptor;
 import java.util.HashSet;
 import java.util.Set;
 import org.camunda.bpm.engine.history.HistoricProcessInstance;
 import org.jspecify.annotations.NonNull;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
 
 @Order(2)
 @Component
 public class ProcessInstanceTransformer implements EntityInterceptor<HistoricProcessInstance, ProcessInstanceDbModelBuilder> {
+
+  @Autowired
+  protected LegacyIdPrefixResolver legacyIdPrefix;
 
   @Override
   public Set<Class<?>> getTypes() {
@@ -35,7 +39,7 @@ public class ProcessInstanceTransformer implements EntityInterceptor<HistoricPro
   public void execute(HistoricProcessInstance entity, ProcessInstanceDbModelBuilder builder) {
     builder
         // Get key from runtime instance/model migration
-        .processDefinitionId(prefixDefinitionId(entity.getProcessDefinitionKey()))
+        .processDefinitionId(legacyIdPrefix.applyTo(entity.getProcessDefinitionKey()))
         .startDate(convertDate(entity.getStartTime()))
         .state(convertState(entity.getState()))
         .tenantId(getTenantId(entity.getTenantId()))

--- a/data-migrator/core/src/main/java/io/camunda/migration/data/impl/interceptor/history/entity/UserTaskTransformer.java
+++ b/data-migrator/core/src/main/java/io/camunda/migration/data/impl/interceptor/history/entity/UserTaskTransformer.java
@@ -7,10 +7,12 @@
  */
 package io.camunda.migration.data.impl.interceptor.history.entity;
 
+import io.camunda.migration.data.impl.util.LegacyIdPrefixResolver;
 import io.camunda.migration.data.interceptor.EntityInterceptor;
 import org.camunda.bpm.engine.history.HistoricTaskInstance;
 
 import java.util.Set;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
 
@@ -18,11 +20,13 @@ import static io.camunda.db.rdbms.write.domain.UserTaskDbModel.*;
 import static io.camunda.migration.data.impl.util.ConverterUtil.convertDate;
 import static io.camunda.migration.data.impl.util.ConverterUtil.getNextKey;
 import static io.camunda.migration.data.impl.util.ConverterUtil.getTenantId;
-import static io.camunda.migration.data.impl.util.ConverterUtil.prefixDefinitionId;
 
 @Order(4)
 @Component
 public class UserTaskTransformer implements EntityInterceptor<HistoricTaskInstance, Builder> {
+
+  @Autowired
+  protected LegacyIdPrefixResolver legacyIdPrefix;
 
   @Override
   public Set<Class<?>> getTypes() {
@@ -33,7 +37,7 @@ public class UserTaskTransformer implements EntityInterceptor<HistoricTaskInstan
   public void execute(HistoricTaskInstance entity, Builder builder) {
     builder.userTaskKey(getNextKey())
         .elementId(entity.getTaskDefinitionKey())
-        .processDefinitionId(prefixDefinitionId(entity.getProcessDefinitionKey()))
+        .processDefinitionId(legacyIdPrefix.applyTo(entity.getProcessDefinitionKey()))
         .creationDate(convertDate(entity.getStartTime()))
         .assignee(entity.getAssignee())
         .state(convertState(entity.getTaskState()))

--- a/data-migrator/core/src/main/java/io/camunda/migration/data/impl/interceptor/history/entity/VariableTransformer.java
+++ b/data-migrator/core/src/main/java/io/camunda/migration/data/impl/interceptor/history/entity/VariableTransformer.java
@@ -10,9 +10,9 @@ package io.camunda.migration.data.impl.interceptor.history.entity;
 import static io.camunda.db.rdbms.write.domain.VariableDbModel.*;
 import static io.camunda.migration.data.impl.util.ConverterUtil.getNextKey;
 import static io.camunda.migration.data.impl.util.ConverterUtil.getTenantId;
-import static io.camunda.migration.data.impl.util.ConverterUtil.prefixDefinitionId;
 
 import io.camunda.migration.data.impl.VariableService;
+import io.camunda.migration.data.impl.util.LegacyIdPrefixResolver;
 import io.camunda.migration.data.interceptor.EntityInterceptor;
 import java.util.Set;
 import org.camunda.bpm.engine.history.HistoricVariableInstance;
@@ -28,6 +28,9 @@ public class VariableTransformer implements EntityInterceptor<HistoricVariableIn
   @Autowired
   protected VariableService variableService;
 
+  @Autowired
+  protected LegacyIdPrefixResolver legacyIdPrefix;
+
   @Override
   public Set<Class<?>> getTypes() {
     return Set.of(HistoricVariableInstance.class);
@@ -38,7 +41,7 @@ public class VariableTransformer implements EntityInterceptor<HistoricVariableIn
     builder.variableKey(getNextKey())
         .name(entity.getName())
         .value(variableService.convertValue(entity))
-        .processDefinitionId(prefixDefinitionId(entity.getProcessDefinitionKey()))
+        .processDefinitionId(legacyIdPrefix.applyTo(entity.getProcessDefinitionKey()))
         .tenantId(getTenantId(entity.getTenantId()));
     // Note: partitionId is set externally by VariableMigrator to match the parent process instance
     // processInstanceKey, scopeKey, and elementInstanceKey are set externally

--- a/data-migrator/core/src/main/java/io/camunda/migration/data/impl/logging/ConfigurationLogs.java
+++ b/data-migrator/core/src/main/java/io/camunda/migration/data/impl/logging/ConfigurationLogs.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.migration.data.impl.logging;
 
+import static io.camunda.migration.data.constants.MigratorConstants.DEFAULT_LEGACY_ID_PREFIX;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -26,12 +28,16 @@ public class ConfigurationLogs {
   public static final String C8_SCHEMA_PROPERTY_ERROR = "Could not determine property for C8 database schema creation.";
   public static final String JDBC_DRIVER_CLASS_NOT_FOUND_ERROR = "Configured JDBC driver [{}] was not found on the classpath. Please make sure that the JDBC driver jar is in the configuration/userlib/ directory.";
   public static final String INVALID_IDENTITY_PROPERTIES_ERROR = "Invalid property combination: skip-groups cannot be enabled if skip-users is disabled";
+  public static final String LEGACY_ID_PREFIX_BLANK_ERROR = "Invalid property camunda.migrator.history.legacy-id-prefix: the prefix must not be blank. Remove the property to use the default '%s', or configure a non-blank value.";
+  public static final String LEGACY_ID_PREFIX_TOO_LONG_ERROR = "Invalid property camunda.migrator.history.legacy-id-prefix '%s': the prefix must not exceed %d characters.";
+  public static final String LEGACY_ID_PREFIX_INVALID_CHARS_ERROR = "Invalid property camunda.migrator.history.legacy-id-prefix '%s': the prefix must start with a letter or underscore and may only contain letters, digits, '.', '-' and '_'.";
 
   // Info Messages
   public static final String INFO_CONFIGURING_INTERCEPTORS = "Configuring {} interceptors";
   public static final String INFO_TOTAL_INTERCEPTORS_CONFIGURED = "In total {} {} interceptors configured";
   public static final String INFO_SUCCESSFULLY_REGISTERED = "Successfully registered interceptor: {}";
   public static final String INFO_LIQUIBASE_CREATING_TABLE_SCHEMA = "Creating table schema with Liquibase change log file '{}' with table prefix '{}'.";
+  public static final String INFO_LEGACY_ID_PREFIX = "Using Camunda 7 legacy definition ID prefix '{}' for history migration.";
 
   // Debug Messages
   public static final String DEBUG_NO_INTERCEPTORS = "No interceptors configured in configuration file";
@@ -196,6 +202,39 @@ public class ConfigurationLogs {
 
   public static void logInvalidIdentityPropertyCombination() {
     LOGGER.error(INVALID_IDENTITY_PROPERTIES_ERROR);
+  }
+
+  /**
+   * Logs the effective prefix applied to migrated Camunda 7 historical definition IDs.
+   *
+   * @param prefix the effective legacy ID prefix
+   */
+  public static void logEffectiveLegacyIdPrefix(String prefix) {
+    LOGGER.info(INFO_LEGACY_ID_PREFIX, prefix);
+  }
+
+  /**
+   * @return the error message for a blank legacy ID prefix.
+   */
+  public static String getLegacyIdPrefixBlankError() {
+    return String.format(LEGACY_ID_PREFIX_BLANK_ERROR, DEFAULT_LEGACY_ID_PREFIX);
+  }
+
+  /**
+   * @param prefix    the invalid prefix
+   * @param maxLength the maximum allowed length
+   * @return the error message for a legacy ID prefix that exceeds the maximum length.
+   */
+  public static String getLegacyIdPrefixTooLongError(String prefix, int maxLength) {
+    return String.format(LEGACY_ID_PREFIX_TOO_LONG_ERROR, prefix, maxLength);
+  }
+
+  /**
+   * @param prefix the invalid prefix
+   * @return the error message for a legacy ID prefix containing disallowed characters.
+   */
+  public static String getLegacyIdPrefixInvalidCharsError(String prefix) {
+    return String.format(LEGACY_ID_PREFIX_INVALID_CHARS_ERROR, prefix);
   }
 
 }

--- a/data-migrator/core/src/main/java/io/camunda/migration/data/impl/util/ConverterUtil.java
+++ b/data-migrator/core/src/main/java/io/camunda/migration/data/impl/util/ConverterUtil.java
@@ -16,9 +16,9 @@ import java.util.Date;
 import org.apache.commons.lang3.StringUtils;
 
 import static io.camunda.migration.data.constants.MigratorConstants.C7_HISTORY_PARTITION_ID;
-import static io.camunda.migration.data.constants.MigratorConstants.C7_LEGACY_PREFIX;
 import static io.camunda.migration.data.constants.MigratorConstants.C7_MULTI_INSTANCE_BODY_SUFFIX;
 import static io.camunda.migration.data.constants.MigratorConstants.C8_DEFAULT_TENANT;
+import static io.camunda.migration.data.constants.MigratorConstants.DEFAULT_LEGACY_ID_PREFIX;
 import static io.camunda.zeebe.protocol.Protocol.KEY_BITS;
 
 public class ConverterUtil {
@@ -51,11 +51,24 @@ public class ConverterUtil {
     return StringUtils.isEmpty(c7TenantId) ? C8_DEFAULT_TENANT : c7TenantId;
   }
 
+  /**
+   * Prefixes a Camunda 7 definition ID with the {@link io.camunda.migration.data.constants.MigratorConstants#DEFAULT_LEGACY_ID_PREFIX default}
+   * legacy prefix.
+   * <p>
+   * Production code migrates definition IDs through
+   * {@link io.camunda.migration.data.impl.util.LegacyIdPrefixResolver}, which honours the
+   * configurable {@code camunda.migrator.history.legacy-id-prefix} property. This helper always
+   * uses the default prefix and is retained for building expected values in tests running with the
+   * default configuration.
+   *
+   * @param definitionId the original Camunda 7 definition ID, may be null
+   * @return the prefixed definition ID, or null if the input was null
+   */
   public static String prefixDefinitionId(String definitionId) {
     if (definitionId == null) {
       return null;
     }
-    return String.format("%s-%s", C7_LEGACY_PREFIX, definitionId);
+    return DEFAULT_LEGACY_ID_PREFIX + definitionId;
   }
 
   /**

--- a/data-migrator/core/src/main/java/io/camunda/migration/data/impl/util/LegacyIdPrefixResolver.java
+++ b/data-migrator/core/src/main/java/io/camunda/migration/data/impl/util/LegacyIdPrefixResolver.java
@@ -16,7 +16,6 @@ import static io.camunda.migration.data.impl.logging.ConfigurationLogs.logEffect
 import io.camunda.migration.data.config.property.MigratorProperties;
 import io.camunda.migration.data.config.property.history.HistoryProperties;
 import java.util.regex.Pattern;
-import org.springframework.stereotype.Component;
 
 /**
  * Resolves, validates and applies the prefix prepended to Camunda 7 historical definition IDs

--- a/data-migrator/core/src/main/java/io/camunda/migration/data/impl/util/LegacyIdPrefixResolver.java
+++ b/data-migrator/core/src/main/java/io/camunda/migration/data/impl/util/LegacyIdPrefixResolver.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.migration.data.impl.util;
+
+import static io.camunda.migration.data.constants.MigratorConstants.DEFAULT_LEGACY_ID_PREFIX;
+import static io.camunda.migration.data.impl.logging.ConfigurationLogs.getLegacyIdPrefixBlankError;
+import static io.camunda.migration.data.impl.logging.ConfigurationLogs.getLegacyIdPrefixInvalidCharsError;
+import static io.camunda.migration.data.impl.logging.ConfigurationLogs.getLegacyIdPrefixTooLongError;
+import static io.camunda.migration.data.impl.logging.ConfigurationLogs.logEffectiveLegacyIdPrefix;
+
+import io.camunda.migration.data.config.property.MigratorProperties;
+import io.camunda.migration.data.config.property.history.HistoryProperties;
+import java.util.regex.Pattern;
+import org.springframework.stereotype.Component;
+
+/**
+ * Resolves, validates and applies the prefix prepended to Camunda 7 historical definition IDs
+ * (process, decision and form definitions) when they are migrated to Camunda 8.
+ * <p>
+ * This is the single place that owns the legacy ID prefix. All history migration components apply
+ * the prefix through {@link #applyTo(String)} instead of concatenating the prefix themselves, so the
+ * effective prefix stays consistent across every migrated definition type.
+ * <p>
+ * The prefix defaults to {@code c7-legacy-} and can be overridden with the
+ * {@code camunda.migrator.history.legacy-id-prefix} property. When explicitly configured the value
+ * is validated on startup and an invalid value fails fast:
+ * <ul>
+ *   <li>it must not be blank;</li>
+ *   <li>it must not exceed {@value #MAX_PREFIX_LENGTH} characters;</li>
+ *   <li>it must match {@link #ALLOWED_PREFIX_PATTERN}, i.e. start with an ASCII letter or underscore
+ *       and otherwise contain only ASCII letters, digits, {@code '.'}, {@code '-'} and {@code '_'}.
+ *       This keeps {@code prefix + <original definition id>} a valid XML NCName, which decision (DMN)
+ *       definition IDs are re-parsed as during migration.</li>
+ * </ul>
+ * Prefixing avoids collisions between migrated history definitions and native Camunda 8 definitions
+ * that share the same ID.
+ */
+@Component
+public class LegacyIdPrefixResolver {
+
+  /**
+   * Maximum length allowed for the configured prefix. The prefix is prepended to the original
+   * Camunda 7 definition ID; the combined value must stay within Camunda 8's 255-character
+   * definition ID limit, so the prefix itself is capped well below that.
+   */
+  public static final int MAX_PREFIX_LENGTH = 100;
+
+  /**
+   * Allowed character set for the configured prefix. The value must start with an ASCII letter or
+   * underscore and may otherwise contain ASCII letters, digits, {@code '.'}, {@code '-'} and
+   * {@code '_'}.
+   */
+  public static final String ALLOWED_PREFIX_REGEX = "^[A-Za-z_][A-Za-z0-9._-]*$";
+
+  protected static final Pattern ALLOWED_PREFIX_PATTERN = Pattern.compile(ALLOWED_PREFIX_REGEX);
+
+  protected final String prefix;
+
+  public LegacyIdPrefixResolver(MigratorProperties migratorProperties) {
+    this.prefix = resolveAndValidate(configuredPrefix(migratorProperties));
+    logEffectiveLegacyIdPrefix(this.prefix);
+  }
+
+  protected static String configuredPrefix(MigratorProperties migratorProperties) {
+    HistoryProperties history = migratorProperties.getHistory();
+    return history == null ? null : history.getLegacyIdPrefix();
+  }
+
+  /**
+   * Resolves the effective prefix from the configured value, falling back to the default when it is
+   * not configured, and validates an explicitly configured value.
+   *
+   * @param configuredPrefix the raw configured prefix, or {@code null} when not configured
+   * @return the effective, validated prefix
+   * @throws IllegalArgumentException if an explicitly configured prefix is blank, too long, or
+   *                                  contains disallowed characters
+   */
+  protected static String resolveAndValidate(String configuredPrefix) {
+    if (configuredPrefix == null) {
+      return DEFAULT_LEGACY_ID_PREFIX;
+    }
+    if (configuredPrefix.isBlank()) {
+      throw new IllegalArgumentException(getLegacyIdPrefixBlankError());
+    }
+    if (configuredPrefix.length() > MAX_PREFIX_LENGTH) {
+      throw new IllegalArgumentException(getLegacyIdPrefixTooLongError(configuredPrefix, MAX_PREFIX_LENGTH));
+    }
+    if (!ALLOWED_PREFIX_PATTERN.matcher(configuredPrefix).matches()) {
+      throw new IllegalArgumentException(getLegacyIdPrefixInvalidCharsError(configuredPrefix));
+    }
+    return configuredPrefix;
+  }
+
+  /**
+   * @return the effective prefix, e.g. {@code c7-legacy-} by default.
+   */
+  public String getPrefix() {
+    return prefix;
+  }
+
+  /**
+   * Prepends the effective prefix to the given Camunda 7 definition ID.
+   *
+   * @param definitionId the original Camunda 7 definition ID, may be {@code null}
+   * @return the prefixed definition ID, or {@code null} if the input was {@code null}
+   */
+  public String applyTo(String definitionId) {
+    if (definitionId == null) {
+      return null;
+    }
+    return prefix + definitionId;
+  }
+}

--- a/data-migrator/core/src/main/java/io/camunda/migration/data/impl/util/LegacyIdPrefixResolver.java
+++ b/data-migrator/core/src/main/java/io/camunda/migration/data/impl/util/LegacyIdPrefixResolver.java
@@ -40,7 +40,6 @@ import org.springframework.stereotype.Component;
  * Prefixing avoids collisions between migrated history definitions and native Camunda 8 definitions
  * that share the same ID.
  */
-@Component
 public class LegacyIdPrefixResolver {
 
   /**

--- a/data-migrator/core/src/main/java/io/camunda/migration/data/interceptor/EntityInterceptor.java
+++ b/data-migrator/core/src/main/java/io/camunda/migration/data/interceptor/EntityInterceptor.java
@@ -38,7 +38,7 @@ import java.util.Set;
  *                       EntityConversionContext&lt;HistoricProcessInstance, ProcessInstanceDbModel.ProcessInstanceDbModelBuilder&gt; context) {
  *     // No casting needed!
  *     builder.processInstanceKey(getNextKey())
- *         .processDefinitionId(prefixDefinitionId(entity.getProcessDefinitionKey()))
+ *         .processDefinitionId(entity.getProcessDefinitionKey())
  *         .startDate(convertDate(entity.getStartTime()));
  *   }
  * }

--- a/data-migrator/core/src/main/java/io/camunda/migration/data/interceptor/EntityInterceptor.java
+++ b/data-migrator/core/src/main/java/io/camunda/migration/data/interceptor/EntityInterceptor.java
@@ -36,9 +36,11 @@ import java.util.Set;
  *   public void execute(HistoricProcessInstance entity,
  *                       ProcessInstanceDbModel.ProcessInstanceDbModelBuilder builder,
  *                       EntityConversionContext&lt;HistoricProcessInstance, ProcessInstanceDbModel.ProcessInstanceDbModelBuilder&gt; context) {
- *     // No casting needed!
+ *     // No casting needed! Prefix migrated definition IDs to avoid collisions with native
+ *     // Camunda 8 definitions - production transformers use LegacyIdPrefixResolver#applyTo,
+ *     // which honors the configurable camunda.migrator.history.legacy-id-prefix property.
  *     builder.processInstanceKey(getNextKey())
- *         .processDefinitionId(entity.getProcessDefinitionKey())
+ *         .processDefinitionId(prefixDefinitionId(entity.getProcessDefinitionKey()))
  *         .startDate(convertDate(entity.getStartTime()));
  *   }
  * }

--- a/data-migrator/core/src/test/java/io/camunda/migration/data/LegacyIdPrefixConfigurationTest.java
+++ b/data-migrator/core/src/test/java/io/camunda/migration/data/LegacyIdPrefixConfigurationTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.migration.data;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.migration.data.config.property.MigratorProperties;
+import io.camunda.migration.data.impl.util.LegacyIdPrefixResolver;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
+
+class LegacyIdPrefixConfigurationTest {
+
+  @Nested
+  @SpringBootTest
+  class DefaultPrefixTest {
+
+    @Autowired
+    protected LegacyIdPrefixResolver legacyIdPrefix;
+
+    @Test
+    public void shouldUseDefaultPrefixWhenNotConfigured() {
+      assertThat(legacyIdPrefix.getPrefix()).isEqualTo("c7-legacy-");
+      assertThat(legacyIdPrefix.applyTo("invoice")).isEqualTo("c7-legacy-invoice");
+    }
+  }
+
+  @Nested
+  @SpringBootTest
+  @TestPropertySource(properties = {
+      "camunda.migrator.history.legacy-id-prefix=acme-legacy-"
+  })
+  class CustomPrefixTest {
+
+    @Autowired
+    protected MigratorProperties migratorProperties;
+
+    @Autowired
+    protected LegacyIdPrefixResolver legacyIdPrefix;
+
+    @Test
+    public void shouldBindConfiguredPrefix() {
+      assertThat(migratorProperties.getHistory().getLegacyIdPrefix()).isEqualTo("acme-legacy-");
+    }
+
+    @Test
+    public void shouldApplyConfiguredPrefix() {
+      assertThat(legacyIdPrefix.getPrefix()).isEqualTo("acme-legacy-");
+      assertThat(legacyIdPrefix.applyTo("invoice")).isEqualTo("acme-legacy-invoice");
+    }
+  }
+}

--- a/data-migrator/core/src/test/java/io/camunda/migration/data/history/LegacyIdPrefixResolverTest.java
+++ b/data-migrator/core/src/test/java/io/camunda/migration/data/history/LegacyIdPrefixResolverTest.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.migration.data.history;
+
+import static io.camunda.migration.data.constants.MigratorConstants.DEFAULT_LEGACY_ID_PREFIX;
+import static io.camunda.migration.data.impl.util.LegacyIdPrefixResolver.MAX_PREFIX_LENGTH;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.migration.data.config.property.MigratorProperties;
+import io.camunda.migration.data.config.property.history.HistoryProperties;
+import io.camunda.migration.data.impl.util.LegacyIdPrefixResolver;
+import org.junit.jupiter.api.Test;
+
+class LegacyIdPrefixResolverTest {
+
+  @Test
+  void shouldUseDefaultPrefixWhenHistoryNotConfigured() {
+    // given a configuration without a history block
+    LegacyIdPrefixResolver resolver = resolver(new MigratorProperties());
+
+    // then
+    assertThat(resolver.getPrefix()).isEqualTo(DEFAULT_LEGACY_ID_PREFIX);
+    assertThat(resolver.getPrefix()).isEqualTo("c7-legacy-");
+  }
+
+  @Test
+  void shouldUseDefaultPrefixWhenNotConfigured() {
+    // given a history block without an explicit prefix
+    LegacyIdPrefixResolver resolver = resolver(withPrefix(null));
+
+    // then
+    assertThat(resolver.getPrefix()).isEqualTo(DEFAULT_LEGACY_ID_PREFIX);
+  }
+
+  @Test
+  void shouldUseConfiguredPrefix() {
+    // given
+    LegacyIdPrefixResolver resolver = resolver(withPrefix("acme-legacy-"));
+
+    // then
+    assertThat(resolver.getPrefix()).isEqualTo("acme-legacy-");
+  }
+
+  @Test
+  void shouldApplyPrefixToDefinitionId() {
+    // given
+    LegacyIdPrefixResolver resolver = resolver(withPrefix("acme-"));
+
+    // then
+    assertThat(resolver.applyTo("invoice")).isEqualTo("acme-invoice");
+  }
+
+  @Test
+  void shouldApplyDefaultPrefixToDefinitionId() {
+    // given
+    LegacyIdPrefixResolver resolver = resolver(new MigratorProperties());
+
+    // then
+    assertThat(resolver.applyTo("invoice")).isEqualTo("c7-legacy-invoice");
+  }
+
+  @Test
+  void shouldReturnNullWhenApplyingToNullDefinitionId() {
+    // given
+    LegacyIdPrefixResolver resolver = resolver(withPrefix("acme-"));
+
+    // then
+    assertThat(resolver.applyTo(null)).isNull();
+  }
+
+  @Test
+  void shouldAcceptPrefixWithAllowedCharacters() {
+    // given / then: leading underscore, dots, digits, hyphens and underscores are allowed
+    assertThat(resolver(withPrefix("_c7.legacy-2_")).getPrefix()).isEqualTo("_c7.legacy-2_");
+    assertThat(resolver(withPrefix("Legacy")).getPrefix()).isEqualTo("Legacy");
+  }
+
+  @Test
+  void shouldAcceptPrefixAtMaximumLength() {
+    // given a prefix of exactly the maximum allowed length
+    String maxPrefix = "a".repeat(MAX_PREFIX_LENGTH);
+
+    // then
+    assertThat(resolver(withPrefix(maxPrefix)).getPrefix()).isEqualTo(maxPrefix);
+  }
+
+  @Test
+  void shouldRejectEmptyPrefix() {
+    assertThatThrownBy(() -> resolver(withPrefix("")))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("legacy-id-prefix")
+        .hasMessageContaining("must not be blank");
+  }
+
+  @Test
+  void shouldRejectBlankPrefix() {
+    assertThatThrownBy(() -> resolver(withPrefix("   ")))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("must not be blank");
+  }
+
+  @Test
+  void shouldRejectPrefixExceedingMaximumLength() {
+    // given a prefix one character longer than the maximum
+    String tooLong = "a".repeat(MAX_PREFIX_LENGTH + 1);
+
+    assertThatThrownBy(() -> resolver(withPrefix(tooLong)))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("must not exceed");
+  }
+
+  @Test
+  void shouldRejectPrefixStartingWithDigit() {
+    assertThatThrownBy(() -> resolver(withPrefix("7legacy-")))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("must start with a letter or underscore");
+  }
+
+  @Test
+  void shouldRejectPrefixStartingWithHyphen() {
+    assertThatThrownBy(() -> resolver(withPrefix("-legacy-")))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("must start with a letter or underscore");
+  }
+
+  @Test
+  void shouldRejectPrefixWithWhitespace() {
+    assertThatThrownBy(() -> resolver(withPrefix("c7 legacy-")))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  void shouldRejectPrefixWithDisallowedSymbols() {
+    assertThatThrownBy(() -> resolver(withPrefix("legacy!")))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  protected static LegacyIdPrefixResolver resolver(MigratorProperties properties) {
+    return new LegacyIdPrefixResolver(properties);
+  }
+
+  protected static MigratorProperties withPrefix(String prefix) {
+    MigratorProperties properties = new MigratorProperties();
+    HistoryProperties history = new HistoryProperties();
+    history.setLegacyIdPrefix(prefix);
+    properties.setHistory(history);
+    return properties;
+  }
+}

--- a/data-migrator/core/src/test/java/io/camunda/migration/data/history/LegacyIdPrefixResolverTest.java
+++ b/data-migrator/core/src/test/java/io/camunda/migration/data/history/LegacyIdPrefixResolverTest.java
@@ -26,7 +26,6 @@ class LegacyIdPrefixResolverTest {
 
     // then
     assertThat(resolver.getPrefix()).isEqualTo(DEFAULT_LEGACY_ID_PREFIX);
-    assertThat(resolver.getPrefix()).isEqualTo("c7-legacy-");
   }
 
   @Test

--- a/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/history/entity/CustomLegacyIdPrefixHistoryTest.java
+++ b/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/history/entity/CustomLegacyIdPrefixHistoryTest.java
@@ -8,30 +8,74 @@
 package io.camunda.migration.data.qa.history.entity;
 
 import static io.camunda.migration.data.constants.MigratorConstants.DEFAULT_LEGACY_ID_PREFIX;
+import static io.camunda.migration.data.impl.persistence.IdKeyMapper.TYPE.HISTORY_FLOW_NODE;
+import static io.camunda.migration.data.impl.persistence.IdKeyMapper.TYPE.HISTORY_JOB;
+import static io.camunda.migration.data.impl.persistence.IdKeyMapper.TYPE.HISTORY_PROCESS_DEFINITION;
+import static io.camunda.migration.data.impl.persistence.IdKeyMapper.TYPE.HISTORY_PROCESS_INSTANCE;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.migration.data.qa.history.HistoryMigrationAbstractTest;
+import io.camunda.search.entities.AuditLogEntity;
 import io.camunda.search.entities.DecisionDefinitionEntity;
+import io.camunda.search.entities.DecisionInstanceEntity;
 import io.camunda.search.entities.DecisionRequirementsEntity;
+import io.camunda.search.entities.FlowNodeInstanceEntity;
 import io.camunda.search.entities.FormEntity;
+import io.camunda.search.entities.IncidentEntity;
+import io.camunda.search.entities.JobEntity;
 import io.camunda.search.entities.ProcessDefinitionEntity;
+import io.camunda.search.entities.ProcessInstanceEntity;
+import io.camunda.search.entities.UserTaskEntity;
+import io.camunda.search.entities.VariableEntity;
+import io.camunda.search.query.AuditLogQuery;
 import io.camunda.search.query.DecisionDefinitionQuery;
+import io.camunda.search.query.DecisionInstanceQuery;
 import io.camunda.search.query.DecisionRequirementsQuery;
 import io.camunda.search.query.FormQuery;
+import io.camunda.search.query.IncidentQuery;
 import io.camunda.search.query.ProcessDefinitionQuery;
+import io.camunda.search.query.ProcessInstanceQuery;
 import java.util.List;
+import java.util.Map;
+import org.camunda.bpm.engine.IdentityService;
+import org.camunda.bpm.engine.runtime.ProcessInstance;
+import org.camunda.bpm.engine.task.Task;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.TestPropertySource;
 
 /**
  * Verifies that a custom {@code camunda.migrator.history.legacy-id-prefix} is applied consistently
- * to every migrated history definition type (process, decision and form definitions), and that the
- * default prefix is no longer used when a custom one is configured.
+ * to <b>every</b> migrated history entity whose definition IDs are prefixed, and that the default
+ * prefix is never used when a custom one is configured.
+ * <p>
+ * The default-prefix behaviour of each entity type is already regression-covered by the sibling
+ * {@code History*Test} classes (their {@code searchHistoric*} helpers filter by
+ * {@code ConverterUtil.prefixDefinitionId}, i.e. the default {@code c7-legacy-} prefix). This test
+ * is the counterpart that proves each transformer/migrator resolves the prefix through
+ * {@code LegacyIdPrefixResolver} rather than hard-coding {@code c7-legacy-} — a hard-coded prefix
+ * would pass every default-prefix test but fail here.
+ * <p>
+ * Coverage per prefixed field:
+ * <ul>
+ *   <li>process definition id — process definition, process instance, flow node, user task,
+ *       variable, incident, job, decision instance, audit log;</li>
+ *   <li>decision definition id and decision requirements id — decision definition, decision
+ *       instance, decision requirements definition;</li>
+ *   <li>form id — form definition.</li>
+ * </ul>
+ * Not covered here (tracked separately): the DMN model's internal element/href rewriting in
+ * {@code DecisionRequirementsDefinitionTransformer}, the process-definition start-form id in
+ * {@code ProcessDefinitionMigrator}, and identity authorization resource ids in
+ * {@code AuthorizationManager} (a different, non-history migration path).
  */
 @TestPropertySource(properties = "camunda.migrator.history.legacy-id-prefix=acme-legacy-")
 public class CustomLegacyIdPrefixHistoryTest extends HistoryMigrationAbstractTest {
 
   protected static final String CUSTOM_PREFIX = "acme-legacy-";
+
+  @Autowired
+  protected IdentityService identityService;
 
   @Test
   public void shouldApplyConfiguredPrefixToAllDefinitionTypes() {
@@ -80,5 +124,141 @@ public class CustomLegacyIdPrefixHistoryTest extends HistoryMigrationAbstractTes
             f.formIds(List.of(CUSTOM_PREFIX + "simple-form"))))).items();
     assertThat(forms).singleElement().satisfies(form ->
         assertThat(form.formId()).isEqualTo(CUSTOM_PREFIX + "simple-form"));
+  }
+
+  @Test
+  public void shouldApplyConfiguredPrefixToProcessInstanceGraph() {
+    // given a completed process instance with a variable, so process instance, flow node, user
+    // task and variable history are all produced
+    deployer.deployCamunda7Process("userTaskProcess.bpmn", null);
+    runtimeService.startProcessInstanceByKey("userTaskProcessId", Map.of("myVar", "myValue"));
+    completeAllUserTasksWithDefaultUserTaskId();
+
+    // when
+    historyMigrator.migrate();
+
+    // then the process instance carries the configured prefix (and not the default one)
+    List<ProcessInstanceEntity> processInstances = processInstanceReader
+        .search(ProcessInstanceQuery.of(q -> q.filter(f ->
+            f.processDefinitionIds(CUSTOM_PREFIX + "userTaskProcessId")))).items();
+    assertThat(processInstances).singleElement().satisfies(pi ->
+        assertThat(pi.processDefinitionId()).isEqualTo(CUSTOM_PREFIX + "userTaskProcessId"));
+    long processInstanceKey = processInstances.getFirst().processInstanceKey();
+
+    assertThat(processInstanceReader
+        .search(ProcessInstanceQuery.of(q -> q.filter(f ->
+            f.processDefinitionIds(DEFAULT_LEGACY_ID_PREFIX + "userTaskProcessId")))).items())
+        .as("default prefix must not be used").isEmpty();
+
+    // and every flow node instance carries the configured prefix
+    List<FlowNodeInstanceEntity> flowNodes = searchHistoricFlowNodes(processInstanceKey);
+    assertThat(flowNodes).isNotEmpty().allSatisfy(flowNode ->
+        assertThat(flowNode.processDefinitionId()).isEqualTo(CUSTOM_PREFIX + "userTaskProcessId"));
+
+    // and every user task carries the configured prefix
+    List<UserTaskEntity> userTasks = searchHistoricUserTasks(processInstanceKey);
+    assertThat(userTasks).isNotEmpty().allSatisfy(userTask ->
+        assertThat(userTask.processDefinitionId()).isEqualTo(CUSTOM_PREFIX + "userTaskProcessId"));
+
+    // and the migrated variable carries the configured prefix
+    List<VariableEntity> variables = searchHistoricVariables("myVar");
+    assertThat(variables).singleElement().satisfies(variable ->
+        assertThat(variable.processDefinitionId()).isEqualTo(CUSTOM_PREFIX + "userTaskProcessId"));
+  }
+
+  @Test
+  public void shouldApplyConfiguredPrefixToIncident() {
+    // given a process instance with an incident on its user task
+    deployer.deployCamunda7Process("userTaskProcess.bpmn", null);
+    runtimeService.startProcessInstanceByKey("userTaskProcessId");
+    Task task = taskService.createTaskQuery().taskDefinitionKey("userTaskId").singleResult();
+    runtimeService.createIncident("foo", task.getExecutionId(), "bar");
+
+    // when
+    historyMigrator.migrate();
+
+    // then the migrated incident carries the configured prefix
+    List<IncidentEntity> incidents = incidentReader
+        .search(IncidentQuery.of(q -> q.filter(f ->
+            f.processDefinitionIds(CUSTOM_PREFIX + "userTaskProcessId")))).items();
+    assertThat(incidents).singleElement().satisfies(incident ->
+        assertThat(incident.processDefinitionId()).isEqualTo(CUSTOM_PREFIX + "userTaskProcessId"));
+  }
+
+  @Test
+  public void shouldApplyConfiguredPrefixToJob() {
+    // given an async-before job that has been executed (produces a historic job log)
+    deployer.deployCamunda7Process("asyncBeforeUserTaskProcess.bpmn");
+    runtimeService.startProcessInstanceByKey("asyncBeforeUserTaskProcessId");
+    String c7JobId = managementService.createJobQuery().singleResult().getId();
+    managementService.executeJob(c7JobId);
+
+    // when (flow nodes must be migrated before jobs since C8 requires a non-null elementInstanceKey)
+    historyMigrator.migrateByType(HISTORY_PROCESS_DEFINITION);
+    historyMigrator.migrateByType(HISTORY_PROCESS_INSTANCE);
+    historyMigrator.migrateByType(HISTORY_FLOW_NODE);
+    historyMigrator.migrateByType(HISTORY_JOB);
+
+    // then the migrated job carries the configured prefix
+    List<ProcessInstanceEntity> processInstances = processInstanceReader
+        .search(ProcessInstanceQuery.of(q -> q.filter(f ->
+            f.processDefinitionIds(CUSTOM_PREFIX + "asyncBeforeUserTaskProcessId")))).items();
+    assertThat(processInstances).hasSize(1);
+
+    List<JobEntity> jobs = searchJobs(processInstances.getFirst().processInstanceKey());
+    assertThat(jobs).singleElement().satisfies(job ->
+        assertThat(job.processDefinitionId()).isEqualTo(CUSTOM_PREFIX + "asyncBeforeUserTaskProcessId"));
+  }
+
+  @Test
+  public void shouldApplyConfiguredPrefixToDecisionInstance() {
+    // given a process that evaluates a decision, producing a historic decision instance
+    deployer.deployCamunda7Decision("simpleDmn.dmn");
+    deployer.deployCamunda7Process("businessRuleProcess.bpmn");
+    runtimeService.startProcessInstanceByKey("businessRuleProcessId", Map.of("inputA", "A"));
+
+    // when
+    historyMigrator.migrate();
+
+    // then the decision instance's decision definition id carries the configured prefix — the
+    // reader only matches when the stored id was prefixed by DecisionInstanceTransformer
+    // (DecisionInstanceEntity does not expose processDefinitionId/decisionRequirementsId accessors,
+    // so those prefixed fields are asserted on the definition entities above / in the sibling test)
+    List<DecisionInstanceEntity> customPrefixed = decisionInstanceReader
+        .search(DecisionInstanceQuery.of(q -> q.filter(f ->
+            f.decisionDefinitionIds(List.of(CUSTOM_PREFIX + "simpleDecisionId"))))).items();
+    assertThat(customPrefixed).as("decision instance uses the configured prefix").singleElement();
+
+    // and the default prefix is not used
+    assertThat(decisionInstanceReader
+        .search(DecisionInstanceQuery.of(q -> q.filter(f ->
+            f.decisionDefinitionIds(List.of(DEFAULT_LEGACY_ID_PREFIX + "simpleDecisionId"))))).items())
+        .as("default prefix must not be used").isEmpty();
+  }
+
+  @Test
+  public void shouldApplyConfiguredPrefixToAuditLog() {
+    // given a process instance started by an authenticated user (produces a user operation log)
+    deployer.deployCamunda7Process("simpleProcess.bpmn");
+    identityService.setAuthenticatedUserId("demo");
+    ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("simpleProcess");
+    Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+    if (task != null) {
+      taskService.complete(task.getId());
+    }
+
+    // when
+    try {
+      historyMigrator.migrate();
+    } finally {
+      identityService.clearAuthentication();
+    }
+
+    // then every migrated audit log entry carries the configured prefix
+    List<AuditLogEntity> auditLogs = auditLogReader
+        .search(AuditLogQuery.of(q -> q.filter(f ->
+            f.processDefinitionIds(CUSTOM_PREFIX + "simpleProcess")))).items();
+    assertThat(auditLogs).isNotEmpty().allSatisfy(log ->
+        assertThat(log.processDefinitionId()).isEqualTo(CUSTOM_PREFIX + "simpleProcess"));
   }
 }

--- a/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/history/entity/CustomLegacyIdPrefixHistoryTest.java
+++ b/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/history/entity/CustomLegacyIdPrefixHistoryTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.migration.data.qa.history.entity;
+
+import static io.camunda.migration.data.constants.MigratorConstants.DEFAULT_LEGACY_ID_PREFIX;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.migration.data.qa.history.HistoryMigrationAbstractTest;
+import io.camunda.search.entities.DecisionDefinitionEntity;
+import io.camunda.search.entities.DecisionRequirementsEntity;
+import io.camunda.search.entities.FormEntity;
+import io.camunda.search.entities.ProcessDefinitionEntity;
+import io.camunda.search.query.DecisionDefinitionQuery;
+import io.camunda.search.query.DecisionRequirementsQuery;
+import io.camunda.search.query.FormQuery;
+import io.camunda.search.query.ProcessDefinitionQuery;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.context.TestPropertySource;
+
+/**
+ * Verifies that a custom {@code camunda.migrator.history.legacy-id-prefix} is applied consistently
+ * to every migrated history definition type (process, decision and form definitions), and that the
+ * default prefix is no longer used when a custom one is configured.
+ */
+@TestPropertySource(properties = "camunda.migrator.history.legacy-id-prefix=acme-legacy-")
+public class CustomLegacyIdPrefixHistoryTest extends HistoryMigrationAbstractTest {
+
+  protected static final String CUSTOM_PREFIX = "acme-legacy-";
+
+  @Test
+  public void shouldApplyConfiguredPrefixToAllDefinitionTypes() {
+    // given process, decision and form definitions deployed to Camunda 7
+    deployer.deployCamunda7Process("userTaskProcess.bpmn", null);
+    deployer.deployCamunda7Decision("simpleDmn.dmn");
+    repositoryService.createDeployment()
+        .addClasspathResource("io/camunda/migration/data/bpmn/c7/processWithForm.bpmn")
+        .addClasspathResource("io/camunda/migration/data/form/simple-form.form")
+        .deploy();
+
+    // when history is migrated
+    historyMigrator.migrate();
+
+    // then the process definition id uses the configured prefix
+    List<ProcessDefinitionEntity> processDefinitions = processDefinitionReader
+        .search(ProcessDefinitionQuery.of(q -> q.filter(f ->
+            f.processDefinitionIds(CUSTOM_PREFIX + "userTaskProcessId")))).items();
+    assertThat(processDefinitions).singleElement().satisfies(definition ->
+        assertThat(definition.processDefinitionId()).isEqualTo(CUSTOM_PREFIX + "userTaskProcessId"));
+
+    // and the default prefix is not used for the process definition
+    assertThat(processDefinitionReader
+        .search(ProcessDefinitionQuery.of(q -> q.filter(f ->
+            f.processDefinitionIds(DEFAULT_LEGACY_ID_PREFIX + "userTaskProcessId")))).items())
+        .isEmpty();
+
+    // and the decision definition and its requirements id use the configured prefix
+    List<DecisionDefinitionEntity> decisions = decisionDefinitionReader
+        .search(DecisionDefinitionQuery.of(q -> q.filter(f ->
+            f.decisionDefinitionIds(CUSTOM_PREFIX + "simpleDecisionId")))).items();
+    assertThat(decisions).singleElement().satisfies(decision -> {
+      assertThat(decision.decisionDefinitionId()).isEqualTo(CUSTOM_PREFIX + "simpleDecisionId");
+      assertThat(decision.decisionRequirementsId()).isEqualTo(CUSTOM_PREFIX + "simpleDmnId");
+    });
+
+    List<DecisionRequirementsEntity> decisionRequirements = decisionRequirementsReader
+        .search(DecisionRequirementsQuery.of(q -> q.filter(f ->
+            f.decisionRequirementsIds(CUSTOM_PREFIX + "simpleDmnId")))).items();
+    assertThat(decisionRequirements).singleElement().satisfies(drd ->
+        assertThat(drd.decisionRequirementsId()).isEqualTo(CUSTOM_PREFIX + "simpleDmnId"));
+
+    // and the form id uses the configured prefix
+    List<FormEntity> forms = formReader
+        .search(FormQuery.of(q -> q.filter(f ->
+            f.formIds(List.of(CUSTOM_PREFIX + "simple-form"))))).items();
+    assertThat(forms).singleElement().satisfies(form ->
+        assertThat(form.formId()).isEqualTo(CUSTOM_PREFIX + "simple-form"));
+  }
+}


### PR DESCRIPTION
## Description

Makes the prefix applied to Camunda 7 **historical definition IDs** (process, decision and form definitions) configurable during migration to Camunda 8. Previously the prefix was hard-coded to `c7-legacy-`.

- New property `camunda.migrator.history.legacy-id-prefix` (default `c7-legacy-`, so existing behavior is unchanged).
- New `LegacyIdPrefixResolver` centralises prefix resolution, validation and application (`applyTo(...)`), avoiding ad-hoc string concatenation.
- All history definition-ID prefixing (13 entity transformers, 2 history migrators and `AuthorizationManager`) now goes through the resolver, so migrated IDs stay consistent across every entity type (definitions, instances, tasks, jobs, incidents, variables, audit logs, decision instances, authorizations).
- Validation on startup (fail-fast): rejects a blank value, a value longer than 100 chars, or one containing characters that would produce invalid definition IDs (must start with a letter/underscore, then letters/digits/`.`/`-`/`_`). The effective prefix is logged at startup.
- The C7-origin data **tag** (`c7-legacy`) on process instances is intentionally left fixed — it's an origin marker, not an ID prefix.

Prefixing avoids ID collisions between migrated history definitions and native Camunda 8 definitions that share the same ID; changing/removing it carries that risk, which is documented.

## Type of Change
- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

## Testing Checklist

### Black-Box Testing Requirements
- [x] Tests verify behavior through observable outputs (startup log, C8 API queries)
- [x] Tests do not access `..impl..` from qa (integration test asserts via readers + the `constants` default; ArchUnit's existing `ConverterUtil` carve-out is unchanged)
- [x] Architecture tests pass (`mvn test -Dtest=ArchitectureTest -pl data-migrator/qa`)

### Test Coverage
- [x] Unit tests for resolver defaulting/validation/negatives (`LegacyIdPrefixResolverTest`, 15 cases)
- [x] Spring context test for property binding, default + custom (`LegacyIdPrefixConfigurationTest`)
- [x] History integration test (`CustomLegacyIdPrefixHistoryTest`) now asserts the configured prefix — and the absence of the default — across **all** prefixed history entities:
  - definition level: process, decision (+ decision requirements), form
  - instance level: process instance, flow node, user task, variable, incident, job, decision instance, audit log
  - rationale: every default-prefix `History*Test` filters via `ConverterUtil.prefixDefinitionId` (the default `c7-legacy-`), so a transformer that regressed to a hard-coded prefix would pass all of them but break a custom prefix — this test is the guard against that.
- [x] Core unit tests pass locally; qa integration tests compile locally (full run requires Docker → CI)

Not asserted end-to-end (noted for follow-up): the DMN model's internal element/href rewriting in `DecisionRequirementsDefinitionTransformer`, the process-definition start-form id in `ProcessDefinitionMigrator`, and identity authorization resource IDs in `AuthorizationManager` (a different, non-history migration path). All route through the same resolver.

## Documentation
- [x] Added Javadoc for the new property, resolver and helper
- [x] Documented the option in the distribution `application.yml`
- [ ] A companion PR to camunda-docs documents the option in the user guide (linked below)

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed the code
- [x] No new compiler warnings

## Related Issues

Closes #1432