### PR TITLE
feat(code-conversion): add advanced gRPC examples

### DIFF
--- a/code-conversion/patterns/code-examples/camunda-8/README.md
+++ b/code-conversion/patterns/code-examples/camunda-8/README.md
@@ -1,0 +1,56 @@
+# Advanced Camunda 8 gRPC examples
+
+These examples show the two levels of gRPC access available to a Java process solution:
+
+| Approach | Choose it when | You are responsible for |
+| --- | --- | --- |
+| [Streaming job worker](src/main/java/io/camunda/conversion/advanced/grpc/StreamingJobWorkerExample.java) | Implementing normal Camunda 8 job workers | The handler, job outcomes, worker sizing, and application lifecycle |
+| [Generated gateway stub](src/main/java/io/camunda/conversion/advanced/grpc/GeneratedGatewayStubExample.java) | A required gateway RPC is not exposed by the supported client API | Channel and TLS setup, authentication metadata and token refresh, deadlines, retries, request construction, error handling, and shutdown |
+
+Prefer the high-level `CamundaClient` API. It is the supported application-facing API and manages job streaming, backpressure, command creation, and reconnect behavior. Generated gateway classes are a lower-level escape hatch. They follow the gateway protocol rather than the Java client's public API and can change with the Camunda version.
+
+## Streaming job worker
+
+`StreamingJobWorkerExample` opens a streaming worker for jobs of type `process-payment`, waits until the process receives a shutdown signal, and closes both the worker and client. Set the job variable `outcome` to exercise each result:
+
+- `complete` (or omit it) completes the job
+- `failure` reports a technical failure with reduced retries and a retry backoff
+- `bpmn-error` throws the BPMN error `PAYMENT_REJECTED`
+
+Configure a local cluster without authentication:
+
+```bash
+export CAMUNDA_GRPC_ADDRESS=http://localhost:26500
+```
+
+For an OAuth-secured cluster, also set:
+
+```bash
+export CAMUNDA_CLIENT_ID=...
+export CAMUNDA_CLIENT_SECRET=...
+export CAMUNDA_TOKEN_AUDIENCE=...
+export CAMUNDA_TOKEN_URL=https://.../oauth/token
+```
+
+Run the example from this directory:
+
+```bash
+mvn compile exec:java \
+  -Dexec.mainClass=io.camunda.conversion.advanced.grpc.StreamingJobWorkerExample
+```
+
+Stop it with `Ctrl+C`; the shutdown hook lets the try-with-resources block close the worker before closing the client.
+
+## Generated gateway stub
+
+`GeneratedGatewayStubExample` calls the representative `Topology` RPC. It configures a plaintext or TLS channel from the address scheme, optionally attaches bearer-token metadata, applies a deadline, prints the returned brokers, and always shuts down the channel.
+
+```bash
+export CAMUNDA_GRPC_ADDRESS=https://example.camunda.io:443
+export CAMUNDA_GRPC_TOKEN=...
+
+mvn compile exec:java \
+  -Dexec.mainClass=io.camunda.conversion.advanced.grpc.GeneratedGatewayStubExample
+```
+
+Omit `CAMUNDA_GRPC_TOKEN` only when the target cluster has authentication disabled. A static token keeps this example focused on direct stub usage; a real application must acquire and refresh tokens securely, classify gRPC status errors, and apply an appropriate retry policy.

--- a/code-conversion/patterns/code-examples/camunda-8/README.md
+++ b/code-conversion/patterns/code-examples/camunda-8/README.md
@@ -11,7 +11,7 @@ Prefer the high-level `CamundaClient` API. It is the supported application-facin
 
 ## Streaming job worker
 
-`StreamingJobWorkerExample` opens a streaming worker for jobs of type `process-payment`, waits until the process receives a shutdown signal, and closes both the worker and client. Set the job variable `outcome` to exercise each result:
+`StreamingJobWorkerExample` opens a streaming worker for jobs of type `process-payment`, waits until the JVM receives a shutdown signal, and closes both the worker and client. Set the job variable `outcome` to exercise each result:
 
 - `complete` (or omit it) completes the job
 - `failure` reports a technical failure with reduced retries and a retry backoff

