### PR TITLE
fix(ci): scope API mapping Pages deployment

### DIFF
--- a/.github/workflows/deploy-code-conversion-to-pages.yml
+++ b/.github/workflows/deploy-code-conversion-to-pages.yml
@@ -6,9 +6,12 @@ on:
   push:
     branches:
       - main
+    paths:
+      - "code-conversion/api-mapping/**"
+      - ".github/workflows/deploy-code-conversion-to-pages.yml"
 
-    # Allows you to run this workflow manually from the Actions tab
-    workflow_dispatch:
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
 
 # Sets the GITHUB_TOKEN permissions to allow deployment to GitHub Pages
 permissions:


### PR DESCRIPTION
## Summary

- run the Pages deployment on pushes only when API Mapping or its workflow changes
- correctly enable manual workflow dispatch

## Validation

- `mvn clean install` with Java 21
- validated YAML trigger structure and whitespace

## Baseline

- `7212c8f61d2f20b2eabca4d354c4d3d8be07b21c`