### PR TITLE
chore(deps): bump Camunda 8 to 8.8.31 [maintenance/0.2]

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
     <version.java>21</version.java>
 
     <version.camunda-7>7.24.5-ee</version.camunda-7>
-    <version.camunda-8>8.8.29</version.camunda-8>
+    <version.camunda-8>8.8.31</version.camunda-8>
     <camunda8.docker.image>camunda/camunda:${version.camunda-8}</camunda8.docker.image>
     <version.elasticsearch>8.19.6</version.elasticsearch>
     <version.spring-boot>3.5.16</version.spring-boot>


### PR DESCRIPTION
## Summary
- Bump `version.camunda-8` from 8.8.29 to 8.8.31 (latest 8.8.x tag) ahead of release
- `version.camunda-7` stays at 7.24.5-ee — `camunda-engine-spring-6` is unpublished past that patch, newer EE tags broke data-migrator dependency resolution in CI

## Test plan
- [ ] CI green (build + data-migrator dep resolution)
