### PR TITLE
fix(ci): add missing error pattern for Windows runner communication loss [backport maintenance/0.2]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -735,6 +735,7 @@ jobs:
             The runner has received a shutdown signal
             Could not transfer artifact
             ContainerFetchException: Can't get Docker image: RemoteDockerImage
+            The hosted runner lost communication with the server
           run-id: ${{ github.run_id }}
           repository: ${{ github.repository }}
           vault-addr: ${{ secrets.VAULT_ADDR }}


### PR DESCRIPTION
Backport of #1669 to `maintenance/0.2`.

Adds `The hosted runner lost communication with the server` to the `rerun-failed-jobs` error-messages list so Windows runner preemption/OOM failures are automatically retried.

**Original PR:** #1669