### PR TITLE
fix(ci): shard database compatibility matrix to prevent fork timeouts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -914,6 +914,8 @@ jobs:
       matrix:
         database: [postgresql, postgresql-15, oracle, oracle-19, mysql, mariadb, mariadb-10, sqlserver]
         camunda-version: ${{ fromJSON(needs.read-versions.outputs.camunda-versions) }}
+        # Keep every test fork below Surefire's 65-minute hang detector.
+        suite: [runtime-core, runtime-element, runtime-jobtype, runtime-variables, history-only, identity-only]
         include:
           - camunda-version: ${{ needs.read-versions.outputs.camunda-8-version }}
             camunda-docker-image-version: ${{ needs.read-versions.outputs.camunda-8-docker-image-version }}
@@ -946,14 +948,13 @@ jobs:
           vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
 
-      - name: Run integration tests with ${{ matrix.database }} (Camunda ${{ matrix.camunda-version }})
+      - name: Run ${{ matrix.suite }} tests with ${{ matrix.database }} (Camunda ${{ matrix.camunda-version }})
         working-directory: data-migrator
         run: >-
-          mvn verify -P${{ matrix.database }},integration
+          mvn verify -P${{ matrix.database }},integration,${{ matrix.suite }}
           -Dversion.camunda-8=${{ matrix.camunda-version }}
           -Dc8.api=${{ matrix.c8-api }}
           -Dcamunda.process-test.camunda-docker-image-version=${{ matrix.camunda-docker-image-version }}
-          -Dsurefire.rerunFailingTestsCount=1
 
   # Rerun failed jobs running on self-hosted runners in case of network issues or node preemption
   rerun-failed-jobs:


### PR DESCRIPTION
## Description

The last ten failed `main` CI runs contained six healthy integration-test forks that Surefire killed at its configured 3,900-second limit. The latest failure reached 654 passing tests before the fork timeout. The single serial compatibility suite had outgrown a timeout intentionally sized for smaller CI jobs.

Run each database/Camunda version combination through the existing exhaustive suite profiles:

- Four runtime shards, each designed for approximately 20 minutes
- History
- Identity

This preserves the 65-minute stuck-fork detector while ensuring healthy suites finish well below it. It also removes `surefire.rerunFailingTestsCount`; retries hide startup defects rather than fixing them.

PR #1768 already fixed the dominant Oracle connection-pool starvation found in 36 failed jobs. This PR addresses the independent timeout that remained on its merge commit.

Baseline commit: `b29b80e061e4472654fc32ac8c19a0614198875a`

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Test-only changes (no production code changes)

## Testing Checklist

### Black-Box Testing Requirements
- [x] Tests follow **black-box testing approach**: verify behavior through observable outputs (logs, C8 API queries, real-world skip scenarios)
- [x] Tests **DO NOT** access implementation details (`DbClient`, `IdKeyMapper`, `..impl..` packages except logging constants)
- [x] Architecture tests pass (`ArchitectureTest` validates these rules)

### Test Coverage
- [ ] Added tests for new functionality
- [x] Updated tests for modified functionality
- [ ] All tests pass locally

Verified that every concrete integration test is selected by at least one matrix suite profile. The `ci:previous-c8-version` label runs the changed compatibility matrix on this PR.

## Architecture Compliance

No application or test architecture changed. `ArchitectureTest` remains included in every runtime shard and in the history and identity profiles.

## Documentation
- [ ] Updated TESTING_GUIDELINES.md if adding new test patterns
- [ ] Added Javadoc comments for public APIs
- [ ] Updated README if user-facing changes

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed the code
- [x] Added comments for complex logic
- [x] No new compiler warnings
- [x] Dependent changes have been merged

## Related Issues

Related to #1768
