### PR TITLE
chore(deps): bump Camunda 7 to 7.24.11-ee [main]

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
     <maven.compiler.target>21</maven.compiler.target>
     <version.java>21</version.java>
 
-    <version.camunda-7>7.24.9-ee</version.camunda-7>
+    <version.camunda-7>7.24.11-ee</version.camunda-7>
     <version.camunda-8>8.10.0-SNAPSHOT</version.camunda-8>
     <version.camunda-8.previous>8.9.0</version.camunda-8.previous>
     <camunda8.docker.image>camunda/camunda:SNAPSHOT</camunda8.docker.image>


### PR DESCRIPTION
## Summary
- `version.camunda-7`: 7.24.9-ee -> 7.24.11-ee — latest EE patch for `camunda-engine-spring`, `camunda-engine-plugin-spin`, `camunda-dmn-model`, `camunda-spin-dataformat-all`, confirmed via authenticated artifactory
- `version.camunda-8` untouched — main tracks the SNAPSHOT dev line intentionally

## Test plan
- [ ] CI green (dependency resolution already verified locally)
