### PR TITLE
fix(deps): pin log4j-bom to 2.26.1 to fix CVE-2026-49844 (maintenance/0.2)

### DIFF
--- a/code-conversion/recipes/pom.xml
+++ b/code-conversion/recipes/pom.xml
@@ -41,6 +41,17 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
+      <!-- CVE-2026-49844: pin log4j-bom ahead of Spring Boot BOM, which
+           manages log4j-api (transitively via
+           camunda-bpm-spring-boot-starter-external-task-client) below the
+           2.26.1 fix. -->
+      <dependency>
+        <groupId>org.apache.logging.log4j</groupId>
+        <artifactId>log4j-bom</artifactId>
+        <version>${version.log4j-bom}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
       <dependency>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-dependencies</artifactId>

--- a/data-migrator/core/pom.xml
+++ b/data-migrator/core/pom.xml
@@ -26,6 +26,16 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
+      <!-- CVE-2026-49844: pin log4j-bom ahead of Spring Boot BOM, which
+           manages log4j-api (via the log4j-to-slf4j bridge) below the
+           2.26.1 fix. -->
+      <dependency>
+        <groupId>org.apache.logging.log4j</groupId>
+        <artifactId>log4j-bom</artifactId>
+        <version>${version.log4j-bom}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
       <!-- netty-bom must be imported before spring-boot-dependencies to ensure
            the pinned Netty version takes precedence over the version pulled in
            transitively by gRPC (via spring-boot-dependencies). -->

--- a/data-migrator/distro/pom.xml
+++ b/data-migrator/distro/pom.xml
@@ -26,6 +26,16 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
+      <!-- CVE-2026-49844: pin log4j-bom ahead of Spring Boot BOM, which
+           manages log4j-api (via the log4j-to-slf4j bridge) below the
+           2.26.1 fix. -->
+      <dependency>
+        <groupId>org.apache.logging.log4j</groupId>
+        <artifactId>log4j-bom</artifactId>
+        <version>${version.log4j-bom}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
       <!-- netty-bom must be imported before spring-boot-dependencies and zeebe-parent
            to ensure the pinned Netty version takes precedence over the version pulled in
            transitively by gRPC. -->

--- a/diagram-converter/pom.xml
+++ b/diagram-converter/pom.xml
@@ -49,6 +49,16 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
+      <!-- CVE-2026-49844: pin log4j-bom ahead of Spring Boot BOM, which
+           manages log4j-api (via the log4j-to-slf4j bridge) below the
+           2.26.1 fix. -->
+      <dependency>
+        <groupId>org.apache.logging.log4j</groupId>
+        <artifactId>log4j-bom</artifactId>
+        <version>${version.log4j-bom}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
       <dependency>
         <groupId>org.camunda.bpm</groupId>
         <artifactId>camunda-bom</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,7 @@
     <version.elasticsearch>8.19.6</version.elasticsearch>
     <version.spring-boot>3.5.16</version.spring-boot>
     <version.jackson-bom>2.21.5</version.jackson-bom>
+    <version.log4j-bom>2.26.1</version.log4j-bom>
     <tomcat.version>11.0.24</tomcat.version>
     <logback.version>1.5.37</logback.version>
     <version.assertj>3.27.7</version.assertj>


### PR DESCRIPTION
## Summary

- CVE-2026-49844: Apache Log4j API `MapMessage.asJson()` / `MapMessage.getFormattedMessage(new String[]{"JSON"})` emits invalid JSON (bare `NaN`/`Infinity`/`-Infinity` tokens instead of quoted strings) when a `MapMessage` value is a non-finite floating-point number. Affects 2.13.1-2.25.4 and 2.26.0; fixed upstream in 2.25.5 / 2.26.1.
- Internal triage found the vulnerable path unreachable in this repo: no code constructs `MapMessage`, no `JsonTemplateLayout`/`JsonLayout` config exists anywhere, and `log4j-core` is not on the classpath at all — `log4j-api` is present only transitively, via Spring Boot's `log4j-to-slf4j` bridge (and, in `code-conversion`, also via `camunda-bpm-spring-boot-starter-external-task-client`). This is a hygiene fix to clear SCA scanner flags, not incident response.
- Root cause: Spring Boot 3.5.16's BOM manages `log4j-api`/`log4j-to-slf4j` at `2.24.3`, inside the vulnerable range. 2.24.x itself was never patched upstream, so the fix jumps to the latest line, 2.26.1. Same shape as the `CVE-2026-59889` jackson-bom fix (#1779): a top-level property override doesn't cascade into Spring Boot's nested BOM, so the only reliable fix is importing our own `log4j-bom` ahead of `spring-boot-dependencies`.

## Changes

- `pom.xml`: add `version.log4j-bom=2.26.1` property, next to `version.jackson-bom`.
- `data-migrator/core/pom.xml`, `data-migrator/distro/pom.xml`, `diagram-converter/pom.xml`: import `org.apache.logging.log4j:log4j-bom:${version.log4j-bom}` before each module's `spring-boot-dependencies` import (same modules and same precedence trick as the jackson-bom fix).
- `code-conversion/recipes/pom.xml`: also gets the same override. Unlike the jackson CVE — where this module had no `jackson-databind` in its dependency tree at all — it independently imports `spring-boot-dependencies` and was still resolving `log4j-api` to the vulnerable `2.24.3` (pulled in via `camunda-bpm-spring-boot-starter-external-task-client:7.24.5-ee`). This module wasn't in scope for #1779 but is in scope here, so it's included in this PR.
- `data-migrator/plugins/cockpit` and `data-migrator/examples/variable-interceptor` are intentionally left unpinned: both depend on `data-migrator-core` at `provided` scope and are meant to run inside a host-supplied Camunda 7 classloader (the Cockpit webapp / a customer's external project) at runtime, so the log4j version there is platform-controlled, outside this repo's build — mirroring how `data-migrator/plugins/cockpit` was left unpinned for the jackson CVE.
- `data-migrator/assembly`'s own `dependency:tree` still shows `2.24.3` for `log4j-to-slf4j`, but that's a false signal: the assembly module doesn't compile any code or resolve a runtime classpath of its own — it only copies the already-built `distro` fat jar (which bundles `log4j-api 2.26.1` via `spring-boot-maven-plugin` repackage). The shipped artifact is unaffected.

## Test plan

- [x] `mvn clean install -DskipTests` — full reactor build succeeds
- [x] `mvn dependency:tree -Dincludes=org.apache.logging.log4j` (root, `data-migrator/`, `diagram-converter/`, `code-conversion/`) — confirms `2.26.1` resolved everywhere except the two provided-scope, platform-controlled modules noted above
- [x] `mvn test -pl data-migrator/core,data-migrator/plugins/cockpit,code-conversion/recipes,diagram-converter/core,diagram-converter/webapp,diagram-converter/cli,diagram-converter/extension-example -am` — all pass (e.g. 55 tests in code-conversion/recipes, 8 in diagram-converter/webapp, 11 in diagram-converter/cli)
- [x] `mvn test -Dtest=ArchitectureTest -pl data-migrator/qa/integration-tests -Pintegration` — 13/13 pass

## Baseline

Built from commit: `f6a75e0f`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
