### PR TITLE
feat: Pin openrewrite by target camunda version

### DIFF
--- a/agentic-migration-skills/skills/migrate-c7-to-c8-code/SKILL.md
+++ b/agentic-migration-skills/skills/migrate-c7-to-c8-code/SKILL.md
@@ -61,7 +61,7 @@ Ask which specific Camunda 8 version the user is migrating to (user can't select
 - **8.9** *(latest stable)* — adds Business ID (business key successor), BPMN conditional events, global user task listeners, batch delete, History/Identity Data Migrator.
 - **8.8** — first version with the unified Orchestration Cluster API, CamundaClient, and Camunda Process Test. No Business ID (use tags), no conditional events.
 
-The target version changes which patterns apply **and** is passed to the Diagram Converter as `--platform-version` (valid values `8.8`–`8.10`). Record the concrete `major.minor` the user selects and use it throughout.
+The target version changes which patterns apply **and** is passed to the Diagram Converter as `--platform-version` (valid values `8.0`–`8.10`; this skill only offers `8.8`–`8.10`). Record the concrete `major.minor` the user selects and use it throughout.
 
 **Question 3 — Migration scope**
 

--- a/agentic-migration-skills/skills/migrate-c7-to-c8-code/SKILL.md
+++ b/agentic-migration-skills/skills/migrate-c7-to-c8-code/SKILL.md
@@ -37,14 +37,21 @@ These apply throughout — referenced below instead of repeated.
 
 Before calling `AskUserQuestion`, pick a candidate project root (use the provided argument if present, otherwise the current working directory), then detect the build tool by checking that directory for `pom.xml` (Maven) or `build.gradle` / `build.gradle.kts` (Gradle). Also glob for models (`**/*.bpmn`, `**/*.bpmn20.xml`, `**/*.dmn`, `**/*.dmn11.xml`) so you can tailor the scope question to what is actually present.
 
-Then call `AskUserQuestion` **once** with all questions below (combine them in a single call — do not ask one at a time):
+Then ask the questions below with `AskUserQuestion`. **Tool limits: at most 4 questions per call, and every question that supplies `options` must have at least 2 options.** Because up to 6 questions may apply, batch them:
+
+- **Call 1** — the always-applicable questions: Q1, Q2, Q3 (3 questions).
+- **Call 2** — the conditional approach questions that apply given the Q3 answer and your detection: any of Q4, Q5, Q6 (≤3 questions).
+
+Only include a conditional question when its stated condition holds, and never put more than 4 in one call. If a single call would exceed 4, split it further.
 
 **Question 1 — Project location**
 
-"What is the path to the project root?" (let user propose other option)
+Confirm the project root you detected. Provide two options so the question is valid:
 
-- If an argument was passed to the command, propose that path (e.g. "I'll use `/path/to/project` — is that correct?").
-- Otherwise propose the current working directory.
+- **Use `<detected path>`** *(recommended)* — the argument path if one was passed, otherwise the current working directory.
+- **Enter a different path** — let the user type the path in the free-form field.
+
+(If you prefer a pure free-text prompt instead, omit `options` entirely — do not send a single-option question.)
 
 **Question 2 — Target Camunda 8 version**
 
@@ -54,7 +61,7 @@ Ask which specific Camunda 8 version the user is migrating to (user can't select
 - **8.9** *(latest stable)* — adds Business ID (business key successor), BPMN conditional events, global user task listeners, batch delete, History/Identity Data Migrator.
 - **8.8** — first version with the unified Orchestration Cluster API, CamundaClient, and Camunda Process Test. No Business ID (use tags), no conditional events.
 
-The target version changes which patterns apply **and** is passed to the Diagram Converter as `--platform-version` (valid values `8.0`–`8.10`). Record the concrete `major.minor` the user selects and use it throughout.
+The target version changes which patterns apply **and** is passed to the Diagram Converter as `--platform-version` (valid values `8.8`–`8.10`). Record the concrete `major.minor` the user selects and use it throughout.
 
 **Question 3 — Migration scope**
 

--- a/agentic-migration-skills/skills/migrate-c7-to-c8-code/SKILL.md
+++ b/agentic-migration-skills/skills/migrate-c7-to-c8-code/SKILL.md
@@ -203,11 +203,11 @@ Confirm each item before the next (commit policy: Shared rules). Tags mark what 
 
 **1. Run OpenRewrite** — deterministic bulk transforms for delegates, external workers, and client code.
 
-Before adding the plugin, resolve the latest released versions via WebFetch:
+RECIPES_VERSION by Camunda target, use the latest from these minor versions: 8.8 → `0.2.x`; 8.9 and 8.10 → `0.3.x`.
 
-
+REWRITE_VERSION: Before adding the plugin, resolve the latest released version via WebFetch:
 - `rewrite-maven-plugin` (OpenRewrite): `https://search.maven.org/solrsearch/select?q=g:org.openrewrite.maven+AND+a:rewrite-maven-plugin&rows=1&wt=json` → read `response.docs[0].latestVersion`
-- `camunda-7-to-8-code-conversion-recipes`: `https://search.maven.org/solrsearch/select?q=g:io.camunda+AND+a:camunda-7-to-8-code-conversion-recipes&rows=1&wt=json` → read `response.docs[0].latestVersion`
+
 
 Use those resolved versions in the snippets below (replacing `REWRITE_VERSION` and `RECIPES_VERSION`).
 


### PR DESCRIPTION
# Pull Request Template

Different Camunda versions need different migration recipes. As the recipes can't have a target version, use the appropriate version for the given Camunda target.

## Description

Previously the `migrate-c7-to-c8-code` skill always resolved `camunda-7-to-8-code-conversion-recipes` to its **latest** Maven version via the Solr search API, regardless of which Camunda 8 target version the user selected. Since the recipes artifact is versioned per target Camunda minor, this could apply recipes meant for a newer Camunda version than the one the user is actually migrating to.

This PR replaces the "always latest" lookup with a fixed mapping from target Camunda version to recipe minor version (8.8 → `0.2.x`, 8.9/8.10 → `0.3.x`), resolved from the target version the user already picked in Question 2. The `rewrite-maven-plugin` version is still resolved dynamically via WebFetch, since that dependency isn't tied to the Camunda target.

Also fixes `AskUserQuestion` usage in the skill: the tool caps calls at 4 questions and requires ≥2 options per question, but the skill asked for all 6 questions (Q1–Q6) in a single call and allowed single-option questions. The questions are now split into two calls (Q1–Q3 always, Q4–Q6 conditionally) and Question 1 always provides two options.

Along the way, Question 2's valid target version range was corrected from `8.0`–`8.10` to `8.8`–`8.10` to match what the Diagram Converter actually supports.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Test-only changes (no production code changes)

## Testing Checklist

Not applicable — this change only edits skill instructions (`SKILL.md`), no production Java code.

### Black-Box Testing Requirements
- [x] Tests follow **black-box testing approach**: verify behavior through observable outputs (logs, C8 API queries, real-world skip scenarios)
- [x] Tests **DO NOT** access implementation details (`DbClient`, `IdKeyMapper`, `..impl..` packages except logging constants)
- [ ] Architecture tests pass (`ArchitectureTest` validates these rules)

### Test Coverage
- [ ] Added tests for new functionality
- [ ] Updated tests for modified functionality
- [ ] All tests pass locally

## Architecture Compliance

Not applicable — no Java code changed.

## Documentation
- [ ] Updated TESTING_GUIDELINES.md if adding new test patterns
- [ ] Added Javadoc comments for public APIs
- [x] Updated README if user-facing changes

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed the code
- [ ] Added comments for complex logic
- [ ] No new compiler warnings
- [ ] Dependent changes have been merged

## Related Issues
Fixes #1745
