### PR TITLE
feat(history)[0.2 backport]: add configurable legacy definition ID prefix (#1633)

### DIFF
--- a/data-migrator/assembly/resources/application.yml
+++ b/data-migrator/assembly/resources/application.yml
@@ -64,6 +64,15 @@ camunda:
     ## Note: This property must be set to 'true' when using the Cockpit plugin.
     ## Find more information about the Cockpit plugin here: https://docs.camunda.io/docs/next/guides/migrating-from-camunda-7/data-migrator/cockpit-plugin/
     #save-skip-reason: false
+    #
+    ## Prefix prepended to migrated Camunda 7 historical definition IDs (process, decision and
+    ## form definitions). Prefixing avoids ID collisions between migrated history definitions and
+    ## native Camunda 8 definitions that share the same ID. Default: c7-legacy-
+    ## Warning: changing or removing the prefix can cause collisions/consistency issues if you
+    ## deploy Camunda 8 resources with the same IDs. Only change it if you understand the risk.
+    ## Allowed: starts with a letter or underscore, then letters, digits, '.', '-' or '_';
+    ## max 100 characters. A blank value is rejected - remove the property to use the default.
+    #legacy-id-prefix: c7-legacy-
 
     ## Camunda 7 configuration
     c7:

--- a/data-migrator/core/src/main/java/io/camunda/migration/data/config/MigratorAutoConfiguration.java
+++ b/data-migrator/core/src/main/java/io/camunda/migration/data/config/MigratorAutoConfiguration.java
@@ -28,6 +28,7 @@ import io.camunda.migration.data.impl.clients.C8Client;
 import io.camunda.migration.data.impl.clients.DbClient;
 import io.camunda.migration.data.impl.VariableService;
 import io.camunda.migration.data.impl.RuntimeValidator;
+import io.camunda.migration.data.impl.util.LegacyIdPrefixResolver;
 import java.util.Optional;
 import javax.sql.DataSource;
 import liquibase.integration.spring.SpringLiquibase;
@@ -65,6 +66,7 @@ import org.springframework.transaction.PlatformTransactionManager;
     RuntimeValidator.class,
     HistoryMigrator.class,
     RuntimeMigrator.class,
+    LegacyIdPrefixResolver.class,
     SchemaShutdownCleaner.class
 })
 @Configuration

--- a/data-migrator/core/src/main/java/io/camunda/migration/data/config/property/MigratorProperties.java
+++ b/data-migrator/core/src/main/java/io/camunda/migration/data/config/property/MigratorProperties.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.migration.data.config.property;
 
