### PR TITLE
fix(ci): stabilize recurring db matrix failures on main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -953,6 +953,7 @@ jobs:
           -Dversion.camunda-8=${{ matrix.camunda-version }}
           -Dc8.api=${{ matrix.c8-api }}
           -Dcamunda.process-test.camunda-docker-image-version=${{ matrix.camunda-docker-image-version }}
+          -Dsurefire.rerunFailingTestsCount=1
 
   # Rerun failed jobs running on self-hosted runners in case of network issues or node preemption
   rerun-failed-jobs:

--- a/data-migrator/qa/integration-tests/src/test/resources/application-oracle-19.yml
+++ b/data-migrator/qa/integration-tests/src/test/resources/application-oracle-19.yml
@@ -3,7 +3,7 @@ camunda:
     auto-ddl: true
     c7:
       data-source:
-        maximum-pool-size: 1
+        maximum-pool-size: 2
         minimum-idle: 0
         auto-ddl: true
         jdbc-url: jdbc:oracle:thin:@localhost:15433/ORCLDB
@@ -23,7 +23,7 @@ camunda:
     auto-ddl: true
     c8:
       data-source:
-        maximum-pool-size: 1
+        maximum-pool-size: 2
         minimum-idle: 0
         auto-ddl: true
         jdbc-url: jdbc:oracle:thin:@localhost:15433/ORCLDB

--- a/data-migrator/qa/integration-tests/src/test/resources/application-oracle.yml
+++ b/data-migrator/qa/integration-tests/src/test/resources/application-oracle.yml
@@ -3,7 +3,7 @@ camunda:
     auto-ddl: true
     c7:
       data-source:
-        maximum-pool-size: 1
+        maximum-pool-size: 2
         minimum-idle: 0
         auto-ddl: true
         jdbc-url: jdbc:oracle:thin:@localhost:15432/ORCLDB
@@ -23,7 +23,7 @@ camunda:
     auto-ddl: true
     c8:
       data-source:
-        maximum-pool-size: 1
+        maximum-pool-size: 2
         minimum-idle: 0
         auto-ddl: true
         jdbc-url: jdbc:oracle:thin:@localhost:15432/ORCLDB


### PR DESCRIPTION
## Summary

This PR addresses recurring main CI failures in the database compatibility matrix.

Observed in recent failing runs (sampled jobs):
- it-database-camunda-matrix (oracle, 8.9.0)
- it-database-camunda-matrix (oracle-19, 8.10.0-SNAPSHOT)
- it-database-camunda-matrix (mysql, 8.9.0)

Root-cause findings from logs:
- Oracle lanes: widespread CannotCreateTransaction failures caused by Hikari pool starvation/timeouts with pool size=1.
- MySQL 8.9 lane: transient Testcontainers startup timeout for camunda/camunda:8.9.0 in MixedConfigurationTest.

Changes:
- Increase Oracle test datasource pool size from 1 to 2 (both C7 and C8, both oracle profiles).
  - Keeps the previous ORA-12516 mitigation intent (low pool) while reducing single-connection starvation.
- Add one surefire retry in it-database-camunda-matrix:
  - -Dsurefire.rerunFailingTestsCount=1
  - This absorbs transient container startup flakes without masking deterministic failures.

## Validation performed

- Oracle targeted run:
  - mvn -pl data-migrator/qa/integration-tests -am -Poracle,integration -Dtest=io.camunda.migration.data.qa.persistence.SaveSkipReasonTest -Dsurefire.failIfNoSpecifiedTests=false test
  - Result: BUILD SUCCESS

- MySQL + Camunda 8.9 targeted run:
  - mvn -pl data-migrator/qa/integration-tests -am -Pmysql,integration -Dtest=io.camunda.migration.data.qa.runtime.variables.interceptor.MixedConfigurationTest -Dcamunda.process-test.camunda-docker-image-version=8.9.0 -Dsurefire.failIfNoSpecifiedTests=false test
  - Result: BUILD SUCCESS
