### PR TITLE
fix(deps): pin log4j-bom to 2.26.1 to fix CVE-2026-49844 (main)

### DIFF
--- a/code-conversion/patterns/code-examples/camunda-7/pom.xml
+++ b/code-conversion/patterns/code-examples/camunda-7/pom.xml
@@ -29,6 +29,13 @@
         <scope>import</scope>
       </dependency>
       <dependency>
+        <groupId>org.apache.logging.log4j</groupId>
+        <artifactId>log4j-bom</artifactId>
+        <version>${version.log4j-bom}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-dependencies</artifactId>
         <version>${version.spring-boot}</version>

--- a/code-conversion/patterns/code-examples/camunda-8/pom.xml
+++ b/code-conversion/patterns/code-examples/camunda-8/pom.xml
@@ -24,6 +24,13 @@
 				<type>pom</type>
 			</dependency>
 			<dependency>
+				<groupId>org.apache.logging.log4j</groupId>
+				<artifactId>log4j-bom</artifactId>
+				<version>${version.log4j-bom}</version>
+				<scope>import</scope>
+				<type>pom</type>
+			</dependency>
+			<dependency>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-dependencies</artifactId>
 				<version>${version.spring-boot}</version>

--- a/code-conversion/recipes/pom.xml
+++ b/code-conversion/recipes/pom.xml
@@ -32,6 +32,13 @@
         <scope>import</scope>
       </dependency>
       <dependency>
+        <groupId>org.apache.logging.log4j</groupId>
+        <artifactId>log4j-bom</artifactId>
+        <version>${version.log4j-bom}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
         <groupId>org.openrewrite.recipe</groupId>
         <artifactId>rewrite-recipe-bom</artifactId>
         <version>${version.rewrite-recipe-bom}</version>

--- a/data-migrator/core/pom.xml
+++ b/data-migrator/core/pom.xml
@@ -25,6 +25,13 @@
         <scope>import</scope>
       </dependency>
       <dependency>
+        <groupId>org.apache.logging.log4j</groupId>
+        <artifactId>log4j-bom</artifactId>
+        <version>${version.log4j-bom}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-dependencies</artifactId>
         <version>${version.spring-boot}</version>

--- a/data-migrator/distro/pom.xml
+++ b/data-migrator/distro/pom.xml
@@ -25,6 +25,13 @@
         <scope>import</scope>
       </dependency>
       <dependency>
+        <groupId>org.apache.logging.log4j</groupId>
+        <artifactId>log4j-bom</artifactId>
+        <version>${version.log4j-bom}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-dependencies</artifactId>
         <version>${version.spring-boot}</version>

--- a/diagram-converter/pom.xml
+++ b/diagram-converter/pom.xml
@@ -47,6 +47,13 @@
         <scope>import</scope>
       </dependency>
       <dependency>
+        <groupId>org.apache.logging.log4j</groupId>
+        <artifactId>log4j-bom</artifactId>
+        <version>${version.log4j-bom}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
         <groupId>org.camunda.bpm</groupId>
         <artifactId>camunda-bom</artifactId>
         <version>${version.camunda-7}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,7 @@
     <version.elasticsearch>8.19.6</version.elasticsearch>
     <version.spring-boot>4.1.0</version.spring-boot>
     <version.jackson-bom>2.22.1</version.jackson-bom>
+    <version.log4j-bom>2.26.1</version.log4j-bom>
     <logback.version>1.5.37</logback.version>
     <tomcat.version>11.0.24</tomcat.version>
     <version.protobuf>4.35.1</version.protobuf>


### PR DESCRIPTION
## Summary

- CVE-2026-49844: Apache Log4j API `2.13.1-2.25.4` (and `2.26.0`) emits invalid JSON — bare `NaN`/`Infinity`/`-Infinity` tokens — from `MapMessage.asJson()` / `MapMessage.getFormattedMessage(new String[]{"JSON"})` when the message contains a non-finite floating-point value. Fixed upstream in `2.25.5` / `2.26.1`.
- Internal triage found the vulnerable path is not reachable in this repo: `log4j-api` is present only as a transitive dependency of Spring Boot's `log4j-to-slf4j` bridge (which redirects Log4j2-API calls to SLF4J/Logback); `log4j-core` and `log4j-layout-template-json` are not on the classpath anywhere, and there is no `MapMessage` usage or `JsonTemplateLayout`/`JsonLayout` configuration anywhere in the codebase. This is a hygiene fix to clear SCA scanner flags, not an incident response — the resolved version genuinely sits in the flagged range, so scanners correctly flag it even though it can't be triggered here.
- Root cause: Spring Boot 4.1.0's BOM manages `log4j-api`/`log4j-to-slf4j` at `2.25.4`, below the `2.26.1` fix. Same shape as CVE-2026-59889 (#1778, jackson-databind): the only reliable fix is importing our own `log4j-bom` ahead of `spring-boot-dependencies` in every pom that independently imports it.

## Changes

- `pom.xml`: add `version.log4j-bom=2.26.1` property (right after `version.jackson-bom`)
- `data-migrator/core/pom.xml`, `data-migrator/distro/pom.xml`, `diagram-converter/pom.xml`, `code-conversion/recipes/pom.xml`, `code-conversion/patterns/code-examples/{camunda-7,camunda-8}/pom.xml`: import `org.apache.logging.log4j:log4j-bom:${version.log4j-bom}` before each module's `spring-boot-dependencies` import, so it wins Maven's same-file dependencyManagement precedence — the exact same 7 poms touched by #1778 for jackson-bom.

Verified `mvn dependency:tree -Dincludes=org.apache.logging.log4j` now resolves `2.26.1` for every shipped module (data-migrator core/distro, diagram-converter core/webapp/cli/extension-example, code-conversion recipes/examples), including the `org.apache.poi:poi` transitive path in diagram-converter. `data-migrator/plugins/cockpit` stays at `2.25.4` intentionally — that's the C7-platform-controlled `provided` dependency (pulled in via `camunda-webapp`), out of this repo's control, mirroring exactly how that same module was left unpinned for jackson-databind in #1778.

## Test plan

- [x] `mvn clean install -DskipTests` — full reactor build succeeds
- [x] `mvn test -pl data-migrator/core,code-conversion/recipes,diagram-converter/core,diagram-converter/cli,diagram-converter/webapp,diagram-converter/extension-example` — 631 tests pass (0 failures, 0 errors)
- [x] `mvn test -pl code-conversion/patterns/code-examples/camunda-8` — 2 tests pass
- [x] `mvn dependency:tree -Dincludes=org.apache.logging.log4j` (root + from within `data-migrator/`, `code-conversion/`, `diagram-converter/`) — confirms `2.26.1` resolved everywhere in scope

## Baseline

Built from commit: `82ecc084`

🤖 Generated with [Claude Code](https://claude.com/claude-code)