### PR TITLE
refactor(diagram-converter): replace carbon-compat components with native DS ones

### DIFF
--- a/diagram-converter/webapp/src/main/javascript/package-lock.json
+++ b/diagram-converter/webapp/src/main/javascript/package-lock.json
@@ -9,7 +9,6 @@
       "version": "0.0.0",
       "dependencies": {
         "@camunda/design-system": "^0.21.1",
-        "@carbon/react": "^1.79.0",
         "bpmn-js": "^18.6.1",
         "lucide-react": "1.17.0",
         "react": "^19.0.0",
@@ -262,15 +261,6 @@
         "@babel/core": "^7.0.0-0"
       }
     },
-    "node_modules/@babel/runtime": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
-      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/@babel/template": {
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
@@ -359,185 +349,6 @@
         "@carbon/react": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@carbon/colors": {
-      "version": "11.53.0",
-      "resolved": "https://registry.npmjs.org/@carbon/colors/-/colors-11.53.0.tgz",
-      "integrity": "sha512-PvvBsNFng3IRoBp1f7SsHewmuxMTIsCoyl09ksjrQw5iwNSwScKJ3gcSVVLr1rhjQ0p/DakVANupnAaKp03ReA==",
-      "hasInstallScript": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@ibm/telemetry-js": "^1.5.0"
-      }
-    },
-    "node_modules/@carbon/feature-flags": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@carbon/feature-flags/-/feature-flags-1.4.0.tgz",
-      "integrity": "sha512-ENWuo49HTT4pgWL3TgY+EIMQQyFwTykWnmfCfaXvRzc2mQQ3d22sV0chTJsMiZwclHiRASeb/q5FIZquZb7iFw==",
-      "hasInstallScript": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@ibm/telemetry-js": "^1.5.0"
-      }
-    },
-    "node_modules/@carbon/grid": {
-      "version": "11.57.0",
-      "resolved": "https://registry.npmjs.org/@carbon/grid/-/grid-11.57.0.tgz",
-      "integrity": "sha512-VqRy0gxb+jOzu9c2IiDsCt8m6S08/AEv35M6ehCi1zI8ANVKGG8mLQJvpnYUY80ZtsuCDEmVkcNrcRfz2nkbeg==",
-      "hasInstallScript": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@carbon/layout": "^11.54.0",
-        "@ibm/telemetry-js": "^1.5.0"
-      }
-    },
-    "node_modules/@carbon/icon-helpers": {
-      "version": "10.77.0",
-      "resolved": "https://registry.npmjs.org/@carbon/icon-helpers/-/icon-helpers-10.77.0.tgz",
-      "integrity": "sha512-furqJbaATl7PTn9ZKpaDHwQsNhOBcuFMspRJR0CyErAxxuioMPopnCiYcwG38yXiC1G7FqTMf3l0mErTZuc7Gw==",
-      "hasInstallScript": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@ibm/telemetry-js": "^1.5.0"
-      }
-    },
-    "node_modules/@carbon/icons-react": {
-      "version": "11.83.0",
-      "resolved": "https://registry.npmjs.org/@carbon/icons-react/-/icons-react-11.83.0.tgz",
-      "integrity": "sha512-VECIr2J4WFY1e9N6NZCIw47iKMQP2pgxLKWfdNk3+r51+fQpWQ/b2iiURLqAPNc+JyWzf+8NJzZEPGfZf0BHqw==",
-      "hasInstallScript": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@carbon/icon-helpers": "^10.77.0",
-        "@ibm/telemetry-js": "^1.5.0",
-        "prop-types": "^15.8.1"
-      },
-      "peerDependencies": {
-        "react": ">=16"
-      }
-    },
-    "node_modules/@carbon/layout": {
-      "version": "11.54.0",
-      "resolved": "https://registry.npmjs.org/@carbon/layout/-/layout-11.54.0.tgz",
-      "integrity": "sha512-Jz+kBUKnjx83qHRQI3stz1dhX1JLITdUGxpf0R2YvsghBpT4DQpx1BmHH2zWOFx/Oh/rJijMOCFTSkLizSbySg==",
-      "hasInstallScript": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@ibm/telemetry-js": "^1.5.0"
-      }
-    },
-    "node_modules/@carbon/motion": {
-      "version": "11.47.0",
-      "resolved": "https://registry.npmjs.org/@carbon/motion/-/motion-11.47.0.tgz",
-      "integrity": "sha512-EhMVu6YFak+DzaYv5VPReRhmT8NT9RWMIpN6pWTByseATszOn+gvPu27ggiXMiOxOzTuqgUTKpp+n6jvNyBeZw==",
-      "hasInstallScript": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@ibm/telemetry-js": "^1.5.0"
-      }
-    },
-    "node_modules/@carbon/react": {
-      "version": "1.111.1",
-      "resolved": "https://registry.npmjs.org/@carbon/react/-/react-1.111.1.tgz",
-      "integrity": "sha512-yXOrQ0atdeKGF7y7RcVombtjHoAfYQjy+bfDsWgkgKBNOlSC0RY+0i32AACPIO6zcY0Ou9w7i/ctrbH5VSXmSg==",
-      "hasInstallScript": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@babel/runtime": "^7.27.3",
-        "@carbon/feature-flags": "^1.4.0",
-        "@carbon/icons-react": "^11.83.0",
-        "@carbon/layout": "^11.54.0",
-        "@carbon/styles": "^1.110.1",
-        "@carbon/utilities": "^0.21.0",
-        "@floating-ui/react": "^0.27.4",
-        "@ibm/telemetry-js": "^1.5.0",
-        "classnames": "2.5.1",
-        "copy-to-clipboard": "^3.3.1",
-        "downshift": "9.0.10",
-        "es-toolkit": "^1.27.0",
-        "flatpickr": "4.6.13",
-        "invariant": "^2.2.3",
-        "prop-types": "^15.8.1",
-        "react-fast-compare": "^3.2.2",
-        "tabbable": "^6.2.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.6 || ^17.0.1 || ^18.2.0 || ^19.0.0",
-        "react-dom": "^16.8.6 || ^17.0.1 || ^18.2.0 || ^19.0.0",
-        "react-is": "^16.13.1 || ^17.0.2 || ^18.3.1 || ^19.0.0",
-        "sass": "^1.33.0"
-      }
-    },
-    "node_modules/@carbon/styles": {
-      "version": "1.110.1",
-      "resolved": "https://registry.npmjs.org/@carbon/styles/-/styles-1.110.1.tgz",
-      "integrity": "sha512-UrWTQmM7Da6uN7rPzRaM/KEJ8S4AKgOCETdwZ1OTmGKls28j78CzVE7fD9yWkgOWsboglbnWLXCTADkaDZFfgg==",
-      "hasInstallScript": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@carbon/colors": "^11.53.0",
-        "@carbon/feature-flags": "^1.4.0",
-        "@carbon/grid": "^11.57.0",
-        "@carbon/layout": "^11.54.0",
-        "@carbon/motion": "^11.47.0",
-        "@carbon/themes": "^11.76.1",
-        "@carbon/type": "^11.62.0",
-        "@ibm/plex": "6.4.1",
-        "@ibm/plex-mono": "1.1.0",
-        "@ibm/plex-sans": "1.1.0",
-        "@ibm/plex-sans-arabic": "1.1.0",
-        "@ibm/plex-sans-devanagari": "1.1.0",
-        "@ibm/plex-sans-hebrew": "1.1.0",
-        "@ibm/plex-sans-thai": "1.1.0",
-        "@ibm/plex-sans-thai-looped": "1.1.0",
-        "@ibm/plex-serif": "2.0.0",
-        "@ibm/telemetry-js": "^1.5.0"
-      },
-      "peerDependencies": {
-        "sass": "^1.33.0"
-      },
-      "peerDependenciesMeta": {
-        "sass": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@carbon/themes": {
-      "version": "11.76.1",
-      "resolved": "https://registry.npmjs.org/@carbon/themes/-/themes-11.76.1.tgz",
-      "integrity": "sha512-Oml4pqSoJrTb9hU4uCCIqMKLLV8Ej7zoen7j3fOQoL9rPOBia91/oz73dY1neqpZc6hPbtzbERLKIM5YCHFzLA==",
-      "hasInstallScript": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@carbon/colors": "^11.53.0",
-        "@carbon/layout": "^11.54.0",
-        "@carbon/type": "^11.62.0",
-        "@ibm/telemetry-js": "^1.5.0",
-        "color": "^4.0.0"
-      }
-    },
-    "node_modules/@carbon/type": {
-      "version": "11.62.0",
-      "resolved": "https://registry.npmjs.org/@carbon/type/-/type-11.62.0.tgz",
-      "integrity": "sha512-qSNCK8AUGGAumGz43ZDFwTEW19xTsE9cfYPstxIHYkIobflOiqynwyMj00r2w1oRpPx7YhXIBI9AAJYJL2qjhQ==",
-      "hasInstallScript": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@carbon/grid": "^11.57.0",
-        "@carbon/layout": "^11.54.0",
-        "@ibm/telemetry-js": "^1.5.0"
-      }
-    },
-    "node_modules/@carbon/utilities": {
-      "version": "0.21.0",
-      "resolved": "https://registry.npmjs.org/@carbon/utilities/-/utilities-0.21.0.tgz",
-      "integrity": "sha512-up03L21ebI16Gq+sCW98EuKot7jhKHW9ZLA190z61FGhulzqzsQc1Ov+0Q33Fp1LuXum+XVRV5ris9eBB0aF0w==",
-      "hasInstallScript": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@ibm/telemetry-js": "^1.6.1",
-        "@internationalized/number": "^3.6.1"
       }
     },
     "node_modules/@date-fns/tz": {
@@ -1147,21 +958,6 @@
         "@floating-ui/utils": "^0.2.11"
       }
     },