--- a/code-conversion/patterns/code-examples/camunda-8/pom.xml
+++ b/code-conversion/patterns/code-examples/camunda-8/pom.xml
@@ -58,6 +58,12 @@
 		</dependency>
 
 		<dependency>
+			<groupId>io.camunda</groupId>
+			<artifactId>zeebe-gateway-protocol-impl</artifactId>
+			<version>${version.camunda-8}</version>
+		</dependency>
+
+		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>

--- a/code-conversion/patterns/code-examples/camunda-8/src/main/java/io/camunda/conversion/advanced/grpc/GeneratedGatewayStubExample.java
+++ b/code-conversion/patterns/code-examples/camunda-8/src/main/java/io/camunda/conversion/advanced/grpc/GeneratedGatewayStubExample.java
@@ -58,6 +58,9 @@ public final class GeneratedGatewayStubExample {
             channel.shutdown();
             if (!channel.awaitTermination(5, TimeUnit.SECONDS)) {
                 channel.shutdownNow();
+                if (!channel.awaitTermination(5, TimeUnit.SECONDS)) {
+                    System.err.println("gRPC channel did not terminate");
+                }
             }
         }
     }
@@ -66,22 +69,24 @@ public final class GeneratedGatewayStubExample {
         if (address.getHost() == null) {
             throw new IllegalArgumentException("CAMUNDA_GRPC_ADDRESS must include a host");
         }
+        String scheme = address.getScheme();
+        if (!"http".equalsIgnoreCase(scheme) && !"https".equalsIgnoreCase(scheme)) {
+            throw new IllegalArgumentException(
+                    "CAMUNDA_GRPC_ADDRESS must use the http or https scheme");
+        }
 
         int port = address.getPort();
         ManagedChannelBuilder<?> builder = ManagedChannelBuilder.forAddress(
                 address.getHost(),
-                port >= 0 ? port : defaultPort(address.getScheme()));
+                port >= 0 ? port : defaultPort(scheme));
 
