### PR TITLE
chore(deps): bump Camunda 7 to 7.24.11-ee [maintenance/0.3]

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
     <maven.compiler.target>21</maven.compiler.target>
     <version.java>21</version.java>
 
-    <version.camunda-7>7.24.9-ee</version.camunda-7>
+    <version.camunda-7>7.24.11-ee</version.camunda-7>
     <version.camunda-8>8.9.12</version.camunda-8>
     <camunda8.docker.image>camunda/camunda:${version.camunda-8}</camunda8.docker.image>
     <version.elasticsearch>8.19.6</version.elasticsearch>


### PR DESCRIPTION
## Summary
- Bump `version.camunda-7` from 7.24.9-ee to 7.24.11-ee — confirmed latest EE patch via authenticated artifactory (`mvn versions:display-dependency-updates` against `camunda-engine-spring`, `camunda-engine-plugin-spin`, `camunda-dmn-model`, `camunda-spin-dataformat-all`)
- `version.camunda-8` stays at 8.9.12 — only 8.10.0-alpha3 exists beyond it (next major dev line, not a stable 8.9.x patch)
- Verified with `mvn dependency:resolve` against the bumped version — resolves clean

## Test plan
- [ ] CI green
