### PR TITLE
feat(diagram-converter): add model migration path to migration skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
         "url": "https://github.com/camunda/camunda-7-to-8-migration-tooling.git",
         "path": "agentic-migration-skills"
       },
-      "description": "Migrate Camunda 7 Java codebases to Camunda 8 using AI, OpenRewrite, or both.",
+      "description": "Migrate Camunda 7 projects to Camunda 8 — Java code (AI, OpenRewrite, or both) and BPMN/DMN models (Diagram Converter CLI or agentic).",
       "version": "0.1.0",
       "author": {
         "name": "camunda"

--- a/agentic-migration-skills/README.md
+++ b/agentic-migration-skills/README.md
@@ -41,7 +41,7 @@ The skill asks what to migrate — **code**, **models**, or **both** — then wa
 |----------|-------------|
 | **Diagram Converter CLI** *(recommended)* | Downloads the official converter CLI from GitHub releases and runs it locally against your diagrams, targeting your C8 version. Deterministic; produces converted files + CSV/XLSX analysis. Requires Java 21+ |
 | **Agentic AI** | AI rewrites the BPMN/DMN XML directly — for when Java 21 is unavailable or you want to review every change |
-| **Online converter** | Opt out to the hosted [diagram-converter.camunda.io](https://diagram-converter.camunda.io/) — no local Java, but files leave your machine |
+| **Online converter** | Opt out to the hosted [diagram-converter.camunda.io](https://diagram-converter.camunda.io/) — no local Java needed |
 
 The skill fetches the latest [pattern catalog](../code-conversion/patterns/ALL_IN_ONE.md) and diagram-converter docs at runtime, and resolves the latest Diagram Converter CLI release automatically.
 

--- a/agentic-migration-skills/README.md
+++ b/agentic-migration-skills/README.md
@@ -1,6 +1,6 @@
 # Agentic Migration Skills
 
-[Agent Skills](https://agentskills.io/) for migrating Camunda 7 Java codebases to Camunda 8. Works with any Agent Skills-compatible AI coding agent.
+[Agent Skills](https://agentskills.io/) for migrating Camunda 7 projects to Camunda 8 — both Java code and BPMN/DMN models. Works with any Agent Skills-compatible AI coding agent.
 
 ## Install
 
@@ -25,7 +25,9 @@ From your Camunda 7 project directory:
 /camunda-migration:migrate-c7-to-c8-code
 ```
 
-The skill will assess your codebase and walk you through three options:
+The skill asks what to migrate — **code**, **models**, or **both** — then walks you through the approaches for each.
+
+**Code migration:**
 
 | Approach | What it does |
 |----------|-------------|
@@ -33,7 +35,15 @@ The skill will assess your codebase and walk you through three options:
 | **AI only** | AI migrates everything directly — for non-Maven/Gradle builds or when you want to review every change |
 | **Assessment only** | Scans the codebase and reports files, complexity, and effort estimate — no code changes |
 
-The skill fetches the latest [pattern catalog](../code-conversion/patterns/ALL_IN_ONE.md) at runtime.
+**Model migration (BPMN/DMN):**
+
+| Approach | What it does |
+|----------|-------------|
+| **Diagram Converter CLI** *(recommended)* | Downloads the official converter CLI from GitHub releases and runs it locally against your diagrams, targeting your C8 version. Deterministic; produces converted files + CSV/XLSX analysis. Requires Java 21+ |
+| **Agentic AI** | AI rewrites the BPMN/DMN XML directly — for when Java 21 is unavailable or you want to review every change |
+| **Online converter** | Opt out to the hosted [diagram-converter.camunda.io](https://diagram-converter.camunda.io/) — no local Java, but files leave your machine |
+
+The skill fetches the latest [pattern catalog](../code-conversion/patterns/ALL_IN_ONE.md) and diagram-converter docs at runtime, and resolves the latest Diagram Converter CLI release automatically.
 
 ## Structure
 

--- a/agentic-migration-skills/skills/migrate-c7-to-c8-code/SKILL.md
+++ b/agentic-migration-skills/skills/migrate-c7-to-c8-code/SKILL.md
@@ -14,6 +14,25 @@ You are a migration expert helping the user migrate a Camunda 7 project to Camun
 
 Treat these as separate operations that compose. Ask what the user wants (Step 1, Question 3) and run only the relevant path(s).
 
+## Shared rules
+
+These apply throughout — referenced below instead of repeated.
+
+- **Distinguish code from models.** OpenRewrite/AI handles code; the Diagram Converter handles models. Never hand-edit BPMN/DMN in the code flow. Ask for scope (Q3) rather than assuming.
+- **Commits are opt-in.** Verify a clean tree (`git status`) first; if dirty, ask the user to commit or stash. Never auto-commit. After each phase, ask whether to commit and proceed only on explicit approval.
+- **Never mutate user assets silently.** Models convert to `converted-c8-*` copies; originals stay intact. Converted files and CSV/XLSX/MD reports are generated outputs for the user to review.
+- **Load the reference before editing.** Never guess API/XML mappings. For gaps, prefer `docs.camunda.io` via WebFetch over training knowledge.
+  - Code → pattern catalog: `https://raw.githubusercontent.com/camunda/camunda-7-to-8-migration-tooling/main/code-conversion/patterns/ALL_IN_ONE.md`. If context is tight, fetch only the individual files under `code-conversion/patterns/`.
+  - Agentic models → diagram-converter docs (see M2).
+- **Respect the target version** (Q2). Don't offer 8.9 features (businessId, conditional events, global user task listeners, batch delete) to an 8.8 target, or 8.8 workarounds to 8.9+. Pass the same version to the CLI via `--platform-version`.
+- **Prefer deterministic over agentic.** Code: OpenRewrite + AI over AI-only. Models: CLI (M1) over agentic rewrite (M2). Use agentic only when the deterministic path can't run.
+- **Conversion is not completion.** Converter finding severities: WARNING, TASK, REVIEW, INFO. TASK/REVIEW/WARNING need human follow-up and JUEL conversion is partial — always say so, then offer the Step 5 follow-up.
+- **Diagram Converter: fail fast on Java, download don't ask.** Require Java 21+; stop with a clear message (offer M2/M3) if missing. Download the CLI from the latest GitHub release into `.camunda-migration/`, reuse an existing download, never commit the JAR.
+- **Don't redo what the tools changed.** In Approach A, check for existing transforms before rewriting. After a converter run, don't re-apply conversions it already did.
+- **Ask before High-complexity files and edge cases.** Auto-apply only unambiguous 1:1 mappings. For anything else — JUEL invoking beans, BPMN error mapping, async/correlation, IdentityService/FormService, custom batches, multi-instance listeners, ambiguous TODOs or findings, compile errors without a direct catalog match — propose via `AskUserQuestion` first. When unsure, ask.
+- **Keep changes minimal.** No refactors, renames, or improvements beyond the migration.
+- **Keep `MIGRATION_REPORT.md` current** — both inventories, decisions, phase status, validation results.
+
 ## Step 1: Gather inputs
 
 Before calling `AskUserQuestion`, pick a candidate project root (use the provided argument if present, otherwise the current working directory), then detect the build tool by checking that directory for `pom.xml` (Maven) or `build.gradle` / `build.gradle.kts` (Gradle). Also glob for models (`**/*.bpmn`, `**/*.bpmn20.xml`, `**/*.dmn`, `**/*.dmn11.xml`) so you can tailor the scope question to what is actually present.
@@ -123,17 +142,66 @@ Use `AskUserQuestion` to wait for user confirmation before proceeding.
 
 ## Step 3: Execute migration
 
-**Git checkpoint rule (applies to all approaches):** before changing anything, verify the working tree is clean (`git status`). If not, ask the user to commit or stash first. Do not create commits automatically. After OpenRewrite, after the Diagram Converter run, and after each completed phase, ask whether the user wants a commit; only commit if they explicitly approve, using a clear message (e.g. `migration: resolve delegate TODOs`). This keeps every step reviewable and reversible while preserving user control.
-
-Run **Part A** if the scope includes code, **Part B** if it includes models. For **Code + models**, see "Composing code + model migration" at the end of this step.
+Commit policy and reference loading: see Shared rules. Run **Part A** if the scope includes code, **Part B** if it includes models. For **Code + models**, see "Composing code + model migration" at the end of this step.
 
 ---
 
 ## Part A — Code migration (Java/Spring)
 
+Both approaches apply the same **Transform checklist** below. Approach A runs OpenRewrite first for the deterministic bulk, then uses the checklist for the rest; Approach B works the whole checklist manually.
+
+### Transform checklist
+
+Confirm each item before the next (commit policy: Shared rules). Tags mark what OpenRewrite already handles.
+
+**1. Dependencies & configuration**
+- Resolve the latest Camunda version via WebFetch: `https://search.maven.org/solrsearch/select?q=g:io.camunda+AND+a:camunda-spring-boot-starter&rows=1&wt=json` → `response.docs[0].latestVersion`. For 8.8 targets use the latest `8.8.x`; for 8.9+ use it as-is.
+- Pick the starter by Spring Boot version: 3.x → `io.camunda:camunda-spring-boot-3-starter`; 4.x → `io.camunda:camunda-spring-boot-starter`.
+- Add the Camunda public repo if artifacts aren't on Maven Central:
+  - Maven: `<repository><id>camunda-public</id><url>https://artifacts.camunda.com/artifactory/public/</url></repository>`
+  - Gradle: `maven { url "https://artifacts.camunda.com/artifactory/public/" }`
+- Remove `org.camunda.bpm.*`, `camunda-bom`, and embedded-engine deps (H2, JDBC starter).
+- Add the starter; add `io.camunda:camunda-process-test-spring` (test scope) if tests exist.
+- Ensure Spring Boot dependency management is set (parent or BOM); don't add `spring-boot-starter` just for jakarta.annotation.
+- Replace `@EnableProcessApplication` with `@Deployment`.
+- Replace `camunda.*` keys with `camunda.client.*` in `application.properties`/`.yaml` ([properties reference](https://docs.camunda.io/docs/apis-tools/camunda-spring-boot-starter/properties-reference/)).
+- Reference: "Maven dependency and configuration".
+
+**2. Client code** (`ProcessEngine` → `CamundaClient`)
+- Replace `ProcessEngine`/service autowiring (RuntimeService, TaskService, HistoryService, DecisionService, ManagementService) with `CamundaClient`.
+- Map: start instances (incl. `businessId`/tags), message correlation, signal broadcast, cancel, user tasks, variables, `HistoryService` → search requests, `DecisionService` → `newEvaluateDecisionCommand`, batch `...Async` → batch operations (8.8+).
+- Reference: "Client code → ProcessEngine" (incl. Business Key, Batch Operations, Evaluate Decisions, Query History).
+
+**3. JavaDelegate → Job Worker** *(OpenRewrite covers this)*
+- Remove `implements JavaDelegate`; convert `execute(DelegateExecution)` to a `@JobWorker` method.
+- Variable access → method params / `@Variable`. `BpmnError` → `CamundaError.bpmnError(...)`. Remove `TypedValue` usage.
+- Reference: "Glue code → JavaDelegate → Job Worker".
+
+**4. External task workers** *(OpenRewrite covers this)*
+- `@ExternalTaskSubscription` → `@JobWorker`; update variable access and failure/incident handling.
+- Reference: "Glue code → External Task Worker".
+
+**5. Listeners** *(not covered by OpenRewrite)*
+- `ExecutionListener` → execution listener job workers (`zeebe:executionListener` + `@JobWorker`).
+- `TaskListener` → user task listener job workers (job result with corrections/deny).
+- Globally registered listeners (engine plugins, parse listeners) on user tasks → global user task listeners (8.9+).
+- Flag multi-instance body listeners that prepare collections — requires a model change.
+- Reference: "Glue code → Listeners".
+
+**6. Test code** *(not fully covered by OpenRewrite)*
+- `@Rule` Camunda test rules → `@CamundaSpringProcessTest`.
+- Update assertions (`isWaitingAt("id")` → `hasActiveElements("id")`), message correlation, timers, and user task completion — use `processTestContext` (`completeUserTask`, `completeJob`, `mockJobWorker`, `increaseTime`).
+- Disable real workers where mocked: `camunda.client.worker.defaults.enabled=false` with per-worker overrides.
+- On 8.9+, use CPT shared-runtime mode for large suites.
+- Reference: "Test assertions".
+
+**7. JUEL expressions** *(not covered by OpenRewrite)*
+- Pure data expressions → FEEL (the converter automates this model-side, Part B). Conditional events are native since 8.9. Only bean-invoking expressions need a JUEL job worker or a refactor into job workers.
+- Reference: "Expression → Job Worker".
+
 ### Approach A — OpenRewrite + AI (recommended)
 
-**1. Run OpenRewrite**
+**1. Run OpenRewrite** — deterministic bulk transforms for delegates, external workers, and client code.
 
 Before adding the plugin, resolve the latest released versions via WebFetch:
 
@@ -201,104 +269,20 @@ rewrite {
 ```
 Run: `./gradlew rewriteRun`
 
-Before AI cleanup, ask whether to commit the OpenRewrite result. Commit only if the user explicitly approves.
+Before AI cleanup, ask whether to commit the OpenRewrite result (commit policy: Shared rules).
 
-**2. AI cleanup — after OpenRewrite has run**
+**2. AI cleanup — after OpenRewrite**
 
-Start by prompting the user, if they want run AI cleanup after deterministic code migration. Only progress, if the answer is YES.
+Ask the user whether to run AI cleanup; proceed only on YES. Load the pattern catalog (Shared rules), then work the Transform checklist for what OpenRewrite left:
 
-First, fetch the pattern catalog via WebFetch from `main` — this is your reference for resolving TODOs, config, tests, listeners, and JUEL. Do not rely on training knowledge for API mappings:
-`https://raw.githubusercontent.com/camunda/camunda-7-to-8-migration-tooling/main/code-conversion/patterns/ALL_IN_ONE.md`
-If context budget is tight, fetch only the individual pattern files you need from `code-conversion/patterns/` (same repo, same raw URL scheme) instead of the full catalog.
-
-Work through each of the following. Confirm each before moving on. Do not auto-commit; ask whether to commit after each item and commit only with explicit user approval.
-
-- Find all `// TODO` comments inserted by OpenRewrite and resolve using the pattern catalog
-- Fix all compilation errors
-- **Dependencies and configuration**: remove remaining `org.camunda.bpm.*` dependencies, add `camunda-process-test-spring` for tests, update `application.properties` / `application.yaml` — replace `camunda.*` keys with `camunda.client.*` equivalents (see the [properties reference](https://docs.camunda.io/docs/apis-tools/camunda-spring-boot-starter/properties-reference/))
-- **Listeners**: OpenRewrite does not cover `ExecutionListener` / `TaskListener` implementations — convert per the "Listeners" patterns (execution listener job workers; user task listeners with corrections/deny; global user task listeners for cluster-wide cases on 8.9)
-- **Client code not covered by recipes**: `HistoryService` → search requests; `DecisionService` → `newEvaluateDecisionCommand`; batch `...Async` methods → batch operation endpoints (8.8+); `businessKey` → `businessId` (8.9) or tags (8.8)
-- **Test code**: replace `@Rule` Camunda test rules with `@CamundaSpringProcessTest`, update assertions (e.g. `isWaitingAt("id")` → `hasActiveElements("id")`), message correlation, timer handling (`processTestContext.increaseTime(...)`), user task completion (`processTestContext.completeUserTask(...)`), worker mocking (`processTestContext.mockJobWorker(...)`) — OpenRewrite doesn't fully cover tests. For large suites on 8.9+, recommend CPT *shared runtime* mode to cut execution time.
-- **JUEL expressions**: triage per the "Expression → Job Worker" pattern — pure data expressions convert to FEEL (the Diagram Converter automates this on the model side, see Part B), conditional events are supported natively since 8.9, only bean-invoking expressions need a JUEL job worker or a refactor into regular job workers
+- Resolve all `// TODO` comments it inserted, and fix compile errors.
+- Apply items **1** (deps/config), **5** (listeners), **6** (tests), **7** (JUEL), and any **2** (client code) the recipes didn't cover.
 
 ---
 
 ### Approach B — AI only
 
-First, fetch the pattern catalog via WebFetch from `main` — this is your primary reference for all C7→C8 transformations. Do not rely on training knowledge for API mappings:
-`https://raw.githubusercontent.com/camunda/camunda-7-to-8-migration-tooling/main/code-conversion/patterns/ALL_IN_ONE.md`
-If context budget is tight, fetch only the individual pattern files you need from `code-conversion/patterns/` instead of the full catalog.
-
-Work through each phase sequentially. Confirm completion of each phase before moving to the next. Do not auto-commit; ask whether to commit after each phase and commit only with explicit user approval.
-
-**Phase 1: Dependencies and configuration**
-
-Before modifying the build file, resolve the latest released Camunda version via WebFetch:
-- `https://search.maven.org/solrsearch/select?q=g:io.camunda+AND+a:camunda-spring-boot-starter&rows=1&wt=json` → read `response.docs[0].latestVersion` as `CAMUNDA_VERSION`
-
-If the user's target is 8.8, use the latest 8.8.x patch (`8.8.x`); if 8.9+, `CAMUNDA_VERSION` is fine as-is.
-
-Detect the Spring Boot version from the existing `pom.xml` or `build.gradle`:
-- Spring Boot 3.x → use `io.camunda:camunda-spring-boot-3-starter` (supported for 8.9+; use for 8.8 too)
-- Spring Boot 4.x → use `io.camunda:camunda-spring-boot-starter`
-
-Add the Camunda public repository if not already present (some Camunda artifacts may not be on Maven Central):
-
-- **Maven (`pom.xml`)**:
-    <repository>
-      <id>camunda-public</id>
-      <name>Camunda Public Repository</name>
-      <url>https://artifacts.camunda.com/artifactory/public/</url>
-    </repository>
-
-- **Gradle (`build.gradle` / `build.gradle.kts`)**:
-    repositories {
-      maven { url "https://artifacts.camunda.com/artifactory/public/" }
-    }
-
-Then:
-- Remove all `org.camunda.bpm.*` dependencies and `camunda-bom` from `pom.xml` / `build.gradle`
-- Remove embedded-engine dependencies (H2, JDBC starter) — no longer needed without the embedded engine
-- Add the resolved starter at the resolved version; add `io.camunda:camunda-process-test-spring` at the same version in test scope if tests exist
-- Ensure Spring Boot dependency management is correctly configured (e.g., `spring-boot-starter-parent` or the Spring Boot BOM); avoid adding `org.springframework.boot:spring-boot-starter` solely to “get jakarta.annotation”.
-- Replace `@EnableProcessApplication` with `@Deployment`
-- Update `application.properties` / `application.yaml` — replace `camunda.*` keys with `camunda.client.*` equivalents (see the [properties reference](https://docs.camunda.io/docs/apis-tools/camunda-spring-boot-starter/properties-reference/))
-- Reference: "Maven dependency and configuration" section in patterns
-
-**Phase 2: Client code**
-- Replace `ProcessEngine` autowiring with `CamundaClient`
-- Update all service method calls (RuntimeService, TaskService, HistoryService, DecisionService, etc.)
-- Key changes: starting instances (incl. `businessId`/tags), correlating messages, broadcasting signals, cancelling instances, user task handling, variable handling, history queries → search requests, DMN evaluation, batch operations
-- Reference: "Client code → ProcessEngine" patterns (incl. "Business Key", "Batch Operations", "Evaluate Decisions", "Query History")
-
-**Phase 3: JavaDelegate → Job Worker**
-- Remove `implements JavaDelegate`
-- Convert `execute(DelegateExecution execution)` to `@JobWorker`-annotated method
-- Update variable access: `execution.getVariable()` → method parameters or `@Variable` annotations
-- Map BPMN errors: `BpmnError` → `CamundaError.bpmnError(...)`
-- Remove all `TypedValue` API usage
-- Reference: "Glue code → JavaDelegate → Job Worker" patterns
-
-**Phase 4: External task workers**
-- Replace `@ExternalTaskSubscription` with `@JobWorker`
-- Update variable access and failure/incident handling
-- Reference: "Glue code → External Task Worker" patterns
-
-**Phase 5: Listeners**
-- Convert `ExecutionListener` implementations to execution listener job workers (`zeebe:executionListener` + `@JobWorker`)
-- Convert `TaskListener` implementations to user task listener job workers (job result with corrections / deny)
-- For listeners registered globally (engine plugins, parse listeners) on user tasks: use global user task listeners (8.9+, configuration-based)
-- Flag multi-instance body listeners that prepare collections — requires model change
-- Reference: "Glue code → Listeners" patterns
-
-**Phase 6: Test code**
-- Replace `@Rule` Camunda test rules with `@CamundaSpringProcessTest`
-- Update process instance startup patterns
-- Replace assertion methods: e.g. `isWaitingAt("id")` → `hasActiveElements("id")`
-- Update message correlation, timer handling, user task completion in tests (use `processTestContext` utilities: `completeUserTask`, `completeJob`, `mockJobWorker`, `increaseTime`)
-- Disable real workers where mocks are used: `camunda.client.worker.defaults.enabled=false` with per-worker overrides
-- On 8.9+, recommend CPT shared runtime mode for large suites
-- Reference: "Test assertions" patterns
+Load the pattern catalog (Shared rules), then work the full Transform checklist (items 1–7) in order, confirming each before the next.
 
 ---
 
@@ -318,9 +302,7 @@ Write the full report to `MIGRATION_REPORT.md`. Then stop — make no code chang
 
 ## Part B — Model migration (BPMN/DMN)
 
-Model migration converts BPMN/DMN diagrams from the Camunda 7 (`camunda:`) namespace to the Camunda 8 (`zeebe:`) namespace: job types for delegates, listener mappings, simple JUEL→FEEL, event definitions, version-gated features. This is the model-side analogue of OpenRewrite: prefer the **deterministic** Diagram Converter (M1) over agentic rewriting (M2).
-
-**Conversion is not full migration.** The converter emits findings at severities **WARNING**, **TASK**, **REVIEW**, and **INFO**. TASK/REVIEW/WARNING items still need human follow-up, and JUEL conversion is only partial. Always tell the user this after a run.
+Converts BPMN/DMN from the `camunda:` namespace to `zeebe:`: job types for delegates, listener mappings, simple JUEL→FEEL, event definitions, version-gated features. Prefer the deterministic CLI (M1). See Shared rules for severities and "conversion is not completion".
 
 ### Approach M1 — Diagram Converter CLI +AI (deterministic, recommended)
 
@@ -390,9 +372,9 @@ After the run, report back:
 - **Analysis findings** — summarize from the CLI stdout and/or the CSV/XLSX report, grouped by severity (WARNING / TASK / REVIEW / INFO) with counts and the top items.
 - **Analysis artifacts** — if you generated `--csv` / `--xlsx`, point the user to them for review.
 
-**5. Explain that conversion ≠ done, then offer to help with findings**
+**5. Follow up on findings**
 
-Tell the user plainly that REVIEW/WARNING/TASK findings remain and JUEL conversion is partial — these need follow-up. Then **offer to take care of them agentically**: for findings with an unambiguous fix, propose editing the converted BPMN/DMN (e.g. filling a job type, adjusting a FEEL expression), apply with `Edit`, and then **ask the human to review** the result. For ambiguous findings, consult via `AskUserQuestion` before changing anything (see the behavior rule on edge cases). Never overwrite the user's original diagrams — work on the `converted-c8-*` copies.
+REVIEW/WARNING/TASK findings remain and JUEL conversion is partial — resolve them in Step 5, working on the `converted-c8-*` copies (never the originals).
 
 ### Approach M2 — Agentic AI (direct XML rewrite)
 
@@ -490,21 +472,3 @@ Use `AskUserQuestion` with:
 - **No, I'll handle the rest manually** — Stop here; record remaining items in `MIGRATION_REPORT.md`.
 
 When the user opts in, work through items one at a time: apply unambiguous fixes directly (using the pattern catalog / converter docs as reference), propose ambiguous ones via `AskUserQuestion`, and skip anything the user declines. Ask whether to commit after each batch of resolved items.
-
----
-
-## Behavior rules
-
-- **Distinguish code from models.** Run OpenRewrite/AI on code and the Diagram Converter on models — never hand-edit BPMN/DMN as part of the code flow. Ask for scope (Step 1 Q3) rather than assuming.
-- **Always load the reference before touching anything.** For code, load the pattern catalog; for agentic model work, load the diagram-converter docs. Never guess API or XML mappings. For details not covered, prefer official Camunda docs (`docs.camunda.io`) via `WebFetch` over training knowledge.
-- **Respect the target version.** Do not recommend 8.9 features (businessId, conditional events, global user task listeners, batch delete) to an 8.8 target, and do not send 8.9 targets down 8.8 workarounds. Pass the same version to the Diagram Converter via `--platform-version`.
-- **Prefer deterministic over agentic.** For code, prefer OpenRewrite + AI over AI-only. For models, prefer the Diagram Converter CLI (M1) over agentic rewriting (M2). Use the agentic/manual path only when the deterministic one can't run.
-- **Diagram Converter: fail fast on Java, download don't ask.** Require Java 21+ and stop with a clear message (offer M2/M3) if it's missing. Resolve and download the CLI automatically from the latest GitHub release into `.camunda-migration/`; reuse an existing download; never commit the JAR.
-- **Never mutate user assets silently.** The converter writes `converted-c8-*` copies — keep originals intact. Treat converted files and CSV/XLSX/markdown as generated outputs returned to the user for inspection.
-- **Conversion is not completion.** Always explain that REVIEW/WARNING/TASK findings and partial JUEL conversion remain, then offer to fix the unambiguous ones agentically and ask the human to review.
-- **One phase at a time; commits are opt-in.** Confirm each phase before starting the next. Never start on a dirty working tree. Ask before each commit and proceed only when the user explicitly allows it.
-- **Keep `MIGRATION_REPORT.md` current.** Both inventories, decisions, phase status, validation results.
-- **Don't rewrite what the tools already changed.** In Approach A, check for existing transforms before rewriting. After a Diagram Converter run, don't re-do conversions it already applied.
-- **Ask before High complexity files.** Describe the options and confirm before proceeding.
-- **Keep changes minimal.** Don't refactor, rename, or improve beyond what the migration requires.
-- **Consult on edge cases, don't auto-fix.** Auto-apply changes only when the reference gives an unambiguous 1:1 mapping. For anything else — JUEL expressions invoking beans, BPMN error mapping, async/correlation, IdentityService/FormService usage, custom batches, multi-instance listener patterns, ambiguous TODOs from OpenRewrite, ambiguous model findings, or compile errors whose fix isn't a direct catalog match — propose the change via `AskUserQuestion` before applying. When unsure whether a case is unambiguous, ask.

--- a/agentic-migration-skills/skills/migrate-c7-to-c8-code/SKILL.md
+++ b/agentic-migration-skills/skills/migrate-c7-to-c8-code/SKILL.md
@@ -1,21 +1,26 @@
 ---
 name: migrate-c7-to-c8-code
-description: Use this when migrating or converting a Camunda 7 / camunda-bpm Java/Spring codebase to Camunda 8 — including JavaDelegates, ExternalTaskWorkers, ProcessEngine/RuntimeService client code, execution/task listeners, and application.properties/application.yaml with camunda.* keys.
+description: Use this when migrating or converting a Camunda 7 / camunda-bpm project to Camunda 8 — both Java/Spring code (JavaDelegates, ExternalTaskWorkers, ProcessEngine/RuntimeService client code, execution/task listeners, application.properties/application.yaml with camunda.* keys) and BPMN/DMN models (diagrams with the camunda: namespace). Handles code migration, model migration, or both.
 argument-hint: Optional path to project root (defaults to current directory)
 allowed-tools: Bash, Read, Write, Edit, Glob, Grep, WebFetch, AskUserQuestion
 ---
 
-# Camunda 7 → 8 Code Migration
+# Camunda 7 → 8 Migration
 
-You are a migration expert helping the user migrate a Java codebase from Camunda 7 to Camunda 8.
+You are a migration expert helping the user migrate a Camunda 7 project to Camunda 8. A project can contain **two independent kinds of assets**, each with its own migration path:
+
+- **Code** — Java/Spring glue and client code, config, tests. Migrated with **OpenRewrite recipes** (deterministic) plus AI cleanup.
+- **Models** — BPMN/DMN diagrams using the `camunda:` namespace. Migrated with the **Diagram Converter** (deterministic) or agentically.
+
+Treat these as separate operations that compose. Do not conflate "migrate my code" with "migrate my diagrams" — ask what the user wants (Step 1, Question 3) and run only the relevant path(s).
 
 ## Step 1: Gather inputs
 
-Before calling `AskUserQuestion`, pick a candidate project root (use the provided argument if present, otherwise the current working directory), then detect the build tool by checking that directory for `pom.xml` (Maven) or `build.gradle` / `build.gradle.kts` (Gradle).
+Before calling `AskUserQuestion`, pick a candidate project root (use the provided argument if present, otherwise the current working directory), then detect the build tool by checking that directory for `pom.xml` (Maven) or `build.gradle` / `build.gradle.kts` (Gradle). Also glob for models (`**/*.bpmn`, `**/*.bpmn20.xml`, `**/*.dmn`, `**/*.dmn11.xml`) so you can tailor the scope question to what is actually present.
 
 Then call `AskUserQuestion` **once** with Questions 1-3 below (combine them in a single call — do not ask one at a time):
 
-**Question 1 — Code location**
+**Question 1 — Project location**
 
 "What is the path to the project root?"
 
@@ -29,36 +34,49 @@ Ask which Camunda 8 version the user is migrating to:
 - **8.9 or later** *(recommended)* — includes Business ID (business key successor), BPMN conditional events, global user task listeners, batch delete, History/Identity Data Migrator.
 - **8.8** — first version with the unified Orchestration Cluster API, CamundaClient, and Camunda Process Test. No Business ID (use tags), no conditional events.
 
-The target version changes which patterns apply — record the answer and use it throughout.
+The target version changes which patterns apply **and** is passed to the Diagram Converter as `--platform-version` (valid values `8.0`–`8.10`). Record the concrete `major.minor` (e.g. `8.9`, `8.10`); if the user says "8.9 or later" without a specific minor, confirm the exact minor to target (default to the latest, `8.10`). Use the answer throughout.
 
-**Question 3 — Migration approach**
+**Question 3 — Migration scope**
 
-Ask the user to choose one of:
+Ask what the user wants to migrate (tailor the wording to what you detected — code files, model files, or both):
+
+- **Code only** — Java/Spring code. Runs Part A.
+- **Models only** — BPMN/DMN diagrams. Runs Part B.
+- **Code + models** *(recommended when both are present)* — Runs both Part A and Part B and composes them.
+- **Assessment only** — Scan and report scope/complexity/effort for code and models. No changes.
+
+**Follow-up questions (second `AskUserQuestion` call, after Question 3 is answered)**
+
+Ask only the follow-ups that apply to the chosen scope. Combine them into a single call where possible.
+
+*If scope includes code* — **Code migration approach**:
 
 - **A. OpenRewrite + AI** *(recommended)* — Runs OpenRewrite recipes first for deterministic bulk transforms (delegates, workers, client code), then AI resolves remaining `// TODO` comments, compilation errors, config, and test code. Best for most codebases.
 - **B. AI only** — AI migrates everything directly without OpenRewrite. Use this when you can't run OpenRewrite (non-Maven/Gradle builds, restricted environments) or want to review every change individually.
-- **C. Assessment only** — Scan the codebase and produce a report: file inventory, complexity estimate, effort breakdown. No code changes. Use this first if you want to understand the scope before committing.
+- **C. Assessment only** — Scan the codebase and produce a report: file inventory, complexity estimate, effort breakdown. No code changes.
 
-**Question 4 — Build tool**
+*If scope includes models* — **Model migration approach**:
 
-Ask this only as a follow-up `AskUserQuestion` call after the user answers Question 3, and only if both conditions are true:
+- **M1. Diagram Converter CLI (deterministic)** *(recommended)* — Downloads the official `camunda-7-to-8-diagram-converter-cli` from GitHub releases into the project and runs it locally against your BPMN/DMN files, targeting your Camunda 8 version. Deterministic and repeatable; produces converted files plus analysis reports (CSV/XLSX). **Requires Java 21+.** This is the diagram equivalent of "OpenRewrite for code".
+- **M2. Agentic AI** — AI rewrites the BPMN/DMN XML directly (namespace, listeners, JUEL→FEEL, event mappings). Use when Java 21 is unavailable, you want to review every change, or a niche case the CLI doesn't cover. Slower and non-deterministic.
+- **M3. Online Diagram Converter (hosted)** — You upload your diagrams to **https://diagram-converter.camunda.io/** and download the converted results yourself. No local Java needed, but **files leave your machine** — do not use for confidential models. Use this to opt out of the local CLI entirely.
+- Any of the above can be run in **analyze-only** mode first (see "Analyze-only mode" in Part B) to see findings without producing converted files.
 
-- The user chose **A. OpenRewrite + AI**.
-- Build-tool detection was ambiguous (both Maven and Gradle were found, or neither was found).
-
-If exactly one build tool was detected, do not ask Question 4; state the detection in the question text of Question 3 instead (for example, "Detected Maven.").
-
-When you do ask Question 4, use explicit question text such as: "Which build tool should I use for the OpenRewrite step: Maven or Gradle?" Do not proceed until you have the answer.
+*If scope includes code and approach is A (OpenRewrite + AI)* — **Build tool** (only if detection was ambiguous — both Maven and Gradle found, or neither): "Which build tool should I use for the OpenRewrite step: Maven or Gradle?" If exactly one build tool was detected, do not ask; state the detection in the approach question text instead (e.g. "Detected Maven."). Do not proceed until you have the answer.
 
 ---
 
-## Step 2: Assessment (always runs, regardless of approach)
+## Step 2: Assessment (always runs, regardless of scope)
 
-Scan the codebase at the provided path. Identify and classify all Camunda 7 related files:
+Scan the project at the provided path. Produce two inventories as relevant to the chosen scope.
+
+### Code inventory
+
+Identify and classify all Camunda 7 related Java/config files:
 
 | File | Type | Complexity | Notes |
 |------|------|------------|-------|
-| ... | JavaDelegate / ExternalTaskWorker / Listener / ClientCode / TestCode / Config / JUEL / DMN | Low / Medium / High | Key concerns |
+| ... | JavaDelegate / ExternalTaskWorker / Listener / ClientCode / TestCode / Config / JUEL | Low / Medium / High | Key concerns |
 
 **Detection hints:**
 - `implements JavaDelegate` → JavaDelegate
@@ -73,21 +91,32 @@ Scan the codebase at the provided path. Identify and classify all Camunda 7 rela
 - `ZeebeClient` / Spring Zeebe SDK (`io.camunda.spring:spring-boot-starter-camunda` or `zeebe-client-java`) → legacy C8 client code; migrate to `CamundaClient` / `camunda-spring-boot-starter` (ZeebeClient is removed in 8.10)
 - `@Test` + Camunda 7 test rules → Test code
 - `application.properties` / `application.yaml` with `camunda.*` keys → Config
-- `.bpmn` files with `camunda:` namespace attributes → BPMN (flag only — convert using the online tool, see below)
 - `ProcessEnginePlugin`, BPMN parse listeners → flag: global behavior; user-task cases map to global user task listeners (8.9+), others need manual design
 
 **Special blockers to flag explicitly:**
 - Listeners or delegates attached to multi-instance *bodies* that compute the collection variable — this sequencing does not exist in C8 (listeners fire after collection evaluation). Requires model change (preceding service task). High complexity.
 - Custom batch handlers (`ManagementService#createBatch` with custom jobs) — no generic C8 equivalent.
 
-After the table, present:
-- Total files to migrate
+### Model inventory
+
+Glob for `**/*.bpmn`, `**/*.bpmn20.xml`, `**/*.dmn`, `**/*.dmn11.xml`. For each, note whether it uses the `camunda:` namespace (needs conversion) and record its path:
+
+| File | Type | Uses `camunda:` ns | Notes |
+|------|------|--------------------|-------|
+| ... | BPMN / DMN | yes / no | e.g. JavaDelegate refs, JUEL expressions, listeners |
+
+These are migrated in **Part B** (not by OpenRewrite). Do not attempt to hand-edit them here — that is the Diagram Converter's job.
+
+### Summary
+
+After the tables, present:
+- Total code files and total model files to migrate
 - Overall complexity estimate
 - Whether OpenRewrite would help (JavaDelegates or ExternalTaskWorkers present?)
 - Any blockers requiring manual decision before starting
-- One short note on data migration scope: running instances, history/audit data, and authorizations are **not** code migration — point to the [Data Migrator](https://docs.camunda.io/docs/guides/migrating-from-camunda-7/migration-tooling/data-migrator/) (runtime since 8.8; history and identity since 8.9, history requires RDBMS secondary storage)
+- One short note on data migration scope: running instances, history/audit data, and authorizations are **not** code or model migration — point to the [Data Migrator](https://docs.camunda.io/docs/guides/migrating-from-camunda-7/migration-tooling/data-migrator/) (runtime since 8.8; history and identity since 8.9, history requires RDBMS secondary storage)
 
-**Write the assessment to `MIGRATION_REPORT.md` in the project root** (table, decisions, blockers). Keep this file updated as phases complete — it is the durable record of the migration across sessions.
+**Write the assessment to `MIGRATION_REPORT.md` in the project root** (both tables, decisions, blockers). Keep this file updated as phases complete — it is the durable record of the migration across sessions.
 
 Use `AskUserQuestion` to wait for user confirmation before proceeding.
 
@@ -95,7 +124,13 @@ Use `AskUserQuestion` to wait for user confirmation before proceeding.
 
 ## Step 3: Execute migration
 
-**Git checkpoint rule (applies to A and B):** before changing anything, verify the working tree is clean (`git status`). If not, ask the user to commit or stash first. Do not create commits automatically. After OpenRewrite and after each completed phase, ask whether the user wants a commit; only commit if they explicitly approve, using a clear message (e.g. `migration: resolve delegate TODOs`). This keeps every step reviewable and reversible while preserving user control.
+**Git checkpoint rule (applies to all approaches):** before changing anything, verify the working tree is clean (`git status`). If not, ask the user to commit or stash first. Do not create commits automatically. After OpenRewrite, after the Diagram Converter run, and after each completed phase, ask whether the user wants a commit; only commit if they explicitly approve, using a clear message (e.g. `migration: resolve delegate TODOs`). This keeps every step reviewable and reversible while preserving user control.
+
+Run **Part A** if the scope includes code, **Part B** if it includes models. For **Code + models**, see "Composing code + model migration" at the end of this step.
+
+---
+
+## Part A — Code migration (Java/Spring)
 
 ### Approach A — OpenRewrite + AI (recommended)
 
@@ -182,7 +217,7 @@ Work through each of the following. Confirm each before moving on. Do not auto-c
 - **Listeners**: OpenRewrite does not cover `ExecutionListener` / `TaskListener` implementations — convert per the "Listeners" patterns (execution listener job workers; user task listeners with corrections/deny; global user task listeners for cluster-wide cases on 8.9)
 - **Client code not covered by recipes**: `HistoryService` → search requests; `DecisionService` → `newEvaluateDecisionCommand`; batch `...Async` methods → batch operation endpoints (8.8+); `businessKey` → `businessId` (8.9) or tags (8.8)
 - **Test code**: replace `@Rule` Camunda test rules with `@CamundaSpringProcessTest`, update assertions (e.g. `isWaitingAt("id")` → `hasActiveElements("id")`), message correlation, timer handling (`processTestContext.increaseTime(...)`), user task completion (`processTestContext.completeUserTask(...)`), worker mocking (`processTestContext.mockJobWorker(...)`) — OpenRewrite doesn't fully cover tests. For large suites on 8.9+, recommend CPT *shared runtime* mode to cut execution time.
-- **JUEL expressions**: triage per the "Expression → Job Worker" pattern — pure data expressions convert to FEEL (Diagram Converter automates this), conditional events are supported natively since 8.9, only bean-invoking expressions need a JUEL job worker or a refactor into regular job workers
+- **JUEL expressions**: triage per the "Expression → Job Worker" pattern — pure data expressions convert to FEEL (the Diagram Converter automates this on the model side, see Part B), conditional events are supported natively since 8.9, only bean-invoking expressions need a JUEL job worker or a refactor into regular job workers
 
 ---
 
@@ -267,7 +302,7 @@ Then:
 
 ### Approach C — Assessment only
 
-Present the assessment table from Step 2 with additional detail:
+Present the code assessment table from Step 2 with additional detail:
 - Per-file effort estimate (hours)
 - Total estimated effort
 - Which files OpenRewrite can handle automatically vs. require manual AI work
@@ -279,7 +314,121 @@ Write the full report to `MIGRATION_REPORT.md`. Then stop — make no code chang
 
 ---
 
+## Part B — Model migration (BPMN/DMN)
+
+Model migration converts BPMN/DMN diagrams from the Camunda 7 (`camunda:`) namespace to the Camunda 8 (`zeebe:`) namespace: job types for delegates, listener mappings, simple JUEL→FEEL, event definitions, version-gated features. This is the model-side analogue of OpenRewrite: prefer the **deterministic** Diagram Converter (M1) over agentic rewriting (M2).
+
+**Conversion is not full migration.** The converter emits findings at severities **WARNING**, **TASK**, **REVIEW**, and **INFO**. TASK/REVIEW/WARNING items still need human follow-up, and JUEL conversion is only partial. Always tell the user this after a run.
+
+### Approach M1 — Diagram Converter CLI (deterministic, recommended)
+
+**1. Java 21+ prerequisite — fail fast**
+
+```bash
+java -version   # read the major version
+```
+
+If `java` is missing or the major version is **< 21**, STOP the CLI path and explain clearly, e.g.:
+
+> The Diagram Converter CLI requires Java 21+. Detected: `<version or "not found">`. Install Java 21+ and re-run, or choose **M2 (agentic AI)** which needs no Java, or **M3 (online converter)**.
+
+Do not silently skip model migration — surface the blocker and offer the alternatives.
+
+**2. Resolve the latest release and download the CLI into the project**
+
+The CLI is published as a self-contained executable JAR named `camunda-7-to-8-diagram-converter-cli-<version>.jar` on the repo's GitHub releases. Resolve the latest release tag, then download the matching asset into a project-local directory (reuse it if already present — don't re-download):
+
+```bash
+REPO=camunda/camunda-7-to-8-migration-tooling
+DEST_DIR=.camunda-migration
+mkdir -p "$DEST_DIR"
+
+# Preferred: GitHub CLI resolves the latest release tag
+TAG=$(gh release view --repo "$REPO" --json tagName -q .tagName)
+# Fallback without gh:
+#   TAG=$(curl -fsSL https://api.github.com/repos/$REPO/releases/latest | python3 -c 'import sys,json;print(json.load(sys.stdin)["tag_name"])')
+
+JAR="$DEST_DIR/camunda-7-to-8-diagram-converter-cli-${TAG}.jar"
+if [ ! -f "$JAR" ]; then
+  curl -fL -o "$JAR" \
+    "https://github.com/$REPO/releases/download/${TAG}/camunda-7-to-8-diagram-converter-cli-${TAG}.jar"
+fi
+```
+
+The JAR is large (~30 MB). If the project is a git repo, add `.camunda-migration/` to `.gitignore` — do not commit the downloaded tool.
+
+**3. Run the converter in local mode, targeting the user's C8 version**
+
+The CLI's `local` subcommand accepts a single file **or** a directory (recursive by default). Always pass `--platform-version` set to the version from Step 1 Question 2 so version-gated conversions (e.g. conditional events on 8.9+) are applied correctly.
+
+```bash
+java -Dfile.encoding=UTF-8 -jar "$JAR" local <FILE_OR_DIR> \
+  --platform-version <TARGET_MINOR> \   # e.g. 8.9 or 8.10 (from Step 1)
+  --csv --xlsx                          # optional analysis artifacts (see below)
+# add -o / --override   to overwrite pre-existing converted files
+# add --check           for analyze-only (no converted diagrams exported) — see "Analyze-only mode"
+# add -nr / --not-recursive  to disable recursive search when a directory is given
+```
+
+Useful options:
+- `--platform-version <v>` — target C8 version (`8.0`–`8.10`); defaults to latest if omitted. **Always set it.**
+- `--prefix <str>` — prefix for generated filenames (default `converted-c8-`). The converter writes a **new file next to the source**, e.g. `converted-c8-order-process.bpmn`, so originals are never mutated in place.
+- `-o` / `--override` — overwrite an existing converted file (otherwise it writes `... (1).bpmn` to avoid clobbering).
+- `--csv`, `--xlsx`, `--md` — write an analysis report (`analysis-results.csv` / `.xlsx` / `.md`) in the target directory.
+- `--check` — analyze only; no converted diagrams are exported.
+
+**4. Surface the outputs to the user**
+
+After the run, report back:
+- **Converted files** — list every `converted-c8-*.bpmn` / `*.dmn` produced and where.
+- **Analysis findings** — summarize from the CLI stdout and/or the CSV/XLSX report, grouped by severity (WARNING / TASK / REVIEW / INFO) with counts and the top items.
+- **Analysis artifacts** — if you generated `--csv` / `--xlsx`, point the user to them for review.
+
+**5. Explain that conversion ≠ done, then offer to help with findings**
+
+Tell the user plainly that REVIEW/WARNING/TASK findings remain and JUEL conversion is partial — these need follow-up. Then **offer to take care of them agentically**: for findings with an unambiguous fix, propose editing the converted BPMN/DMN (e.g. filling a job type, adjusting a FEEL expression), apply with `Edit`, and then **ask the human to review** the result. For ambiguous findings, consult via `AskUserQuestion` before changing anything (see the behavior rule on edge cases). Never overwrite the user's original diagrams — work on the `converted-c8-*` copies.
+
+### Approach M2 — Agentic AI (direct XML rewrite)
+
+Use when Java 21 is unavailable, the user wants to review every change, or the CLI can't handle a case. Fetch the current diagram-conversion guidance rather than relying on training knowledge:
+`https://raw.githubusercontent.com/camunda/camunda-docs/main/docs/guides/migrating-from-camunda-7/migration-tooling/diagram-converter.md`
+
+Then, for each in-scope diagram, produce a **new** `converted-c8-<name>.bpmn`/`.dmn` (never edit the original in place) applying, respecting the target version:
+- `camunda:` namespace/extension elements → `zeebe:` equivalents (task definitions/job types, IO mappings, headers)
+- Execution/task listeners → `zeebe:executionListeners` / user task listeners
+- JavaDelegate/expression references → job types (or blank, to be filled)
+- Simple JUEL → FEEL for pure data expressions; flag bean-invoking expressions for manual work
+- Conditional events natively only on 8.9+; otherwise flag
+- DMN: update decision/definition namespaces and expression language as needed
+
+Emit a findings summary mirroring the CLI severities (WARNING/TASK/REVIEW/INFO) and ask for human review. This path is slower and non-deterministic — recommend M1 whenever Java 21 is available.
+
+### Approach M3 — Online Diagram Converter (hosted, opt out)
+
+If the user prefers not to run the local CLI, point them to the hosted converter:
+
+> Upload your BPMN/DMN files at **https://diagram-converter.camunda.io/**, set the target version there, and download the converted results. Note: your diagrams leave your machine and are processed by the hosted service — don't use this for confidential models.
+
+This ticket does not automate the hosted service. Once the user brings the converted files back into the project, you can offer the same agentic findings follow-up as in M1 step 5.
+
+### Analyze-only mode
+
+For "analyze but don't convert": run M1 with `--check` (optionally `--csv`/`--xlsx`) to produce findings and reports with no converted files, or do an M2 read-only pass. Present the findings grouped by severity and stop — make no diagram changes.
+
+---
+
+## Composing code + model migration
+
+When the scope is **Code + models**:
+- The two paths are independent — run each with its chosen approach. Order doesn't strictly matter; a reasonable default is **models first** (diagrams define the job types/listeners the code must implement), then code, but follow the user's preference.
+- Keep both inventories and both sets of results in `MIGRATION_REPORT.md`.
+- After both complete, cross-check: job types emitted by the Diagram Converter should match the `@JobWorker(type = ...)` values produced by the code migration. Flag mismatches for the user.
+
+---
+
 ## Step 4: Validation (always runs)
+
+### Code validation (if code was migrated)
 
 1. **Compile**: `mvn compile` or `./gradlew compileJava` — fix all errors
 2. **Check for remaining C7 references**: Search for `org.camunda.bpm` imports — each is a missed migration
@@ -294,6 +443,12 @@ Write the full report to `MIGRATION_REPORT.md`. Then stop — make no code chang
   - `HistoryService` references — map to Orchestration Cluster search endpoints (eventually consistent — no read-after-write inside workers); historic *data* needs the History Data Migrator (8.9, RDBMS)
   - Batch operations — available since 8.8 via the Orchestration Cluster API (cancel/resolve/migrate/modify; delete since 8.9); only *custom* batch handlers need manual design
 
+### Model validation (if models were migrated)
+
+1. **Converted files present**: confirm a `converted-c8-*` file exists for each in-scope diagram (unless analyze-only).
+2. **Findings triaged**: every WARNING/TASK/REVIEW finding is either fixed (with human review) or explicitly recorded as remaining follow-up in `MIGRATION_REPORT.md`.
+3. **Originals intact**: the user's original diagrams were not overwritten.
+
 Present a summary:
 ```
 Validation Summary
@@ -303,6 +458,8 @@ Validation Summary
 ⚠️  Remaining TODOs: 5 → [list them]
 ⚠️  Remaining businessKey usages: 2 → [list them]
 ✅ Tests: 42 passed, 0 failed
+✅ Models converted: 4 → [list converted-c8-* files]
+⚠️  Model findings needing follow-up: 6 (2 REVIEW, 3 TASK, 1 WARNING) → [see analysis report]
 ```
 
 Record the summary in `MIGRATION_REPORT.md`. For any remaining issues, ask the user: fix now, skip, or flag for manual review.
@@ -311,12 +468,16 @@ Record the summary in `MIGRATION_REPORT.md`. For any remaining issues, ask the u
 
 ## Behavior rules
 
-- **Always load the pattern catalog before touching any code.** Never guess API mappings. For API details not covered by the catalog, prefer the official Camunda docs (`docs.camunda.io`) via `WebFetch` over training knowledge.
-- **Respect the target version.** Do not recommend 8.9 features (businessId, conditional events, global user task listeners, batch delete) to an 8.8 target, and do not send 8.9 targets down 8.8 workarounds.
+- **Distinguish code from models.** Run OpenRewrite/AI on code and the Diagram Converter on models — never hand-edit BPMN/DMN as part of the code flow. Ask for scope (Step 1 Q3) rather than assuming.
+- **Always load the reference before touching anything.** For code, load the pattern catalog; for agentic model work, load the diagram-converter docs. Never guess API or XML mappings. For details not covered, prefer official Camunda docs (`docs.camunda.io`) via `WebFetch` over training knowledge.
+- **Respect the target version.** Do not recommend 8.9 features (businessId, conditional events, global user task listeners, batch delete) to an 8.8 target, and do not send 8.9 targets down 8.8 workarounds. Pass the same version to the Diagram Converter via `--platform-version`.
+- **Prefer deterministic over agentic.** For code, prefer OpenRewrite + AI over AI-only. For models, prefer the Diagram Converter CLI (M1) over agentic rewriting (M2). Use the agentic/manual path only when the deterministic one can't run.
+- **Diagram Converter: fail fast on Java, download don't ask.** Require Java 21+ and stop with a clear message (offer M2/M3) if it's missing. Resolve and download the CLI automatically from the latest GitHub release into `.camunda-migration/`; reuse an existing download; never commit the JAR.
+- **Never mutate user assets silently.** The converter writes `converted-c8-*` copies — keep originals intact. Treat converted files and CSV/XLSX/markdown as generated outputs returned to the user for inspection.
+- **Conversion is not completion.** Always explain that REVIEW/WARNING/TASK findings and partial JUEL conversion remain, then offer to fix the unambiguous ones agentically and ask the human to review.
 - **One phase at a time; commits are opt-in.** Confirm each phase before starting the next. Never start on a dirty working tree. Ask before each commit and proceed only when the user explicitly allows it.
-- **Keep `MIGRATION_REPORT.md` current.** Assessment, decisions, phase status, validation results.
-- **Don't rewrite what OpenRewrite already changed.** In Approach A, check for existing transforms before rewriting.
-- **Flag BPMN files.** If `.bpmn` files use `camunda:` attributes, mention them in the assessment summary and recommend the user convert them at **https://diagram-converter.camunda.io/** — it handles namespace updates, listener mappings, simple JUEL→FEEL conversions, and (since 8.9) conditional events. Suggest running it after the code migration.
+- **Keep `MIGRATION_REPORT.md` current.** Both inventories, decisions, phase status, validation results.
+- **Don't rewrite what the tools already changed.** In Approach A, check for existing transforms before rewriting. After a Diagram Converter run, don't re-do conversions it already applied.
 - **Ask before High complexity files.** Describe the options and confirm before proceeding.
-- **Keep changes minimal.** Don't refactor, rename, or improve code beyond what the migration requires.
-- **Consult on edge cases, don't auto-fix.** Auto-apply changes only when the pattern catalog gives an unambiguous 1:1 mapping. For anything else — JUEL expressions invoking beans, BPMN error mapping, async/correlation, IdentityService/FormService usage, custom batches, multi-instance listener patterns, ambiguous TODOs from OpenRewrite, or compile errors whose fix isn't a direct catalog match — propose the change via `AskUserQuestion` before applying. When unsure whether a case is unambiguous, ask.
+- **Keep changes minimal.** Don't refactor, rename, or improve beyond what the migration requires.
+- **Consult on edge cases, don't auto-fix.** Auto-apply changes only when the reference gives an unambiguous 1:1 mapping. For anything else — JUEL expressions invoking beans, BPMN error mapping, async/correlation, IdentityService/FormService usage, custom batches, multi-instance listener patterns, ambiguous TODOs from OpenRewrite, ambiguous model findings, or compile errors whose fix isn't a direct catalog match — propose the change via `AskUserQuestion` before applying. When unsure whether a case is unambiguous, ask.

--- a/agentic-migration-skills/skills/migrate-c7-to-c8-code/SKILL.md
+++ b/agentic-migration-skills/skills/migrate-c7-to-c8-code/SKILL.md
@@ -362,12 +362,16 @@ The JAR is large (~30 MB). If the project is a git repo, add `.camunda-migration
 The CLI's `local` subcommand accepts a single file **or** a directory (recursive by default). Always pass `--platform-version` set to the version from Step 1 Question 2 so version-gated conversions (e.g. conditional events on 8.9+) are applied correctly.
 
 ```bash
+# TARGET_MINOR is the version from Step 1, e.g. 8.9 or 8.10
 java -Dfile.encoding=UTF-8 -jar "$JAR" local <FILE_OR_DIR> \
-  --platform-version <TARGET_MINOR> \   # e.g. 8.9 or 8.10 (from Step 1)
-  --csv --xlsx                          # optional analysis artifacts (see below)
-# add -o / --override   to overwrite pre-existing converted files
-# add --check           for analyze-only (no converted diagrams exported) — see "Analyze-only mode"
-# add -nr / --not-recursive  to disable recursive search when a directory is given
+  --platform-version <TARGET_MINOR> \
+  --csv \
+  --xlsx
+# Optional flags to add above:
+#   --csv / --xlsx             write analysis reports (already shown)
+#   -o / --override            overwrite pre-existing converted files
+#   --check                    analyze-only (no converted diagrams exported) — see "Analyze-only mode"
+#   -nr / --not-recursive      disable recursive search when a directory is given
 ```
 
 Useful options:

--- a/agentic-migration-skills/skills/migrate-c7-to-c8-code/SKILL.md
+++ b/agentic-migration-skills/skills/migrate-c7-to-c8-code/SKILL.md
@@ -18,7 +18,7 @@ Treat these as separate operations that compose. Do not conflate "migrate my cod
 
 Before calling `AskUserQuestion`, pick a candidate project root (use the provided argument if present, otherwise the current working directory), then detect the build tool by checking that directory for `pom.xml` (Maven) or `build.gradle` / `build.gradle.kts` (Gradle). Also glob for models (`**/*.bpmn`, `**/*.bpmn20.xml`, `**/*.dmn`, `**/*.dmn11.xml`) so you can tailor the scope question to what is actually present.
 
-Then call `AskUserQuestion` **once** with Questions 1-3 below (combine them in a single call — do not ask one at a time):
+Then call `AskUserQuestion` **once** with all questions below (combine them in a single call — do not ask one at a time):
 
 **Question 1 — Project location**
 
@@ -29,40 +29,39 @@ Then call `AskUserQuestion` **once** with Questions 1-3 below (combine them in a
 
 **Question 2 — Target Camunda 8 version**
 
-Ask which Camunda 8 version the user is migrating to:
+Ask which specific Camunda 8 version the user is migrating to:
 
-- **8.9 or later** *(recommended)* — includes Business ID (business key successor), BPMN conditional events, global user task listeners, batch delete, History/Identity Data Migrator.
+- **8.10** *(recommended, latest)* — latest GA release; includes all features from 8.8 and 8.9.
+- **8.9** — adds Business ID (business key successor), BPMN conditional events, global user task listeners, batch delete, History/Identity Data Migrator.
 - **8.8** — first version with the unified Orchestration Cluster API, CamundaClient, and Camunda Process Test. No Business ID (use tags), no conditional events.
 
-The target version changes which patterns apply **and** is passed to the Diagram Converter as `--platform-version` (valid values `8.0`–`8.10`). Record the concrete `major.minor` (e.g. `8.9`, `8.10`); if the user says "8.9 or later" without a specific minor, confirm the exact minor to target (default to the latest, `8.10`). Use the answer throughout.
+The target version changes which patterns apply **and** is passed to the Diagram Converter as `--platform-version` (valid values `8.0`–`8.10`). Record the concrete `major.minor` the user selects and use it throughout.
 
 **Question 3 — Migration scope**
 
 Ask what the user wants to migrate (tailor the wording to what you detected — code files, model files, or both):
 
+- **Code + models** *(recommended when both are present — default to this)* — Runs both Part A and Part B and composes them.
 - **Code only** — Java/Spring code. Runs Part A.
 - **Models only** — BPMN/DMN diagrams. Runs Part B.
-- **Code + models** *(recommended when both are present)* — Runs both Part A and Part B and composes them.
 - **Assessment only** — Scan and report scope/complexity/effort for code and models. No changes.
 
-**Follow-up questions (second `AskUserQuestion` call, after Question 3 is answered)**
-
-Ask only the follow-ups that apply to the chosen scope. Combine them into a single call where possible.
-
-*If scope includes code* — **Code migration approach**:
+**Question 4 — Code migration approach** *(include only if code files are present)*:
 
 - **A. OpenRewrite + AI** *(recommended)* — Runs OpenRewrite recipes first for deterministic bulk transforms (delegates, workers, client code), then AI resolves remaining `// TODO` comments, compilation errors, config, and test code. Best for most codebases.
 - **B. AI only** — AI migrates everything directly without OpenRewrite. Use this when you can't run OpenRewrite (non-Maven/Gradle builds, restricted environments) or want to review every change individually.
 - **C. Assessment only** — Scan the codebase and produce a report: file inventory, complexity estimate, effort breakdown. No code changes.
 
-*If scope includes models* — **Model migration approach**:
+**Question 5 — Model migration approach** *(include only if model files are present)*:
 
 - **M1. Diagram Converter CLI (deterministic)** *(recommended)* — Downloads the official `camunda-7-to-8-diagram-converter-cli` from GitHub releases into the project and runs it locally against your BPMN/DMN files, targeting your Camunda 8 version. Deterministic and repeatable; produces converted files plus analysis reports (CSV/XLSX). **Requires Java 21+.** This is the diagram equivalent of "OpenRewrite for code".
 - **M2. Agentic AI** — AI rewrites the BPMN/DMN XML directly (namespace, listeners, JUEL→FEEL, event mappings). Use when Java 21 is unavailable, you want to review every change, or a niche case the CLI doesn't cover. Slower and non-deterministic.
-- **M3. Online Diagram Converter (hosted)** — You upload your diagrams to **https://diagram-converter.camunda.io/** and download the converted results yourself. No local Java needed, but **files leave your machine** — do not use for confidential models. Use this to opt out of the local CLI entirely.
+- **M3. Online Diagram Converter (hosted)** — Upload your diagrams at **https://diagram-converter.camunda.io/** and download the converted results. No local Java needed; uses the hosted service.
 - Any of the above can be run in **analyze-only** mode first (see "Analyze-only mode" in Part B) to see findings without producing converted files.
 
-*If scope includes code and approach is A (OpenRewrite + AI)* — **Build tool** (only if detection was ambiguous — both Maven and Gradle found, or neither): "Which build tool should I use for the OpenRewrite step: Maven or Gradle?" If exactly one build tool was detected, do not ask; state the detection in the approach question text instead (e.g. "Detected Maven."). Do not proceed until you have the answer.
+**Question 6 — Build tool** *(include only if scope includes code, approach is A, and detection was ambiguous — both Maven and Gradle found, or neither)*: "Which build tool should I use for the OpenRewrite step: Maven or Gradle?" If exactly one build tool was detected, do not ask; state the detection in the approach question text instead (e.g. "Detected Maven."). Do not proceed until you have the answer.
+
+When the user accepts the defaults (recommended options) without changing anything, proceed directly. Be opinionated — the recommended options are what most projects need.
 
 ---
 
@@ -407,13 +406,13 @@ Then, for each in-scope diagram, produce a **new** `converted-c8-<name>.bpmn`/`.
 
 Emit a findings summary mirroring the CLI severities (WARNING/TASK/REVIEW/INFO) and ask for human review. This path is slower and non-deterministic — recommend M1 whenever Java 21 is available.
 
-### Approach M3 — Online Diagram Converter (hosted, opt out)
+### Approach M3 — Online Diagram Converter (hosted)
 
 If the user prefers not to run the local CLI, point them to the hosted converter:
 
-> Upload your BPMN/DMN files at **https://diagram-converter.camunda.io/**, set the target version there, and download the converted results. Note: your diagrams leave your machine and are processed by the hosted service — don't use this for confidential models.
+> Upload your BPMN/DMN files at **https://diagram-converter.camunda.io/**, set the target version there, and download the converted results.
 
-This ticket does not automate the hosted service. Once the user brings the converted files back into the project, you can offer the same agentic findings follow-up as in M1 step 5.
+This path does not automate the hosted service. Once the user brings the converted files back into the project, you can offer the same agentic findings follow-up as in M1 step 5.
 
 ### Analyze-only mode
 
@@ -466,7 +465,28 @@ Validation Summary
 ⚠️  Model findings needing follow-up: 6 (2 REVIEW, 3 TASK, 1 WARNING) → [see analysis report]
 ```
 
-Record the summary in `MIGRATION_REPORT.md`. For any remaining issues, ask the user: fix now, skip, or flag for manual review.
+Record the summary in `MIGRATION_REPORT.md`.
+
+---
+
+## Step 5: AI follow-up (offer after validation)
+
+After presenting the validation summary, if there are remaining TODOs, REVIEW/WARNING/TASK findings, compilation issues, or unresolved items, **proactively offer** to resolve them:
+
+> I found [N] remaining items that need follow-up. Would you like me to take care of them? I can:
+> - Fix remaining `// TODO` comments based on the pattern catalog
+> - Resolve REVIEW/TASK/WARNING findings in the converted models
+> - Suggest fixes for compilation errors or test failures
+> - Fill in blank job types or FEEL expressions where the mapping is clear
+>
+> I'll propose each change for your review before applying it.
+
+Use `AskUserQuestion` with:
+- **Yes, fix what you can** *(recommended)* — AI resolves unambiguous items, proposes each for review.
+- **Show me the list first** — Present the full list of remaining items grouped by type, then ask which to fix.
+- **No, I'll handle the rest manually** — Stop here; record remaining items in `MIGRATION_REPORT.md`.
+
+When the user opts in, work through items one at a time: apply unambiguous fixes directly (using the pattern catalog / converter docs as reference), propose ambiguous ones via `AskUserQuestion`, and skip anything the user declines. Ask whether to commit after each batch of resolved items.
 
 ---
 

--- a/agentic-migration-skills/skills/migrate-c7-to-c8-code/SKILL.md
+++ b/agentic-migration-skills/skills/migrate-c7-to-c8-code/SKILL.md
@@ -12,7 +12,7 @@ You are a migration expert helping the user migrate a Camunda 7 project to Camun
 - **Code** — Java/Spring glue and client code, config, tests. Migrated with **OpenRewrite recipes** (deterministic) plus AI cleanup.
 - **Models** — BPMN/DMN diagrams using the `camunda:` namespace. Migrated with the **Diagram Converter** (deterministic) or agentically.
 
-Treat these as separate operations that compose. Do not conflate "migrate my code" with "migrate my diagrams" — ask what the user wants (Step 1, Question 3) and run only the relevant path(s).
+Treat these as separate operations that compose. Ask what the user wants (Step 1, Question 3) and run only the relevant path(s).
 
 ## Step 1: Gather inputs
 
@@ -22,39 +22,39 @@ Then call `AskUserQuestion` **once** with all questions below (combine them in a
 
 **Question 1 — Project location**
 
-"What is the path to the project root?"
+"What is the path to the project root?" (let user propose other option)
 
 - If an argument was passed to the command, propose that path (e.g. "I'll use `/path/to/project` — is that correct?").
 - Otherwise propose the current working directory.
 
 **Question 2 — Target Camunda 8 version**
 
-Ask which specific Camunda 8 version the user is migrating to:
+Ask which specific Camunda 8 version the user is migrating to (user can't select anything else):
 
-- **8.10** *(recommended, latest)* — latest GA release; includes all features from 8.8 and 8.9.
-- **8.9** — adds Business ID (business key successor), BPMN conditional events, global user task listeners, batch delete, History/Identity Data Migrator.
+- **8.10** *(next version, not yet GA)* —; includes all features from 8.8 and 8.9 too.
+- **8.9** *(latest stable)* — adds Business ID (business key successor), BPMN conditional events, global user task listeners, batch delete, History/Identity Data Migrator.
 - **8.8** — first version with the unified Orchestration Cluster API, CamundaClient, and Camunda Process Test. No Business ID (use tags), no conditional events.
 
 The target version changes which patterns apply **and** is passed to the Diagram Converter as `--platform-version` (valid values `8.0`–`8.10`). Record the concrete `major.minor` the user selects and use it throughout.
 
 **Question 3 — Migration scope**
 
-Ask what the user wants to migrate (tailor the wording to what you detected — code files, model files, or both):
+Ask what the user wants to migrate (tailor the wording to what you detected — code files, model files, or both, user can't select anything else):
 
 - **Code + models** *(recommended when both are present — default to this)* — Runs both Part A and Part B and composes them.
 - **Code only** — Java/Spring code. Runs Part A.
 - **Models only** — BPMN/DMN diagrams. Runs Part B.
 - **Assessment only** — Scan and report scope/complexity/effort for code and models. No changes.
 
-**Question 4 — Code migration approach** *(include only if code files are present)*:
+**Question 4 — Code migration approach** *(include only if code files are present and user selected code migration, user can't select anything else)*:
 
-- **A. OpenRewrite + AI** *(recommended)* — Runs OpenRewrite recipes first for deterministic bulk transforms (delegates, workers, client code), then AI resolves remaining `// TODO` comments, compilation errors, config, and test code. Best for most codebases.
+- **A. OpenRewrite (deterministic) + AI** *(recommended)* — Runs OpenRewrite recipes first for deterministic bulk transforms (delegates, workers, client code). When prompted you can ask AI to resolve remaining `// TODO` comments, compilation errors, config, and test code. Best for most codebases.
 - **B. AI only** — AI migrates everything directly without OpenRewrite. Use this when you can't run OpenRewrite (non-Maven/Gradle builds, restricted environments) or want to review every change individually.
 - **C. Assessment only** — Scan the codebase and produce a report: file inventory, complexity estimate, effort breakdown. No code changes.
 
-**Question 5 — Model migration approach** *(include only if model files are present)*:
+**Question 5 — Model migration approach** *(include only if model files are present and user asked for migrating models, user can't select anything else)*:
 
-- **M1. Diagram Converter CLI (deterministic)** *(recommended)* — Downloads the official `camunda-7-to-8-diagram-converter-cli` from GitHub releases into the project and runs it locally against your BPMN/DMN files, targeting your Camunda 8 version. Deterministic and repeatable; produces converted files plus analysis reports (CSV/XLSX). **Requires Java 21+.** This is the diagram equivalent of "OpenRewrite for code".
+- **M1. Diagram Converter CLI (deterministic) + AI** *(recommended)* — Downloads the official `camunda-7-to-8-diagram-converter-cli` from GitHub releases into the project and runs it locally against your BPMN/DMN files, targeting your Camunda 8 version. Deterministic and repeatable; produces converted files plus analysis reports (CSV/XLSX). **Requires Java 21+.**. When prompted you can ask AI to address remaining TODO items and suggest changes.
 - **M2. Agentic AI** — AI rewrites the BPMN/DMN XML directly (namespace, listeners, JUEL→FEEL, event mappings). Use when Java 21 is unavailable, you want to review every change, or a niche case the CLI doesn't cover. Slower and non-deterministic.
 - **M3. Online Diagram Converter (hosted)** — Upload your diagrams at **https://diagram-converter.camunda.io/** and download the converted results. No local Java needed; uses the hosted service.
 - Any of the above can be run in **analyze-only** mode first (see "Analyze-only mode" in Part B) to see findings without producing converted files.
@@ -137,6 +137,7 @@ Run **Part A** if the scope includes code, **Part B** if it includes models. For
 
 Before adding the plugin, resolve the latest released versions via WebFetch:
 
+
 - `rewrite-maven-plugin` (OpenRewrite): `https://search.maven.org/solrsearch/select?q=g:org.openrewrite.maven+AND+a:rewrite-maven-plugin&rows=1&wt=json` → read `response.docs[0].latestVersion`
 - `camunda-7-to-8-code-conversion-recipes`: `https://search.maven.org/solrsearch/select?q=g:io.camunda+AND+a:camunda-7-to-8-code-conversion-recipes&rows=1&wt=json` → read `response.docs[0].latestVersion`
 
@@ -203,6 +204,8 @@ Run: `./gradlew rewriteRun`
 Before AI cleanup, ask whether to commit the OpenRewrite result. Commit only if the user explicitly approves.
 
 **2. AI cleanup — after OpenRewrite has run**
+
+Start by prompting the user, if they want run AI cleanup after deterministic code migration. Only progress, if the answer is YES.
 
 First, fetch the pattern catalog via WebFetch from `main` — this is your reference for resolving TODOs, config, tests, listeners, and JUEL. Do not rely on training knowledge for API mappings:
 `https://raw.githubusercontent.com/camunda/camunda-7-to-8-migration-tooling/main/code-conversion/patterns/ALL_IN_ONE.md`
@@ -319,7 +322,7 @@ Model migration converts BPMN/DMN diagrams from the Camunda 7 (`camunda:`) names
 
 **Conversion is not full migration.** The converter emits findings at severities **WARNING**, **TASK**, **REVIEW**, and **INFO**. TASK/REVIEW/WARNING items still need human follow-up, and JUEL conversion is only partial. Always tell the user this after a run.
 
-### Approach M1 — Diagram Converter CLI (deterministic, recommended)
+### Approach M1 — Diagram Converter CLI +AI (deterministic, recommended)
 
 **1. Java 21+ prerequisite — fail fast**
 


### PR DESCRIPTION
## Summary

- The `migrate-c7-to-c8-code` skill handled only Java code and merely *flagged* BPMN/DMN files pointing to the online converter. This adds a first-class **model migration** path that mirrors the code flow (deterministic tool preferred over agentic), closing the end-to-end gap.
- New scope question routes each request to **code**, **models**, **both**, or **assessment** — so the skill no longer conflates "migrate my code" with "migrate my diagrams".
- Model migration offers three approaches, deterministic recommended: **Diagram Converter CLI** (download + run locally), **agentic AI**, or **opt out to the hosted online converter**.

## Changes

- `agentic-migration-skills/skills/migrate-c7-to-c8-code/SKILL.md`:
  - **Step 1**: added migration-scope question; target C8 version now also feeds the converter's `--platform-version`.
  - **Step 2**: added a BPMN/DMN model inventory alongside the code inventory.
  - **Part B — model migration**:
    - **M1 Diagram Converter CLI (recommended)** — Java 21+ fail-fast; resolve the latest GitHub release; download `camunda-7-to-8-diagram-converter-cli-<version>.jar` into `.camunda-migration/` (reuse, don't commit); run `local` mode on a file/dir with `--platform-version <target>`, `--csv`/`--xlsx`, `--prefix`, `-o`; surface converted files + findings by severity.
    - **M2 agentic AI** — direct XML rewrite when Java 21 is unavailable or per-change review is wanted.
    - **M3 online converter** — opt out to https://diagram-converter.camunda.io/ (files leave the machine).
    - Explains conversion ≠ completion (REVIEW/WARNING/TASK + partial JUEL) and offers to fix unambiguous findings with human review. Never mutates originals (`converted-c8-*` copies).
  - **Step 4**: added model validation checks.
  - Composes model + code migration when both are in scope; code flow (OpenRewrite + AI) unchanged.
- `agentic-migration-skills/README.md`, `.claude-plugin/marketplace.json`: document model migration + approach table.

## Test plan

- [x] CLI invocation validated end-to-end: resolved latest release (`0.3.3`), downloaded the CLI, ran `local <dir> --platform-version 8.9 --csv` on a sample C7 BPMN → produced `converted-c8-sample.bpmn` + `analysis-results.csv`, original left intact.
- [x] Verified documented option names against `local --help` (`--check`, `--csv`, `--xlsx`, `--prefix`, `-o`, `--platform-version`, `-nr`).
- [x] Confirmed `--platform-version` accepts `8.0`–`8.10` (`SemanticVersion`), and the CLI handles both BPMN (`.bpmn`, `.bpmn20.xml`) and DMN (`.dmn`, `.dmn11.xml`) (`DiagramType`).
- [ ] Reviewer: skill is markdown guidance for the agent — no Maven module touched, so no build/test impact; validated by running the documented commands.

## Baseline

Built from commit: 88671901

closes #1421

🤖 Generated with [Claude Code](https://claude.com/claude-code)