-        return switch (address.getScheme()) {
-            case "https" -> builder.useTransportSecurity().build();
-            case "http" -> builder.usePlaintext().build();
-            default -> throw new IllegalArgumentException(
-                    "CAMUNDA_GRPC_ADDRESS must use the http or https scheme");
-        };
+        return "https".equalsIgnoreCase(scheme)
+                ? builder.useTransportSecurity().build()
+                : builder.usePlaintext().build();
     }
 
     private static int defaultPort(String scheme) {
-        return "https".equals(scheme) ? 443 : 80;
+        return "https".equalsIgnoreCase(scheme) ? 443 : 80;
     }
 
     private static String requiredEnvironmentVariable(String name) {

--- a/code-conversion/patterns/code-examples/camunda-8/src/main/java/io/camunda/conversion/advanced/grpc/GeneratedGatewayStubExample.java
+++ b/code-conversion/patterns/code-examples/camunda-8/src/main/java/io/camunda/conversion/advanced/grpc/GeneratedGatewayStubExample.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.conversion.advanced.grpc;
+
+import io.camunda.zeebe.gateway.protocol.GatewayGrpc;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.TopologyRequest;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.TopologyResponse;
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+import io.grpc.Metadata;
+import io.grpc.StatusRuntimeException;
+import io.grpc.stub.MetadataUtils;
+
+import java.net.URI;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+
+public final class GeneratedGatewayStubExample {
+
+    private static final Metadata.Key<String> AUTHORIZATION = Metadata.Key.of(
+            "authorization",
+            Metadata.ASCII_STRING_MARSHALLER);
+
+    private GeneratedGatewayStubExample() {
+    }
+
+    public static void main(String[] args) throws InterruptedException {
+        URI address = URI.create(requiredEnvironmentVariable("CAMUNDA_GRPC_ADDRESS"));
+        ManagedChannel channel = createChannel(address);
+
+        try {
+            GatewayGrpc.GatewayBlockingStub stub = GatewayGrpc.newBlockingStub(channel)
+                    .withDeadlineAfter(Duration.ofSeconds(10));
+
+            String token = System.getenv("CAMUNDA_GRPC_TOKEN");
+            if (token != null && !token.isBlank()) {
+                Metadata headers = new Metadata();
+                headers.put(AUTHORIZATION, "Bearer " + token);
+                stub = stub.withInterceptors(MetadataUtils.newAttachHeadersInterceptor(headers));
+            }
+
+            TopologyResponse topology = stub.topology(TopologyRequest.getDefaultInstance());
+            topology.getBrokersList().forEach(broker -> System.out.printf(
+                    "Broker %d: %s:%d (%s)%n",
+                    broker.getNodeId(),
+                    broker.getHost(),
+                    broker.getPort(),
+                    broker.getVersion()));
+        } catch (StatusRuntimeException e) {
+            System.err.printf("Topology request failed with gRPC status %s%n", e.getStatus());
+            throw e;
+        } finally {
+            channel.shutdown();
+            if (!channel.awaitTermination(5, TimeUnit.SECONDS)) {
+                channel.shutdownNow();
+            }
+        }
+    }
+
+    private static ManagedChannel createChannel(URI address) {
+        if (address.getHost() == null) {
+            throw new IllegalArgumentException("CAMUNDA_GRPC_ADDRESS must include a host");
+        }
+
+        int port = address.getPort();
+        ManagedChannelBuilder<?> builder = ManagedChannelBuilder.forAddress(
+                address.getHost(),
+                port >= 0 ? port : defaultPort(address.getScheme()));
+
+        return switch (address.getScheme()) {
+            case "https" -> builder.useTransportSecurity().build();
+            case "http" -> builder.usePlaintext().build();
+            default -> throw new IllegalArgumentException(
+                    "CAMUNDA_GRPC_ADDRESS must use the http or https scheme");
+        };
+    }
+
+    private static int defaultPort(String scheme) {
+        return "https".equals(scheme) ? 443 : 80;
+    }
+
+    private static String requiredEnvironmentVariable(String name) {
+        String value = System.getenv(name);
+        if (value == null || value.isBlank()) {
+            throw new IllegalStateException("Environment variable " + name + " is required");
+        }
+        return value;
+    }
+}

--- a/code-conversion/patterns/code-examples/camunda-8/src/main/java/io/camunda/conversion/advanced/grpc/StreamingJobWorkerExample.java
+++ b/code-conversion/patterns/code-examples/camunda-8/src/main/java/io/camunda/conversion/advanced/grpc/StreamingJobWorkerExample.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.conversion.advanced.grpc;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.CamundaClientBuilder;
+import io.camunda.client.api.response.ActivatedJob;
+import io.camunda.client.api.worker.JobClient;
+import io.camunda.client.api.worker.JobWorker;
+import io.camunda.client.impl.oauth.OAuthCredentialsProviderBuilder;
+
+import java.net.URI;
+import java.time.Duration;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+
+public final class StreamingJobWorkerExample {
+
+    private static final String JOB_TYPE = "process-payment";
+
+    private StreamingJobWorkerExample() {
+    }
+
+    public static void main(String[] args) throws InterruptedException {
+        CountDownLatch shutdownRequested = new CountDownLatch(1);
+        CountDownLatch cleanupComplete = new CountDownLatch(1);
+        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+            shutdownRequested.countDown();
+            try {
+                cleanupComplete.await();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        }));
+
+        try {
+            try (CamundaClient client = createClient();
+                 JobWorker worker = client.newWorker()
+                         .jobType(JOB_TYPE)
+                         .handler(StreamingJobWorkerExample::handleJob)
+                         .name("payment-stream-worker")
+                         .maxJobsActive(32)
+                         .timeout(Duration.ofMinutes(2))
+                         .streamEnabled(true)
+                         .streamTimeout(Duration.ofMinutes(1))
+                         .open()) {
+                System.out.printf("Streaming worker '%s' started. Press Ctrl+C to stop.%n", JOB_TYPE);
+                shutdownRequested.await();
+            }
+        } finally {
+            cleanupComplete.countDown();
+        }
+    }
+
+    static void handleJob(JobClient client, ActivatedJob job) {
+        String outcome = String.valueOf(job.getVariablesAsMap().getOrDefault("outcome", "complete"));
+
+        switch (outcome) {
+            case "complete" -> client.newCompleteCommand(job)
+                    .variables(Map.of("paymentStatus", "captured"))
+                    .send()
+                    .join();
+            case "failure" -> client.newFailCommand(job)
+                    .retries(Math.max(0, job.getRetries() - 1))
+                    .errorMessage("Payment provider is temporarily unavailable")
+                    .retryBackoff(Duration.ofSeconds(30))
+                    .send()
+                    .join();
+            case "bpmn-error" -> client.newThrowErrorCommand(job)
+                    .errorCode("PAYMENT_REJECTED")
+                    .errorMessage("The payment was rejected")
+                    .variables(Map.of("paymentStatus", "rejected"))
+                    .send()
+                    .join();
+            default -> client.newFailCommand(job)
+                    .retries(0)
+                    .errorMessage("Unsupported outcome: " + outcome)
+                    .send()
+                    .join();
+        }
+    }
+
+    private static CamundaClient createClient() {
+        CamundaClientBuilder builder = CamundaClient.newClientBuilder()
+                .grpcAddress(URI.create(requiredEnvironmentVariable("CAMUNDA_GRPC_ADDRESS")))
+                .preferRestOverGrpc(false)
+                .defaultJobWorkerName("payment-stream-worker");
+
+        String clientId = System.getenv("CAMUNDA_CLIENT_ID");
+        if (clientId != null && !clientId.isBlank()) {
+            builder.credentialsProvider(new OAuthCredentialsProviderBuilder()
+                    .clientId(clientId)
+                    .clientSecret(requiredEnvironmentVariable("CAMUNDA_CLIENT_SECRET"))
+                    .audience(requiredEnvironmentVariable("CAMUNDA_TOKEN_AUDIENCE"))
+                    .authorizationServerUrl(requiredEnvironmentVariable("CAMUNDA_TOKEN_URL"))
+                    .build());
+        }
+
+        return builder.build();
+    }
+
+    private static String requiredEnvironmentVariable(String name) {
+        String value = System.getenv(name);
+        if (value == null || value.isBlank()) {
+            throw new IllegalStateException("Environment variable " + name + " is required");
+        }
+        return value;
+    }
+}

