### PR TITLE
fix(ci): shard database compatibility matrix to prevent fork timeouts (backport #1776)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1071,6 +1071,8 @@ jobs:
       fail-fast: false
       matrix:
         database: [postgresql, postgresql-15, oracle, oracle-19, mysql, mariadb, mariadb-10, sqlserver]
+        # Keep every test fork below Surefire's 65-minute hang detector.
+        suite: [runtime-core, runtime-element, runtime-jobtype, runtime-variables, history-only, identity-only]
     steps:
       - name: Checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
@@ -1096,11 +1098,10 @@ jobs:
           vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
 
-      - name: Run integration tests with ${{ matrix.database }}
+      - name: Run ${{ matrix.suite }} tests with ${{ matrix.database }}
         working-directory: data-migrator
         run: >-
-          mvn verify -P${{ matrix.database }},integration
-          -Dsurefire.rerunFailingTestsCount=1
+          mvn verify -P${{ matrix.database }},integration,${{ matrix.suite }}
 
   # Rerun failed jobs running on self-hosted runners in case of network issues or node preemption
   rerun-failed-jobs:


### PR DESCRIPTION
## Description

Backport of #1776 to `maintenance/0.3`. The automated backport bot could not cherry-pick cleanly because `maintenance/0.3`'s `it-database-matrix` job predates the `camunda-version`/`c8-api` compatibility-matrix feature (main-only) — it only has a `database` dimension. This PR applies the equivalent fix to that simpler structure: adds a `suite` matrix dimension (`runtime-core`, `runtime-element`, `runtime-jobtype`, `runtime-variables`, `history-only`, `identity-only`) so no single Surefire fork runs long enough to hit the 65-minute stuck-fork detector, and drops `-Dsurefire.rerunFailingTestsCount=1` since retries were hiding startup defects rather than fixing them.

Note: a corresponding backport to `maintenance/0.2` was evaluated and is **not applicable** — that branch never adopted the unified `it-database-matrix` job; it already runs each database as separate per-DB jobs (`it-runtime-postgresql`, `it-runtime-oracle`, etc.) with no fork-timeout issue to fix.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Testing Checklist

### Black-Box Testing Requirements
- [x] Tests follow **black-box testing approach**: verify behavior through observable outputs (logs, C8 API queries, real-world skip scenarios)
- [x] Tests **DO NOT** access implementation details (`DbClient`, `IdKeyMapper`, `..impl..` packages except logging constants)
- [x] Architecture tests pass (`ArchitectureTest` validates these rules)

### Test Coverage
- [ ] Added tests for new functionality
- [x] Updated tests for modified functionality
- [ ] All tests pass locally

CI-only change; verified the referenced Maven profiles (`runtime-core`, `runtime-element`, `runtime-jobtype`, `runtime-variables`, `history-only`, `identity-only`) already exist in `data-migrator/qa/integration-tests/pom.xml` on this branch, and validated the resulting `ci.yml` parses as valid YAML.

## Architecture Compliance

No application or test architecture changed.

## Documentation
- [ ] Updated TESTING_GUIDELINES.md if adding new test patterns
- [ ] Added Javadoc comments for public APIs
- [ ] Updated README if user-facing changes

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed the code
- [ ] Added comments for complex logic
- [x] No new compiler warnings
- [x] Dependent changes have been merged

## Related Issues

Backport of #1776