### PR TITLE
fix(security): pin logback, httpcore5-h2, jackson-databind (CVE-2026-13006, CVE-2026-54428, CVE-2026-54515) (maintenance/0.3)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -132,6 +132,29 @@
         <artifactId>httpcore5</artifactId>
         <version>${version.httpcore5}</version>
       </dependency>
+      <!-- CVE-2026-54428: pin httpcore5-h2 to 5.4.3 (separate artifact from httpcore5, not covered by the entry above) -->
+      <dependency>
+        <groupId>org.apache.httpcomponents.core5</groupId>
+        <artifactId>httpcore5-h2</artifactId>
+        <version>${version.httpcore5}</version>
+      </dependency>
+      <!-- CVE-2026-13006: pin logback to 1.5.37 (a property override alone is a no-op against modules that pull logback in via an imported spring-boot-dependencies BOM) -->
+      <dependency>
+        <groupId>ch.qos.logback</groupId>
+        <artifactId>logback-classic</artifactId>
+        <version>${logback.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>ch.qos.logback</groupId>
+        <artifactId>logback-core</artifactId>
+        <version>${logback.version}</version>
+      </dependency>
+      <!-- CVE-2026-54515 / CVE-2026-59889: close residual jackson-databind gaps in modules not covered by the per-module jackson-bom import (plugins/cockpit, examples/*) -->
+      <dependency>
+        <groupId>com.fasterxml.jackson.core</groupId>
+        <artifactId>jackson-databind</artifactId>
+        <version>${version.jackson-bom}</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 


### PR DESCRIPTION
## Summary

- Adds real `dependencyManagement` entries (root `pom.xml`) for `logback-classic`, `logback-core`, `httpcore5-h2`, and `jackson-databind` — pinned to the versions already declared in existing properties (`logback.version=1.5.37`, `version.httpcore5=5.4.3`, `version.jackson-bom=2.22.1`)
- Fixes a real gap in three prior "fixes":
  - **CVE-2026-13006**: #1576 only overrode the `logback.version` *property*. That property is never consulted by modules that pull logback in via an *imported* `spring-boot-dependencies` BOM — Maven resolves an imported BOM's own placeholders against its own internal properties before merging, so the override was a complete no-op. `dependency:tree` on the merged tip still resolved `logback-core:1.5.34` (in the CVE's affected range) despite the PR being merged.
  - **CVE-2026-54428**: `httpcore5-h2` is a separate Maven artifact from `httpcore5` (the HPACK decoder DoS lives in the H2-specific module) and was never pinned — only the base `httpcore5` artifact was fixed under CVE-2026-54399.
  - **CVE-2026-54515** (and the related CVE-2026-59889 jackson-databind gap it shares): the recent `jackson-bom` fix (#1780) only reaches modules that locally import `spring-boot-dependencies`. `plugins/cockpit`, `examples/{variable,entity}-interceptor`, and the process-solution example module consume `jackson-databind` transitively (via a plain `<dependency>` on `data-migrator-core`, not an import) and were still resolving `2.21.4`.
- A direct `dependencyManagement` entry at the root always outranks a BOM pulled in via `<scope>import</scope>` in a descendant module — same pattern already used successfully for the `httpcore5` pin in this same block.

## Verification

- `mvn dependency:tree -Dincludes=ch.qos.logback,org.apache.httpcomponents.core5,com.fasterxml.jackson.core:jackson-databind` — every module now resolves `logback-classic/core:1.5.37`, `httpcore5/httpcore5-h2:5.4.3`, `jackson-databind:2.22.1`.
- `mvn clean install -DskipTests` — full build green.
- `mvn test -pl data-migrator/core -am` and `mvn test -pl diagram-converter/webapp -am` — green.

## Security context

None of these are active incidents (all already assessed `No` for exploitability). This is a hygiene fix so the SCA scanner stops flagging versions that are, in fact, no longer resolved once this merges.

## Test plan

- [x] `mvn dependency:tree` confirms fixed versions resolve in every module
- [x] `mvn clean install -DskipTests` passes
- [x] Targeted tests (`data-migrator/core`, `diagram-converter/webapp`) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)