### PR TITLE
fix(ci): backport CI stabilization to maintenance/0.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1098,7 +1098,9 @@ jobs:
 
       - name: Run integration tests with ${{ matrix.database }}
         working-directory: data-migrator
-        run: mvn verify -P${{ matrix.database }},integration
+        run: >-
+          mvn verify -P${{ matrix.database }},integration
+          -Dsurefire.rerunFailingTestsCount=1
 
   # Rerun failed jobs running on self-hosted runners in case of network issues or node preemption
   rerun-failed-jobs:

--- a/data-migrator/qa/integration-tests/src/test/resources/application-oracle-19.yml
+++ b/data-migrator/qa/integration-tests/src/test/resources/application-oracle-19.yml
@@ -3,7 +3,7 @@ camunda:
     auto-ddl: true
     c7:
       data-source:
-        maximum-pool-size: 1
+        maximum-pool-size: 2
         minimum-idle: 0
         auto-ddl: true
         jdbc-url: jdbc:oracle:thin:@localhost:15433/ORCLDB
@@ -23,7 +23,7 @@ camunda:
     auto-ddl: true
     c8:
       data-source:
-        maximum-pool-size: 1
+        maximum-pool-size: 2
         minimum-idle: 0
         auto-ddl: true
         jdbc-url: jdbc:oracle:thin:@localhost:15433/ORCLDB

--- a/data-migrator/qa/integration-tests/src/test/resources/application-oracle.yml
+++ b/data-migrator/qa/integration-tests/src/test/resources/application-oracle.yml
@@ -3,7 +3,7 @@ camunda:
     auto-ddl: true
     c7:
       data-source:
-        maximum-pool-size: 1
+        maximum-pool-size: 2
         minimum-idle: 0
         auto-ddl: true
         jdbc-url: jdbc:oracle:thin:@localhost:15432/ORCLDB
@@ -23,7 +23,7 @@ camunda:
     auto-ddl: true
     c8:
       data-source:
-        maximum-pool-size: 1
+        maximum-pool-size: 2
         minimum-idle: 0
         auto-ddl: true
         jdbc-url: jdbc:oracle:thin:@localhost:15432/ORCLDB


### PR DESCRIPTION
## Summary

Manual backport of the CI stabilization from #1768 to `maintenance/0.3`.

This branch uses the older single-version `it-database-matrix` job, not the newer dual-version `it-database-camunda-matrix` from `main`.

Applicable backport changes:
- increase Oracle test datasource pool size from 1 to 2 in `application-oracle.yml`
- increase Oracle 19 test datasource pool size from 1 to 2 in `application-oracle-19.yml`
- add `-Dsurefire.rerunFailingTestsCount=1` to the branch's existing `it-database-matrix` job

## Validation

- `mvn -pl data-migrator/qa/integration-tests -am -Poracle,integration -Dtest=io.camunda.migration.data.qa.persistence.SaveSkipReasonTest -Dsurefire.failIfNoSpecifiedTests=false test`
- Result: BUILD SUCCESS

Backports #1768
