### PR TITLE
fix(deps): pin jackson-bom to 2.22.1 to fix CVE-2026-59889 (maintenance/0.3)

### DIFF
--- a/code-conversion/patterns/code-examples/camunda-7/pom.xml
+++ b/code-conversion/patterns/code-examples/camunda-7/pom.xml
@@ -22,6 +22,13 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
+        <groupId>com.fasterxml.jackson</groupId>
+        <artifactId>jackson-bom</artifactId>
+        <version>${version.jackson-bom}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-dependencies</artifactId>
         <version>${version.spring-boot}</version>

--- a/code-conversion/patterns/code-examples/camunda-8/pom.xml
+++ b/code-conversion/patterns/code-examples/camunda-8/pom.xml
@@ -17,6 +17,13 @@
 	<dependencyManagement>
 		<dependencies>
 			<dependency>
+				<groupId>com.fasterxml.jackson</groupId>
+				<artifactId>jackson-bom</artifactId>
+				<version>${version.jackson-bom}</version>
+				<scope>import</scope>
+				<type>pom</type>
+			</dependency>
+			<dependency>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-dependencies</artifactId>
 				<version>${version.spring-boot}</version>

--- a/code-conversion/recipes/pom.xml
+++ b/code-conversion/recipes/pom.xml
@@ -25,6 +25,13 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
+        <groupId>com.fasterxml.jackson</groupId>
+        <artifactId>jackson-bom</artifactId>
+        <version>${version.jackson-bom}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
         <groupId>org.openrewrite.recipe</groupId>
         <artifactId>rewrite-recipe-bom</artifactId>
         <version>${version.rewrite-recipe-bom}</version>

--- a/data-migrator/core/pom.xml
+++ b/data-migrator/core/pom.xml
@@ -18,6 +18,13 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
+        <groupId>com.fasterxml.jackson</groupId>
+        <artifactId>jackson-bom</artifactId>
+        <version>${version.jackson-bom}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-dependencies</artifactId>
         <version>${version.spring-boot}</version>

--- a/data-migrator/distro/pom.xml
+++ b/data-migrator/distro/pom.xml
@@ -17,6 +17,15 @@
 
   <dependencyManagement>
     <dependencies>
+      <!-- CVE-2026-59889: pin jackson-bom ahead of Spring Boot BOM, which
+           manages jackson-databind at 2.21.4 (below the 2.22.1 fix). -->
+      <dependency>
+        <groupId>com.fasterxml.jackson</groupId>
+        <artifactId>jackson-bom</artifactId>
+        <version>${version.jackson-bom}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
       <!-- netty-bom must be imported before spring-boot-dependencies to ensure
      the pinned Netty version takes precedence over the version pulled in
      transitively by gRPC (via spring-boot-dependencies). -->

--- a/diagram-converter/pom.xml
+++ b/diagram-converter/pom.xml
@@ -40,6 +40,13 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
+        <groupId>com.fasterxml.jackson</groupId>
+        <artifactId>jackson-bom</artifactId>
+        <version>${version.jackson-bom}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
         <groupId>org.camunda.bpm</groupId>
         <artifactId>camunda-bom</artifactId>
         <version>${version.camunda-7}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,7 @@
     <camunda8.docker.image>camunda/camunda:${version.camunda-8}</camunda8.docker.image>
     <version.elasticsearch>8.19.6</version.elasticsearch>
     <version.spring-boot>4.1.0</version.spring-boot>
+    <version.jackson-bom>2.22.1</version.jackson-bom>
     <logback.version>1.5.37</logback.version>
     <tomcat.version>11.0.24</tomcat.version>
     <version.netty>4.2.16.Final</version.netty>


### PR DESCRIPTION
## Summary

- CVE-2026-59889: jackson-databind `UnwrappedPropertyHandler.processUnwrapped()` skips the `@JsonView` visibility guard for `@JsonUnwrapped` properties, letting attacker JSON write into view-restricted fields. Fixed upstream in 2.18.9 / 2.21.5 / 2.22.1 / 3.1.5 / 3.2.1.
- Not exploitable here — `@JsonView` is not used anywhere in this codebase's production sources — but the resolved jackson-databind version genuinely sat in the vulnerable range (`2.21.4`) despite prior "bump jackson to 2.22.1" Renovate PRs (#1511, #1713), which only ever touched the `data-migrator/qa/integration-tests` test-scope pin, not the real compile/runtime version.
- Root cause: Spring Boot 4.1.0's BOM manages jackson-databind at `2.21.4` via its own `jackson-2-bom.version` property, silently overriding the `2.22.1` that `camunda-db-rdbms`/`camunda-client-java` declare natively. A top-level property override does not cascade into that nested BOM-of-BOM (verified empirically), so the only reliable fix is importing our own `jackson-bom` ahead of `spring-boot-dependencies`.

## Changes

- `pom.xml`: add `version.jackson-bom=2.22.1` property
- `data-migrator/core/pom.xml`, `data-migrator/distro/pom.xml`, `diagram-converter/pom.xml`, `code-conversion/recipes/pom.xml`, `code-conversion/patterns/code-examples/{camunda-7,camunda-8}/pom.xml`: import `com.fasterxml.jackson:jackson-bom:${version.jackson-bom}` before each module's `spring-boot-dependencies` import, so it wins Maven's same-file dependencyManagement precedence

Verified `mvn dependency:tree -Dincludes=com.fasterxml.jackson.core:jackson-databind` now resolves `2.22.1` for every shipped module (core, distro, diagram-converter cli/webapp, code-conversion). `data-migrator/plugins/cockpit` stays at `2.21.4` intentionally — that's the C7-platform-controlled `provided` dependency, out of this repo's control.

## Test plan

- [x] `mvn clean install -DskipTests` — full reactor build succeeds
- [x] `mvn test -pl data-migrator/core` — 120 tests pass
- [x] `mvn test -pl diagram-converter/webapp` — 9 tests pass (includes the one real JSON-deserializing REST endpoint in the repo)
- [x] `mvn dependency:tree -Dincludes=com.fasterxml.jackson.core:jackson-databind` — confirms 2.22.1 resolved on all shipped modules

## Baseline

Built from commit: `8824bbf8`

🤖 Generated with [Claude Code](https://claude.com/claude-code)