### PR TITLE
ci: increase it-runtime-h2 shard timeout to 40min

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -324,7 +324,7 @@ jobs:
   it-runtime-h2:
     needs: [detect-changes]
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 40
     # Split the runtime suite into 4 parallel shards (was 1 serial job, ~53 min).
     # Each shard name matches its Maven profile (runtime-<shard>) and describes
     # the sub-set of test packages it covers.


### PR DESCRIPTION
## Summary
- Bumps `timeout-minutes` for `it-runtime-h2` from 30 → 40
- The `core` shard (catch-all for new packages) regularly runs in ~26–30 min; the 30-min limit leaves no headroom and causes sporadic cancellations when CI runners are under load
- Observed on PRs #1642 and #1643: all tests passed but the job was killed during post-run cleanup

## Test plan
- [ ] `it-runtime-h2` shards complete without cancellation