### PR TITLE
fix(diagram-converter): add missing 8.10 target version to SemanticVersion

### DIFF
--- a/diagram-converter/core/src/main/java/io/camunda/migration/diagram/converter/version/SemanticVersion.java
+++ b/diagram-converter/core/src/main/java/io/camunda/migration/diagram/converter/version/SemanticVersion.java
@@ -17,7 +17,8 @@ public enum SemanticVersion {
   _8_6("8.6"),
   _8_7("8.7"),
   _8_8("8.8"),
-  _8_9("8.9");
+  _8_9("8.9"),
+  _8_10("8.10");
 
   private final String name;
 

--- a/diagram-converter/core/src/test/java/io/camunda/migration/diagram/converter/version/SemanticVersionTest.java
+++ b/diagram-converter/core/src/test/java/io/camunda/migration/diagram/converter/version/SemanticVersionTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.migration.diagram.converter.version;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+class SemanticVersionTest {
+
+  @ParameterizedTest
+  @EnumSource(SemanticVersion.class)
+  void parseRoundTripsEveryDeclaredVersion(SemanticVersion version) {
+    assertThat(SemanticVersion.parse(version.toString())).isEqualTo(version);
+  }
+
+  @ParameterizedTest
+  @EnumSource(SemanticVersion.class)
+  void parseIsNotConfusedByLongerVersionsSharingAPrefix(SemanticVersion version) {
+    // e.g. "8.1" must not match "8.10", and "8.10" must not match "8.1"
+    for (SemanticVersion other : SemanticVersion.values()) {
+      if (other != version && other.toString().startsWith(version.toString())) {
+        assertThat(SemanticVersion.parse(other.toString())).isEqualTo(other);
+      }
+    }
+  }
+
+  @org.junit.jupiter.api.Test
+  void parseRejectsUnknownVersion() {
+    assertThatThrownBy(() -> SemanticVersion.parse("8.999"))
+        .isInstanceOf(IllegalStateException.class);
+  }
+}

--- a/diagram-converter/core/src/test/java/io/camunda/migration/diagram/converter/version/SemanticVersionTest.java
+++ b/diagram-converter/core/src/test/java/io/camunda/migration/diagram/converter/version/SemanticVersionTest.java
@@ -10,6 +10,7 @@ package io.camunda.migration.diagram.converter.version;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 
@@ -32,7 +33,7 @@ class SemanticVersionTest {
     }
   }
 
-  @org.junit.jupiter.api.Test
+  @Test
   void parseRejectsUnknownVersion() {
     assertThatThrownBy(() -> SemanticVersion.parse("8.999"))
         .isInstanceOf(IllegalStateException.class);


### PR DESCRIPTION
## Summary

- The live diagram converter (`0.3.4`, built from `maintenance/0.3`) lets users pick "8.10" as a target version in the UI, but the backend `SemanticVersion` enum on that branch stops at `8.9` — that UI option was backported (#1501 lineage) without also backporting the enum addition from #1336 (which landed on `main` first, long before the selector existed).
- Selecting 8.10 makes `SemanticVersion.parse("8.10")` throw `IllegalStateException`. That exception is caught per-element by `AbstractFilteringVisitor.visit()`'s blanket `catch (Exception e)`, which only logs and notifies an internal Slack webhook — never the HTTP caller. Because `BpmnDefinitionsVisitor`/`DmnDefinitionsVisitor` call `SemanticVersion.parse(...)` as the *first* statement before registering the `zeebe:`/`modeler:` namespaces and stamping `modeler:executionPlatform`/`executionPlatformVersion`, that failure aborts before any of it happens — so the download comes back as HTTP 200 but the file still looks like Camunda 7, with no visible error.
- `main` already has `_8_10` (added by #1336, well before the UI option existed) — this is purely a `maintenance/0.3` backport gap, confirmed by diffing `SemanticVersion.java` between `main` and `origin/maintenance/0.3`.
- Confirmed `maintenance/0.2`'s webapp doesn't offer "8.10" at all, so this branch is the only one affected.

## Changes

- `diagram-converter/core/.../version/SemanticVersion.java`: add the missing `_8_10("8.10")` enum constant (the exact one-line diff `main` already has).
- `diagram-converter/core/.../version/SemanticVersionTest.java` (new): parameterized test asserting `SemanticVersion.parse(v.toString())` round-trips for every declared version, and that longer versions sharing a numeric prefix (e.g. `8.1` vs `8.10`) don't get confused by the `startsWith` anchoring — plus a case asserting an unknown version still throws.

Deliberately scoped to just the enum constant, not a full cherry-pick of #1336 (which also adds the unrelated job-priority-conversion feature) — this is a stability-branch bugfix, not a feature backport.

## Test plan

- [x] `mvn test -pl diagram-converter/core` passes (405 tests, including the new `SemanticVersionTest`)
- [x] `mvn clean install -DskipTests -pl diagram-converter/core,diagram-converter/webapp,diagram-converter/cli` builds clean
- [ ] After merge, cut a `0.3.5` release so the fix reaches the live site

## Baseline

Built from `origin/maintenance/0.3` commit: 1c362b62c2e12406e79fba3eece00ee0b770aa57

closes #1769

🤖 Generated with [Claude Code](https://claude.com/claude-code)