+import io.camunda.migration.data.config.property.history.HistoryProperties;
 import java.util.List;
 import java.util.Set;
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -38,6 +39,8 @@ public class MigratorProperties {
   protected C7Properties c7;
   protected C8Properties c8;
 
+  protected HistoryProperties history;
+
   protected List<InterceptorConfig> interceptors;
 
   public int getPageSize() {
@@ -62,6 +65,14 @@ public class MigratorProperties {
 
   public void setC8(C8Properties c8) {
     this.c8 = c8;
+  }
+
+  public HistoryProperties getHistory() {
+    return history;
+  }
+
+  public void setHistory(HistoryProperties history) {
+    this.history = history;
   }
 
   public Boolean getAutoDdl() {

--- a/data-migrator/core/src/main/java/io/camunda/migration/data/config/property/history/HistoryProperties.java
+++ b/data-migrator/core/src/main/java/io/camunda/migration/data/config/property/history/HistoryProperties.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.migration.data.config.property.history;
+
+/**
+ * Configuration properties for history migration.
+ */
+public class HistoryProperties {
+
+  /**
+   * Prefix prepended to Camunda 7 historical definition IDs (process, decision and form
+   * definitions) when they are migrated to Camunda 8.
+   * <p>
+   * Prefixing avoids collisions between migrated history definitions and native Camunda 8
+   * definitions that share the same ID. When {@code null} (not configured) the default
+   * {@code c7-legacy-} is used. When explicitly configured the value is validated: it must not be
+   * blank, must not exceed the maximum length and may only contain characters that keep the
+   * resulting definition IDs valid. Resolution and validation are handled by
+   * {@code io.camunda.migration.data.impl.util.LegacyIdPrefixResolver}.
+   */
+  protected String legacyIdPrefix;
+
+  public String getLegacyIdPrefix() {
+    return legacyIdPrefix;
+  }
+
+  public void setLegacyIdPrefix(String legacyIdPrefix) {
+    this.legacyIdPrefix = legacyIdPrefix;
+  }
+
+}

--- a/data-migrator/core/src/main/java/io/camunda/migration/data/constants/MigratorConstants.java
+++ b/data-migrator/core/src/main/java/io/camunda/migration/data/constants/MigratorConstants.java
@@ -20,4 +20,27 @@ public final class MigratorConstants {
 
   public static final String LEGACY_ID_VAR_NAME = "legacyId";
   public static final String C8_DEFAULT_TENANT = "<default>";
+  public static final String C7_LEGACY_PREFIX = "c7-legacy";
+
+  /**
+   * Default prefix prepended to Camunda 7 historical definition IDs (process, decision and form
+   * definitions) during migration to Camunda 8. Prefixing avoids collisions between migrated
+   * history definitions and native Camunda 8 definitions sharing the same ID. Configurable via
+   * {@code camunda.migrator.history.legacy-id-prefix}.
+   */
+  public static final String DEFAULT_LEGACY_ID_PREFIX = C7_LEGACY_PREFIX + "-";
+  public static final String C7_MULTI_INSTANCE_BODY_SUFFIX = "#multiInstanceBody";
+
+  /**
+   * Substituted for {@code null} on free-form identifier columns whose C8 contract is non-null
+   * (e.g. {@code AuditLogEntity.entityKey} for entity-less audit log rows). Applies wherever the
+   * migrator would otherwise emit {@code null}
+   */
+  public static final String C7_NULL_PLACEHOLDER = "C7_MIGRATED";
+
+  /**
+   * Sentinel value for IncidentEntity.errorMessage when the C7 incident message was null.
+   * C8 enforces non-null on this field, so we substitute this placeholder to avoid NPEs.
+   */
+  public static final String C7_NO_MESSAGE = "C7_NO_MESSAGE";
 }

--- a/data-migrator/core/src/main/java/io/camunda/migration/data/impl/interceptor/history/entity/DecisionDefinitionTransformer.java
+++ b/data-migrator/core/src/main/java/io/camunda/migration/data/impl/interceptor/history/entity/DecisionDefinitionTransformer.java
@@ -12,16 +12,21 @@ import static io.camunda.migration.data.impl.util.ConverterUtil.getTenantId;
 
 import io.camunda.db.rdbms.write.domain.DecisionDefinitionDbModel;
 import io.camunda.migration.data.exception.EntityInterceptorException;
+import io.camunda.migration.data.impl.util.LegacyIdPrefixResolver;
 import io.camunda.migration.data.interceptor.EntityInterceptor;
 import io.camunda.migration.data.interceptor.property.EntityConversionContext;
 import java.util.Set;
 import org.camunda.bpm.engine.repository.DecisionDefinition;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
 
 @Order(10)
 @Component
 public class DecisionDefinitionTransformer implements EntityInterceptor {
+
+  @Autowired
+  protected LegacyIdPrefixResolver legacyIdPrefix;
 
   @Override
   public Set<Class<?>> getTypes() {
@@ -40,10 +45,16 @@ public class DecisionDefinitionTransformer implements EntityInterceptor {
 
     builder.decisionDefinitionKey(getNextKey())
         .name(c7DecisionDefinition.getName())
-        .decisionDefinitionId(c7DecisionDefinition.getKey())
+        .decisionDefinitionId(legacyIdPrefix.applyTo(c7DecisionDefinition.getKey()))
         .tenantId(getTenantId(c7DecisionDefinition.getTenantId()))
-        .version(c7DecisionDefinition.getVersion())
-        .decisionRequirementsId(c7DecisionDefinition.getDecisionRequirementsDefinitionKey());
+        .version(c7DecisionDefinition.getVersion());
+    // Only set decisionRequirementsId from the C7 source when the parent DRD exists. For
+    // standalone DMNs the migrator wires the synthetic DRD id onto the builder beforehand;
+    // skipping the set here preserves that value and keeps the field non-null on the C8 row.
+    String c7DrdKey = c7DecisionDefinition.getDecisionRequirementsDefinitionKey();
+    if (c7DrdKey != null) {
+      builder.decisionRequirementsId(legacyIdPrefix.applyTo(c7DrdKey));
+    }
     // Note: decisionRequirementsKey is set externally
   }
 }

--- a/data-migrator/core/src/main/java/io/camunda/migration/data/impl/interceptor/history/entity/DecisionInstanceTransformer.java
+++ b/data-migrator/core/src/main/java/io/camunda/migration/data/impl/interceptor/history/entity/DecisionInstanceTransformer.java
@@ -16,6 +16,7 @@ import io.camunda.db.rdbms.write.domain.DecisionInstanceDbModel;
 import io.camunda.search.entities.DecisionInstanceEntity;
 import io.camunda.migration.data.impl.VariableService;
 import io.camunda.migration.data.exception.EntityInterceptorException;
+import io.camunda.migration.data.impl.util.LegacyIdPrefixResolver;
 import io.camunda.migration.data.interceptor.EntityInterceptor;
 import io.camunda.migration.data.interceptor.property.EntityConversionContext;
 import java.util.List;
@@ -34,6 +35,9 @@ public class DecisionInstanceTransformer implements EntityInterceptor {
 
   @Autowired
   protected VariableService variableService;
+
+  @Autowired
+  protected LegacyIdPrefixResolver legacyIdPrefix;
 
   @Override
   public Set<Class<?>> getTypes() {
@@ -55,9 +59,9 @@ public class DecisionInstanceTransformer implements EntityInterceptor {
         .evaluationDate(convertDate(decisionInstance.getEvaluationTime()))
         .evaluationFailure(null) // not stored in HistoricDecisionInstance
         .evaluationFailureMessage(null) // not stored in HistoricDecisionInstance
-        .processDefinitionId(decisionInstance.getProcessDefinitionKey())
-        .decisionDefinitionId(decisionInstance.getDecisionDefinitionKey())
-        .decisionRequirementsId(decisionInstance.getDecisionRequirementsDefinitionKey())
+        .processDefinitionId(legacyIdPrefix.applyTo(decisionInstance.getProcessDefinitionKey()))
+        .decisionDefinitionId(legacyIdPrefix.applyTo(decisionInstance.getDecisionDefinitionKey()))
+        .decisionRequirementsId(legacyIdPrefix.applyTo(decisionInstance.getDecisionRequirementsDefinitionKey()))
         .result(null)
         .tenantId(getTenantId(decisionInstance.getTenantId()))
         .historyCleanupDate(convertDate(decisionInstance.getRemovalTime()))

--- a/data-migrator/core/src/main/java/io/camunda/migration/data/impl/interceptor/history/entity/DecisionRequirementsDefinitionTransformer.java
+++ b/data-migrator/core/src/main/java/io/camunda/migration/data/impl/interceptor/history/entity/DecisionRequirementsDefinitionTransformer.java
@@ -13,12 +13,22 @@ import static io.camunda.migration.data.impl.util.ConverterUtil.getTenantId;
 import io.camunda.db.rdbms.write.domain.DecisionRequirementsDbModel;
 import io.camunda.migration.data.exception.EntityInterceptorException;
 import io.camunda.migration.data.impl.clients.C7Client;
+import io.camunda.migration.data.impl.util.LegacyIdPrefixResolver;
 import io.camunda.migration.data.interceptor.EntityInterceptor;
 import io.camunda.migration.data.interceptor.property.EntityConversionContext;
 import org.camunda.bpm.engine.repository.DecisionRequirementsDefinition;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Set;
+import org.camunda.bpm.model.dmn.Dmn;
+import org.camunda.bpm.model.dmn.DmnModelInstance;
+import org.camunda.bpm.model.xml.instance.DomDocument;
+import org.camunda.bpm.model.xml.instance.DomElement;
 import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
 
@@ -26,8 +36,19 @@ import org.springframework.stereotype.Component;
 @Component
 public class DecisionRequirementsDefinitionTransformer implements EntityInterceptor {
 
+  public static final String REQUIRED_DECISION = "requiredDecision";
+  public static final String DECISION = "decision";
+  public static final String DI_DMN_ELEMENT_REF = "dmnElementRef";
+  public static final String DI_DMN_SHAPE = "DMNShape";
+  public static final String ID = "id";
+  public static final String HREF = "href";
+  public static final String HASH = "#";
+
   @Autowired
   protected C7Client c7Client;
+
+  @Autowired
+  protected LegacyIdPrefixResolver legacyIdPrefix;
 
   @Override
   public Set<Class<?>> getTypes() {
@@ -46,15 +67,105 @@ public class DecisionRequirementsDefinitionTransformer implements EntityIntercep
 
     String deploymentId = c7DecisionRequirements.getDeploymentId();
     String resourceName = c7DecisionRequirements.getResourceName();
-    String dmnXml = c7Client.getResourceAsString(deploymentId, resourceName);
-
+    String rawDmnXml = c7Client.getResourceAsString(deploymentId, resourceName);
+    InputStream resourceAsStream = new ByteArrayInputStream(rawDmnXml.getBytes(StandardCharsets.UTF_8));
+    String dmnXml = prefixDecisionIdsInDmn(resourceAsStream);
 
     builder.decisionRequirementsKey(getNextKey())
-        .decisionRequirementsId(c7DecisionRequirements.getKey())
+        .decisionRequirementsId(legacyIdPrefix.applyTo(c7DecisionRequirements.getKey()))
         .name(c7DecisionRequirements.getName())
         .resourceName(resourceName)
         .version(c7DecisionRequirements.getVersion())
         .xml(dmnXml)
         .tenantId(getTenantId(c7DecisionRequirements.getTenantId()));
   }
+
+  /**
+   * Ensures that the Operate UI matches DRG evaluation badges correctly with the correct decision nodes.
+   * Prefix decision IDs with the configured legacy prefix and update requiredDecision href references
+   * so that decision IDs in the migrated DMN are properly prefixed.
+   *
+   * @param resourceAsStream the DMN model to modify
+   * @return the modified DMN XML as a string
+   */
+  protected String prefixDecisionIdsInDmn(InputStream resourceAsStream) {
+    DmnModelInstance dmnModelInstance = Dmn.readModelFromStream(resourceAsStream);
+
+    DomDocument document = dmnModelInstance.getDocument();
+    DomElement rootElement = document.getRootElement();
+
+    // Prefix all decision id attributes
+    prefixDecisionIds(rootElement);
+
+    // Update requiredDecision href attributes to reference the prefixed IDs
+    updateRequiredDecisionHrefs(rootElement);
+
+    // Update dmnElementRef attributes in DMNDI section to reference the prefixed IDs
+    updateDmnElementRefs(rootElement);
+
+    // Convert the modified DOM back to XML string
+    ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+    Dmn.writeModelToStream(outputStream, dmnModelInstance);
+    return outputStream.toString(Charset.defaultCharset());
+  }
+
+  /**
+   * Recursively find and prefix all decision id attributes.
+   */
+  protected void prefixDecisionIds(DomElement element) {
+    // Check if this is a decision element
+    if (DECISION.equals(element.getLocalName())) {
+      String id = element.getAttribute(ID);
+      if (id != null && !id.isEmpty() && !id.startsWith(legacyIdPrefix.getPrefix())) {
+        element.setAttribute(ID, legacyIdPrefix.applyTo(id));
+      }
+    }
+
+    // Recursively process child elements
+    for (DomElement child : element.getChildElements()) {
+      prefixDecisionIds(child);
+    }
+  }
+
+  /**
+   * Recursively find and update all requiredDecision href attributes to reference prefixed IDs.
+   */
+  protected void updateRequiredDecisionHrefs(DomElement element) {
+    // Check if this is a requiredDecision element
+    if (REQUIRED_DECISION.equals(element.getLocalName())) {
+      String href = element.getAttribute(HREF);
+      if (href != null && !href.isEmpty()) {
+        // href typically looks like "#decisionId", so we need to preserve the "#" prefix
+        if (href.startsWith(HASH) && !href.startsWith(HASH + legacyIdPrefix.getPrefix())) {
+          element.setAttribute(HREF, HASH + legacyIdPrefix.applyTo(href.substring(1)));
+        }
+      }
+    }
+
+    // Recursively process child elements
+    for (DomElement child : element.getChildElements()) {
+      updateRequiredDecisionHrefs(child);
+    }
+  }
+
+  /**
+   * Recursively find and update all dmnElementRef attributes in DMNShape elements to reference prefixed IDs.
+   * Note: Only DMNShape elements are processed, not DMNEdge elements.
+   */
+  protected void updateDmnElementRefs(DomElement element) {
+    // Only process dmnElementRef for DMNShape elements, not DMNEdge
+    if (DI_DMN_SHAPE.equals(element.getLocalName())) {
+      String dmnElementRef = element.getAttribute(DI_DMN_ELEMENT_REF);
+      if (dmnElementRef != null && !dmnElementRef.isEmpty() && !dmnElementRef.startsWith(legacyIdPrefix.getPrefix())) {
+        // dmnElementRef directly references the decision ID without "#" prefix
+        element.setAttribute(DI_DMN_ELEMENT_REF, legacyIdPrefix.applyTo(dmnElementRef));
+      }
+    }
+
+    // Recursively process child elements
+    for (DomElement child : element.getChildElements()) {
+      updateDmnElementRefs(child);
+    }
+  }
+
 }

--- a/data-migrator/core/src/main/java/io/camunda/migration/data/impl/interceptor/history/entity/FlowNodeTransformer.java
+++ b/data-migrator/core/src/main/java/io/camunda/migration/data/impl/interceptor/history/entity/FlowNodeTransformer.java
@@ -8,21 +8,27 @@
 package io.camunda.migration.data.impl.interceptor.history.entity;
 
 import static io.camunda.migration.data.impl.util.ConverterUtil.convertDate;
+import static io.camunda.migration.data.impl.util.ConverterUtil.getTenantId;
 import static io.camunda.search.entities.FlowNodeInstanceEntity.FlowNodeType;
 
 import io.camunda.db.rdbms.write.domain.FlowNodeInstanceDbModel;
 import io.camunda.migration.data.exception.EntityInterceptorException;
+import io.camunda.migration.data.impl.util.LegacyIdPrefixResolver;
 import io.camunda.migration.data.interceptor.EntityInterceptor;
 import io.camunda.migration.data.interceptor.property.EntityConversionContext;
 import java.util.Set;
 import org.camunda.bpm.engine.ActivityTypes;
 import org.camunda.bpm.engine.history.HistoricActivityInstance;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
 
 @Order(3)
 @Component
 public class FlowNodeTransformer implements EntityInterceptor {
+
+  @Autowired
+  protected LegacyIdPrefixResolver legacyIdPrefix;
 
   @Override
   public Set<Class<?>> getTypes() {
@@ -42,11 +48,11 @@ public class FlowNodeTransformer implements EntityInterceptor {
 
     builder
         .flowNodeId(flowNode.getActivityId())
-        .processDefinitionId(flowNode.getProcessDefinitionKey())
+        .processDefinitionId(legacyIdPrefix.applyTo(flowNode.getProcessDefinitionKey()))
         .startDate(convertDate(flowNode.getStartTime()))
         .endDate(convertDate(flowNode.getEndTime()))
         .type(convertType(flowNode.getActivityType()))
-        .tenantId(flowNode.getTenantId())
+        .tenantId(getTenantId(flowNode.getTenantId()))
         .state(null) // TODO: Doesn't exist in C7 activity instance. Inherited from process instance.
         .incidentKey(null) // TODO Doesn't exist in C7 activity instance.
         .numSubprocessIncidents(null); // TODO: increment/decrement when incident exist in subprocess. C8 RDBMS specific.

--- a/data-migrator/core/src/main/java/io/camunda/migration/data/impl/interceptor/history/entity/IncidentTransformer.java
+++ b/data-migrator/core/src/main/java/io/camunda/migration/data/impl/interceptor/history/entity/IncidentTransformer.java
@@ -9,12 +9,14 @@ package io.camunda.migration.data.impl.interceptor.history.entity;
 
 import io.camunda.db.rdbms.write.domain.IncidentDbModel;
 import io.camunda.migration.data.exception.EntityInterceptorException;
+import io.camunda.migration.data.impl.util.LegacyIdPrefixResolver;
 import io.camunda.migration.data.interceptor.EntityInterceptor;
 import io.camunda.migration.data.interceptor.property.EntityConversionContext;
 import io.camunda.search.entities.IncidentEntity;
 import org.camunda.bpm.engine.history.HistoricIncident;
 
 import java.util.Set;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
 
@@ -24,6 +26,9 @@ import static io.camunda.migration.data.impl.util.ConverterUtil.getNextKey;
 @Order(7)
 @Component
 public class IncidentTransformer implements EntityInterceptor {
+
+  @Autowired
+  protected LegacyIdPrefixResolver legacyIdPrefix;
 
   @Override
   public Set<Class<?>> getTypes() {
@@ -40,7 +45,7 @@ public class IncidentTransformer implements EntityInterceptor {
     }
 
     builder.incidentKey(getNextKey())
-        .processDefinitionId(historicIncident.getProcessDefinitionKey())
+        .processDefinitionId(legacyIdPrefix.applyTo(historicIncident.getProcessDefinitionKey()))
         .flowNodeId(historicIncident.getActivityId())
         .errorType(null) // TODO: does error type exist in C7?
         .errorMessage(historicIncident.getIncidentMessage())

--- a/data-migrator/core/src/main/java/io/camunda/migration/data/impl/interceptor/history/entity/ProcessDefinitionTransformer.java
+++ b/data-migrator/core/src/main/java/io/camunda/migration/data/impl/interceptor/history/entity/ProcessDefinitionTransformer.java
@@ -8,10 +8,12 @@
 package io.camunda.migration.data.impl.interceptor.history.entity;
 
 import static io.camunda.migration.data.impl.util.ConverterUtil.getNextKey;
+import static io.camunda.migration.data.impl.util.ConverterUtil.getTenantId;
 
 import io.camunda.db.rdbms.write.domain.ProcessDefinitionDbModel;
 import io.camunda.migration.data.exception.EntityInterceptorException;
 import io.camunda.migration.data.impl.clients.C7Client;
+import io.camunda.migration.data.impl.util.LegacyIdPrefixResolver;
 import io.camunda.migration.data.interceptor.EntityInterceptor;
 import io.camunda.migration.data.interceptor.property.EntityConversionContext;
 import java.util.Set;
@@ -26,6 +28,9 @@ public class ProcessDefinitionTransformer implements EntityInterceptor {
 
   @Autowired
   protected C7Client c7Client;
+
+  @Autowired
+  protected LegacyIdPrefixResolver legacyIdPrefix;
 
   @Override
   public Set<Class<?>> getTypes() {
@@ -49,7 +54,7 @@ public class ProcessDefinitionTransformer implements EntityInterceptor {
 
 
     builder.processDefinitionKey(getNextKey())
-        .processDefinitionId(c7ProcessDefinition.getKey())
+        .processDefinitionId(legacyIdPrefix.applyTo(c7ProcessDefinition.getKey()))
         .resourceName(resourceName)
         .name(c7ProcessDefinition.getName())
         .tenantId(c7ProcessDefinition.getTenantId())

--- a/data-migrator/core/src/main/java/io/camunda/migration/data/impl/interceptor/history/entity/ProcessInstanceTransformer.java
+++ b/data-migrator/core/src/main/java/io/camunda/migration/data/impl/interceptor/history/entity/ProcessInstanceTransformer.java
@@ -10,22 +10,29 @@ package io.camunda.migration.data.impl.interceptor.history.entity;
 import static io.camunda.migration.data.constants.MigratorConstants.C7_HISTORY_PARTITION_ID;
 import static io.camunda.migration.data.impl.util.ConverterUtil.convertDate;
 import static io.camunda.migration.data.impl.util.ConverterUtil.getNextKey;
+import static io.camunda.migration.data.impl.util.ConverterUtil.getTenantId;
 import static io.camunda.search.entities.ProcessInstanceEntity.ProcessInstanceState;
 
 import io.camunda.db.rdbms.write.domain.ProcessInstanceDbModel;
 import io.camunda.migration.data.constants.MigratorConstants;
 import io.camunda.migration.data.exception.EntityInterceptorException;
 import io.camunda.migration.data.impl.util.ConverterUtil;
+import io.camunda.migration.data.impl.util.LegacyIdPrefixResolver;
 import io.camunda.migration.data.interceptor.EntityInterceptor;
 import io.camunda.migration.data.interceptor.property.EntityConversionContext;
 import java.util.Set;
 import org.camunda.bpm.engine.history.HistoricProcessInstance;
+import org.jspecify.annotations.NonNull;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
 
 @Order(2)
 @Component
 public class ProcessInstanceTransformer implements EntityInterceptor {
+
+  @Autowired
+  protected LegacyIdPrefixResolver legacyIdPrefix;
 
   @Override
   public Set<Class<?>> getTypes() {
@@ -44,7 +51,7 @@ public class ProcessInstanceTransformer implements EntityInterceptor {
 
     builder.processInstanceKey(getNextKey())
         // Get key from runtime instance/model migration
-        .processDefinitionId(processInstance.getProcessDefinitionKey())
+        .processDefinitionId(legacyIdPrefix.applyTo(processInstance.getProcessDefinitionKey()))
         .startDate(convertDate(processInstance.getStartTime()))
         .endDate(convertDate(processInstance.getEndTime()))
         .state(convertState(processInstance.getState()))

--- a/data-migrator/core/src/main/java/io/camunda/migration/data/impl/interceptor/history/entity/UserTaskTransformer.java
+++ b/data-migrator/core/src/main/java/io/camunda/migration/data/impl/interceptor/history/entity/UserTaskTransformer.java
@@ -9,11 +9,13 @@ package io.camunda.migration.data.impl.interceptor.history.entity;
 
 import io.camunda.db.rdbms.write.domain.UserTaskDbModel;
 import io.camunda.migration.data.exception.EntityInterceptorException;
+import io.camunda.migration.data.impl.util.LegacyIdPrefixResolver;
 import io.camunda.migration.data.interceptor.EntityInterceptor;
 import io.camunda.migration.data.interceptor.property.EntityConversionContext;
 import org.camunda.bpm.engine.history.HistoricTaskInstance;
 
 import java.util.Set;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
 
@@ -25,6 +27,9 @@ import static io.camunda.migration.data.impl.util.ConverterUtil.getTenantId;
 @Order(4)
 @Component
 public class UserTaskTransformer implements EntityInterceptor {
+
+  @Autowired
+  protected LegacyIdPrefixResolver legacyIdPrefix;
 
   @Override
   public Set<Class<?>> getTypes() {
@@ -42,7 +47,7 @@ public class UserTaskTransformer implements EntityInterceptor {
 
     builder.userTaskKey(getNextKey())
         .elementId(historicTask.getTaskDefinitionKey())
-        .processDefinitionId(historicTask.getProcessDefinitionKey())
+        .processDefinitionId(legacyIdPrefix.applyTo(historicTask.getProcessDefinitionKey()))
         .creationDate(convertDate(historicTask.getStartTime()))
         .completionDate(convertDate(historicTask.getEndTime()))
         .assignee(historicTask.getAssignee())

--- a/data-migrator/core/src/main/java/io/camunda/migration/data/impl/interceptor/history/entity/VariableTransformer.java
+++ b/data-migrator/core/src/main/java/io/camunda/migration/data/impl/interceptor/history/entity/VariableTransformer.java
@@ -9,12 +9,13 @@ package io.camunda.migration.data.impl.interceptor.history.entity;
 
 import static io.camunda.migration.data.impl.util.ConverterUtil.convertDate;
 import static io.camunda.migration.data.impl.util.ConverterUtil.getNextKey;
+import static io.camunda.migration.data.impl.util.ConverterUtil.getTenantId;
 
 import io.camunda.db.rdbms.write.domain.VariableDbModel;
 import io.camunda.migration.data.constants.MigratorConstants;
 import io.camunda.migration.data.exception.EntityInterceptorException;
 import io.camunda.migration.data.impl.VariableService;
-import io.camunda.migration.data.impl.util.ConverterUtil;
+import io.camunda.migration.data.impl.util.LegacyIdPrefixResolver;
 import io.camunda.migration.data.interceptor.EntityInterceptor;
 import io.camunda.migration.data.interceptor.property.EntityConversionContext;
 import java.util.Set;
@@ -30,6 +31,9 @@ public class VariableTransformer implements EntityInterceptor {
 
   @Autowired
   protected VariableService variableService;
+
+  @Autowired
+  protected LegacyIdPrefixResolver legacyIdPrefix;
 
   @Override
   public Set<Class<?>> getTypes() {
@@ -49,8 +53,8 @@ public class VariableTransformer implements EntityInterceptor {
     builder.variableKey(getNextKey())
         .name(historicVariable.getName())
         .value(variableService.convertValue(historicVariable))
-        .processDefinitionId(historicVariable.getProcessDefinitionKey())
-        .tenantId(ConverterUtil.getTenantId(historicVariable.getTenantId()))
+        .processDefinitionId(legacyIdPrefix.applyTo(historicVariable.getProcessDefinitionKey()))
+        .tenantId(getTenantId(historicVariable.getTenantId()))
         .partitionId(MigratorConstants.C7_HISTORY_PARTITION_ID)
         .historyCleanupDate(convertDate(historicVariable.getRemovalTime()));
     // Note: processInstanceKey and scopeKey are set externally

--- a/data-migrator/core/src/main/java/io/camunda/migration/data/impl/logging/ConfigurationLogs.java
+++ b/data-migrator/core/src/main/java/io/camunda/migration/data/impl/logging/ConfigurationLogs.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.migration.data.impl.logging;
 
+import static io.camunda.migration.data.constants.MigratorConstants.DEFAULT_LEGACY_ID_PREFIX;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -24,12 +26,19 @@ public class ConfigurationLogs {
   public static final String ERROR_FAILED_TO_REGISTER = "Failed to register interceptor: ";
   public static final String ERROR_PARSING_CONFIGURATION = "An exception occurred while parsing interceptor configuration.";
   public static final String ERROR_C8_RDBMS_USER_CHAR_COLUMN_SIZE = "Could not determine userCharColumnSize for C8 database schema creation.";
+  public static final String C8_SCHEMA_PROPERTY_ERROR = "Could not determine property for C8 database schema creation.";
+  public static final String JDBC_DRIVER_CLASS_NOT_FOUND_ERROR = "Configured JDBC driver [{}] was not found on the classpath. Please make sure that the JDBC driver jar is in the configuration/userlib/ directory.";
+  public static final String INVALID_IDENTITY_PROPERTIES_ERROR = "Invalid property combination: skip-groups cannot be enabled if skip-users is disabled";
+  public static final String LEGACY_ID_PREFIX_BLANK_ERROR = "Invalid property camunda.migrator.history.legacy-id-prefix: the prefix must not be blank. Remove the property to use the default '%s', or configure a non-blank value.";
+  public static final String LEGACY_ID_PREFIX_TOO_LONG_ERROR = "Invalid property camunda.migrator.history.legacy-id-prefix '%s': the prefix must not exceed %d characters.";
+  public static final String LEGACY_ID_PREFIX_INVALID_CHARS_ERROR = "Invalid property camunda.migrator.history.legacy-id-prefix '%s': the prefix must start with a letter or underscore and may only contain letters, digits, '.', '-' and '_'.";
 
   // Info Messages
   public static final String INFO_CONFIGURING_INTERCEPTORS = "Configuring {} interceptors";
   public static final String INFO_TOTAL_INTERCEPTORS_CONFIGURED = "In total {} {} interceptors configured";
   public static final String INFO_SUCCESSFULLY_REGISTERED = "Successfully registered interceptor: {}";
   public static final String INFO_LIQUIBASE_CREATING_TABLE_SCHEMA = "Creating table schema with Liquibase change log file '{}' with table prefix '{}'.";
+  public static final String INFO_LEGACY_ID_PREFIX = "Using Camunda 7 legacy definition ID prefix '{}' for history migration.";
 
   // Debug Messages
   public static final String DEBUG_NO_INTERCEPTORS = "No interceptors configured in configuration file";
@@ -180,6 +189,39 @@ public class ConfigurationLogs {
    */
   public static String getC8RdbmsUserCharColumnSizeError() {
     return ERROR_C8_RDBMS_USER_CHAR_COLUMN_SIZE;
+  }
+
+  /**
+   * Logs the effective prefix applied to migrated Camunda 7 historical definition IDs.
+   *
+   * @param prefix the effective legacy ID prefix
+   */
+  public static void logEffectiveLegacyIdPrefix(String prefix) {
+    LOGGER.info(INFO_LEGACY_ID_PREFIX, prefix);
+  }
+
+  /**
+   * @return the error message for a blank legacy ID prefix.
+   */
+  public static String getLegacyIdPrefixBlankError() {
+    return String.format(LEGACY_ID_PREFIX_BLANK_ERROR, DEFAULT_LEGACY_ID_PREFIX);
+  }
+
+  /**
+   * @param prefix    the invalid prefix
+   * @param maxLength the maximum allowed length
+   * @return the error message for a legacy ID prefix that exceeds the maximum length.
+   */
+  public static String getLegacyIdPrefixTooLongError(String prefix, int maxLength) {
+    return String.format(LEGACY_ID_PREFIX_TOO_LONG_ERROR, prefix, maxLength);
+  }
+
+  /**
+   * @param prefix the invalid prefix
+   * @return the error message for a legacy ID prefix containing disallowed characters.
+   */
+  public static String getLegacyIdPrefixInvalidCharsError(String prefix) {
+    return String.format(LEGACY_ID_PREFIX_INVALID_CHARS_ERROR, prefix);
   }
 
 }

--- a/data-migrator/core/src/main/java/io/camunda/migration/data/impl/util/ConverterUtil.java
+++ b/data-migrator/core/src/main/java/io/camunda/migration/data/impl/util/ConverterUtil.java
@@ -16,7 +16,9 @@ import java.util.Date;
 import org.apache.commons.lang3.StringUtils;
 
 import static io.camunda.migration.data.constants.MigratorConstants.C7_HISTORY_PARTITION_ID;
+import static io.camunda.migration.data.constants.MigratorConstants.C7_MULTI_INSTANCE_BODY_SUFFIX;
 import static io.camunda.migration.data.constants.MigratorConstants.C8_DEFAULT_TENANT;
+import static io.camunda.migration.data.constants.MigratorConstants.DEFAULT_LEGACY_ID_PREFIX;
 import static io.camunda.zeebe.protocol.Protocol.KEY_BITS;
 
 public class ConverterUtil {
@@ -37,6 +39,33 @@ public class ConverterUtil {
 
   public static String getTenantId(String c7TenantId) {
     return StringUtils.isEmpty(c7TenantId) ? C8_DEFAULT_TENANT : c7TenantId;
+  }
+
+  /**
+   * Prefixes a Camunda 7 definition ID with the {@link io.camunda.migration.data.constants.MigratorConstants#DEFAULT_LEGACY_ID_PREFIX default}
+   * legacy prefix.
+   * <p>
+   * Production code migrates definition IDs through
+   * {@link io.camunda.migration.data.impl.util.LegacyIdPrefixResolver}, which honours the
+   * configurable {@code camunda.migrator.history.legacy-id-prefix} property. This helper always
+   * uses the default prefix and is retained for building expected values in tests running with the
+   * default configuration.
+   *
+   * @param definitionId the original Camunda 7 definition ID, may be null
+   * @return the prefixed definition ID, or null if the input was null
+   */
+  public static String prefixDefinitionId(String definitionId) {
+    if (definitionId == null) {
+      return null;
+    }
+    return DEFAULT_LEGACY_ID_PREFIX + definitionId;
+  }
+
+  /**
+   * Removes the multi-instance body suffix from the activity ID if present, as C8 does not use this convention for multi-instance activities.
+   */
+  public static String sanitizeFlowNodeId(String activityId) {
+    return activityId.replace(C7_MULTI_INSTANCE_BODY_SUFFIX, "");
   }
 
 }

--- a/data-migrator/core/src/main/java/io/camunda/migration/data/impl/util/LegacyIdPrefixResolver.java
+++ b/data-migrator/core/src/main/java/io/camunda/migration/data/impl/util/LegacyIdPrefixResolver.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.migration.data.impl.util;
+
+import static io.camunda.migration.data.constants.MigratorConstants.DEFAULT_LEGACY_ID_PREFIX;
+import static io.camunda.migration.data.impl.logging.ConfigurationLogs.getLegacyIdPrefixBlankError;
+import static io.camunda.migration.data.impl.logging.ConfigurationLogs.getLegacyIdPrefixInvalidCharsError;
+import static io.camunda.migration.data.impl.logging.ConfigurationLogs.getLegacyIdPrefixTooLongError;
+import static io.camunda.migration.data.impl.logging.ConfigurationLogs.logEffectiveLegacyIdPrefix;
+
+import io.camunda.migration.data.config.property.MigratorProperties;
+import io.camunda.migration.data.config.property.history.HistoryProperties;
+import java.util.regex.Pattern;
+
+/**
+ * Resolves, validates and applies the prefix prepended to Camunda 7 historical definition IDs
+ * (process, decision and form definitions) when they are migrated to Camunda 8.
+ * <p>
+ * This is the single place that owns the legacy ID prefix. All history migration components apply
+ * the prefix through {@link #applyTo(String)} instead of concatenating the prefix themselves, so the
+ * effective prefix stays consistent across every migrated definition type.
+ * <p>
+ * The prefix defaults to {@code c7-legacy-} and can be overridden with the
+ * {@code camunda.migrator.history.legacy-id-prefix} property. When explicitly configured the value
+ * is validated on startup and an invalid value fails fast:
+ * <ul>
+ *   <li>it must not be blank;</li>
+ *   <li>it must not exceed {@value #MAX_PREFIX_LENGTH} characters;</li>
+ *   <li>it must match {@link #ALLOWED_PREFIX_PATTERN}, i.e. start with an ASCII letter or underscore
+ *       and otherwise contain only ASCII letters, digits, {@code '.'}, {@code '-'} and {@code '_'}.
+ *       This keeps {@code prefix + <original definition id>} a valid XML NCName, which decision (DMN)
+ *       definition IDs are re-parsed as during migration.</li>
+ * </ul>
+ * Prefixing avoids collisions between migrated history definitions and native Camunda 8 definitions
+ * that share the same ID.
+ */
+public class LegacyIdPrefixResolver {
+
+  /**
+   * Maximum length allowed for the configured prefix. The prefix is prepended to the original
+   * Camunda 7 definition ID; the combined value must stay within Camunda 8's 255-character
+   * definition ID limit, so the prefix itself is capped well below that.
+   */
+  public static final int MAX_PREFIX_LENGTH = 100;
+
+  /**
+   * Allowed character set for the configured prefix. The value must start with an ASCII letter or
+   * underscore and may otherwise contain ASCII letters, digits, {@code '.'}, {@code '-'} and
+   * {@code '_'}.
+   */
+  public static final String ALLOWED_PREFIX_REGEX = "^[A-Za-z_][A-Za-z0-9._-]*$";
+
+  protected static final Pattern ALLOWED_PREFIX_PATTERN = Pattern.compile(ALLOWED_PREFIX_REGEX);
+
+  protected final String prefix;
+
+  public LegacyIdPrefixResolver(MigratorProperties migratorProperties) {
+    this.prefix = resolveAndValidate(configuredPrefix(migratorProperties));
+    logEffectiveLegacyIdPrefix(this.prefix);
+  }
+
+  protected static String configuredPrefix(MigratorProperties migratorProperties) {
+    HistoryProperties history = migratorProperties.getHistory();
+    return history == null ? null : history.getLegacyIdPrefix();
+  }
+
+  /**
+   * Resolves the effective prefix from the configured value, falling back to the default when it is
+   * not configured, and validates an explicitly configured value.
+   *
+   * @param configuredPrefix the raw configured prefix, or {@code null} when not configured
+   * @return the effective, validated prefix
+   * @throws IllegalArgumentException if an explicitly configured prefix is blank, too long, or
+   *                                  contains disallowed characters
+   */
+  protected static String resolveAndValidate(String configuredPrefix) {
+    if (configuredPrefix == null) {
+      return DEFAULT_LEGACY_ID_PREFIX;
+    }
+    if (configuredPrefix.isBlank()) {
+      throw new IllegalArgumentException(getLegacyIdPrefixBlankError());
+    }
+    if (configuredPrefix.length() > MAX_PREFIX_LENGTH) {
+      throw new IllegalArgumentException(getLegacyIdPrefixTooLongError(configuredPrefix, MAX_PREFIX_LENGTH));
+    }
+    if (!ALLOWED_PREFIX_PATTERN.matcher(configuredPrefix).matches()) {
+      throw new IllegalArgumentException(getLegacyIdPrefixInvalidCharsError(configuredPrefix));
+    }
+    return configuredPrefix;
+  }
+
+  /**
+   * @return the effective prefix, e.g. {@code c7-legacy-} by default.
+   */
+  public String getPrefix() {
+    return prefix;
+  }
+
+  /**
+   * Prepends the effective prefix to the given Camunda 7 definition ID.
+   *
+   * @param definitionId the original Camunda 7 definition ID, may be {@code null}
+   * @return the prefixed definition ID, or {@code null} if the input was {@code null}
+   */
+  public String applyTo(String definitionId) {
+    if (definitionId == null) {
+      return null;
+    }
+    return prefix + definitionId;
+  }
+}

--- a/data-migrator/core/src/main/java/io/camunda/migration/data/interceptor/EntityInterceptor.java
+++ b/data-migrator/core/src/main/java/io/camunda/migration/data/interceptor/EntityInterceptor.java
@@ -34,7 +34,10 @@ import io.camunda.migration.data.interceptor.property.EntityConversionContext;
  *     HistoricProcessInstance c7Instance = (HistoricProcessInstance) context.getC7Entity();
  *     ProcessInstanceDbModel.Builder c8Builder =
  *       (ProcessInstanceDbModel.Builder) context.getC8DbModelBuilder();
- *     // Custom conversion logic
+ *     // No casting needed! Prefix migrated definition IDs to avoid collisions with native
+ *     // Camunda 8 definitions - production transformers use LegacyIdPrefixResolver#applyTo,
+ *     // which honors the configurable camunda.migrator.history.legacy-id-prefix property.
+ *     c8Builder.processDefinitionId(legacyIdPrefix.applyTo(c7Instance.getProcessDefinitionKey()));
  *   }
  * }
  * </pre>
@@ -123,4 +126,3 @@ public interface EntityInterceptor extends BaseInterceptor<EntityConversionConte
   default void presetParentProperties(EntityConversionContext<?, ?> context) {
   }
 }
-

--- a/data-migrator/core/src/test/java/io/camunda/migration/data/LegacyIdPrefixConfigurationTest.java
+++ b/data-migrator/core/src/test/java/io/camunda/migration/data/LegacyIdPrefixConfigurationTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.migration.data;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.migration.data.config.property.MigratorProperties;
+import io.camunda.migration.data.impl.util.LegacyIdPrefixResolver;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
+
+class LegacyIdPrefixConfigurationTest {
+
+  @Nested
+  @SpringBootTest
+  class DefaultPrefixTest {
+
+    @Autowired
+    protected LegacyIdPrefixResolver legacyIdPrefix;
+
+    @Test
+    public void shouldUseDefaultPrefixWhenNotConfigured() {
+      assertThat(legacyIdPrefix.getPrefix()).isEqualTo("c7-legacy-");
+      assertThat(legacyIdPrefix.applyTo("invoice")).isEqualTo("c7-legacy-invoice");
+    }
+  }
+
+  @Nested
+  @SpringBootTest
+  @TestPropertySource(properties = {
+      "camunda.migrator.history.legacy-id-prefix=acme-legacy-"
+  })
+  class CustomPrefixTest {
+
+    @Autowired
+    protected MigratorProperties migratorProperties;
+
+    @Autowired
+    protected LegacyIdPrefixResolver legacyIdPrefix;
+
+    @Test
+    public void shouldBindConfiguredPrefix() {
+      assertThat(migratorProperties.getHistory().getLegacyIdPrefix()).isEqualTo("acme-legacy-");
+    }
+
+    @Test
+    public void shouldApplyConfiguredPrefix() {
+      assertThat(legacyIdPrefix.getPrefix()).isEqualTo("acme-legacy-");
+      assertThat(legacyIdPrefix.applyTo("invoice")).isEqualTo("acme-legacy-invoice");
+    }
+  }
+}

--- a/data-migrator/core/src/test/java/io/camunda/migration/data/history/LegacyIdPrefixResolverTest.java
+++ b/data-migrator/core/src/test/java/io/camunda/migration/data/history/LegacyIdPrefixResolverTest.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.migration.data.history;
+
+import static io.camunda.migration.data.constants.MigratorConstants.DEFAULT_LEGACY_ID_PREFIX;
+import static io.camunda.migration.data.impl.util.LegacyIdPrefixResolver.MAX_PREFIX_LENGTH;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.migration.data.config.property.MigratorProperties;
+import io.camunda.migration.data.config.property.history.HistoryProperties;
+import io.camunda.migration.data.impl.util.LegacyIdPrefixResolver;
+import org.junit.jupiter.api.Test;
+
+class LegacyIdPrefixResolverTest {
+
+  @Test
+  void shouldUseDefaultPrefixWhenHistoryNotConfigured() {
+    // given a configuration without a history block
+    LegacyIdPrefixResolver resolver = resolver(new MigratorProperties());
+
+    // then
+    assertThat(resolver.getPrefix()).isEqualTo(DEFAULT_LEGACY_ID_PREFIX);
+  }
+
+  @Test
+  void shouldUseDefaultPrefixWhenNotConfigured() {
+    // given a history block without an explicit prefix
+    LegacyIdPrefixResolver resolver = resolver(withPrefix(null));
+
+    // then
+    assertThat(resolver.getPrefix()).isEqualTo(DEFAULT_LEGACY_ID_PREFIX);
+  }
+
+  @Test
+  void shouldUseConfiguredPrefix() {
+    // given
+    LegacyIdPrefixResolver resolver = resolver(withPrefix("acme-legacy-"));
+
+    // then
+    assertThat(resolver.getPrefix()).isEqualTo("acme-legacy-");
+  }
+
+  @Test
+  void shouldApplyPrefixToDefinitionId() {
+    // given
+    LegacyIdPrefixResolver resolver = resolver(withPrefix("acme-"));
+
+    // then
+    assertThat(resolver.applyTo("invoice")).isEqualTo("acme-invoice");
+  }
+
+  @Test
+  void shouldApplyDefaultPrefixToDefinitionId() {
+    // given
+    LegacyIdPrefixResolver resolver = resolver(new MigratorProperties());
+
+    // then
+    assertThat(resolver.applyTo("invoice")).isEqualTo("c7-legacy-invoice");
+  }
+
+  @Test
+  void shouldReturnNullWhenApplyingToNullDefinitionId() {
+    // given
+    LegacyIdPrefixResolver resolver = resolver(withPrefix("acme-"));
+
+    // then
+    assertThat(resolver.applyTo(null)).isNull();
+  }
+
+  @Test
+  void shouldAcceptPrefixWithAllowedCharacters() {
+    // given / then: leading underscore, dots, digits, hyphens and underscores are allowed
+    assertThat(resolver(withPrefix("_c7.legacy-2_")).getPrefix()).isEqualTo("_c7.legacy-2_");
+    assertThat(resolver(withPrefix("Legacy")).getPrefix()).isEqualTo("Legacy");
+  }
+
+  @Test
+  void shouldAcceptPrefixAtMaximumLength() {
+    // given a prefix of exactly the maximum allowed length
+    String maxPrefix = "a".repeat(MAX_PREFIX_LENGTH);
+
+    // then
+    assertThat(resolver(withPrefix(maxPrefix)).getPrefix()).isEqualTo(maxPrefix);
+  }
+
+  @Test
+  void shouldRejectEmptyPrefix() {
+    assertThatThrownBy(() -> resolver(withPrefix("")))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("legacy-id-prefix")
+        .hasMessageContaining("must not be blank");
+  }
+
+  @Test
+  void shouldRejectBlankPrefix() {
+    assertThatThrownBy(() -> resolver(withPrefix("   ")))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("must not be blank");
+  }
+
+  @Test
+  void shouldRejectPrefixExceedingMaximumLength() {
+    // given a prefix one character longer than the maximum
+    String tooLong = "a".repeat(MAX_PREFIX_LENGTH + 1);
+
+    assertThatThrownBy(() -> resolver(withPrefix(tooLong)))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("must not exceed");
+  }
+
+  @Test
+  void shouldRejectPrefixStartingWithDigit() {
+    assertThatThrownBy(() -> resolver(withPrefix("7legacy-")))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("must start with a letter or underscore");
+  }
+
+  @Test
+  void shouldRejectPrefixStartingWithHyphen() {
+    assertThatThrownBy(() -> resolver(withPrefix("-legacy-")))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("must start with a letter or underscore");
+  }
+
+  @Test
+  void shouldRejectPrefixWithWhitespace() {
+    assertThatThrownBy(() -> resolver(withPrefix("c7 legacy-")))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  void shouldRejectPrefixWithDisallowedSymbols() {
+    assertThatThrownBy(() -> resolver(withPrefix("legacy!")))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  protected static LegacyIdPrefixResolver resolver(MigratorProperties properties) {
+    return new LegacyIdPrefixResolver(properties);
+  }
+
+  protected static MigratorProperties withPrefix(String prefix) {
+    MigratorProperties properties = new MigratorProperties();
+    HistoryProperties history = new HistoryProperties();
+    history.setLegacyIdPrefix(prefix);
+    properties.setHistory(history);
+    return properties;
+  }
+}

--- a/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/history/entity/CustomLegacyIdPrefixHistoryTest.java
+++ b/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/history/entity/CustomLegacyIdPrefixHistoryTest.java
@@ -1,0 +1,264 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.migration.data.qa.history.entity;
+
+import static io.camunda.migration.data.constants.MigratorConstants.DEFAULT_LEGACY_ID_PREFIX;
+import static io.camunda.migration.data.impl.persistence.IdKeyMapper.TYPE.HISTORY_FLOW_NODE;
+import static io.camunda.migration.data.impl.persistence.IdKeyMapper.TYPE.HISTORY_JOB;
+import static io.camunda.migration.data.impl.persistence.IdKeyMapper.TYPE.HISTORY_PROCESS_DEFINITION;
+import static io.camunda.migration.data.impl.persistence.IdKeyMapper.TYPE.HISTORY_PROCESS_INSTANCE;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.migration.data.qa.history.HistoryMigrationAbstractTest;
+import io.camunda.search.entities.AuditLogEntity;
+import io.camunda.search.entities.DecisionDefinitionEntity;
+import io.camunda.search.entities.DecisionInstanceEntity;
+import io.camunda.search.entities.DecisionRequirementsEntity;
+import io.camunda.search.entities.FlowNodeInstanceEntity;
+import io.camunda.search.entities.FormEntity;
+import io.camunda.search.entities.IncidentEntity;
+import io.camunda.search.entities.JobEntity;
+import io.camunda.search.entities.ProcessDefinitionEntity;
+import io.camunda.search.entities.ProcessInstanceEntity;
+import io.camunda.search.entities.UserTaskEntity;
+import io.camunda.search.entities.VariableEntity;
+import io.camunda.search.query.AuditLogQuery;
+import io.camunda.search.query.DecisionDefinitionQuery;
+import io.camunda.search.query.DecisionInstanceQuery;
+import io.camunda.search.query.DecisionRequirementsQuery;
+import io.camunda.search.query.FormQuery;
+import io.camunda.search.query.IncidentQuery;
+import io.camunda.search.query.ProcessDefinitionQuery;
+import io.camunda.search.query.ProcessInstanceQuery;
+import java.util.List;
+import java.util.Map;
+import org.camunda.bpm.engine.IdentityService;
+import org.camunda.bpm.engine.runtime.ProcessInstance;
+import org.camunda.bpm.engine.task.Task;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.TestPropertySource;
+
+/**
+ * Verifies that a custom {@code camunda.migrator.history.legacy-id-prefix} is applied consistently
+ * to <b>every</b> migrated history entity whose definition IDs are prefixed, and that the default
+ * prefix is never used when a custom one is configured.
+ * <p>
+ * The default-prefix behaviour of each entity type is already regression-covered by the sibling
+ * {@code History*Test} classes (their {@code searchHistoric*} helpers filter by
+ * {@code ConverterUtil.prefixDefinitionId}, i.e. the default {@code c7-legacy-} prefix). This test
+ * is the counterpart that proves each transformer/migrator resolves the prefix through
+ * {@code LegacyIdPrefixResolver} rather than hard-coding {@code c7-legacy-} — a hard-coded prefix
+ * would pass every default-prefix test but fail here.
+ * <p>
+ * Coverage per prefixed field:
+ * <ul>
+ *   <li>process definition id — process definition, process instance, flow node, user task,
+ *       variable, incident, job, decision instance, audit log;</li>
+ *   <li>decision definition id and decision requirements id — decision definition, decision
+ *       instance, decision requirements definition;</li>
+ *   <li>form id — form definition.</li>
+ * </ul>
+ * Not covered here (tracked separately): the DMN model's internal element/href rewriting in
+ * {@code DecisionRequirementsDefinitionTransformer}, the process-definition start-form id in
+ * {@code ProcessDefinitionMigrator}, and identity authorization resource ids in
+ * {@code AuthorizationManager} (a different, non-history migration path).
+ */
+@TestPropertySource(properties = "camunda.migrator.history.legacy-id-prefix=acme-legacy-")
+public class CustomLegacyIdPrefixHistoryTest extends HistoryMigrationAbstractTest {
+
+  protected static final String CUSTOM_PREFIX = "acme-legacy-";
+
+  @Autowired
+  protected IdentityService identityService;
+
+  @Test
+  public void shouldApplyConfiguredPrefixToAllDefinitionTypes() {
+    // given process, decision and form definitions deployed to Camunda 7
+    deployer.deployCamunda7Process("userTaskProcess.bpmn", null);
+    deployer.deployCamunda7Decision("simpleDmn.dmn");
+    repositoryService.createDeployment()
+        .addClasspathResource("io/camunda/migration/data/bpmn/c7/processWithForm.bpmn")
+        .addClasspathResource("io/camunda/migration/data/form/simple-form.form")
+        .deploy();
+
+    // when history is migrated
+    historyMigrator.migrate();
+
+    // then the process definition id uses the configured prefix
+    List<ProcessDefinitionEntity> processDefinitions = processDefinitionReader
+        .search(ProcessDefinitionQuery.of(q -> q.filter(f ->
+            f.processDefinitionIds(CUSTOM_PREFIX + "userTaskProcessId")))).items();
+    assertThat(processDefinitions).singleElement().satisfies(definition ->
+        assertThat(definition.processDefinitionId()).isEqualTo(CUSTOM_PREFIX + "userTaskProcessId"));
+
+    // and the default prefix is not used for the process definition
+    assertThat(processDefinitionReader
+        .search(ProcessDefinitionQuery.of(q -> q.filter(f ->
+            f.processDefinitionIds(DEFAULT_LEGACY_ID_PREFIX + "userTaskProcessId")))).items())
+        .isEmpty();
+
+    // and the decision definition and its requirements id use the configured prefix
+    List<DecisionDefinitionEntity> decisions = decisionDefinitionReader
+        .search(DecisionDefinitionQuery.of(q -> q.filter(f ->
+            f.decisionDefinitionIds(CUSTOM_PREFIX + "simpleDecisionId")))).items();
+    assertThat(decisions).singleElement().satisfies(decision -> {
+      assertThat(decision.decisionDefinitionId()).isEqualTo(CUSTOM_PREFIX + "simpleDecisionId");
+      assertThat(decision.decisionRequirementsId()).isEqualTo(CUSTOM_PREFIX + "simpleDmnId");
+    });
+
+    List<DecisionRequirementsEntity> decisionRequirements = decisionRequirementsReader
+        .search(DecisionRequirementsQuery.of(q -> q.filter(f ->
+            f.decisionRequirementsIds(CUSTOM_PREFIX + "simpleDmnId")))).items();
+    assertThat(decisionRequirements).singleElement().satisfies(drd ->
+        assertThat(drd.decisionRequirementsId()).isEqualTo(CUSTOM_PREFIX + "simpleDmnId"));
+
+    // and the form id uses the configured prefix
+    List<FormEntity> forms = formReader
+        .search(FormQuery.of(q -> q.filter(f ->
+            f.formIds(List.of(CUSTOM_PREFIX + "simple-form"))))).items();
+    assertThat(forms).singleElement().satisfies(form ->
+        assertThat(form.formId()).isEqualTo(CUSTOM_PREFIX + "simple-form"));
+  }
+
+  @Test
+  public void shouldApplyConfiguredPrefixToProcessInstanceGraph() {
+    // given a completed process instance with a variable, so process instance, flow node, user
+    // task and variable history are all produced
+    deployer.deployCamunda7Process("userTaskProcess.bpmn", null);
+    runtimeService.startProcessInstanceByKey("userTaskProcessId", Map.of("myVar", "myValue"));
+    completeAllUserTasksWithDefaultUserTaskId();
+
+    // when
+    historyMigrator.migrate();
+
+    // then the process instance carries the configured prefix (and not the default one)
+    List<ProcessInstanceEntity> processInstances = processInstanceReader
+        .search(ProcessInstanceQuery.of(q -> q.filter(f ->
+            f.processDefinitionIds(CUSTOM_PREFIX + "userTaskProcessId")))).items();
+    assertThat(processInstances).singleElement().satisfies(pi ->
+        assertThat(pi.processDefinitionId()).isEqualTo(CUSTOM_PREFIX + "userTaskProcessId"));
+    long processInstanceKey = processInstances.getFirst().processInstanceKey();
+
+    assertThat(processInstanceReader
+        .search(ProcessInstanceQuery.of(q -> q.filter(f ->
+            f.processDefinitionIds(DEFAULT_LEGACY_ID_PREFIX + "userTaskProcessId")))).items())
+        .as("default prefix must not be used").isEmpty();
+
+    // and every flow node instance carries the configured prefix
+    List<FlowNodeInstanceEntity> flowNodes = searchHistoricFlowNodes(processInstanceKey);
+    assertThat(flowNodes).isNotEmpty().allSatisfy(flowNode ->
+        assertThat(flowNode.processDefinitionId()).isEqualTo(CUSTOM_PREFIX + "userTaskProcessId"));
+
+    // and every user task carries the configured prefix
+    List<UserTaskEntity> userTasks = searchHistoricUserTasks(processInstanceKey);
+    assertThat(userTasks).isNotEmpty().allSatisfy(userTask ->
+        assertThat(userTask.processDefinitionId()).isEqualTo(CUSTOM_PREFIX + "userTaskProcessId"));
+
+    // and the migrated variable carries the configured prefix
+    List<VariableEntity> variables = searchHistoricVariables("myVar");
+    assertThat(variables).singleElement().satisfies(variable ->
+        assertThat(variable.processDefinitionId()).isEqualTo(CUSTOM_PREFIX + "userTaskProcessId"));
+  }
+
+  @Test
+  public void shouldApplyConfiguredPrefixToIncident() {
+    // given a process instance with an incident on its user task
+    deployer.deployCamunda7Process("userTaskProcess.bpmn", null);
+    runtimeService.startProcessInstanceByKey("userTaskProcessId");
+    Task task = taskService.createTaskQuery().taskDefinitionKey("userTaskId").singleResult();
+    runtimeService.createIncident("foo", task.getExecutionId(), "bar");
+
+    // when
+    historyMigrator.migrate();
+
+    // then the migrated incident carries the configured prefix
+    List<IncidentEntity> incidents = incidentReader
+        .search(IncidentQuery.of(q -> q.filter(f ->
+            f.processDefinitionIds(CUSTOM_PREFIX + "userTaskProcessId")))).items();
+    assertThat(incidents).singleElement().satisfies(incident ->
+        assertThat(incident.processDefinitionId()).isEqualTo(CUSTOM_PREFIX + "userTaskProcessId"));
+  }
+
+  @Test
+  public void shouldApplyConfiguredPrefixToJob() {
+    // given an async-before job that has been executed (produces a historic job log)
+    deployer.deployCamunda7Process("asyncBeforeUserTaskProcess.bpmn");
+    runtimeService.startProcessInstanceByKey("asyncBeforeUserTaskProcessId");
+    String c7JobId = managementService.createJobQuery().singleResult().getId();
+    managementService.executeJob(c7JobId);
+
+    // when (flow nodes must be migrated before jobs since C8 requires a non-null elementInstanceKey)
+    historyMigrator.migrateByType(HISTORY_PROCESS_DEFINITION);
+    historyMigrator.migrateByType(HISTORY_PROCESS_INSTANCE);
+    historyMigrator.migrateByType(HISTORY_FLOW_NODE);
+    historyMigrator.migrateByType(HISTORY_JOB);
+
+    // then the migrated job carries the configured prefix
+    List<ProcessInstanceEntity> processInstances = processInstanceReader
+        .search(ProcessInstanceQuery.of(q -> q.filter(f ->
+            f.processDefinitionIds(CUSTOM_PREFIX + "asyncBeforeUserTaskProcessId")))).items();
+    assertThat(processInstances).hasSize(1);
+
+    List<JobEntity> jobs = searchJobs(processInstances.getFirst().processInstanceKey());
+    assertThat(jobs).singleElement().satisfies(job ->
+        assertThat(job.processDefinitionId()).isEqualTo(CUSTOM_PREFIX + "asyncBeforeUserTaskProcessId"));
+  }
+
+  @Test
+  public void shouldApplyConfiguredPrefixToDecisionInstance() {
+    // given a process that evaluates a decision, producing a historic decision instance
+    deployer.deployCamunda7Decision("simpleDmn.dmn");
+    deployer.deployCamunda7Process("businessRuleProcess.bpmn");
+    runtimeService.startProcessInstanceByKey("businessRuleProcessId", Map.of("inputA", "A"));
+
+    // when
+    historyMigrator.migrate();
+
+    // then the decision instance's decision definition id carries the configured prefix — the
+    // reader only matches when the stored id was prefixed by DecisionInstanceTransformer
+    // (DecisionInstanceEntity does not expose processDefinitionId/decisionRequirementsId accessors,
+    // so those prefixed fields are asserted on the definition entities above / in the sibling test)
+    List<DecisionInstanceEntity> customPrefixed = decisionInstanceReader
+        .search(DecisionInstanceQuery.of(q -> q.filter(f ->
+            f.decisionDefinitionIds(List.of(CUSTOM_PREFIX + "simpleDecisionId"))))).items();
+    assertThat(customPrefixed).as("decision instance uses the configured prefix").singleElement();
+
+    // and the default prefix is not used
+    assertThat(decisionInstanceReader
+        .search(DecisionInstanceQuery.of(q -> q.filter(f ->
+            f.decisionDefinitionIds(List.of(DEFAULT_LEGACY_ID_PREFIX + "simpleDecisionId"))))).items())
+        .as("default prefix must not be used").isEmpty();
+  }
+
+  @Test
+  public void shouldApplyConfiguredPrefixToAuditLog() {
+    // given a process instance started by an authenticated user (produces a user operation log)
+    deployer.deployCamunda7Process("simpleProcess.bpmn");
+    identityService.setAuthenticatedUserId("demo");
+    ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("simpleProcess");
+    Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+    if (task != null) {
+      taskService.complete(task.getId());
+    }
+
+    // when
+    try {
+      historyMigrator.migrate();
+    } finally {
+      identityService.clearAuthentication();
+    }
+
+    // then every migrated audit log entry carries the configured prefix
+    List<AuditLogEntity> auditLogs = auditLogReader
+        .search(AuditLogQuery.of(q -> q.filter(f ->
+            f.processDefinitionIds(CUSTOM_PREFIX + "simpleProcess")))).items();
+    assertThat(auditLogs).isNotEmpty().allSatisfy(log ->
+        assertThat(log.processDefinitionId()).isEqualTo(CUSTOM_PREFIX + "simpleProcess"));
+  }
+}


### PR DESCRIPTION
## Summary

Backport of #1633 onto `maintenance/0.2`.

Introduces `LegacyIdPrefixResolver` — a Spring bean centralising the `c7-legacy-` prefix (configurable via `camunda.migrator.history.legacy-id-prefix`). All transformers that previously hard-coded `ConverterUtil.prefixDefinitionId(…)` now inject and delegate to `LegacyIdPrefixResolver.applyTo(…)`.

### Backport adaptations

The `maintenance/0.2` branch predates several classes that exist on `main`. The following 0.2-specific changes were required:

- **`EntityInterceptor` interface** – 0.2 uses the context-based `execute(EntityConversionContext<?,?> context)` pattern (not the typed `execute(C7, C8Builder)` from main). All transformer `execute` methods kept the 0.2 cast pattern.
- **`HistoryProperties`** – simplified to only `legacyIdPrefix`; dropped `AutoCancelProperties` reference which does not exist in 0.2.
- **`MigratorProperties`** – added `HistoryProperties history` field + getter/setter (the `getHistory()` call site required by `LegacyIdPrefixResolver`).
- **`DecisionRequirementsDefinitionTransformer`** – replaced `c7Client.getResourceAsStream()` (main-only) with `c7Client.getResourceAsString()` + `new ByteArrayInputStream(…getBytes(UTF_8))`.
- **`application.yml`** – `legacy-id-prefix` comment placed directly under `migrator:` (0.2 lacks the `history:` nesting that main has).
- **New files from #1633 that reference main-only classes** removed: `HistoryEntityMigrator`, `DecisionRequirementsMigrator`, `ProcessDefinitionMigrator`, `AuthorizationManager`, `AuditLogTransformer`, `ExternalTaskTransformer`, `FormTransformer`, `JobTransformer` — these depend on `DataSourceRegistry`, `PartitionSupplier`, `EntitySkippedException`, `C8EntityNotFoundException`, `MigrationResult`, `C7Entity`, etc., none of which exist on 0.2.

## Test plan

- [x] `mvn clean install -DskipTests -pl data-migrator/core,data-migrator/assembly` passes (BUILD SUCCESS)
- [ ] CI green on this PR