### PR TITLE
fix(deps): bump httpcore5 to 5.4.3 to resolve CVE-2026-54399 (backport #1754)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,7 @@
     <version.errorprone>2.50.0</version.errorprone>
     <version.node>v20.18.1</version.node>
     <version.npm>10.8.2</version.npm>
+    <version.httpcore5>5.4.3</version.httpcore5>
     <plugin.version.compiler>3.15.0</plugin.version.compiler>
     <plugin.version.nexus-staging>1.7.0</plugin.version.nexus-staging>
     <plugin.version.frontend-maven>2.0.1</plugin.version.frontend-maven>
@@ -122,6 +123,12 @@
         <groupId>org.apache.tomcat.embed</groupId>
         <artifactId>tomcat-embed-websocket</artifactId>
         <version>${tomcat.version}</version>
+      </dependency>
+      <!-- CVE-2026-54399: pin httpcore5 to 5.4.3 -->
+      <dependency>
+        <groupId>org.apache.httpcomponents.core5</groupId>
+        <artifactId>httpcore5</artifactId>
+        <version>${version.httpcore5}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
Backport of #1754 to `maintenance/0.3`.

Pins `org.apache.httpcomponents.core5:httpcore5` to `5.4.3` via root `dependencyManagement` to override the vulnerable transitive version. Mirrors the fix applied in #1702 for `maintenance/0.2` and #1754 for `main`.

**CVE-2026-54399:** Uncontrolled resource consumption in the HTTP/1.1 message parser — denial of service via memory exhaustion.

## Description

- `pom.xml` (`<properties>`): add `<version.httpcore5>5.4.3</version.httpcore5>`
- `pom.xml` (`<dependencyManagement>`): add explicit `httpcore5` entry pinned to `${version.httpcore5}`