### PR TITLE
fix(qa): unblock Operate e2e and multi-tenancy runtime tests on Camunda 8.10 SNAPSHOT

### DIFF
--- a/data-migrator/qa/e2e-tests/src/main/resources/docker-compose.yml.template
+++ b/data-migrator/qa/e2e-tests/src/main/resources/docker-compose.yml.template
@@ -82,6 +82,14 @@ services:
       - CAMUNDA_CLIENT_MODE=self-managed
       - CAMUNDA_CLIENT_GRPC_ADDRESS=http://camunda8:26500
       - CAMUNDA_CLIENT_REST_ADDRESS=http://camunda8:8080
+      # C8 API auth is enforced (unprotected-api: false, required for the Operate UI
+      # login flow to work), so the migrator client must authenticate as the demo user.
+      - CAMUNDA_CLIENT_AUTH_USERNAME=demo
+      - CAMUNDA_CLIENT_AUTH_PASSWORD=demo
+      # Keep the client request timeout below the REST socket timeout so the
+      # authenticated job-activation long-poll returns cleanly instead of the
+      # socket timing out during the runtime migration.
+      - CAMUNDA_CLIENT_REQUEST_TIMEOUT=PT8S
     command:
       - /bin/bash
       - -c
@@ -144,7 +152,7 @@ configs:
         security:
           authentication:
             method: "basic"
-            unprotectedApi: true
+            unprotected-api: false
           authorizations:
             enabled: false
           initialization:

--- a/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/runtime/tenant/MultiTenancyRetryTest.java
+++ b/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/runtime/tenant/MultiTenancyRetryTest.java
@@ -12,6 +12,7 @@ import static io.camunda.migration.data.impl.logging.RuntimeValidatorLogs.NO_C8_
 import static io.camunda.migration.data.qa.util.LogMessageFormatter.formatMessage;
 import static io.camunda.process.test.api.CamundaAssert.assertThat;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
 
 import io.camunda.client.CamundaClient;
 import io.camunda.migration.data.MigratorMode;
@@ -19,6 +20,7 @@ import io.camunda.migration.data.RuntimeMigrator;
 import io.camunda.migration.data.exception.RuntimeMigratorException;
 import io.camunda.migration.data.qa.runtime.RuntimeMigrationAbstractTest;
 import io.github.netmikey.logunit.api.LogCapturer;
+import java.time.Duration;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -82,7 +84,12 @@ class MultiTenancyRetryTest extends RuntimeMigrationAbstractTest {
     deployer.deployCamunda8Process(SIMPLE_PROCESS_BPMN, TENANT_ID_2);
 
     runtimeMigrator.setMode(MigratorMode.RETRY_SKIPPED);
-    runtimeMigrator.start();
+    // Assigning the user to tenant-2 above is eventually consistent: the migrator's
+    // job activation can be rejected with "user is not authorized" until the new
+    // tenant authorization propagates. Retry the migration until it takes effect.
+    await().ignoreException(RuntimeMigratorException.class)
+        .timeout(Duration.ofSeconds(30))
+        .untilAsserted(runtimeMigrator::start);
 
     // then
     assertThatProcessInstanceCountIsEqualTo(1);


### PR DESCRIPTION
Two independent test failures surfaced by running the suite against the rolling `camunda/camunda:SNAPSHOT` (8.10) image. Both are **auth-behavior drift in the SNAPSHOT**, not regressions in this repo — they flipped green→red on unchanged commits because the image is rebuilt daily. Fixed together so main CI goes green.

## Fix 1 — e2e Operate UI login ("Credentials could not be verified")
`data-migrator/qa/e2e-tests/src/main/resources/docker-compose.yml.template`

The e2e Camunda 8 config set `unprotectedApi: true`. On recent 8.10 SNAPSHOT builds the Operate login SPA validates the new session with `GET /v2/authentication/me` right after `POST /login`. With the API unprotected there is no authenticated principal on that call → `/me` returns 401 → the UI shows "Credentials could not be verified", even though the login POST itself succeeds (204). Every Operate test then fails at login and cascade-skips the rest.

Changes:
- `unprotected-api: false` — enforce API auth so the session-based `/me` check returns 200 and UI login completes.
- `CAMUNDA_CLIENT_AUTH_USERNAME/PASSWORD=demo` — the migrator must now authenticate against the protected API.
- `CAMUNDA_CLIENT_REQUEST_TIMEOUT=PT8S` — keep the runtime migrator's job-activation long-poll under the client's ~11s REST socket timeout, so the runtime phase doesn't socket-time-out.

## Fix 2 — `MultiTenancyRetryTest` (it-runtime-h2): 401 activating jobs for tenant-2
`data-migrator/qa/integration-tests/.../runtime/tenant/MultiTenancyRetryTest.java`

Assigning the demo user to a newly-created tenant is **eventually consistent** on 8.10. The test assigned the user to `tenant-2` and immediately re-ran the migrator, so job activation was rejected with "user is not authorized" before the authorization propagated → deterministic failure.

Change: wrap the retry migration in `Awaitility.await().ignoreException(RuntimeMigratorException.class).timeout(30s)` so it retries until the authorization takes effect. This matches the module's existing convention for identity/authz eventual consistency (`RuntimeMigrationExtension`, `GroupMigrationTest`). Re-invoking `RETRY_SKIPPED` is safe — the tenant-2 instance is recorded as migrated on the first attempt, so it is not re-created. Only this test is affected; the sibling tenant tests assign in `@BeforeEach`, so the assignment settles before the migrator runs.

## Verification
- Fix 1 reproduced and fixed locally against `camunda/camunda:SNAPSHOT` (network trace + full-stack run, 34 e2e tests pass across chromium + firefox).
- Fix 2 compile-verified locally; runtime-verified in CI (local Docker unavailable).
- CI run all green: `e2e`, all four `it-runtime-h2` shards, `it-history-h2`, `it-identity-h2`, windows.

_Note: branch name `fix/e2e-operate-readiness-race` is legacy — the initial readiness-poll approach was ruled out by local reproduction and dropped._