### PR TITLE
fix(runtime): increase activation timeout margin

### DIFF
--- a/data-migrator/assembly/resources/application.yml
+++ b/data-migrator/assembly/resources/application.yml
@@ -9,6 +9,8 @@ camunda:
     #grpc-address: https://your-camunda-host:26500
     ## The REST API endpoint for Camunda 8 Platform
     #rest-address: https://your-camunda-host:8080
+    ## Additional time for long-polling responses to arrive after the server request timeout
+    request-timeout-offset: PT10S
     ## The path to the CA certificate
     #ca-certificate-path:
     ## Authentication configuration for the client

--- a/data-migrator/core/src/test/java/io/camunda/migration/data/CamundaClientConfigurationTest.java
+++ b/data-migrator/core/src/test/java/io/camunda/migration/data/CamundaClientConfigurationTest.java
@@ -7,19 +7,20 @@
  */
 package io.camunda.migration.data;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import io.camunda.client.CamundaClient;
 import io.camunda.client.CamundaClientConfiguration;
+import java.net.URI;
+import java.time.Duration;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
-import java.net.URI;
-
-import static org.assertj.core.api.Assertions.assertThat;
-
 @SpringBootTest(properties = {
     "camunda.client.grpc-address=http://helloworld:33333",
-    "camunda.client.rest-address=http://helloworld:44444"
+    "camunda.client.rest-address=http://helloworld:44444",
+    "camunda.client.request-timeout-offset=PT10S"
 })
 public class CamundaClientConfigurationTest {
 
@@ -36,5 +37,7 @@ public class CamundaClientConfigurationTest {
     // then
     assertThat(configuration.getGrpcAddress()).isEqualTo(URI.create("http://helloworld:33333"));
     assertThat(configuration.getRestAddress()).isEqualTo(URI.create("http://helloworld:44444"));
+    assertThat(configuration.getDefaultRequestTimeoutOffset()).isEqualTo(Duration.ofSeconds(10));
   }
+
 }

--- a/data-migrator/qa/integration-tests/src/test/resources/application.yml
+++ b/data-migrator/qa/integration-tests/src/test/resources/application.yml
@@ -1,4 +1,6 @@
 camunda:
+  client:
+    request-timeout-offset: PT10S
   migrator:
     auto-ddl: true
     c7:


### PR DESCRIPTION
## Summary

- configure a 10-second Camunda client response-timeout offset for the distributed data migrator
- apply the same offset to integration tests
- verify the Spring client binds the configured offset

The failed MariaDB runtime-jobtype job started an empty activation poll at `01:34:21.840` and failed at `01:34:32.852` with `SocketTimeoutException: 11000 MILLISECONDS`. The Camunda client gives its 10-second server request timeout only a 1-second response margin by default; under CI load, the legitimate empty response missed that margin. Every runtime migration performs a terminal empty activation poll, so this protects the full runtime migration surface rather than one test.

This preserves timeout failures instead of retrying activation or treating a timeout as an empty result. Both alternatives could silently skip work because job activation leases jobs.

Baseline: `7212c8f61d2f20b2eabca4d354c4d3d8be07b21c`

Failed job: https://github.com/camunda/camunda-7-to-8-migration-tooling/actions/runs/29710594455/job/88253801458
Same-SHA successful rerun: https://github.com/camunda/camunda-7-to-8-migration-tooling/actions/runs/29720575601/job/88282636891

## Tests

- `mvn clean install`
- `mvn test -pl data-migrator/core -Dtest=CamundaClientConfigurationTest`
- `mvn verify -f data-migrator/pom.xml -Pintegration,runtime-jobtype,mariadb -Dtest=ValidationJobTypeOnlyTest -Dsurefire.failIfNoSpecifiedTests=false`

related to #1487