### PR TITLE
revert(diagram-converter): restore pure Camunda Design System defaults

### DIFF
--- a/diagram-converter/webapp/src/main/javascript/src/App.jsx
+++ b/diagram-converter/webapp/src/main/javascript/src/App.jsx
@@ -760,11 +760,11 @@ function App() {
 
       <div id="bpmnDiagram" className="diagram-container"></div>
       {previewTableRows.length === 0 && (
-        <p style={{ color: '#525252', marginTop: '1rem' }}>No findings for this model.</p>
+        <p style={{ color: 'var(--neutral-foreground-subtle)', marginTop: '1rem' }}>No findings for this model.</p>
       )}
       {previewTableRows.length > 0 && <>
       <h3>Findings</h3>
-      <p style={{ color: '#525252', marginBottom: '0.75rem' }}>
+      <p style={{ color: 'var(--neutral-foreground-subtle)', marginBottom: '0.75rem' }}>
         Elements in this model that need attention during migration. Each row describes one finding — its location, severity, and a message explaining what to address.
       </p>
       <Table className="analysis-table">

--- a/diagram-converter/webapp/src/main/javascript/src/FileItem.jsx
+++ b/diagram-converter/webapp/src/main/javascript/src/FileItem.jsx
@@ -48,7 +48,7 @@ export default function FileItem({
 
         {error && (
           <Tooltip label={error}>
-            <div style={{ color: "#da1e28" }}>
+            <div style={{ color: "var(--danger-action-default)" }}>
               <AlertTriangle />
             </div>
           </Tooltip>

--- a/diagram-converter/webapp/src/main/javascript/src/c4-ui.css
+++ b/diagram-converter/webapp/src/main/javascript/src/c4-ui.css
@@ -14,19 +14,3 @@
  * back to Arial) and off the custom version-selector segments. Removed.
  */
 
-/* Consumer overrides.
- *
- * The DS "primary" action token is near-black; this app follows a
- * Camunda-blue-forward look (matching the pre-DS design), where the
- * blue "info" action is the brand accent used by the hero strip, step
- * numbers, dropzone and version selector. Remap the primary action to
- * the blue info action inside our scope so DS primary buttons and the
- * Stepper render blue, consistent with the rest of the page.
- */
-.c4-ui {
-  --primary-action-default: var(--info-action-default);
-  --primary-action-hover: var(--info-action-hover);
-  --primary-action-active: var(--info-action-active);
-  --primary-action-disabled: var(--info-action-disabled);
-  --primary-action-foreground: var(--info-action-foreground);
-}

--- a/diagram-converter/webapp/src/main/javascript/src/index.css
+++ b/diagram-converter/webapp/src/main/javascript/src/index.css
@@ -10,9 +10,11 @@
  * Token legend (all resolved inside .c4-ui except --color-* which are :root):
  *   Surfaces    --neutral-background-subtle (white), --color-zinc-100 (light gray bg)
  *   Text        --foreground, --neutral-foreground-subtle
- *   Blue        --info-action-default/hover/active, --info-background-subtle/strong,
- *               --info-border-subtle/strong, --info-foreground-subtle/strong
- *   Warning     --warning-background-subtle, --warning-foreground-strong
+ *   Primary     --primary-action-default/hover/active, --primary-background-subtle/strong,
+ *               --primary-border-subtle/strong, --primary-foreground-subtle/strong
+ *   Accent      --accent-action-default/hover/active, --accent-border-subtle/strong
+ *   Info        --info-action-default (BPMN "info"/"review" highlight only)
+ *   Warning     --warning-background-subtle, --warning-foreground-strong, --warning-action-default
  *   Borders     --border
  */
 
@@ -31,8 +33,8 @@ body {
   margin: 0;
   min-width: 320px;
   min-height: 100vh;
-  /* --color-blue-50 and --color-zinc-100 are defined on :root by the DS */
-  background: linear-gradient(180deg, var(--color-blue-50) 0%, var(--color-zinc-100) 280px, var(--color-zinc-100) 100%);
+  /* --color-zinc-50 and --color-zinc-100 are defined on :root by the DS */
+  background: linear-gradient(180deg, var(--color-zinc-50) 0%, var(--color-zinc-100) 280px, var(--color-zinc-100) 100%);
   color: var(--color-zinc-900);
 }
 
@@ -104,7 +106,7 @@ h1 {
 
 .heroMeta a {
   font-size: 14px;
-  color: var(--info-foreground-subtle);
+  color: var(--primary-action-default);
   text-decoration: none;
 }
 
@@ -112,7 +114,7 @@ h1 {
   text-decoration: underline;
 }
 
-/* Hero card: Camunda-blue gradient strip at the top */
+/* Hero card: accent gradient strip at the top */
 .whiteBox.hero {
   position: relative;
   overflow: hidden;
@@ -126,9 +128,9 @@ h1 {
   height: 5px;
   background: linear-gradient(
     90deg,
-    var(--info-action-active) 0%,
-    var(--info-action-default) 60%,
-    var(--info-border-strong) 100%
+    var(--accent-action-active) 0%,
+    var(--accent-action-default) 60%,
+    var(--accent-border-strong) 100%
   );
 }
 
@@ -158,7 +160,7 @@ h1 {
 
   button {
     border: none;
-    color: var(--info-foreground-subtle);
+    color: var(--primary-action-default);
     background: transparent;
     cursor: pointer;
   }
@@ -178,7 +180,7 @@ h1 {
 .convertAction button {
   border-radius: 10px;
   font-weight: 600;
-  box-shadow: 0 4px 14px color-mix(in srgb, var(--info-action-default) 28%, transparent);
+  box-shadow: 0 4px 14px color-mix(in srgb, var(--primary-action-default) 28%, transparent);
 }
 
 .ctaVersion {
@@ -187,8 +189,8 @@ h1 {
 }
 
 .DropZone {
-  background-color: var(--info-background-subtle);
-  border: 2px dashed var(--info-border-subtle);
+  background-color: var(--primary-background-subtle);
+  border: 2px dashed var(--primary-border-subtle);
   border-radius: 12px;
   height: 160px;
   margin-bottom: 12px;
@@ -204,8 +206,8 @@ h1 {
   transition: border-color 0.15s ease, background-color 0.15s ease, transform 0.15s ease;
 
   &:hover {
-    border-color: var(--info-action-default);
-    background-color: var(--info-background-strong);
+    border-color: var(--primary-action-default);
+    background-color: var(--primary-background-strong);
     transform: translateY(-1px);
   }
 
@@ -256,7 +258,7 @@ h1 {
       font-size: 14px;
 
       &.downloadable {
-        color: var(--info-foreground-subtle);
+        color: var(--primary-action-default);
         cursor: pointer;
 
         &:hover {
@@ -280,7 +282,7 @@ h1 {
     }
 
     button.download {
-      color: var(--info-foreground-subtle);
+      color: var(--primary-action-default);
     }
   }
 }
@@ -455,7 +457,7 @@ th, td {
 
 .configToggle:hover,
 .configToggle:hover svg {
-  color: var(--info-action-default);
+  color: var(--primary-action-default);
 }
 
 /* Guided "flow of steps" on the upload screen */
@@ -472,7 +474,7 @@ th, td {
   top: 36px;
   bottom: -4px;
   width: 2px;
-  background: var(--info-border-subtle);
+  background: var(--accent-border-subtle);
 }
 
 .flowStep:last-child {
@@ -507,12 +509,12 @@ th, td {
   width: 36px;
   height: 36px;
   border-radius: 50%;
-  background: linear-gradient(135deg, var(--info-action-default) 0%, var(--info-border-strong) 100%);
-  color: var(--info-action-foreground);
+  background: linear-gradient(135deg, var(--accent-action-default) 0%, var(--accent-border-strong) 100%);
+  color: var(--accent-action-foreground);
   font-weight: 600;
   font-size: 16px;
   flex-shrink: 0;
-  box-shadow: 0 2px 6px color-mix(in srgb, var(--info-action-default) 35%, transparent);
+  box-shadow: 0 2px 6px color-mix(in srgb, var(--accent-action-default) 35%, transparent);
 }
 
 .flowStep p {
@@ -543,7 +545,7 @@ th, td {
 }
 
 .versionSegmented:focus-within {
-  outline: 2px solid var(--info-action-default);
+  outline: 2px solid var(--primary-action-default);
   outline-offset: 2px;
 }
 
@@ -568,16 +570,16 @@ th, td {
 }
 
 .versionSegment:hover:not(.versionSegment--selected) {
-  background: var(--info-background-subtle);
+  background: var(--primary-background-subtle);
 }
 
 .versionSegment--selected {
-  background: var(--info-action-default);
-  color: var(--info-action-foreground);
+  background: var(--primary-action-default);
+  color: var(--primary-action-foreground);
 }
 
 .versionSegment:focus-visible {
-  outline: 2px solid var(--info-action-default);
+  outline: 2px solid var(--primary-action-default);
   outline-offset: 2px;
 }
 

--- a/diagram-converter/webapp/src/main/javascript/src/index.css
+++ b/diagram-converter/webapp/src/main/javascript/src/index.css
@@ -12,7 +12,6 @@
  *   Text        --foreground, --neutral-foreground-subtle
  *   Primary     --primary-action-default/hover/active, --primary-background-subtle/strong,
  *               --primary-border-subtle/strong, --primary-foreground-subtle/strong
- *   Accent      --accent-action-default/hover/active, --accent-border-subtle/strong
  *   Info        --info-action-default (BPMN "info"/"review" highlight only)
  *   Warning     --warning-background-subtle, --warning-foreground-strong, --warning-action-default
  *   Borders     --border
@@ -33,8 +32,7 @@ body {
   margin: 0;
   min-width: 320px;
   min-height: 100vh;
-  /* --color-zinc-50 and --color-zinc-100 are defined on :root by the DS */
-  background: linear-gradient(180deg, var(--color-zinc-50) 0%, var(--color-zinc-100) 280px, var(--color-zinc-100) 100%);
+  background-color: var(--color-zinc-100);
   color: var(--color-zinc-900);
 }
 
@@ -74,16 +72,15 @@ h1 {
   padding: 28px 32px;
   background-color: var(--neutral-background-subtle);
   margin-bottom: 24px;
-  border-radius: 14px;
+  border-radius: var(--radius-lg);
   border: 1px solid var(--border);
-  box-shadow: 0 1px 2px rgba(16, 24, 40, 0.04), 0 8px 24px rgba(16, 24, 40, 0.06);
+  box-shadow: var(--shadow-sm);
 
   h2 {
     font-size: 24px;
     line-height: 32px;
     font-weight: 600;
     margin-bottom: 10px;
-    letter-spacing: -0.01em;
   }
 
   p {
@@ -112,26 +109,6 @@ h1 {
 
 .heroMeta a:hover {
   text-decoration: underline;
-}
-
-/* Hero card: accent gradient strip at the top */
-.whiteBox.hero {
-  position: relative;
-  overflow: hidden;
-  padding-top: 32px;
-}
-
-.whiteBox.hero::before {
-  content: "";
-  position: absolute;
-  inset: 0 0 auto 0;
-  height: 5px;
-  background: linear-gradient(
-    90deg,
-    var(--accent-action-active) 0%,
-    var(--accent-action-default) 60%,
-    var(--accent-border-strong) 100%
-  );
 }
 
 .whiteBox.hero > p:last-of-type {
@@ -178,9 +155,8 @@ h1 {
 }
 
 .convertAction button {
-  border-radius: 10px;
+  border-radius: var(--radius-lg);
   font-weight: 600;
-  box-shadow: 0 4px 14px color-mix(in srgb, var(--primary-action-default) 28%, transparent);
 }
 
 .ctaVersion {
@@ -191,7 +167,7 @@ h1 {
 .DropZone {
   background-color: var(--primary-background-subtle);
   border: 2px dashed var(--primary-border-subtle);
-  border-radius: 12px;
+  border-radius: var(--radius-lg);
   height: 160px;
   margin-bottom: 12px;
 
@@ -272,13 +248,12 @@ h1 {
     margin-right: 10px;
     display: flex;
     align-items: center;
-    gap: 3px;
+    gap: 8px;
     button {
       border: none;
       background-color: transparent;
       cursor: pointer;
       display: flex;
-      margin-right: -6px;
     }
 
     button.download {
@@ -296,7 +271,6 @@ h3 {
   font-size: 19px;
   line-height: 26px;
   text-decoration: none;
-  letter-spacing: -0.01em;
 }
 
 hr {
@@ -328,14 +302,14 @@ hr {
   height: 400px;
   width: 100%;
   border: 1px solid var(--border);
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   margin-bottom: 20px;
 }
 
 .modal-backdrop {
   position: fixed;
   inset: 0;
-  background: rgba(0, 0, 0, 0.5);
+  background: var(--overlay);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -349,16 +323,15 @@ hr {
   width: 100%;
   max-height: 95vh;
   overflow-y: auto;
-  border-radius: 14px;
+  border-radius: var(--radius-lg);
   border: 1px solid var(--border);
-  box-shadow: 0 8px 40px rgba(16, 24, 40, 0.18);
+  box-shadow: var(--shadow-lg);
 
   h2 {
     font-size: 24px;
     line-height: 32px;
     font-weight: 600;
     margin-bottom: 10px;
-    letter-spacing: -0.01em;
   }
 
   .modal-header {
@@ -414,7 +387,7 @@ th, td {
   font-weight: 600;
   color: var(--warning-foreground-strong);
   background: var(--warning-background-subtle);
-  border-radius: 10px;
+  border-radius: var(--radius-xl);
   padding: 1px 7px;
   white-space: nowrap;
 }
@@ -424,7 +397,7 @@ th, td {
   padding: 1.25rem 1.5rem;
   background-color: var(--color-zinc-50);
   border: 1px solid var(--border);
-  border-radius: 12px;
+  border-radius: var(--radius-lg);
 }
 
 .configToggle {
@@ -474,7 +447,7 @@ th, td {
   top: 36px;
   bottom: -4px;
   width: 2px;
-  background: var(--accent-border-subtle);
+  background: var(--border);
 }
 
 .flowStep:last-child {
@@ -509,12 +482,11 @@ th, td {
   width: 36px;
   height: 36px;
   border-radius: 50%;
-  background: linear-gradient(135deg, var(--accent-action-default) 0%, var(--accent-border-strong) 100%);
-  color: var(--accent-action-foreground);
+  background: var(--primary-action-default);
+  color: var(--primary-action-foreground);
   font-weight: 600;
   font-size: 16px;
   flex-shrink: 0;
-  box-shadow: 0 2px 6px color-mix(in srgb, var(--accent-action-default) 35%, transparent);
 }
 
 .flowStep p {
@@ -539,7 +511,7 @@ th, td {
   display: inline-flex;
   margin-top: 12px;
   border: 1.5px solid var(--border);
-  border-radius: 12px;
+  border-radius: var(--radius-lg);
   overflow: hidden;
   background: var(--neutral-background-subtle);
 }


### PR DESCRIPTION
## Description
The diagram-converter webapp's Carbon→DS migration (#1733) layered a custom "Camunda-blue-forward" brand theme on top of the DS tokens: primary buttons/Stepper remapped from DS default near-black to `--info-action-*` (blue), plus a hero gradient strip, gradient step badges, colored box-shadows, hardcoded card radii, and a hardcoded `#525252`/`#da1e28` from the old Carbon palette.

This reverts all of that back to plain DS defaults — no custom accent/brand color layer, no decorative gradients/shadows, only DS tokens (`--primary-*`, `--neutral-*`, `--radius-*`, `--shadow-*`, `--overlay`). `--info-action-default` is kept only on the two BPMN severity-highlight classes, where blue is semantic (info/review), not brand.

Also fixes a pre-existing spacing bug on the results page: the eye/download icon buttons had a `-6px` negative margin (a leftover Carbon hit-padding compensation) that over-compressed against DS's tighter buttons, making them look crowded. Replaced with an 8px gap.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactoring (no functional changes)
- [ ] Test-only changes (no production code changes)

## Testing Checklist
N/A — CSS/JSX styling revert only, no Java/backend code touched. No new tests required; verified visually via manual review of token mappings against `@camunda/design-system/dist/styles.css`.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed the code
- [x] No new compiler warnings

## Related Issues
Follow-up to #1733