### PR TITLE
feat(recipes): detect @Profile negation and warn for manual migration

### DIFF
--- a/code-conversion/recipes/src/main/java/io/camunda/migration/code/recipes/sharedRecipes/WarnSpringProfileNegationRecipe.java
+++ b/code-conversion/recipes/src/main/java/io/camunda/migration/code/recipes/sharedRecipes/WarnSpringProfileNegationRecipe.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.migration.code.recipes.sharedRecipes;
+
+import java.util.regex.Pattern;
+import org.jspecify.annotations.NonNull;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.text.PlainText;
+import org.openrewrite.text.PlainTextVisitor;
+
+/**
+ * Detects Spring {@code @Profile} annotations using negation syntax (e.g. {@code @Profile("!test")})
+ * and adds a TODO comment before each occurrence.
+ *
+ * <p>OpenRewrite's Java printer cannot round-trip {@code @Profile("!...")} correctly — the string
+ * literal is corrupted during printing, causing the print-idempotency safety check to fail. As a
+ * result, OpenRewrite silently excludes the entire file from all recipe rewrites. This recipe
+ * operates at the plain-text level (bypassing the Java parser) so it can still process affected
+ * files and leave an actionable TODO for manual migration.
+ *
+ * @see <a href="https://github.com/camunda/camunda-7-to-8-migration-tooling/issues/1548">Issue #1548</a>
+ */
+public class WarnSpringProfileNegationRecipe extends Recipe {
+
+  static final String MARKER =
+      "Manual migration required - @Profile annotation with negation syntax";
+
+  private static final String ISSUE_LINK =
+      "https://github.com/camunda/camunda-7-to-8-migration-tooling/issues/1548";
+
+  private static final Pattern PROFILE_NEGATION_PATTERN =
+      Pattern.compile("@Profile\\s*\\(\\s*\"!");
+
+  @Override
+  public @NonNull String getDisplayName() {
+    return "Warn about Spring @Profile annotation with negation syntax";
+  }
+
+  @Override
+  public @NonNull String getDescription() {
+    return "Adds a TODO comment before Spring @Profile annotations that use negation syntax "
+        + "(e.g., @Profile(\"!test\")). OpenRewrite's Java printer corrupts these annotations, "
+        + "causing the file to be silently skipped during migration. "
+        + "This recipe detects the pattern and prompts for manual migration.";
+  }
+
+  @Override
+  public @NonNull TreeVisitor<?, ExecutionContext> getVisitor() {
+    return new PlainTextVisitor<>() {
+
+      @Override
+      public PlainText visitText(PlainText text, ExecutionContext ctx) {
+        if (!text.getSourcePath().toString().endsWith(".java")) {
+          return text;
+        }
+
+        String content = text.getText();
+
+        if (!PROFILE_NEGATION_PATTERN.matcher(content).find()) {
+          return text;
+        }
+
+        if (content.contains(MARKER)) {
+          return text;
+        }
+
+        String[] lines = content.split("\n", -1);
+        StringBuilder result = new StringBuilder();
+        boolean changed = false;
+
+        for (int i = 0; i < lines.length; i++) {
+          String line = lines[i];
+          if (PROFILE_NEGATION_PATTERN.matcher(line).find()) {
+            String indent = leadingWhitespace(line);
+            result
+                .append(indent)
+                .append("// TODO: ")
+                .append(MARKER)
+                .append(" (\"!...\").\n")
+                .append(indent)
+                .append(
+                    "// OpenRewrite's Java printer corrupts this annotation and silently skips this file during migration.\n")
+                .append(indent)
+                .append("// Migrate this file manually. See: ")
+                .append(ISSUE_LINK)
+                .append("\n");
+            changed = true;
+          }
+          result.append(line);
+          if (i < lines.length - 1) {
+            result.append("\n");
+          }
+        }
+
+        return changed ? text.withText(result.toString()) : text;
+      }
+
+      private String leadingWhitespace(String line) {
+        int i = 0;
+        while (i < line.length() && (line.charAt(i) == ' ' || line.charAt(i) == '\t')) {
+          i++;
+        }
+        return line.substring(0, i);
+      }
+    };
+  }
+}