-    "node_modules/@floating-ui/react": {
-      "version": "0.27.19",
-      "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.27.19.tgz",
-      "integrity": "sha512-31B8h5mm8YxotlE7/AU/PhNAl8eWxAmjL/v2QOxroDNkTFLk3Uu82u63N3b6TXa4EGJeeZLVcd/9AlNlVqzeog==",
-      "license": "MIT",
-      "dependencies": {
-        "@floating-ui/react-dom": "^2.1.8",
-        "@floating-ui/utils": "^0.2.11",
-        "tabbable": "^6.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=17.0.0",
-        "react-dom": ">=17.0.0"
-      }
-    },
     "node_modules/@floating-ui/react-dom": {
       "version": "2.1.8",
       "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.8.tgz",
@@ -1247,114 +1043,6 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
-    "node_modules/@ibm/plex": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/@ibm/plex/-/plex-6.4.1.tgz",
-      "integrity": "sha512-fnsipQywHt3zWvsnlyYKMikcVI7E2fEwpiPnIHFqlbByXVfQfANAAeJk1IV4mNnxhppUIDlhU0TzwYwL++Rn2g==",
-      "hasInstallScript": true,
-      "license": "OFL-1.1",
-      "dependencies": {
-        "@ibm/telemetry-js": "^1.5.1"
-      }
-    },
-    "node_modules/@ibm/plex-mono": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@ibm/plex-mono/-/plex-mono-1.1.0.tgz",
-      "integrity": "sha512-hpsdRxR3BRJkC6wGM4MZcUFD6C8M+mmK76RtAy/hlsfPro9FzpXVdIWC+G3jeQOXof109dxlUvmeKxpeKUG68A==",
-      "hasInstallScript": true,
-      "license": "OFL-1.1",
-      "dependencies": {
-        "@ibm/telemetry-js": "^1.6.1"
-      }
-    },
-    "node_modules/@ibm/plex-sans": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@ibm/plex-sans/-/plex-sans-1.1.0.tgz",
-      "integrity": "sha512-WPgvO6Yfj2w5YbhyAr1tv95RUz4LRJlqN+CmYvBglabXteufP1D1E9BABMde+ZIKdRbFJDoKF5eQzfhpnbgZcQ==",
-      "hasInstallScript": true,
-      "license": "OFL-1.1",
-      "dependencies": {
-        "@ibm/telemetry-js": "^1.6.1"
-      }
-    },
-    "node_modules/@ibm/plex-sans-arabic": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@ibm/plex-sans-arabic/-/plex-sans-arabic-1.1.0.tgz",
-      "integrity": "sha512-u8wIS6szLAOFvlBjCFZmtpKIqbhuIuniG2N0J+sio8vV6INH58hP0t0QNYrSl9SZtCv2Fwb4oQGuZJY3kJ4+QA==",
-      "hasInstallScript": true,
-      "license": "OFL-1.1",
-      "dependencies": {
-        "@ibm/telemetry-js": "^1.6.1"
-      }
-    },
-    "node_modules/@ibm/plex-sans-devanagari": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@ibm/plex-sans-devanagari/-/plex-sans-devanagari-1.1.0.tgz",
-      "integrity": "sha512-IVNV9NxXZDzcGZRao/xj+kiFwkdLkcw5vNiKwY8wEzzkpjApXJnPhJ0a7mIKNAh8oIadTIF68+iGtzRKK3nXAQ==",
-      "hasInstallScript": true,
-      "license": "OFL-1.1",
-      "dependencies": {
-        "@ibm/telemetry-js": "^1.6.1"
-      }
-    },
-    "node_modules/@ibm/plex-sans-hebrew": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@ibm/plex-sans-hebrew/-/plex-sans-hebrew-1.1.0.tgz",
-      "integrity": "sha512-iix0rLpUD0E8dE8q+/t3B7u1or7h6gEzoy6TK9NwP41AN31WE55f2cFwQAXomBDwr0Ozc9sHYy97NutEukZXzQ==",
-      "hasInstallScript": true,
-      "license": "OFL-1.1",
-      "dependencies": {
-        "@ibm/telemetry-js": "^1.6.1"
-      }
-    },
-    "node_modules/@ibm/plex-sans-thai": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@ibm/plex-sans-thai/-/plex-sans-thai-1.1.0.tgz",
-      "integrity": "sha512-vk7IrjdO69eEElJpFBppCha/wvU48DFyVuDewcfIf5L6Z11s0vbROANCvKipVPRUz1LE4ron8KoitWGcl3AlfA==",
-      "hasInstallScript": true,
-      "license": "OFL-1.1",
-      "dependencies": {
-        "@ibm/telemetry-js": "^1.6.1"
-      }
-    },
-    "node_modules/@ibm/plex-sans-thai-looped": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@ibm/plex-sans-thai-looped/-/plex-sans-thai-looped-1.1.0.tgz",
-      "integrity": "sha512-9zbDGzmtscHgBRTF88y3/92zQx6lmKjz5ZxhgcljilwOpj08BAytDc3mzUl9XGUh+DmOMl0Ql1lk6ecsEYYg2w==",
-      "hasInstallScript": true,
-      "license": "OFL-1.1",
-      "dependencies": {
-        "@ibm/telemetry-js": "^1.6.1"
-      }
-    },
-    "node_modules/@ibm/plex-serif": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@ibm/plex-serif/-/plex-serif-2.0.0.tgz",
-      "integrity": "sha512-xVu9JsC18tBoQF2M6fofpsWrHj5a94saxlOZbYmXoC0E3UfjgS1JlibgrnaUJjnkLlEyCpMgI2PdhkDxijw0gA==",
-      "hasInstallScript": true,
-      "license": "OFL-1.1",
-      "dependencies": {
-        "@ibm/telemetry-js": "^1.6.1"
-      }
-    },
-    "node_modules/@ibm/telemetry-js": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@ibm/telemetry-js/-/telemetry-js-1.11.0.tgz",
-      "integrity": "sha512-RO/9j+URJnSfseWg9ZkEX9p+a3Ousd33DBU7rOafoZB08RqdzxFVYJ2/iM50dkBuD0o7WX7GYt1sLbNgCoE+pA==",
-      "license": "Apache-2.0",
-      "bin": {
-        "ibmtelemetry": "dist/collect.js"
-      }
-    },
-    "node_modules/@internationalized/number": {
-      "version": "3.6.7",
-      "resolved": "https://registry.npmjs.org/@internationalized/number/-/number-3.6.7.tgz",
-      "integrity": "sha512-3ji1fcrT+FPAK86UqEhB/psHixYo6niWPJtt7+qRaYFynt/BaJG8GhAPimtWUpEiVSTq8ZM8L5psMxGquiB/Vg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@swc/helpers": "^0.5.0"
-      }
-    },
     "node_modules/@isaacs/cliui": {
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-9.0.0.tgz",
@@ -1413,334 +1101,6 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
-      }
-    },
-    "node_modules/@parcel/watcher": {
-      "version": "2.5.6",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.6.tgz",
-      "integrity": "sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "detect-libc": "^2.0.3",
-        "is-glob": "^4.0.3",
-        "node-addon-api": "^7.0.0",
-        "picomatch": "^4.0.3"
-      },
-      "engines": {
-        "node": ">= 10.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      },
-      "optionalDependencies": {
-        "@parcel/watcher-android-arm64": "2.5.6",
-        "@parcel/watcher-darwin-arm64": "2.5.6",
-        "@parcel/watcher-darwin-x64": "2.5.6",
-        "@parcel/watcher-freebsd-x64": "2.5.6",
-        "@parcel/watcher-linux-arm-glibc": "2.5.6",
-        "@parcel/watcher-linux-arm-musl": "2.5.6",
-        "@parcel/watcher-linux-arm64-glibc": "2.5.6",
-        "@parcel/watcher-linux-arm64-musl": "2.5.6",
-        "@parcel/watcher-linux-x64-glibc": "2.5.6",
-        "@parcel/watcher-linux-x64-musl": "2.5.6",
-        "@parcel/watcher-win32-arm64": "2.5.6",
-        "@parcel/watcher-win32-ia32": "2.5.6",
-        "@parcel/watcher-win32-x64": "2.5.6"
-      }
-    },
-    "node_modules/@parcel/watcher-android-arm64": {
-      "version": "2.5.6",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.5.6.tgz",
-      "integrity": "sha512-YQxSS34tPF/6ZG7r/Ih9xy+kP/WwediEUsqmtf0cuCV5TPPKw/PQHRhueUo6JdeFJaqV3pyjm0GdYjZotbRt/A==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 10.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/watcher-darwin-arm64": {
-      "version": "2.5.6",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.5.6.tgz",
-      "integrity": "sha512-Z2ZdrnwyXvvvdtRHLmM4knydIdU9adO3D4n/0cVipF3rRiwP+3/sfzpAwA/qKFL6i1ModaabkU7IbpeMBgiVEA==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 10.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/watcher-darwin-x64": {
-      "version": "2.5.6",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-x64/-/watcher-darwin-x64-2.5.6.tgz",
-      "integrity": "sha512-HgvOf3W9dhithcwOWX9uDZyn1lW9R+7tPZ4sug+NGrGIo4Rk1hAXLEbcH1TQSqxts0NYXXlOWqVpvS1SFS4fRg==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 10.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/watcher-freebsd-x64": {
-      "version": "2.5.6",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-freebsd-x64/-/watcher-freebsd-x64-2.5.6.tgz",
-      "integrity": "sha512-vJVi8yd/qzJxEKHkeemh7w3YAn6RJCtYlE4HPMoVnCpIXEzSrxErBW5SJBgKLbXU3WdIpkjBTeUNtyBVn8TRng==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 10.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/watcher-linux-arm-glibc": {
-      "version": "2.5.6",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-glibc/-/watcher-linux-arm-glibc-2.5.6.tgz",
-      "integrity": "sha512-9JiYfB6h6BgV50CCfasfLf/uvOcJskMSwcdH1PHH9rvS1IrNy8zad6IUVPVUfmXr+u+Km9IxcfMLzgdOudz9EQ==",
-      "cpu": [
-        "arm"
-      ],
-      "libc": [
-        "glibc"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 10.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/watcher-linux-arm-musl": {
-      "version": "2.5.6",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-musl/-/watcher-linux-arm-musl-2.5.6.tgz",
-      "integrity": "sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg==",
-      "cpu": [
-        "arm"
-      ],
-      "libc": [
-        "musl"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 10.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/watcher-linux-arm64-glibc": {
-      "version": "2.5.6",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.5.6.tgz",
-      "integrity": "sha512-f2g/DT3NhGPdBmMWYoxixqYr3v/UXcmLOYy16Bx0TM20Tchduwr4EaCbmxh1321TABqPGDpS8D/ggOTaljijOA==",
-      "cpu": [
-        "arm64"
-      ],
-      "libc": [
-        "glibc"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 10.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/watcher-linux-arm64-musl": {
-      "version": "2.5.6",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.5.6.tgz",
-      "integrity": "sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA==",
-      "cpu": [
-        "arm64"
-      ],
-      "libc": [
-        "musl"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 10.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/watcher-linux-x64-glibc": {
-      "version": "2.5.6",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.5.6.tgz",
-      "integrity": "sha512-kbT5wvNQlx7NaGjzPFu8nVIW1rWqV780O7ZtkjuWaPUgpv2NMFpjYERVi0UYj1msZNyCzGlaCWEtzc+exjMGbQ==",
-      "cpu": [
-        "x64"
-      ],
-      "libc": [
-        "glibc"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 10.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/watcher-linux-x64-musl": {
-      "version": "2.5.6",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.5.6.tgz",
-      "integrity": "sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg==",
-      "cpu": [
-        "x64"
-      ],
-      "libc": [
-        "musl"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 10.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/watcher-win32-arm64": {
-      "version": "2.5.6",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.5.6.tgz",
-      "integrity": "sha512-3ukyebjc6eGlw9yRt678DxVF7rjXatWiHvTXqphZLvo7aC5NdEgFufVwjFfY51ijYEWpXbqF5jtrK275z52D4Q==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 10.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/watcher-win32-ia32": {
-      "version": "2.5.6",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-ia32/-/watcher-win32-ia32-2.5.6.tgz",
-      "integrity": "sha512-k35yLp1ZMwwee3Ez/pxBi5cf4AoBKYXj00CZ80jUz5h8prpiaQsiRPKQMxoLstNuqe2vR4RNPEAEcjEFzhEz/g==",
-      "cpu": [
-        "ia32"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 10.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/watcher-win32-x64": {
-      "version": "2.5.6",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-x64/-/watcher-win32-x64-2.5.6.tgz",
-      "integrity": "sha512-hbQlYcCq5dlAX9Qx+kFb0FHue6vbjlf0FrNzSKdYK2APUf7tGfGxQCk2ihEREmbR6ZMc0MVAD5RIX/41gpUzTw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 10.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
       }
     },
     "node_modules/@radix-ui/number": {
@@ -8743,15 +8103,6 @@
       "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
       "license": "MIT"
     },
-    "node_modules/@swc/helpers": {
-      "version": "0.5.23",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.23.tgz",
-      "integrity": "sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.8.0"
-      }
-    },
     "node_modules/@tanstack/react-table": {
       "version": "8.21.3",
       "resolved": "https://registry.npmjs.org/@tanstack/react-table/-/react-table-8.21.3.tgz",
@@ -9201,22 +8552,6 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
-    "node_modules/chokidar": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
-      "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "readdirp": "^5.0.0"
-      },
-      "engines": {
-        "node": ">= 20.19.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
     "node_modules/class-variance-authority": {
       "version": "0.7.1",
       "resolved": "https://registry.npmjs.org/class-variance-authority/-/class-variance-authority-0.7.1.tgz",
@@ -9228,12 +8563,6 @@
       "funding": {
         "url": "https://polar.sh/cva"
       }
-    },
-    "node_modules/classnames": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
-      "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==",
-      "license": "MIT"
     },
     "node_modules/clsx": {
       "version": "2.1.1",
@@ -9260,23 +8589,11 @@
         "react-dom": "^18 || ^19 || ^19.0.0-rc"
       }
     },
-    "node_modules/color": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
-      "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1",
-        "color-string": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=12.5.0"
-      }
-    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -9289,28 +8606,13 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
       "license": "MIT"
-    },
-    "node_modules/color-string": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
-      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "^1.0.0",
-        "simple-swizzle": "^0.2.2"
-      }
     },
     "node_modules/component-event": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/component-event/-/component-event-0.2.1.tgz",
       "integrity": "sha512-wGA++isMqiDq1jPYeyv2as/Bt/u+3iLW0rEa+8NQ82jAv3TgqMiCM+B2SaBdn2DfLilLjjq736YcezihRYhfxw==",
-      "license": "MIT"
-    },
-    "node_modules/compute-scroll-into-view": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-3.1.1.tgz",
-      "integrity": "sha512-VRhuHOLoKYOy4UbilLbUzbYg93XLjv2PncJC50EuTWPA3gaja1UjBsUP/D/9/juV3vQFr6XBEzn9KCAHdUvOHw==",
       "license": "MIT"
     },
     "node_modules/concat-map": {
@@ -9326,15 +8628,6 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/copy-to-clipboard": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/copy-to-clipboard/-/copy-to-clipboard-3.3.3.tgz",
-      "integrity": "sha512-2KV8NhB5JqC3ky0r9PMCAZKbUHSwtEo4CwCs0KXgruG43gX5PMqDEBbVU4OUzw2MuAWUfsuFmWvEKG5QRfSnJA==",
-      "license": "MIT",
-      "dependencies": {
-        "toggle-selection": "^1.0.6"
-      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -9520,17 +8813,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/detect-libc": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
-      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/detect-node-es": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
@@ -9590,28 +8872,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/downshift": {
-      "version": "9.0.10",
-      "resolved": "https://registry.npmjs.org/downshift/-/downshift-9.0.10.tgz",
-      "integrity": "sha512-TP/iqV6bBok6eGD5tZ8boM8Xt7/+DZvnVNr8cNIhbAm2oUBd79Tudiccs2hbcV9p7xAgS/ozE7Hxy3a9QqS6Mw==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.24.5",
-        "compute-scroll-into-view": "^3.1.0",
-        "prop-types": "^15.8.1",
-        "react-is": "18.2.0",
-        "tslib": "^2.6.2"
-      },
-      "peerDependencies": {
-        "react": ">=16.12.0"
-      }
-    },
-    "node_modules/downshift/node_modules/react-is": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
-      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
-      "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.383",
@@ -9942,12 +9202,6 @@
         "node": ">=16"
       }
     },
-    "node_modules/flatpickr": {
-      "version": "4.6.13",
-      "resolved": "https://registry.npmjs.org/flatpickr/-/flatpickr-4.6.13.tgz",
-      "integrity": "sha512-97PMG/aywoYpB4IvbvUJi0RQi8vearvU0oov1WW3k0WZPBMrTQVqekSX5CjSG/M4Q3i6A/0FKXC7RyAoAUUSPw==",
-      "license": "MIT"
-    },
     "node_modules/flatted": {
       "version": "3.4.2",
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
@@ -10137,13 +9391,6 @@
         "url": "https://opencollective.com/immer"
       }
     },
