### PR TITLE
feat(diagram-converter): prevent CSV formula injection

### DIFF
--- a/diagram-converter/core/src/main/java/io/camunda/migration/diagram/converter/DiagramConverter.java
+++ b/diagram-converter/core/src/main/java/io/camunda/migration/diagram/converter/DiagramConverter.java
@@ -354,17 +354,44 @@ public class DiagramConverter {
                             elementCheckResult.getMessages().stream()
                                 .map(
                                     message ->
-                                        new String[] {
-                                          diagramCheckResult.getFilename(),
-                                          elementCheckResult.getElementName(),
-                                          elementCheckResult.getElementId(),
-                                          elementCheckResult.getElementType(),
-                                          message.getSeverity().name(),
-                                          message.getId(),
-                                          message.getMessage(),
-                                          message.getLink()
-                                        })))
+                                        sanitizeCsvCells(
+                                            new String[] {
+                                              diagramCheckResult.getFilename(),
+                                              elementCheckResult.getElementName(),
+                                              elementCheckResult.getElementId(),
+                                              elementCheckResult.getElementType(),
+                                              message.getSeverity().name(),
+                                              message.getId(),
+                                              message.getMessage(),
+                                              message.getLink()
+                                            }))))
         .collect(Collectors.toList());
+  }
+
+  private String[] sanitizeCsvCells(String[] cells) {
+    return Arrays.stream(cells).map(this::sanitizeCsvCell).toArray(String[]::new);
+  }
+
+  private String sanitizeCsvCell(String value) {
+    if (value == null || value.isEmpty()) {
+      return value;
+    }
+
+    char firstCharacter = value.charAt(0);
+    if (firstCharacter == '\t' || firstCharacter == '\r' || firstCharacter == '\n') {
+      return "'" + value;
+    }
+
+    int index = 0;
+    while (index < value.length()
+        && (Character.isWhitespace(value.charAt(index))
+            || Character.isISOControl(value.charAt(index)))) {
+      index++;
+    }
+    if (index < value.length() && "=+-@".indexOf(value.charAt(index)) >= 0) {
+      return "'" + value;
+    }
+    return value;
   }
 
   public List<DiagramConverterResultDTO> createLineItemDTOList(List<DiagramCheckResult> results) {

--- a/diagram-converter/core/src/main/java/io/camunda/migration/diagram/converter/DiagramConverter.java
+++ b/diagram-converter/core/src/main/java/io/camunda/migration/diagram/converter/DiagramConverter.java
@@ -377,11 +377,6 @@ public class DiagramConverter {
       return value;
     }
 
-    char firstCharacter = value.charAt(0);
-    if (firstCharacter == '\t' || firstCharacter == '\r' || firstCharacter == '\n') {
-      return "'" + value;
-    }
-
     int index = 0;
     while (index < value.length()
         && (Character.isWhitespace(value.charAt(index))

--- a/diagram-converter/core/src/test/java/io/camunda/migration/diagram/converter/CsvWriterTest.java
+++ b/diagram-converter/core/src/test/java/io/camunda/migration/diagram/converter/CsvWriterTest.java
@@ -40,33 +40,65 @@ public class CsvWriterTest {
     List<DiagramCheckResult> results = mockResults();
     SERVICE.writeCsvFile(results, writer);
 
+    List<String[]> lines = readCsv(writer);
+    assertThat(lines).hasSize(2);
+    assertThat(lines.get(0))
+        .containsExactly(
+            "filename",
+            "elementName",
+            "elementId",
+            "elementType",
+            "severity",
+            "messageId",
+            "message",
+            "link");
+    assertThat(lines.get(1))
+        .containsExactly(
+            FILENAME,
+            ELEMENT_NAME,
+            ELEMENT_ID,
+            ELEMENT_TYPE,
+            SEVERITY.name(),
+            MESSAGE_ID,
+            MESSAGE,
+            LINK);
+  }
+
+  @Test
+  public void shouldPreventFormulaInjectionInEveryCsvValue() {
+    DiagramCheckResult result = mockDiagramResult();
+    result.setFilename("=filename");
+    ElementCheckResult element = result.getResults().getFirst();
+    element.setElementName(" +elementName");
+    element.setElementId("\t-elementId");
+    element.setElementType("\u0000@elementType");
+    ElementCheckMessage message = element.getMessages().getFirst();
+    message.setId("\rmessageId");
+    message.setMessage("\nmessage");
+    message.setLink("  =link");
+
+    StringWriter writer = new StringWriter();
+    SERVICE.writeCsvFile(List.of(result), writer);
+
+    assertThat(readCsv(writer).get(1))
+        .containsExactly(
+            "'=filename",
+            "' +elementName",
+            "'\t-elementId",
+            "'\u0000@elementType",
+            SEVERITY.name(),
+            "'\nmessageId",
+            "'\nmessage",
+            "'  =link");
+  }
+
+  private List<String[]> readCsv(StringWriter writer) {
     StringReader reader = new StringReader(writer.toString());
     try (CSVReader csvReader =
         new CSVReaderBuilder(reader)
             .withCSVParser(new CSVParserBuilder().withSeparator(';').build())
             .build()) {
-      List<String[]> lines = csvReader.readAll();
-      assertThat(lines).hasSize(2);
-      assertThat(lines.get(0))
-          .containsExactly(
-              "filename",
-              "elementName",
-              "elementId",
-              "elementType",
-              "severity",
-              "messageId",
-              "message",
-              "link");
-      assertThat(lines.get(1))
-          .containsExactly(
-              FILENAME,
-              ELEMENT_NAME,
-              ELEMENT_ID,
-              ELEMENT_TYPE,
-              SEVERITY.name(),
-              MESSAGE_ID,
-              MESSAGE,
-              LINK);
+      return csvReader.readAll();
     } catch (IOException | CsvException e) {
       throw new RuntimeException(e);
     }

--- a/diagram-converter/core/src/test/java/io/camunda/migration/diagram/converter/CsvWriterTest.java
+++ b/diagram-converter/core/src/test/java/io/camunda/migration/diagram/converter/CsvWriterTest.java
@@ -80,7 +80,9 @@ public class CsvWriterTest {
     StringWriter writer = new StringWriter();
     SERVICE.writeCsvFile(List.of(result), writer);
 
-    assertThat(readCsv(writer).get(1))
+    List<String[]> lines = readCsv(writer);
+    assertThat(lines).hasSize(2);
+    assertThat(lines.get(1))
         .containsExactly(
             "'=filename",
             "' +elementName",

--- a/diagram-converter/core/src/test/java/io/camunda/migration/diagram/converter/CsvWriterTest.java
+++ b/diagram-converter/core/src/test/java/io/camunda/migration/diagram/converter/CsvWriterTest.java
@@ -73,8 +73,8 @@ public class CsvWriterTest {
     element.setElementId("\t-elementId");
     element.setElementType("\u0000@elementType");
     ElementCheckMessage message = element.getMessages().getFirst();
-    message.setId("\nmessageId");
-    message.setMessage("\nmessage");
+    message.setId("\n=messageId");
+    message.setMessage("\n+message");
     message.setLink("  =link");
 
     StringWriter writer = new StringWriter();
@@ -87,8 +87,8 @@ public class CsvWriterTest {
             "'\t-elementId",
             "'\u0000@elementType",
             SEVERITY.name(),
-            "'\nmessageId",
-            "'\nmessage",
+            "'\n=messageId",
+            "'\n+message",
             "'  =link");
   }
 

--- a/diagram-converter/core/src/test/java/io/camunda/migration/diagram/converter/CsvWriterTest.java
+++ b/diagram-converter/core/src/test/java/io/camunda/migration/diagram/converter/CsvWriterTest.java
@@ -73,7 +73,7 @@ public class CsvWriterTest {
     element.setElementId("\t-elementId");
     element.setElementType("\u0000@elementType");
     ElementCheckMessage message = element.getMessages().getFirst();
-    message.setId("\rmessageId");
+    message.setId("\nmessageId");
     message.setMessage("\nmessage");
     message.setLink("  =link");
 


### PR DESCRIPTION
## Summary

- prevent attacker-controlled BPMN/DMN data and upload filenames from becoming executable spreadsheet formulas in CSV exports
- neutralize formula prefixes after leading whitespace or control characters, including `=`, `+`, `-`, and `@`, by preserving the value as spreadsheet text
- cover every exported CSV value category with a regression test while keeping ordinary CSV output unchanged

## Security impact

The public `/check` endpoint accepts user-controlled diagrams and can return their analysis as CSV. Crafted filenames, element metadata, or generated message values could previously begin with a spreadsheet formula marker. If a recipient opened that CSV in spreadsheet software, the client could evaluate the attacker-controlled formula.

This change sanitizes cells centrally in the core CSV writer, protecting webapp and other callers without changing JSON, Excel, or Markdown output. It also handles leading whitespace and control characters that could otherwise bypass a first-character-only check.

## Changes

- `DiagramConverter`: sanitize all CSV row cells immediately before OpenCSV serialization
- `CsvWriterTest`: add category-wide formula-injection coverage for filename, element fields, message fields, links, whitespace, tabs, line breaks, and control characters

## Test plan

- [x] `JAVA_HOME=/opt/homebrew/opt/openjdk@21 mvn test -pl diagram-converter/core -Dtest=CsvWriterTest --batch-mode`
- [x] Existing valid CSV output remains unchanged
- [x] Dangerous values are emitted with a leading apostrophe and parsed as literal text

## Base commit

`e0c2bcfbc12d40f083fd7eb2e9dfb951741ee431`