### PR TITLE
fix(deps): pin jackson-bom to 2.21.5 to fix CVE-2026-59889 (maintenance/0.2)

### DIFF
--- a/data-migrator/core/pom.xml
+++ b/data-migrator/core/pom.xml
@@ -17,6 +17,15 @@
 
   <dependencyManagement>
     <dependencies>
+      <!-- CVE-2026-59889: pin jackson-bom ahead of Spring Boot BOM, which
+           manages jackson-databind at 2.21.4 (below the 2.21.5 fix). -->
+      <dependency>
+        <groupId>com.fasterxml.jackson</groupId>
+        <artifactId>jackson-bom</artifactId>
+        <version>${version.jackson-bom}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
       <!-- netty-bom must be imported before spring-boot-dependencies to ensure
            the pinned Netty version takes precedence over the version pulled in
            transitively by gRPC (via spring-boot-dependencies). -->

--- a/data-migrator/distro/pom.xml
+++ b/data-migrator/distro/pom.xml
@@ -17,6 +17,15 @@
 
   <dependencyManagement>
     <dependencies>
+      <!-- CVE-2026-59889: pin jackson-bom ahead of Spring Boot BOM, which
+           manages jackson-databind at 2.21.4 (below the 2.21.5 fix). -->
+      <dependency>
+        <groupId>com.fasterxml.jackson</groupId>
+        <artifactId>jackson-bom</artifactId>
+        <version>${version.jackson-bom}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
       <!-- netty-bom must be imported before spring-boot-dependencies and zeebe-parent
            to ensure the pinned Netty version takes precedence over the version pulled in
            transitively by gRPC. -->

--- a/diagram-converter/pom.xml
+++ b/diagram-converter/pom.xml
@@ -40,6 +40,15 @@
 
   <dependencyManagement>
     <dependencies>
+      <!-- CVE-2026-59889: pin jackson-bom ahead of Spring Boot BOM, which
+           manages jackson-databind at 2.21.4 (below the 2.21.5 fix). -->
+      <dependency>
+        <groupId>com.fasterxml.jackson</groupId>
+        <artifactId>jackson-bom</artifactId>
+        <version>${version.jackson-bom}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
       <dependency>
         <groupId>org.camunda.bpm</groupId>
         <artifactId>camunda-bom</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,7 @@
     <camunda8.docker.image>camunda/camunda:${version.camunda-8}</camunda8.docker.image>
     <version.elasticsearch>8.19.6</version.elasticsearch>
     <version.spring-boot>3.5.16</version.spring-boot>
+    <version.jackson-bom>2.21.5</version.jackson-bom>
     <tomcat.version>11.0.24</tomcat.version>
     <logback.version>1.5.37</logback.version>
     <version.assertj>3.27.7</version.assertj>


### PR DESCRIPTION
## Summary

- CVE-2026-59889: jackson-databind `UnwrappedPropertyHandler.processUnwrapped()` skips the `@JsonView` visibility guard for `@JsonUnwrapped` properties, letting attacker JSON write into view-restricted fields. Fixed upstream in 2.18.9 / 2.21.5 / 2.22.1 / 3.1.5 / 3.2.1.
- Not exploitable here — `@JsonView` is not used anywhere in this codebase's production sources — but the resolved jackson-databind version genuinely sat in the vulnerable range (`2.21.4`) despite prior "bump jackson to 2.22.1" Renovate PRs (#1509, #1712), which only ever touched the `data-migrator/qa/integration-tests` test-scope pin, not the real compile/runtime version.
- Root cause: Spring Boot 3.5.16's BOM manages jackson-databind at `2.21.4` via its own `jackson-bom.version` property. A top-level property override does not cascade into that nested BOM-of-BOM (verified empirically), so the only reliable fix is importing our own `jackson-bom` ahead of `spring-boot-dependencies`.

## Changes

- `pom.xml`: add `version.jackson-bom=2.21.5` property (this branch stays on the 2.21.x line — Spring Boot 4/jackson 2.22.x upgrade is intentionally deferred per the existing "Spring Boot 4 upgrade is blocked by C7 April Environment Release" comment)
- `data-migrator/core/pom.xml`, `data-migrator/distro/pom.xml`, `diagram-converter/pom.xml`: import `com.fasterxml.jackson:jackson-bom:${version.jackson-bom}` before each module's `spring-boot-dependencies` import, so it wins Maven's same-file dependencyManagement precedence (matches the existing `CVE-2026-55955` tomcat-embed override pattern already in `diagram-converter/pom.xml`)
- `code-conversion/recipes` and the `code-examples` modules are not touched — on this branch they don't resolve `jackson-databind` at all in their dependency tree, so there's nothing to fix there

Verified `mvn dependency:tree -Dincludes=com.fasterxml.jackson.core:jackson-databind` now resolves `2.21.5` for core, distro, and diagram-converter (cli/webapp/core). `data-migrator/plugins/cockpit` stays at `2.21.1` intentionally — that's the C7-platform-controlled `provided` dependency, out of this repo's control.

## Test plan

- [x] `mvn clean install -DskipTests` — full reactor build succeeds
- [x] `mvn test -pl data-migrator/core` — 76 tests pass
- [x] `mvn test -pl diagram-converter/webapp` — 8 tests pass (includes the one real JSON-deserializing REST endpoint in the repo)
- [x] `mvn dependency:tree -Dincludes=com.fasterxml.jackson.core:jackson-databind` — confirms 2.21.5 resolved on all shipped modules

## Baseline

Built from commit: `00d4e2f8`

🤖 Generated with [Claude Code](https://claude.com/claude-code)