-    "node_modules/immutable": {
-      "version": "5.1.9",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.9.tgz",
-      "integrity": "sha512-m8nVez3rwrgmWxtLMt1ZYXB2Lv7OKYn/disyxAlSDYAlKSlFoPPfIAmAM/M5xqL4m4C/wAPw7S2/CNaUii1Hxg==",
-      "license": "MIT",
-      "peer": true
-    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -10186,26 +9433,11 @@
         "node": ">=12"
       }
     },
-    "node_modules/invariant": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
-      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.0.0"
-      }
-    },
-    "node_modules/is-arrayish": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.4.tgz",
-      "integrity": "sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA==",
-      "license": "MIT"
-    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -10215,7 +9447,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
@@ -10251,6 +9483,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -10370,18 +9603,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/loose-envify": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "license": "MIT",
-      "dependencies": {
-        "js-tokens": "^3.0.0 || ^4.0.0"
-      },
-      "bin": {
-        "loose-envify": "cli.js"
-      }
-    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -10498,14 +9719,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/node-addon-api": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
-      "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true
-    },
     "node_modules/node-releases": {
       "version": "2.0.50",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.50.tgz",
@@ -10514,15 +9727,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/object-assign": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/object-refs": {
@@ -10668,7 +9872,7 @@
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
       "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -10725,23 +9929,6 @@
       "engines": {
         "node": ">= 0.8.0"
       }
-    },
-    "node_modules/prop-types": {
-      "version": "15.8.1",
-      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
-      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.4.0",
-        "object-assign": "^4.1.1",
-        "react-is": "^16.13.1"
-      }
-    },
-    "node_modules/prop-types/node_modules/react-is": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "license": "MIT"
     },
     "node_modules/punycode": {
       "version": "2.3.1",
@@ -11190,12 +10377,6 @@
         "react": "^19.1.0"
       }
     },
