### PR TITLE
fix(security): bump tomcat-embed to 10.1.56 (CVE-2026-55955, CVE-2026-53434) (maintenance/0.2)

### DIFF
--- a/diagram-converter/pom.xml
+++ b/diagram-converter/pom.xml
@@ -54,6 +54,22 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
+      <!-- CVE-2026-55955: pin tomcat-embed to 10.1.56 ahead of Spring Boot BOM -->
+      <dependency>
+        <groupId>org.apache.tomcat.embed</groupId>
+        <artifactId>tomcat-embed-core</artifactId>
+        <version>${tomcat.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.tomcat.embed</groupId>
+        <artifactId>tomcat-embed-el</artifactId>
+        <version>${tomcat.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.tomcat.embed</groupId>
+        <artifactId>tomcat-embed-websocket</artifactId>
+        <version>${tomcat.version}</version>
+      </dependency>
       <dependency>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-dependencies</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,7 @@
     <camunda8.docker.image>camunda/camunda:${version.camunda-8}</camunda8.docker.image>
     <version.elasticsearch>8.19.6</version.elasticsearch>
     <version.spring-boot>3.5.16</version.spring-boot>
+    <tomcat.version>10.1.56</tomcat.version>
     <logback.version>1.5.37</logback.version>
     <version.assertj>3.27.7</version.assertj>
     <version.junit.jupiter>6.0.3</version.junit.jupiter>


### PR DESCRIPTION
## Summary
- Pins `tomcat.version=10.1.56` in root pom to address CVE-2026-55955 (Improper Authentication in Apache Tomcat EncryptionInterceptor cluster component)
- Also addresses CVE-2026-53434 (Detection of Error Condition Without Action when configuring CRLs for FFM based connector); trigger (FFM connector + CRL config) is never configured in this repo so actual exploitability is nil
- SCA hygiene: branch had affected version (10.1.55); trigger for both CVEs is never configured in this repo so actual exploitability is nil
- Fixed version: tomcat-embed-core 10.1.56

Note: due to Maven BOM import scoping, the `tomcat.version` property alone is not picked up by the Spring Boot BOM&#39;s internal property resolution. Explicit `dependencyManagement` entries for `tomcat-embed-core`, `tomcat-embed-el`, and `tomcat-embed-websocket` were added in `diagram-converter/pom.xml` ahead of the Spring Boot BOM import to ensure the override takes effect.

## Test plan
- [ ] `mvn dependency:tree -Dincludes=org.apache.tomcat.embed: -pl diagram-converter/webapp -am` shows `tomcat-embed-core:jar:10.1.56`