### PR TITLE
fix(runtime): increase activation timeout margin (#1828) [maintenance/0.2]

### DIFF
--- a/data-migrator/assembly/resources/application.yml
+++ b/data-migrator/assembly/resources/application.yml
@@ -9,6 +9,8 @@ camunda:
     #grpc-address: https://your-camunda-host:26500
     ## The REST API endpoint for Camunda 8 Platform
     #rest-address: https://your-camunda-host:8080
+    ## Additional time for long-polling responses to arrive after the server request timeout
+    request-timeout-offset: PT10S
     ## The path to the CA certificate
     #ca-certificate-path:
     ## Authentication configuration for the client

--- a/data-migrator/core/src/test/java/io/camunda/migration/data/CamundaClientConfigurationTest.java
+++ b/data-migrator/core/src/test/java/io/camunda/migration/data/CamundaClientConfigurationTest.java
@@ -7,19 +7,20 @@
  */
 package io.camunda.migration.data;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import io.camunda.client.CamundaClient;
 import io.camunda.client.CamundaClientConfiguration;
+import java.net.URI;
+import java.time.Duration;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
-import java.net.URI;
-
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-
 @SpringBootTest(properties = {
     "camunda.client.grpc-address=http://helloworld:33333",
-    "camunda.client.rest-address=http://helloworld:44444"
+    "camunda.client.rest-address=http://helloworld:44444",
+    "camunda.client.request-timeout-offset=PT10S"
 })
 public class CamundaClientConfigurationTest {
 
@@ -36,5 +37,7 @@ public class CamundaClientConfigurationTest {
     // then
     assertThat(configuration.getGrpcAddress()).isEqualTo(URI.create("http://helloworld:33333"));
     assertThat(configuration.getRestAddress()).isEqualTo(URI.create("http://helloworld:44444"));
+    assertThat(configuration.getDefaultRequestTimeoutOffset()).isEqualTo(Duration.ofSeconds(10));
   }
+
 }

--- a/data-migrator/qa/integration-tests/src/test/resources/application.yml
+++ b/data-migrator/qa/integration-tests/src/test/resources/application.yml
@@ -1,4 +1,6 @@
 camunda:
+  client:
+    request-timeout-offset: PT10S
   migrator:
     auto-ddl: true
     c7:


### PR DESCRIPTION
Backport of #1828 to `maintenance/0.2`.

The runtime migrator on this branch has the same terminal empty activation poll and Camunda client timeout-offset behavior, so it needs the same protection.

## Tests

- `mvn clean install`
- `mvn test -pl data-migrator/core -Dtest=CamundaClientConfigurationTest`
- `mvn verify -f data-migrator/pom.xml -Pintegration,runtime-jobtype -Dtest=ValidationJobTypeOnlyTest -Dsurefire.failIfNoSpecifiedTests=false`

related to #1487