--- a/code-conversion/recipes/src/main/java/io/camunda/migration/code/recipes/sharedRecipes/WarnSpringProfileNegationRecipe.java
+++ b/code-conversion/recipes/src/main/java/io/camunda/migration/code/recipes/sharedRecipes/WarnSpringProfileNegationRecipe.java
@@ -35,8 +35,10 @@ public class WarnSpringProfileNegationRecipe extends Recipe {
   private static final String ISSUE_LINK =
       "https://github.com/camunda/camunda-7-to-8-migration-tooling/issues/1548";
 
+  // Matches @Profile("!..."), @Profile({"!..."}), and @Profile({ "!..."}) on a single line.
+  // Uses [ \t]* (not \s*) to avoid matching across newlines in multi-line annotations.
   private static final Pattern PROFILE_NEGATION_PATTERN =
-      Pattern.compile("@Profile[ \\t]*\\([ \\t]*\"!");
+      Pattern.compile("@Profile[ \\t]*\\([ \\t]*\\{?[ \\t]*\"!");
 
   @Override
   public @NonNull String getDisplayName() {
@@ -46,8 +48,8 @@ public class WarnSpringProfileNegationRecipe extends Recipe {
   @Override
   public @NonNull String getDescription() {
     return "Adds a TODO comment before Spring @Profile annotations that use negation syntax "
-        + "(e.g., @Profile(\"!test\")). OpenRewrite's Java printer corrupts these annotations, "
-        + "causing the file to be silently skipped during migration. "
+        + "(e.g., @Profile(\"!test\") or @Profile({\"!test\"}). OpenRewrite's Java printer "
+        + "corrupts these annotations, causing the file to be silently skipped during migration. "
         + "This recipe detects the pattern and prompts for manual migration.";
   }
 
@@ -67,7 +69,8 @@ public class WarnSpringProfileNegationRecipe extends Recipe {
           return text;
         }
 
-        String[] lines = content.split("\n", -1);
+        String lineSeparator = content.contains("\r\n") ? "\r\n" : "\n";
+        String[] lines = content.split("\r?\n", -1);
         StringBuilder result = new StringBuilder();
         boolean changed = false;
 
@@ -79,19 +82,21 @@ public class WarnSpringProfileNegationRecipe extends Recipe {
                 .append(indent)
                 .append("// TODO: ")
                 .append(MARKER)
-                .append(" (\"!...\").\n")
+                .append(" (\"!...\").")
+                .append(lineSeparator)
                 .append(indent)
                 .append(
-                    "// OpenRewrite's Java printer corrupts this annotation and silently skips this file during migration.\n")
+                    "// OpenRewrite's Java printer corrupts this annotation and silently skips this file during migration.")
+                .append(lineSeparator)
                 .append(indent)
                 .append("// Migrate this file manually. See: ")
                 .append(ISSUE_LINK)
-                .append("\n");
+                .append(lineSeparator);
             changed = true;
           }
           result.append(line);
           if (i < lines.length - 1) {
-            result.append("\n");
+            result.append(lineSeparator);
           }
         }
 
@@ -99,10 +104,14 @@ public class WarnSpringProfileNegationRecipe extends Recipe {
       }
 
       private boolean alreadyAnnotated(String[] lines, int annotationIndex) {
-        int todoLineCount = 3;
-        for (int j = Math.max(0, annotationIndex - todoLineCount); j < annotationIndex; j++) {
-          if (lines[j].contains(MARKER)) {
-            return true;
+        for (int j = annotationIndex - 1; j >= 0; j--) {
+          String trimmed = lines[j].trim();
+          if (trimmed.isEmpty() || trimmed.startsWith("//")) {
+            if (lines[j].contains(MARKER)) {
+              return true;
+            }
+          } else {
+            break;
           }
         }
         return false;

--- a/code-conversion/recipes/src/main/java/io/camunda/migration/code/recipes/sharedRecipes/WarnSpringProfileNegationRecipe.java
+++ b/code-conversion/recipes/src/main/java/io/camunda/migration/code/recipes/sharedRecipes/WarnSpringProfileNegationRecipe.java
@@ -36,7 +36,7 @@ public class WarnSpringProfileNegationRecipe extends Recipe {
       "https://github.com/camunda/camunda-7-to-8-migration-tooling/issues/1548";
 
   private static final Pattern PROFILE_NEGATION_PATTERN =
-      Pattern.compile("@Profile\\s*\\(\\s*\"!");
+      Pattern.compile("@Profile[ \\t]*\\([ \\t]*\"!");
 
   @Override
   public @NonNull String getDisplayName() {
@@ -67,17 +67,13 @@ public class WarnSpringProfileNegationRecipe extends Recipe {
           return text;
         }
 
-        if (content.contains(MARKER)) {
-          return text;
-        }
-
         String[] lines = content.split("\n", -1);
         StringBuilder result = new StringBuilder();
         boolean changed = false;
 
         for (int i = 0; i < lines.length; i++) {
           String line = lines[i];
-          if (PROFILE_NEGATION_PATTERN.matcher(line).find()) {
+          if (PROFILE_NEGATION_PATTERN.matcher(line).find() && !alreadyAnnotated(lines, i)) {
             String indent = leadingWhitespace(line);
             result
                 .append(indent)
@@ -100,6 +96,16 @@ public class WarnSpringProfileNegationRecipe extends Recipe {
         }
 
         return changed ? text.withText(result.toString()) : text;
+      }
+
+      private boolean alreadyAnnotated(String[] lines, int annotationIndex) {
+        int todoLineCount = 3;
+        for (int j = Math.max(0, annotationIndex - todoLineCount); j < annotationIndex; j++) {
+          if (lines[j].contains(MARKER)) {
+            return true;
+          }
+        }
+        return false;
       }
 
       private String leadingWhitespace(String line) {

--- a/code-conversion/recipes/src/main/resources/META-INF/rewrite/clientRecipes.yml
+++ b/code-conversion/recipes/src/main/resources/META-INF/rewrite/clientRecipes.yml
@@ -26,6 +26,7 @@ recipeList:
   - io.camunda.migration.code.recipes.client.MigrateUserTaskMethodsRecipe
   - io.camunda.migration.code.recipes.client.MigrateProcessInstanceQueryMethodsRecipe
   - io.camunda.migration.code.recipes.client.DetectHistoryServiceUsageRecipe
+  - io.camunda.migration.code.recipes.sharedRecipes.WarnSpringProfileNegationRecipe
   - io.camunda.migration.code.recipes.testing.ReplaceAssertionsRecipe
   # Match the Spring Boot 3 starter chosen above: camunda-process-test-spring defaults to
   # Spring Boot 4.0.x since 8.9, so use the dedicated Spring Boot 3 module for test scope.

--- a/code-conversion/recipes/src/test/java/io/camunda/migration/code/recipes/sharedRecipes/WarnSpringProfileNegationTest.java
+++ b/code-conversion/recipes/src/test/java/io/camunda/migration/code/recipes/sharedRecipes/WarnSpringProfileNegationTest.java
@@ -88,7 +88,7 @@ class WarnSpringProfileNegationTest implements RewriteTest {
   }
 
   @Test
-  void isIdempotent() {
+  void isIdempotentForAnnotatedOccurrence() {
     String alreadyAnnotated =
         """
         package org.example;
@@ -103,6 +103,44 @@ class WarnSpringProfileNegationTest implements RewriteTest {
         """;
     rewriteRun(
         text(alreadyAnnotated, spec -> spec.path("src/main/java/org/example/SampleClass.java")));
+  }
+
+  @Test
+  void annotatesNewOccurrenceWhenFirstAlreadyAnnotated() {
+    rewriteRun(
+        text(
+            """
+            package org.example;
+
+            // TODO: Manual migration required - @Profile annotation with negation syntax ("!...").
+            // OpenRewrite's Java printer corrupts this annotation and silently skips this file during migration.
+            // Migrate this file manually. See: https://github.com/camunda/camunda-7-to-8-migration-tooling/issues/1548
+            @Profile("!test")
+            public class ComponentA {
+            }
+
+            @Profile("!prod")
+            public class ComponentB {
+            }
+            """,
+            """
+            package org.example;
+
+            // TODO: Manual migration required - @Profile annotation with negation syntax ("!...").
+            // OpenRewrite's Java printer corrupts this annotation and silently skips this file during migration.
+            // Migrate this file manually. See: https://github.com/camunda/camunda-7-to-8-migration-tooling/issues/1548
+            @Profile("!test")
+            public class ComponentA {
+            }
+
+            // TODO: Manual migration required - @Profile annotation with negation syntax ("!...").
+            // OpenRewrite's Java printer corrupts this annotation and silently skips this file during migration.
+            // Migrate this file manually. See: https://github.com/camunda/camunda-7-to-8-migration-tooling/issues/1548
+            @Profile("!prod")
+            public class ComponentB {
+            }
+            """,
+            spec -> spec.path("src/main/java/org/example/MultiProfile.java")));
   }
 
   @Test

--- a/code-conversion/recipes/src/test/java/io/camunda/migration/code/recipes/sharedRecipes/WarnSpringProfileNegationTest.java
+++ b/code-conversion/recipes/src/test/java/io/camunda/migration/code/recipes/sharedRecipes/WarnSpringProfileNegationTest.java
@@ -192,4 +192,60 @@ class WarnSpringProfileNegationTest implements RewriteTest {
             """,
             spec -> spec.path("src/main/java/org/example/Inline.java")));
   }
+
+  @Test
+  void addsCommentBeforeArrayFormProfileNegation() {
+    rewriteRun(
+        text(
+            """
+            package org.example;
+
+            @Profile({"!test"})
+            public class ArrayProfile {
+            }
+            """,
+            """
+            package org.example;
+
+            // TODO: Manual migration required - @Profile annotation with negation syntax ("!...").
+            // OpenRewrite's Java printer corrupts this annotation and silently skips this file during migration.
+            // Migrate this file manually. See: https://github.com/camunda/camunda-7-to-8-migration-tooling/issues/1548
+            @Profile({"!test"})
+            public class ArrayProfile {
+            }
+            """,
+            spec -> spec.path("src/main/java/org/example/ArrayProfile.java")));
+  }
+
+  @Test
+  void isIdempotentWhenBlankLineSeparatesTodo() {
+    String withBlankLine =
+        """
+        package org.example;
+
+        // TODO: Manual migration required - @Profile annotation with negation syntax ("!...").
+        // OpenRewrite's Java printer corrupts this annotation and silently skips this file during migration.
+        // Migrate this file manually. See: https://github.com/camunda/camunda-7-to-8-migration-tooling/issues/1548
+
+        @Profile("!test")
+        public class SampleClass {
+        }
+        """;
+    rewriteRun(
+        text(withBlankLine, spec -> spec.path("src/main/java/org/example/SampleClass.java")));
+  }
+
+  @Test
+  void preservesCrlfLineEndings() {
+    String crlfBefore = "@Profile(\"!test\")\r\npublic class CrlfClass {\r\n}\r\n";
+    String crlfAfter =
+        "// TODO: Manual migration required - @Profile annotation with negation syntax (\"!...\").\r\n"
+            + "// OpenRewrite's Java printer corrupts this annotation and silently skips this file during migration.\r\n"
+            + "// Migrate this file manually. See: https://github.com/camunda/camunda-7-to-8-migration-tooling/issues/1548\r\n"
+            + "@Profile(\"!test\")\r\n"
+            + "public class CrlfClass {\r\n"
+            + "}\r\n";
+    rewriteRun(
+        text(crlfBefore, crlfAfter, spec -> spec.path("src/main/java/org/example/CrlfClass.java")));
+  }
 }

--- a/code-conversion/recipes/src/test/java/io/camunda/migration/code/recipes/sharedRecipes/WarnSpringProfileNegationTest.java
+++ b/code-conversion/recipes/src/test/java/io/camunda/migration/code/recipes/sharedRecipes/WarnSpringProfileNegationTest.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.migration.code.recipes.sharedRecipes;
+
+import static org.openrewrite.test.SourceSpecs.text;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+class WarnSpringProfileNegationTest implements RewriteTest {
+
+  @Override
+  public void defaults(RecipeSpec spec) {
+    spec.recipe(new WarnSpringProfileNegationRecipe());
+  }
+
+  @Test
+  void addsCommentBeforeProfileNegationAnnotation() {
+    rewriteRun(
+        text(
+            """
+            package org.example;
+
+            import org.springframework.context.annotation.Profile;
+            import org.springframework.stereotype.Component;
+
+            @Component
+            @Profile("!test")
+            public class SampleProcessStarter {
+            }
+            """,
+            """
+            package org.example;
+
+            import org.springframework.context.annotation.Profile;
+            import org.springframework.stereotype.Component;
+
+            @Component
+            // TODO: Manual migration required - @Profile annotation with negation syntax ("!...").
+            // OpenRewrite's Java printer corrupts this annotation and silently skips this file during migration.
+            // Migrate this file manually. See: https://github.com/camunda/camunda-7-to-8-migration-tooling/issues/1548
+            @Profile("!test")
+            public class SampleProcessStarter {
+            }
+            """,
+            spec -> spec.path("src/main/java/org/example/SampleProcessStarter.java")));
+  }
+
+  @Test
+  void addsCommentBeforeEachProfileNegationInFile() {
+    rewriteRun(
+        text(
+            """
+            package org.example;
+
+            @Profile("!test")
+            public class ComponentA {
+            }
+
+            @Profile("!prod")
+            public class ComponentB {
+            }
+            """,
+            """
+            package org.example;
+
+            // TODO: Manual migration required - @Profile annotation with negation syntax ("!...").
+            // OpenRewrite's Java printer corrupts this annotation and silently skips this file during migration.
+            // Migrate this file manually. See: https://github.com/camunda/camunda-7-to-8-migration-tooling/issues/1548
+            @Profile("!test")
+            public class ComponentA {
+            }
+
+            // TODO: Manual migration required - @Profile annotation with negation syntax ("!...").
+            // OpenRewrite's Java printer corrupts this annotation and silently skips this file during migration.
+            // Migrate this file manually. See: https://github.com/camunda/camunda-7-to-8-migration-tooling/issues/1548
+            @Profile("!prod")
+            public class ComponentB {
+            }
+            """,
+            spec -> spec.path("src/main/java/org/example/MultiProfile.java")));
+  }
+
+  @Test
+  void isIdempotent() {
+    String alreadyAnnotated =
+        """
+        package org.example;
+
+        @Component
+        // TODO: Manual migration required - @Profile annotation with negation syntax ("!...").
+        // OpenRewrite's Java printer corrupts this annotation and silently skips this file during migration.
+        // Migrate this file manually. See: https://github.com/camunda/camunda-7-to-8-migration-tooling/issues/1548
+        @Profile("!test")
+        public class SampleClass {
+        }
+        """;
+    rewriteRun(
+        text(alreadyAnnotated, spec -> spec.path("src/main/java/org/example/SampleClass.java")));
+  }
+
+  @Test
+  void doesNotModifyFileWithoutProfileNegation() {
+    rewriteRun(
+        text(
+            """
+            package org.example;
+
+            import org.springframework.context.annotation.Profile;
+            import org.springframework.stereotype.Component;
+
+            @Component
+            @Profile("prod")
+            public class ProductionBean {
+            }
+            """,
+            spec -> spec.path("src/main/java/org/example/ProductionBean.java")));
+  }
+
+  @Test
+  void doesNotModifyNonJavaFile() {
+    rewriteRun(
+        text(
+            """
+            some.property=@Profile("!test")
+            """,
+            spec -> spec.path("src/main/resources/application.properties")));
+  }
+
+  @Test
+  void handlesInlinedAnnotation() {
+    rewriteRun(
+        text(
+            """
+            package org.example;
+
+            @Component @Profile("!test") public class Inline {
+            }
+            """,
+            """
+            package org.example;
+
+            // TODO: Manual migration required - @Profile annotation with negation syntax ("!...").
+            // OpenRewrite's Java printer corrupts this annotation and silently skips this file during migration.
+            // Migrate this file manually. See: https://github.com/camunda/camunda-7-to-8-migration-tooling/issues/1548
+            @Component @Profile("!test") public class Inline {
+            }
+            """,
+            spec -> spec.path("src/main/java/org/example/Inline.java")));
+  }
+}


### PR DESCRIPTION
## Summary

- OpenRewrite's Java printer corrupts `@Profile("!...")` string literals, triggering the print-idempotency safety check and **silently excluding the entire file** from all recipe rewrites
- Users received only a cryptic warning with no indication of which files were affected or what to do next
- Adds `WarnSpringProfileNegationRecipe` — a `PlainTextVisitor`-based recipe that bypasses the Java parser entirely and inserts an actionable TODO comment before each affected annotation

## Changes

- **`WarnSpringProfileNegationRecipe.java`** (`sharedRecipes/`): new recipe — scans `.java` files as plain text, detects `@Profile("!...` pattern, inserts a TODO comment block with a link to #1548 and manual migration instructions; idempotent (skips files already annotated)
- **`WarnSpringProfileNegationTest.java`**: 6 test cases covering single annotation, multiple annotations in one file, idempotency, no-op on files without the pattern, no-op on non-Java files, and inline annotation
- **`clientRecipes.yml`**: added to `AllClientMigrateRecipes` alongside `DetectHistoryServiceUsageRecipe`

## Why PlainTextVisitor?

OpenRewrite's print-idempotency check runs **before** any recipe visitor. Files that fail it are excluded from all Java recipe processing — including detection recipes. A `PlainTextVisitor` operates on the raw file content, bypassing the Java parser entirely, so it can still reach these files and leave a visible TODO.

## Test plan

- [x] `mvn test -pl code-conversion/recipes` passes (58 tests, 0 failures)
- [x] `RecipeDependencyConfigTest` passes (YAML references are valid)
- [x] New `WarnSpringProfileNegationTest` — 6 tests, all green

## Baseline

Built from commit: 344e790d6cbee293803d47d174c0a2a0f25ba389

closes #1548

🤖 Generated with [Claude Code](https://claude.com/claude-code)