--- a/code-conversion/patterns/code-examples/camunda-8/src/main/java/io/camunda/conversion/advanced/grpc/StreamingJobWorkerExample.java
+++ b/code-conversion/patterns/code-examples/camunda-8/src/main/java/io/camunda/conversion/advanced/grpc/StreamingJobWorkerExample.java
@@ -58,7 +58,10 @@ public final class StreamingJobWorkerExample {
     }
 
     static void handleJob(JobClient client, ActivatedJob job) {
-        String outcome = String.valueOf(job.getVariablesAsMap().getOrDefault("outcome", "complete"));
+        Object outcomeVariable = job.getVariablesAsMap().get("outcome");
+        String outcome = outcomeVariable == null || outcomeVariable.toString().isBlank()
+                ? "complete"
+                : outcomeVariable.toString();
 
         switch (outcome) {
             case "complete" -> client.newCompleteCommand(job)

--- a/code-conversion/patterns/code-examples/camunda-8/src/test/java/io/camunda/conversion/advanced/grpc/StreamingJobWorkerExampleTest.java
+++ b/code-conversion/patterns/code-examples/camunda-8/src/test/java/io/camunda/conversion/advanced/grpc/StreamingJobWorkerExampleTest.java
@@ -16,6 +16,7 @@ import java.util.Map;
 import static org.mockito.Answers.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 class StreamingJobWorkerExampleTest {
@@ -30,6 +31,7 @@ class StreamingJobWorkerExampleTest {
         StreamingJobWorkerExample.handleJob(client, job);
 
         verify(client).newCompleteCommand(job);
+        verifyNoMoreInteractions(client);
     }
 
     @Test
@@ -40,6 +42,7 @@ class StreamingJobWorkerExampleTest {
         StreamingJobWorkerExample.handleJob(client, job);
 
         verify(client).newFailCommand(job);
+        verifyNoMoreInteractions(client);
     }
 
     @Test
@@ -49,6 +52,7 @@ class StreamingJobWorkerExampleTest {
         StreamingJobWorkerExample.handleJob(client, job);
 
         verify(client).newThrowErrorCommand(job);
+        verifyNoMoreInteractions(client);
     }
 
     @Test
@@ -58,5 +62,28 @@ class StreamingJobWorkerExampleTest {
         StreamingJobWorkerExample.handleJob(client, job);
 
         verify(client).newFailCommand(job);
+        verifyNoMoreInteractions(client);
+    }
+
+    @Test
+    void shouldCompleteJobWhenOutcomeIsNull() {
+        Map<String, Object> variables = new java.util.HashMap<>();
+        variables.put("outcome", null);
+        when(job.getVariablesAsMap()).thenReturn(variables);
+
+        StreamingJobWorkerExample.handleJob(client, job);
+
+        verify(client).newCompleteCommand(job);
+        verifyNoMoreInteractions(client);
+    }
+
+    @Test
+    void shouldCompleteJobWhenOutcomeIsBlank() {
+        when(job.getVariablesAsMap()).thenReturn(Map.of("outcome", " "));
+
+        StreamingJobWorkerExample.handleJob(client, job);
+
+        verify(client).newCompleteCommand(job);
+        verifyNoMoreInteractions(client);
     }
 }

--- a/code-conversion/patterns/code-examples/camunda-8/src/test/java/io/camunda/conversion/advanced/grpc/StreamingJobWorkerExampleTest.java
+++ b/code-conversion/patterns/code-examples/camunda-8/src/test/java/io/camunda/conversion/advanced/grpc/StreamingJobWorkerExampleTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.conversion.advanced.grpc;
+
+import io.camunda.client.api.response.ActivatedJob;
+import io.camunda.client.api.worker.JobClient;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.mockito.Answers.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class StreamingJobWorkerExampleTest {
+
+    private final JobClient client = mock(JobClient.class, RETURNS_DEEP_STUBS);
+    private final ActivatedJob job = mock(ActivatedJob.class);
+
+    @Test
+    void shouldCompleteSuccessfulJob() {
+        when(job.getVariablesAsMap()).thenReturn(Map.of("outcome", "complete"));
+
+        StreamingJobWorkerExample.handleJob(client, job);
+
+        verify(client).newCompleteCommand(job);
+    }
+
+    @Test
+    void shouldFailJobAfterTechnicalFailure() {
+        when(job.getVariablesAsMap()).thenReturn(Map.of("outcome", "failure"));
+        when(job.getRetries()).thenReturn(3);
+
+        StreamingJobWorkerExample.handleJob(client, job);
+
+        verify(client).newFailCommand(job);
+    }
+
+    @Test
+    void shouldThrowBpmnErrorForBusinessOutcome() {
+        when(job.getVariablesAsMap()).thenReturn(Map.of("outcome", "bpmn-error"));
+
+        StreamingJobWorkerExample.handleJob(client, job);
+
+        verify(client).newThrowErrorCommand(job);
+    }
+
+    @Test
+    void shouldFailUnsupportedOutcomeWithoutRetry() {
+        when(job.getVariablesAsMap()).thenReturn(Map.of("outcome", "unexpected"));
+
+        StreamingJobWorkerExample.handleJob(client, job);
+
+        verify(client).newFailCommand(job);
+    }
+}


### PR DESCRIPTION
## Summary

- add a production-shaped streaming job worker with explicit lifecycle and job outcomes
- add a generated gateway stub example with TLS, bearer metadata, deadlines, and cleanup
- document when to use the supported client API versus direct protocol stubs

## Changes

- `code-conversion/patterns/code-examples/camunda-8`: add runnable high- and low-level gRPC examples
- `code-conversion/patterns/code-examples/camunda-8`: declare the generated gateway protocol dependency
- `code-conversion/patterns/code-examples/camunda-8/README.md`: add configuration, run instructions, and API tradeoffs
- `StreamingJobWorkerExampleTest`: cover completion, technical failure, BPMN error, and unsupported outcomes

## Test plan

- [x] `mvn verify -PcheckFormat -pl code-conversion/patterns/code-examples/camunda-8`
- [x] `mvn test -pl code-conversion/patterns/code-examples/camunda-8 -Dversion.camunda-8=8.9.0`
- [x] all example entry points compile against the current 8.10 snapshot and previous 8.9 client

## Baseline

Built from commit: 880cb097c252e71aa3df28517c978d71b74c0dfd

Related source requirement: https://github.com/camunda/orchestration-cluster-api-go/issues/11

🤖 Generated with GitHub Copilot