### PR TITLE
fix(deps): pin log4j-bom to 2.26.1 to fix CVE-2026-49844 (maintenance/0.3)

### DIFF
--- a/code-conversion/patterns/code-examples/camunda-7/pom.xml
+++ b/code-conversion/patterns/code-examples/camunda-7/pom.xml
@@ -29,6 +29,13 @@
         <scope>import</scope>
       </dependency>
       <dependency>
+        <groupId>org.apache.logging.log4j</groupId>
+        <artifactId>log4j-bom</artifactId>
+        <version>${version.log4j-bom}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-dependencies</artifactId>
         <version>${version.spring-boot}</version>

--- a/code-conversion/patterns/code-examples/camunda-8/pom.xml
+++ b/code-conversion/patterns/code-examples/camunda-8/pom.xml
@@ -24,6 +24,13 @@
 				<type>pom</type>
 			</dependency>
 			<dependency>
+				<groupId>org.apache.logging.log4j</groupId>
+				<artifactId>log4j-bom</artifactId>
+				<version>${version.log4j-bom}</version>
+				<scope>import</scope>
+				<type>pom</type>
+			</dependency>
+			<dependency>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-dependencies</artifactId>
 				<version>${version.spring-boot}</version>

--- a/code-conversion/recipes/pom.xml
+++ b/code-conversion/recipes/pom.xml
@@ -32,6 +32,13 @@
         <scope>import</scope>
       </dependency>
       <dependency>
+        <groupId>org.apache.logging.log4j</groupId>
+        <artifactId>log4j-bom</artifactId>
+        <version>${version.log4j-bom}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
         <groupId>org.openrewrite.recipe</groupId>
         <artifactId>rewrite-recipe-bom</artifactId>
         <version>${version.rewrite-recipe-bom}</version>

--- a/data-migrator/core/pom.xml
+++ b/data-migrator/core/pom.xml
@@ -25,6 +25,13 @@
         <scope>import</scope>
       </dependency>
       <dependency>
+        <groupId>org.apache.logging.log4j</groupId>
+        <artifactId>log4j-bom</artifactId>
+        <version>${version.log4j-bom}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-dependencies</artifactId>
         <version>${version.spring-boot}</version>

--- a/data-migrator/distro/pom.xml
+++ b/data-migrator/distro/pom.xml
@@ -26,6 +26,15 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
+      <!-- CVE-2026-49844: pin log4j-bom ahead of Spring Boot BOM, which
+           manages log4j-api at 2.25.4 (in the affected range up to 2.26.0). -->
+      <dependency>
+        <groupId>org.apache.logging.log4j</groupId>
+        <artifactId>log4j-bom</artifactId>
+        <version>${version.log4j-bom}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
       <!-- netty-bom must be imported before spring-boot-dependencies to ensure
      the pinned Netty version takes precedence over the version pulled in
      transitively by gRPC (via spring-boot-dependencies). -->

--- a/diagram-converter/pom.xml
+++ b/diagram-converter/pom.xml
@@ -47,6 +47,13 @@
         <scope>import</scope>
       </dependency>
       <dependency>
+        <groupId>org.apache.logging.log4j</groupId>
+        <artifactId>log4j-bom</artifactId>
+        <version>${version.log4j-bom}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
         <groupId>org.camunda.bpm</groupId>
         <artifactId>camunda-bom</artifactId>
         <version>${version.camunda-7}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,7 @@
     <version.elasticsearch>8.19.6</version.elasticsearch>
     <version.spring-boot>4.1.0</version.spring-boot>
     <version.jackson-bom>2.22.1</version.jackson-bom>
+    <version.log4j-bom>2.26.1</version.log4j-bom>
     <logback.version>1.5.37</logback.version>
     <tomcat.version>11.0.24</tomcat.version>
     <version.netty>4.2.16.Final</version.netty>


### PR DESCRIPTION
## Summary

