### PR TITLE
fix(recipes): enforce supported Java version (21-25) for OpenRewrite recipe build

### DIFF
--- a/code-conversion/recipes/pom.xml
+++ b/code-conversion/recipes/pom.xml
@@ -249,6 +249,32 @@
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>enforce-java-21</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <requireJavaVersion>
+                  <version>[21,22)</version>
+                  <message>
+OpenRewrite's Java parser relies on javac internals that are only compatible with Java 21 (see AGENTS.md: "Java 21" is the supported/required JDK).
+Newer JDKs (e.g. Java 26) cause OpenRewrite recipe tests to fail deep inside parser internals with confusing errors.
+Point JAVA_HOME at a Java 21 JDK before building this module, e.g.:
+  export JAVA_HOME=/opt/homebrew/opt/openjdk@21
+  export PATH="$JAVA_HOME/bin:$PATH"
+                  </message>
+                </requireJavaVersion>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <version>${plugin.version.surefire}</version>
       </plugin>

--- a/code-conversion/recipes/pom.xml
+++ b/code-conversion/recipes/pom.xml
@@ -260,11 +260,11 @@
             <configuration>
               <rules>
                 <requireJavaVersion>
-                  <version>[21,22)</version>
+                  <version>[21,26)</version>
                   <message>
-This module requires Java 21 (see AGENTS.md: "Java 21" is the supported/required JDK) — detected a different major version.
-OpenRewrite's Java parser relies on javac internals that only match the Java 21 build; other JDKs (older or newer, e.g. Java 26) cause OpenRewrite recipe tests to fail deep inside parser internals with confusing errors.
-Point JAVA_HOME at a Java 21 JDK before building this module, e.g.:
+This module requires a Java 21-25 JDK (see AGENTS.md: "Java 21" is the minimum supported/required JDK) — detected a different major version.
+OpenRewrite's Java parser relies on javac internals; Java 26 introduced a breaking javac internals change that OpenRewrite has not yet restored support for (an interim rewrite-java-next module was added and then reverted upstream), causing recipe tests to fail deep inside parser internals with confusing errors. Java versions below 21 are unsupported per this project's baseline.
+Point JAVA_HOME at a Java 21-25 JDK before building this module, e.g.:
   export JAVA_HOME=/path/to/jdk-21
   export PATH="$JAVA_HOME/bin:$PATH"
                   </message>

--- a/code-conversion/recipes/pom.xml
+++ b/code-conversion/recipes/pom.xml
@@ -262,7 +262,7 @@
                 <requireJavaVersion>
                   <version>[21,26)</version>
                   <message>
-This module requires a Java 21-25 JDK (see AGENTS.md: "Java 21" is the minimum supported/required JDK) — detected a different major version.
+This module requires a Java 21-25 JDK — detected a different major version.
 OpenRewrite's Java parser relies on javac internals; Java 26 introduced a breaking javac internals change that OpenRewrite has not yet restored support for (an interim rewrite-java-next module was added and then reverted upstream), causing recipe tests to fail deep inside parser internals with confusing errors. Java versions below 21 are unsupported per this project's baseline.
 Point JAVA_HOME at a Java 21-25 JDK before building this module, e.g.:
   export JAVA_HOME=/path/to/jdk-21

--- a/code-conversion/recipes/pom.xml
+++ b/code-conversion/recipes/pom.xml
@@ -253,6 +253,7 @@
         <executions>
           <execution>
             <id>enforce-java-21</id>
+            <phase>validate</phase>
             <goals>
               <goal>enforce</goal>
             </goals>
@@ -261,10 +262,10 @@
                 <requireJavaVersion>
                   <version>[21,22)</version>
                   <message>
-OpenRewrite's Java parser relies on javac internals that are only compatible with Java 21 (see AGENTS.md: "Java 21" is the supported/required JDK).
-Newer JDKs (e.g. Java 26) cause OpenRewrite recipe tests to fail deep inside parser internals with confusing errors.
+This module requires Java 21 (see AGENTS.md: "Java 21" is the supported/required JDK) — detected a different major version.
+OpenRewrite's Java parser relies on javac internals that only match the Java 21 build; other JDKs (older or newer, e.g. Java 26) cause OpenRewrite recipe tests to fail deep inside parser internals with confusing errors.
 Point JAVA_HOME at a Java 21 JDK before building this module, e.g.:
-  export JAVA_HOME=/opt/homebrew/opt/openjdk@21
+  export JAVA_HOME=/path/to/jdk-21
   export PATH="$JAVA_HOME/bin:$PATH"
                   </message>
                 </requireJavaVersion>

--- a/code-conversion/recipes/pom.xml
+++ b/code-conversion/recipes/pom.xml
@@ -252,7 +252,7 @@
         <artifactId>maven-enforcer-plugin</artifactId>
         <executions>
           <execution>
-            <id>enforce-java-21</id>
+            <id>enforce-supported-java-version</id>
             <phase>validate</phase>
             <goals>
               <goal>enforce</goal>


### PR DESCRIPTION
## Summary

- OpenRewrite's Java parser reaches into javac internals (see `.mvn/jvm.config`'s `--add-exports jdk.compiler/...`) that break on Java 26. Recipe tests crash deep inside parser internals with a confusing `NoSuchMethodError` instead of a clear message. Upstream OpenRewrite briefly added Java 26 support (`rewrite-java-next`, [openrewrite/rewrite#7719](https://github.com/openrewrite/rewrite/pull/7719)) and reverted it two days later "due to downstream issues" ([openrewrite/rewrite#7764](https://github.com/openrewrite/rewrite/pull/7764)) — no upstream fix currently exists.
- Added a `maven-enforcer-plugin` `requireJavaVersion` rule scoped to `code-conversion/recipes` (not repo-wide, since only this module's OpenRewrite tests are affected) that fails the build immediately with an actionable message pointing at `JAVA_HOME` when run on an unsupported JDK.
- CI is unaffected: `code-conversion`'s CI job already builds on Java 21 by default via `.github/actions/setup-maven`.

## Changes

- `code-conversion/recipes/pom.xml`: added `maven-enforcer-plugin` execution (bound explicitly to the `validate` phase) with a `requireJavaVersion` rule (`[21,26)`), version already managed via `camunda-release-parent` pluginManagement.

## Test plan

Ran the full `code-conversion/recipes` test suite against multiple host JDKs (not just the two endpoints) to find the actual supported boundary rather than assume:

- [x] JDK 17: fails to *compile* (`maven.compiler.release=21` requires the compiler host to be >= 21 — unrelated to OpenRewrite, just a floor).
- [x] JDK 21: 74/74 tests pass.
- [x] JDK 25: 74/74 tests pass (verified with Homebrew OpenJDK 25.0.3) — no javac-internals regression between 21 and 25, so the enforcer rule allows the full `[21,26)` range instead of pinning to exactly 21.
- [x] JDK 26: fails deep in OpenRewrite's parser (verified with Homebrew OpenJDK 26.0.1), matching the issue report exactly (8 failures + 2 errors across the suite). Enforcer now fails fast with a clear message instead.
- [x] `mvn clean install -DskipTests` from repo root passes under Java 21 (no regressions to other modules).

## Baseline

Built from commit: 343b48697bde053585814cf8da1b2b6eb49a49f6

related to #1636

🤖 Generated with [Claude Code](https://claude.com/claude-code)