-    "node_modules/react-fast-compare": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.2.tgz",
-      "integrity": "sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==",
-      "license": "MIT"
-    },
     "node_modules/react-is": {
       "version": "19.1.0",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.1.0.tgz",
@@ -11305,20 +10486,6 @@
         }
       }
     },
-    "node_modules/readdirp": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
-      "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">= 20.19.0"
-      },
-      "funding": {
-        "type": "individual",
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
     "node_modules/recharts": {
       "version": "3.9.2",
       "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.9.2.tgz",
@@ -11425,27 +10592,6 @@
         "fsevents": "~2.3.2"
       }
     },
-    "node_modules/sass": {
-      "version": "1.101.0",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.101.0.tgz",
-      "integrity": "sha512-OL3GoQyoUdDt843DpVmDO6y2k1sc5IhUDSpu8XucEI+35neq5QivZ1iuegnpraEVTJXlQGK1gl27zKcTLEPbQw==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "chokidar": "^5.0.0",
-        "immutable": "^5.1.5",
-        "source-map-js": ">=0.6.2 <2.0.0"
-      },
-      "bin": {
-        "sass": "sass.js"
-      },
-      "engines": {
-        "node": ">=20.19.0"
-      },
-      "optionalDependencies": {
-        "@parcel/watcher": "^2.4.1"
-      }
-    },
     "node_modules/saxen": {
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/saxen/-/saxen-10.0.0.tgz",
@@ -11506,19 +10652,11 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/simple-swizzle": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.4.tgz",
-      "integrity": "sha512-nAu1WFPQSMNr2Zn9PGSZK9AGn4t/y97lEm+MXTtUDwfP0ksAIX4nO+6ruD9Jwut4C49SB1Ws+fbXsm/yScWOHw==",
-      "license": "MIT",
-      "dependencies": {
-        "is-arrayish": "^0.3.1"
-      }
-    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -11549,12 +10687,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/tabbable": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.5.0.tgz",
-      "integrity": "sha512-wieBHXygIm7OyQOu5hQlkk62/WyCFYGlWg7L6/ZCUZwx0o398Zkn4pVmMyfYhfMG8kGrj/Krt8eIk6UKC6VzwA==",
-      "license": "MIT"
     },
     "node_modules/tailwind-merge": {
       "version": "3.6.0",
@@ -11612,12 +10744,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/toggle-selection": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/toggle-selection/-/toggle-selection-1.0.6.tgz",
-      "integrity": "sha512-BiZS+C1OS8g/q2RRbJmy59xpyghNBqrr6k5L/uKBGRsTfxmu3ffiRnd8mlGPUVayg8pvfi5urfnu8TU7DVOkLQ==",
-      "license": "MIT"
     },
     "node_modules/tslib": {
       "version": "2.8.1",

--- a/diagram-converter/webapp/src/main/javascript/package-lock.json
+++ b/diagram-converter/webapp/src/main/javascript/package-lock.json
@@ -8,7 +8,7 @@
       "name": "diagram-converter",
       "version": "0.0.0",
       "dependencies": {
-        "@camunda/design-system": "^0.21.1",
+        "@camunda/design-system": "^0.31.0",
         "bpmn-js": "^18.6.1",
         "lucide-react": "1.17.0",
         "react": "^19.0.0",
@@ -320,9 +320,9 @@
       }
     },
     "node_modules/@camunda/design-system": {
-      "version": "0.21.1",
-      "resolved": "https://registry.npmjs.org/@camunda/design-system/-/design-system-0.21.1.tgz",
-      "integrity": "sha512-xWTQNsIEB1uCBVg538XqaFM0Tl05jWEQ+NXogU1XTQ7+l70ZaGvq3Q3gJjyWZxqmepB1/k+9XKeAX3VpHDMdTA==",
+      "version": "0.31.0",
+      "resolved": "https://registry.npmjs.org/@camunda/design-system/-/design-system-0.31.0.tgz",
+      "integrity": "sha512-bLUrg7iUOnIXTYZZPTl94ptE4WUlaVXEicsM4OMnGnXZHA+4u5DVElRMqy6sltmvreC+o3rMyGU5PGZLbhb3ng==",
       "license": "Apache-2.0",
       "dependencies": {
         "@tanstack/react-table": "^8.20.5",
@@ -331,7 +331,7 @@
         "clsx": "2.1.1",
         "cmdk": "1.1.1",
         "date-fns": "^4.4.0",
-        "lucide-react": "1.17.0",
+        "lucide-react": "1.23.0",
         "radix-ui": "1.4.3",
         "react-day-picker": "^10.0.1",
         "recharts": "^3.8.1",
@@ -349,6 +349,15 @@
         "@carbon/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@camunda/design-system/node_modules/lucide-react": {
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.23.0.tgz",
+      "integrity": "sha512-38BpJcD0JhFosxHApP/BYsBetLpQFRoTRzEzstM/XCc3jsAG7wqaY1lgVwxiUe3xqYE+lNxo2PkCmYwXWrwwIw==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/@date-fns/tz": {

--- a/diagram-converter/webapp/src/main/javascript/package.json
+++ b/diagram-converter/webapp/src/main/javascript/package.json
@@ -11,7 +11,6 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@carbon/react": "^1.79.0",
     "bpmn-js": "^18.6.1",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/diagram-converter/webapp/src/main/javascript/package.json
+++ b/diagram-converter/webapp/src/main/javascript/package.json
@@ -14,7 +14,7 @@
     "bpmn-js": "^18.6.1",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "@camunda/design-system": "^0.21.1",
+    "@camunda/design-system": "^0.31.0",
     "lucide-react": "1.17.0"
   },
   "devDependencies": {

--- a/diagram-converter/webapp/src/main/javascript/src/App.jsx
+++ b/diagram-converter/webapp/src/main/javascript/src/App.jsx
@@ -744,6 +744,7 @@ function App() {
                 size="lg"
                 href="https://docs.camunda.io/docs/guides/migrating-from-camunda-7/migration-journey/?utm_source=analyzer"
                 target="_blank"
+                rel="noopener noreferrer"
               >
                 <ExternalLink />
                 Migration Guide

--- a/diagram-converter/webapp/src/main/javascript/src/App.jsx
+++ b/diagram-converter/webapp/src/main/javascript/src/App.jsx
@@ -438,7 +438,7 @@ function App() {
       </div>
       <div className="whiteBox centered">
         <div className="progressindicators">
-          <Stepper currentStep={step === 0 ? 0 : 1}>
+          <Stepper currentStep={step === 0 ? 0 : 1} aria-label="Migration analysis and conversion steps">
             <StepperStep>Configure</StepperStep>
             <StepperStep>Results</StepperStep>
           </Stepper>

--- a/diagram-converter/webapp/src/main/javascript/src/App.jsx
+++ b/diagram-converter/webapp/src/main/javascript/src/App.jsx
@@ -10,18 +10,17 @@ import { useState, useEffect, useRef } from "react";
 import {
   Button,
   Table,
-  TableHead,
-  TableRow,
   TableHeader,
+  TableRow,
+  TableHead,
   TableBody,
   TableCell,
-  Form,
-  FormGroup,
   Checkbox,
-  TextInput,
-} from "@camunda/design-system/carbon-compat";
-
-import { Alert, Stepper, StepperStep } from "@camunda/design-system";
+  Input,
+  Alert,
+  Stepper,
+  StepperStep,
+} from "@camunda/design-system";
 
 // Carbon icons → lucide-react equivalents:
 //   Launch → ExternalLink, Close → X (rest keep their names)
@@ -509,7 +508,7 @@ function App() {
                 ))}
               </div>
 
-              <Form className="configBox" style={{ marginTop: "1.5rem" }}>
+              <form className="configBox" style={{ marginTop: "1.5rem" }}>
                 <button
                   type="button"
                   className="configToggle"
@@ -523,79 +522,93 @@ function App() {
                   {showConfig ? <ChevronUp /> : <ChevronDown />}
                 </button>
               {showConfig && (
-                  <FormGroup legendText="Advanced configuration options">
-                    <Checkbox
-                      id="addDataMigrationExecutionListener"
-                      labelText="Add Data Migration Execution Listener"
-                      checked={configOptions.addDataMigrationExecutionListener}
-                      helperText="Add a listener to the blank start event of the process to be used by the Camunda 7 Data Migrator. Enable if you want to use the runtime migrator later."
-                      onChange={(e, { checked }) =>
-                        setConfigOptions((prev) => ({
-                          ...prev,
-                          addDataMigrationExecutionListener: checked,
-                        }))
-                      }
-                    />
-                    <TextInput
-                      id="dataMigrationExecutionListenerJobType"
-                      labelText="Execution Listener Job Type"
-                      value={configOptions.dataMigrationExecutionListenerJobType}
-                      disabled={!configOptions.addDataMigrationExecutionListener}
-                      onChange={(e) =>
-                        setConfigOptions((prev) => ({
-                          ...prev,
-                          dataMigrationExecutionListenerJobType: e.target.value,
-                        }))
-                      }
-                    />
+                  <fieldset className="flex flex-col gap-2 rounded-md border bg-background p-4">
+                    <legend className="px-1 text-sm font-medium text-foreground">
+                      Advanced configuration options
+                    </legend>
+                    <label className="flex items-center gap-2">
+                      <Checkbox
+                        id="addDataMigrationExecutionListener"
+                        checked={configOptions.addDataMigrationExecutionListener}
+                        onCheckedChange={(checked) =>
+                          setConfigOptions((prev) => ({
+                            ...prev,
+                            addDataMigrationExecutionListener: checked === true,
+                          }))
+                        }
+                      />
+                      <span>Add Data Migration Execution Listener</span>
+                    </label>
+                    <div className="flex flex-col gap-1">
+                      <label htmlFor="dataMigrationExecutionListenerJobType" className="text-sm font-medium">
+                        Execution Listener Job Type
+                      </label>
+                      <Input
+                        id="dataMigrationExecutionListenerJobType"
+                        value={configOptions.dataMigrationExecutionListenerJobType}
+                        disabled={!configOptions.addDataMigrationExecutionListener}
+                        onChange={(e) =>
+                          setConfigOptions((prev) => ({
+                            ...prev,
+                            dataMigrationExecutionListenerJobType: e.target.value,
+                          }))
+                        }
+                      />
+                    </div>
                     <div className="form-spacer" />
-                    <Checkbox
-                      id="keepJobTypeBlank"
-                      labelText="Keep job type blank"
-                      checked={configOptions.keepJobTypeBlank}
-                      helperText="Don't set the job type in process models at all."
-                      onChange={(e, { checked }) =>
-                        setConfigOptions((prev) => ({
-                          ...prev,
-                          keepJobTypeBlank: checked,
-                        }))
-                      }
-                    />
+                    <label className="flex items-center gap-2">
+                      <Checkbox
+                        id="keepJobTypeBlank"
+                        checked={configOptions.keepJobTypeBlank}
+                        onCheckedChange={(checked) =>
+                          setConfigOptions((prev) => ({
+                            ...prev,
+                            keepJobTypeBlank: checked === true,
+                          }))
+                        }
+                      />
+                      <span>Keep job type blank</span>
+                    </label>
                     <div className="form-spacer" />
-                    <Checkbox
-                      id="alwaysUseDefaultJobType"
-                      labelText="Enable default job type"
-                      checked={configOptions.alwaysUseDefaultJobType}
-                      helperText="If enabled, tasks will always get the job type below. If disabled, the delegate expression or delegate class name will be used as job type."
-                      disabled={configOptions.keepJobTypeBlank}
-                      onChange={(e, { checked }) =>
-                        setConfigOptions((prev) => ({
-                          ...prev,
-                          alwaysUseDefaultJobType: checked,
-                        }))
-                      }
-                    />
-                    <TextInput
-                      id="defaultJobType"
-                      labelText="Default Job Type"
-                      value={configOptions.defaultJobType}
-                      disabled={configOptions.keepJobTypeBlank}
-                      onChange={(e) =>
-                        setConfigOptions((prev) => ({
-                          ...prev,
-                          defaultJobType: e.target.value,
-                        }))
-                      }
-                    />
-                  </FormGroup>
+                    <label className="flex items-center gap-2">
+                      <Checkbox
+                        id="alwaysUseDefaultJobType"
+                        checked={configOptions.alwaysUseDefaultJobType}
+                        disabled={configOptions.keepJobTypeBlank}
+                        onCheckedChange={(checked) =>
+                          setConfigOptions((prev) => ({
+                            ...prev,
+                            alwaysUseDefaultJobType: checked === true,
+                          }))
+                        }
+                      />
+                      <span>Enable default job type</span>
+                    </label>
+                    <div className="flex flex-col gap-1">
+                      <label htmlFor="defaultJobType" className="text-sm font-medium">
+                        Default Job Type
+                      </label>
+                      <Input
+                        id="defaultJobType"
+                        value={configOptions.defaultJobType}
+                        disabled={configOptions.keepJobTypeBlank}
+                        onChange={(e) =>
+                          setConfigOptions((prev) => ({
+                            ...prev,
+                            defaultJobType: e.target.value,
+                          }))
+                        }
+                      />
+                    </div>
+                  </fieldset>
               )}
-              </Form>
+              </form>
             </section>
 
             <div className="convertAction">
               <Button
-                kind="primary"
-                size="xl"
+                variant="default"
+                size="lg"
                 onClick={analyzeAndConvert}
                 disabled={files.length === 0}
               >
@@ -621,7 +634,7 @@ function App() {
                     description="Some elements may not be fully supported in this version. Use the preview per model or download the XLSX report for a complete overview."
                     className="incompatibility-notification"
                   >
-                    <Button kind="tertiary" size="sm" onClick={downloadXLS}>
+                    <Button variant="secondary" size="sm" onClick={downloadXLS}>
                       Download XLSX
                     </Button>
                   </Alert>
@@ -663,12 +676,12 @@ function App() {
                 />
               )}
               <Button
-                kind="primary"
-                size="xl"
-                renderIcon={Download}
+                variant="default"
+                size="lg"
                 onClick={downloadZIP}
                 disabled={validFiles.length === 0}
               >
+                <Download />
                 Download converted models as ZIP
               </Button>
             </section>
@@ -680,13 +693,13 @@ function App() {
               <div className="download-options">
                 <div className="download-row">
                   <Button
-                    kind="primary"
-                    size="md"
-                    renderIcon={Download}
+                    variant="default"
+                    size="default"
                     onClick={downloadXLS}
                     className="withMarginBottom"
                     disabled={validFiles.length === 0}
                   >
+                    <Download />
                     Download XLSX
                   </Button>
                   <p>
@@ -696,12 +709,12 @@ function App() {
                 </div>
                 <div className="download-row">
                   <Button
-                    kind="tertiary"
-                    size="md"
-                    renderIcon={Download}
+                    variant="secondary"
+                    size="default"
                     onClick={downloadCSV}
                     disabled={validFiles.length === 0}
                   >
+                    <Download />
                     Download CSV
                   </Button>
                   <p>
@@ -727,12 +740,12 @@ function App() {
                 8 in the migration guide.
               </p>
               <Button
-                kind="tertiary"
-                size="xl"
-                renderIcon={ExternalLink}
+                variant="secondary"
+                size="lg"
                 href="https://docs.camunda.io/docs/guides/migrating-from-camunda-7/migration-journey/?utm_source=analyzer"
                 target="_blank"
               >
+                <ExternalLink />
                 Migration Guide
               </Button>
             </section>
@@ -748,11 +761,11 @@ function App() {
         </div>
         <div>
           <Button
-            kind="ghost"
+            variant="ghost"
             size="sm"
-            renderIcon={X}
             onClick={() => setIsPreviewOpen(false)}
           >
+            <X />
             Close
           </Button>
         </div>
@@ -768,15 +781,15 @@ function App() {
         Elements in this model that need attention during migration. Each row describes one finding — its location, severity, and a message explaining what to address.
       </p>
       <Table className="analysis-table">
-        <TableHead>
+        <TableHeader>
           <TableRow>
             {previewTableHeader.map((header) => (
-              <TableHeader key={header.key}>
+              <TableHead key={header.key}>
                 {header.header}
-              </TableHeader>
+              </TableHead>
             ))}
           </TableRow>
-        </TableHead>
+        </TableHeader>
         <TableBody>
           {previewTableRows.map((row) => (
             <TableRow key={row.id}>

--- a/diagram-converter/webapp/src/main/javascript/src/FileItem.jsx
+++ b/diagram-converter/webapp/src/main/javascript/src/FileItem.jsx
@@ -66,7 +66,12 @@ export default function FileItem({
           <TooltipProvider>
             <Tooltip>
               <TooltipTrigger asChild>
-                <div style={{ color: "var(--danger-action-default)" }}>
+                <div
+                  tabIndex={0}
+                  role="img"
+                  aria-label={error}
+                  style={{ color: "var(--danger-action-default)" }}
+                >
                   <AlertTriangle />
                 </div>
               </TooltipTrigger>

--- a/diagram-converter/webapp/src/main/javascript/src/FileItem.jsx
+++ b/diagram-converter/webapp/src/main/javascript/src/FileItem.jsx
@@ -5,7 +5,12 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-import { Loading, Tooltip } from "@camunda/design-system/carbon-compat";
+import {
+  Tooltip,
+  TooltipTrigger,
+  TooltipContent,
+  TooltipProvider,
+} from "@camunda/design-system";
 
 import {
   Download,
@@ -13,7 +18,18 @@ import {
   Eye,
   AlertTriangle,
   Check,
+  Loader2,
 } from "lucide-react";
+
+function Spinner() {
+  return (
+    <Loader2
+      aria-label="Loading"
+      role="status"
+      className="size-4 animate-spin text-primary-action-default"
+    />
+  );
+}
 
 export default function FileItem({
   name,
@@ -47,19 +63,24 @@ export default function FileItem({
         )}
 
         {error && (
-          <Tooltip label={error}>
-            <div style={{ color: "var(--danger-action-default)" }}>
-              <AlertTriangle />
-            </div>
-          </Tooltip>
+          <TooltipProvider>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <div style={{ color: "var(--danger-action-default)" }}>
+                  <AlertTriangle />
+                </div>
+              </TooltipTrigger>
+              <TooltipContent>{error}</TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
         )}
-        {status === "uploading" && !isChecked && <Loading small withOverlay={false} />}
+        {status === "uploading" && !isChecked && <Spinner />}
         {isChecked && previewAction && (
           <button className="download" onClick={previewAction} title="Preview the analyzer results for this model">
             <Eye />
           </button>
         )}
-        {status === "uploading" && !isConverted && <Loading small withOverlay={false} />}
+        {status === "uploading" && !isConverted && <Spinner />}
         {isConverted && downloadAction && !error && (
           <button className="download" onClick={downloadAction} title="Download the converted model">
             <Download />

--- a/diagram-converter/webapp/src/main/javascript/src/c4-ui.css
+++ b/diagram-converter/webapp/src/main/javascript/src/c4-ui.css
@@ -4,11 +4,10 @@
  * (`import "@camunda/design-system/styles.css"`). PostCSS does NOT
  * honor `exports`, so do NOT `@import` it from here.
  *
- * This app renders exclusively DS-native components (the
- * `@camunda/design-system/carbon-compat` re-exports we use — Button,
- * Table, Form, Checkbox, TextInput — all resolve to the DS shadcn
- * primitives, not Carbon). It renders zero real `.cds--*` markup, so
- * the Carbon-coexistence resets that camunda-hub needs are unnecessary
+ * This app renders exclusively DS-native components (Button, Table,
+ * Checkbox, Input, Tooltip, etc. from `@camunda/design-system`). It
+ * renders zero real `.cds--*` markup, so the Carbon-coexistence resets
+ * that camunda-hub needs are unnecessary
  * here — and harmful: reverting `font`/`padding` on every `<button>`
  * inside `.c4-ui` stripped the Camunda font off DS buttons (they fell
  * back to Arial) and off the custom version-selector segments. Removed.

--- a/diagram-converter/webapp/src/main/javascript/src/index.css
+++ b/diagram-converter/webapp/src/main/javascript/src/index.css
@@ -72,7 +72,7 @@ h1 {
   padding: 28px 32px;
   background-color: var(--neutral-background-subtle);
   margin-bottom: 24px;
-  border-radius: var(--radius-lg);
+  border-radius: var(--radius);
   border: 1px solid var(--border);
   box-shadow: var(--shadow-sm);
 
@@ -155,7 +155,7 @@ h1 {
 }
 
 .convertAction button {
-  border-radius: var(--radius-lg);
+  border-radius: var(--radius);
   font-weight: 600;
 }
 
@@ -167,7 +167,7 @@ h1 {
 .DropZone {
   background-color: var(--primary-background-subtle);
   border: 2px dashed var(--primary-border-subtle);
-  border-radius: var(--radius-lg);
+  border-radius: var(--radius);
   height: 160px;
   margin-bottom: 12px;
 
@@ -302,7 +302,7 @@ hr {
   height: 400px;
   width: 100%;
   border: 1px solid var(--border);
-  border-radius: var(--radius-lg);
+  border-radius: var(--radius);
   margin-bottom: 20px;
 }
 
@@ -323,7 +323,7 @@ hr {
   width: 100%;
   max-height: 95vh;
   overflow-y: auto;
-  border-radius: var(--radius-lg);
+  border-radius: var(--radius);
   border: 1px solid var(--border);
   box-shadow: var(--shadow-lg);
 
@@ -387,7 +387,7 @@ th, td {
   font-weight: 600;
   color: var(--warning-foreground-strong);
   background: var(--warning-background-subtle);
-  border-radius: var(--radius-xl);
+  border-radius: calc(var(--radius) + 4px);
   padding: 1px 7px;
   white-space: nowrap;
 }
@@ -397,7 +397,7 @@ th, td {
   padding: 1.25rem 1.5rem;
   background-color: var(--color-zinc-50);
   border: 1px solid var(--border);
-  border-radius: var(--radius-lg);
+  border-radius: var(--radius);
 }
 
 .configToggle {
@@ -511,7 +511,7 @@ th, td {
   display: inline-flex;
   margin-top: 12px;
   border: 1.5px solid var(--border);
-  border-radius: var(--radius-lg);
+  border-radius: var(--radius);
   overflow: hidden;
   background: var(--neutral-background-subtle);
 }

--- a/diagram-converter/webapp/src/main/javascript/vite.config.js
+++ b/diagram-converter/webapp/src/main/javascript/vite.config.js
@@ -7,14 +7,8 @@
  */
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
-import path from "path";
 
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
-  resolve: {
-    alias: {
-      "~@ibm/plex": path.resolve(__dirname, "node_modules/@ibm/plex"),
-    },
-  },
 });


### PR DESCRIPTION
## Description
Replaces every `@camunda/design-system/carbon-compat` import in the diagram-converter webapp (`Button`, `Table`/`TableHead`/`TableHeader`/`TableRow`/`TableBody`/`TableCell`, `Form`, `FormGroup`, `Checkbox`, `TextInput`, `Loading`, `Tooltip`) with the native `@camunda/design-system` equivalents.

The carbon-compat layer already wraps the same native DS/shadcn primitives underneath a Carbon-shaped prop API (`kind`→`variant`, `labelText`→separate `<label>`, etc.) — it renders identical underlying components, not real `@carbon/react`. So this is a pure prop-API refactor with no visual or behavioral change, verified in-browser.

Notable naming gotcha: native `TableHead`/`TableHeader` are swapped vs. the Carbon convention (Carbon's `TableHead` = `<thead>`, native's `TableHead` = `<th>`) — JSX tags were relabeled accordingly, not just the import path.

Also removes `@carbon/react` from `package.json` and the now-dead `~@ibm/plex` vite alias — both were only there to support carbon-compat's type shims and were never bundled or used at runtime. `npm install` dropped 52 transitive packages as a result.

## Type of Change
- [x] Refactoring (no functional changes)

## Testing
- `npm run lint` — clean (1 pre-existing unrelated warning)
- `npm run build` — succeeds, bundle size unchanged
- Verified in browser via Playwright: Advanced options fieldset, checkboxes, text inputs all render and wire up correctly (checked state toggles disabled state on dependent inputs), zero console errors
- Did not exercise the step-2/results flow (Table, download buttons) end-to-end since it requires the backend — reviewed those code paths against the exact carbon-compat source they replace

## Known pre-existing issues (not introduced or fixed by this PR)
- 3 `Checkbox` instances have `helperText` that was already silently dropped by carbon-compat (never rendered) — preserved as-is
- The "Migration Guide" button uses `href`/`target` with no `onClick`; a native `<button>` with `href` is inert — was already broken before this change