- CVE-2026-49844: Apache Log4j API's `MapMessage.asJson()` / `MapMessage.getFormattedMessage(new String[]{"JSON"})` emits invalid JSON — bare `NaN`/`Infinity`/`-Infinity` tokens — for non-finite floating-point values, in versions 2.13.1-2.25.4 (and 2.26.0). Fixed upstream in 2.25.5 / 2.26.1.
- Internal triage found the vulnerable path is not reachable in this repo: `log4j-core` and `log4j-layout-template-json` are not on the classpath anywhere, no code constructs `MapMessage`, and no `JsonTemplateLayout`/`JsonLayout` config exists anywhere. `log4j-api` is present repo-wide only as a transitive dependency of Spring Boot's `log4j-to-slf4j` bridge (redirects Log4j2-API calls to SLF4J/Logback). This is a hygiene fix to clear SCA scanner flags, not an incident response — the resolved version genuinely sits in the flagged range, so scanners correctly flag it even though it can't be triggered here.
- Root cause (same shape as #1780/CVE-2026-59889): Spring Boot 4.1.0's BOM manages `log4j-api`/`log4j-to-slf4j` at `2.25.4`, inside the affected range, overriding any newer version wherever it's imported.

## Changes

- `pom.xml`: add `version.log4j-bom=2.26.1` property (next to `version.jackson-bom`)
- `data-migrator/core/pom.xml`, `data-migrator/distro/pom.xml`, `diagram-converter/pom.xml`, `code-conversion/recipes/pom.xml`, `code-conversion/patterns/code-examples/{camunda-7,camunda-8}/pom.xml`: import `org.apache.logging.log4j:log4j-bom:${version.log4j-bom}` before each module's `spring-boot-dependencies` import, so it wins Maven's same-file dependencyManagement precedence — mirrors the exact pattern used for jackson-bom in #1780.

Verified `mvn dependency:tree -Dincludes=org.apache.logging.log4j` now resolves `2.26.1` for `log4j-api`/`log4j-to-slf4j` on every module that ships (root, data-migrator core/distro, diagram-converter core/webapp/cli/example, code-conversion recipes/code-examples).

Three modules stay at `2.25.4` intentionally, mirroring the exact same modules left unpinned for jackson-databind in #1780:
- `data-migrator/plugins/cockpit` — all dependencies are `provided` scope (Camunda 7 Cockpit webapp classes, `camunda-engine`), platform-controlled and outside this repo's control.
- `data-migrator/examples/variable-interceptor` and `data-migrator/examples/entity-interceptor` — depend on `data-migrator-core` at `provided` scope only; they don't independently import `jackson-bom`/`spring-boot-dependencies` either, so they were never in scope for the same-precedence fix.

`data-migrator/assembly` (the distribution aggregator) shows `log4j-api:2.25.4` in its own `dependency:tree` output, but this is a Maven-graph artifact of the aggregator having no `dependencyManagement` of its own (same behavior jackson-databind shows there, at `2.21.4`) — it does not reflect the shipped bundle. `assembly.xml` packages the already-built `distro` jar as a single file rather than re-resolving dependencies, and `distro`'s own build correctly resolves `log4j-api` to `2.26.1`.

## Test plan

- [x] `mvn clean install -DskipTests` — full reactor build succeeds (required switching `JAVA_HOME` to a JDK 21 toolchain; `code-conversion/recipes` enforces Java 21-25 due to an OpenRewrite/javac-internals constraint, pre-existing and unrelated to this change)
- [x] `mvn test -pl data-migrator/core` — 120 tests pass
- [x] `mvn test -pl diagram-converter/webapp,diagram-converter/core` — 405 + 9 tests pass
- [x] `mvn test -pl code-conversion/recipes,code-conversion/patterns/code-examples/camunda-8` — 71 + 2 tests pass
- [x] `mvn dependency:tree -Dincludes=org.apache.logging.log4j` from repo root and from within `data-migrator/`, `code-conversion/`, `diagram-converter/` — confirms `2.26.1` resolved everywhere in scope
- Note: `mvn test -Dtest=ArchitectureTest -pl data-migrator/qa/integration-tests -Pintegration` fails on a pre-existing test-source compile error (`HistoryMigrationExtension.java:235`, unrelated `String[]`/`String` type mismatch) — confirmed via `git stash` that this fails identically on the unmodified baseline, so it's not a regression introduced by this change.

## Baseline

Built from commit: `e5040812`

🤖 Generated with [Claude Code](https://claude.com/claude-code)