### PR TITLE
chore(deps): bump Camunda 8 to 8.10.0-alpha3, Camunda 7 to 7.24.11-ee

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,10 +29,10 @@
     <maven.compiler.target>21</maven.compiler.target>
     <version.java>21</version.java>
 
-    <version.camunda-7>7.24.9-ee</version.camunda-7>
-    <version.camunda-8>8.10.0-SNAPSHOT</version.camunda-8>
+    <version.camunda-7>7.24.11-ee</version.camunda-7>
+    <version.camunda-8>8.10.0-alpha3</version.camunda-8>
     <version.camunda-8.previous>8.9.0</version.camunda-8.previous>
-    <camunda8.docker.image>camunda/camunda:SNAPSHOT</camunda8.docker.image>
+    <camunda8.docker.image>camunda/camunda:${version.camunda-8}</camunda8.docker.image>
     <version.elasticsearch>8.19.6</version.elasticsearch>
     <version.spring-boot>4.1.0</version.spring-boot>
     <logback.version>1.5.37</logback.version>


### PR DESCRIPTION
Closing — main tracks Camunda 8 dev SNAPSHOT intentionally, no version fixing needed here.