### PR TITLE
fix(deps): pin Jackson 3 to 3.1.5 (#1854)

### DIFF
--- a/diagram-converter/pom.xml
+++ b/diagram-converter/pom.xml
@@ -53,6 +53,13 @@
            manages log4j-api (via the log4j-to-slf4j bridge) below the
            2.26.1 fix. -->
       <dependency>
+        <groupId>tools.jackson</groupId>
+        <artifactId>jackson-bom</artifactId>
+        <version>${version.jackson-3-bom}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-bom</artifactId>
         <version>${version.log4j-bom}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,7 @@
     <version.elasticsearch>8.19.6</version.elasticsearch>
     <version.spring-boot>3.5.16</version.spring-boot>
     <version.jackson-bom>2.22.1</version.jackson-bom>
+    <version.jackson-3-bom>3.1.5</version.jackson-3-bom>
     <version.log4j-bom>2.26.1</version.log4j-bom>
     <tomcat.version>11.0.24</tomcat.version>
     <logback.version>1.5.38</logback.version>
@@ -55,6 +56,7 @@
     <plugin.version.failsafe>3.5.6</plugin.version.failsafe>
     <plugin.version.resources>3.5.0</plugin.version.resources>
     <plugin.version.dependency>3.11.0</plugin.version.dependency>
+    <plugin.version.enforcer>3.6.3</plugin.version.enforcer>
 
     <url.source>jdbc:h2:~/Downloads/c8_rdbms-source.db;TRACE_LEVEL_FILE=0;DB_CLOSE_ON_EXIT=FALSE</url.source>
     <url.target>jdbc:h2:~/Downloads/c8_rdbms-target.db;TRACE_LEVEL_FILE=0;DB_CLOSE_ON_EXIT=FALSE</url.target>
@@ -151,6 +153,12 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
+      <!-- CVE-2026-59889: close residual Jackson 3 gaps in modules not covered by a per-module tools.jackson BOM import -->
+      <dependency>
+        <groupId>tools.jackson.core</groupId>
+        <artifactId>jackson-databind</artifactId>
+        <version>${version.jackson-3-bom}</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 
@@ -229,6 +237,11 @@
           <artifactId>maven-dependency-plugin</artifactId>
           <version>${plugin.version.dependency}</version>
         </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-enforcer-plugin</artifactId>
+          <version>${plugin.version.enforcer}</version>
+        </plugin>
       </plugins>
     </pluginManagement>
 
@@ -273,6 +286,36 @@
               <goal>clean</goal>
             </goals>
             <phase>clean</phase>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>reject-vulnerable-jackson-databind</id>
+            <phase>validate</phase>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <bannedDependencies>
+                  <excludes>
+                    <exclude>com.fasterxml.jackson.core:jackson-databind:[2.8,2.18.9)</exclude>
+                    <exclude>com.fasterxml.jackson.core:jackson-databind:[2.19,2.21.5)</exclude>
+                    <exclude>com.fasterxml.jackson.core:jackson-databind:[2.22,2.22.1)</exclude>
+                    <exclude>tools.jackson.core:jackson-databind:[3.0,3.1.5)</exclude>
+                    <exclude>tools.jackson.core:jackson-databind:[3.2,3.2.1)</exclude>
+                  </excludes>
+                  <message>
+                    jackson-databind must not resolve to a version affected by CVE-2026-54515 or CVE-2026-59889.
+                  </message>
+                  <searchTransitive>true</searchTransitive>
+                </bannedDependencies>
+              </rules>
+            </configuration>
           </execution>
         </executions>
       </plugin>


### PR DESCRIPTION
## Summary

- backports #1854 to `maintenance/0.2`
- keeps `jackson-databind` on patched Jackson 2.22.1 for the Spring Boot 3 branch
- adds the reactor-wide Maven Enforcer guard against versions affected by CVE-2026-54515 and CVE-2026-59889
- preserves maintenance/0.2-specific Commons Lang and JUnit dependency management while resolving the cherry-pick conflict

## Test plan

- [x] reactor-wide `mvn validate` passes the Enforcer rule
- [x] forcing `version.jackson-bom=2.22.0` fails the Enforcer rule
- [x] `mvn verify -Pdistro,checkFormat --batch-mode -f diagram-converter/pom.xml`

Backport of #1854.

🤖 Generated with GitHub Copilot CLI
