### PR TITLE
fix(ci): backport Oracle pool fix to maintenance/0.2

### DIFF
--- a/data-migrator/qa/integration-tests/src/test/resources/application-oracle.yml
+++ b/data-migrator/qa/integration-tests/src/test/resources/application-oracle.yml
@@ -23,7 +23,7 @@ camunda:
     auto-ddl: true
     c8:
       data-source:
-        maximum-pool-size: 1
+        maximum-pool-size: 2
         minimum-idle: 0
         auto-ddl: true
         jdbc-url: jdbc:oracle:thin:@localhost:15432/ORCLDB


### PR DESCRIPTION
## Summary

Manual backport of the Oracle CI stabilization from #1768 to `maintenance/0.2`.

This branch does not contain the newer dual-version DB compatibility matrix from `main`, so the applicable backport here is only:
- increase the Oracle C8 test datasource pool size from 1 to 2 in `application-oracle.yml`

## Validation

- `mvn -pl data-migrator/qa/integration-tests -am -Poracle,integration -Dtest=io.camunda.migration.data.qa.persistence.SaveSkipReasonTest -Dsurefire.failIfNoSpecifiedTests=false test`
- Result: BUILD SUCCESS

Backports #1768
