### PR TITLE
fix(ci): stabilize history-h2 windows distribution smoke timeout

### DIFF
--- a/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/distribution/DistributionSmokeTest.java
+++ b/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/distribution/DistributionSmokeTest.java
@@ -277,7 +277,7 @@ public class DistributionSmokeTest {
   }
 
   @Test
-  @Timeout(value = 90, unit = TimeUnit.SECONDS)
+  @Timeout(value = 240, unit = TimeUnit.SECONDS)
   void shouldAcceptValidFlags() throws Exception {
     // given
     String[][] validFlags = {
@@ -299,7 +299,9 @@ public class DistributionSmokeTest {
       // when
       Process currentProcess = processBuilder.start();
       try {
-        String output = readProcessOutputUntil(currentProcess, expected, 10, TimeUnit.SECONDS);
+        // Starting the distribution repeatedly in a single test is slower on Windows CI.
+        // Use a per-invocation budget that tolerates host variance while still failing deterministically.
+        String output = readProcessOutputUntil(currentProcess, expected, 20, TimeUnit.SECONDS);
 
         // then
         assertThat(output).contains(expected);


### PR DESCRIPTION
## Summary

This addresses the intermittent CI failures in the Windows history lane by fixing a deterministic timeout budget issue in distribution smoke tests.

Root cause:
- the `it-history-h2-windows` lane was failing in `DistributionSmokeTest.shouldAcceptValidFlags`
- that test launches the distribution process 9 times in one test method
- it had a single 90s timeout budget, which is too tight for slower Windows runners and causes flakiness

Changes:
- increase method timeout in `shouldAcceptValidFlags` from `90s` to `240s`
- increase per-flag wait budget in `readProcessOutputUntil` from `10s` to `20s`
- keep assertions and coverage unchanged

This removes false-negative timeouts while preserving the same behavior checks.

## Validation

- Verified compile of integration tests module:
  - `mvn -f data-migrator/pom.xml -Pintegration -pl qa/integration-tests -am -DskipTests test-compile`
- Built distribution artifacts used by smoke tests:
  - `mvn -f data-migrator/pom.xml -pl assembly -am -DskipTests package`
- Verified flaky test method directly:
  - `mvn -f data-migrator/qa/integration-tests/pom.xml -Dtest=io.camunda.migration.data.qa.distribution.DistributionSmokeTest#shouldAcceptValidFlags -Dsurefire.failIfNoSpecifiedTests=false test`
  - result: `BUILD SUCCESS`
