### PR TITLE
fix(deps): bump httpcore5 to 5.4.3 to resolve CVE-2026-54399 (maintenance/0.2)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,7 @@
     <version.node>v20.18.1</version.node>
     <version.npm>10.8.2</version.npm>
     <version.netty>4.2.16.Final</version.netty>
+    <version.httpcore5>5.4.3</version.httpcore5>
     <version.commons-lang3>3.20.0</version.commons-lang3>
     <plugin.version.compiler>3.15.0</plugin.version.compiler>
     <plugin.version.nexus-staging>1.7.0</plugin.version.nexus-staging>
@@ -107,6 +108,11 @@
         <version>${version.netty}</version>
         <type>pom</type>
         <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.httpcomponents.core5</groupId>
+        <artifactId>httpcore5</artifactId>
+        <version>${version.httpcore5}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
## Summary

- Pins `org.apache.httpcomponents.core5:httpcore5` to `5.4.3` in root `dependencyManagement` to override the `5.3.6` version delivered transitively via `camunda-client-java:8.8.29`
- Fixes CVE-2026-54399: uncontrolled resource consumption in the HTTP/1.1 message parser allows a remote attacker to cause denial of service through memory exhaustion by sending messages with excessive headers or excessive header length (CVSS 7.5)
- Only `maintenance/0.2` is affected; `maintenance/0.3` and `main` are not in the vulnerable range

## Changes

- `pom.xml`: add `version.httpcore5=5.4.3` property and `httpcore5` entry in `dependencyManagement`

## Test plan

- [x] `mvn dependency:tree -Dincludes=org.apache.httpcomponents.core5:httpcore5` — all 16 modules resolve `5.4.3` (previously `5.3.6`)
- [x] `mvn clean install -DskipTests` passes on the patched branch

## Baseline

Built from commit: `2e2756a1` (fix(deps): update dependency io.netty:netty-bom to v4.2.16.final)

🤖 Generated with [Claude Code](https://claude.com/claude-code)