### PR TITLE
fix(deps): remove vulnerable shaded Spin dependency (maintenance/0.2)

### DIFF
--- a/code-conversion/pom.xml
+++ b/code-conversion/pom.xml
@@ -17,4 +17,35 @@
     <module>recipes</module>
   </modules>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>reject-shaded-spin-dataformat-all</id>
+            <phase>validate</phase>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <bannedDependencies>
+                  <excludes>
+                    <exclude>org.camunda.spin:camunda-spin-dataformat-all</exclude>
+                  </excludes>
+                  <message>
+                    camunda-spin-dataformat-all shades dependencies that cannot be secured through dependency management; use the individual Spin data-format artifacts.
+                  </message>
+                  <searchTransitive>true</searchTransitive>
+                </bannedDependencies>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
 </project>

--- a/code-conversion/recipes/pom.xml
+++ b/code-conversion/recipes/pom.xml
@@ -174,7 +174,12 @@
     </dependency>
     <dependency>
       <groupId>org.camunda.spin</groupId>
-      <artifactId>camunda-spin-dataformat-all</artifactId>
+      <artifactId>camunda-spin-dataformat-json-jackson</artifactId>
+      <version>${version.camunda-7}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.camunda.spin</groupId>
+      <artifactId>camunda-spin-dataformat-xml-dom</artifactId>
       <version>${version.camunda-7}</version>
     </dependency>
     <dependency>


### PR DESCRIPTION
## Summary

- replace `camunda-spin-dataformat-all` in code-conversion recipes with the individual JSON/Jackson and XML/DOM Spin modules
- allow the existing Jackson BOM and direct dependency management to supply patched versions
- ban the shaded aggregate in code-conversion modules to prevent regression

## Root cause

`camunda-spin-dataformat-all` relocates and embeds Jackson, so Maven dependency management cannot override its vulnerable copy. This dependency was invisible when scanning only the thin recipes JAR but remains present in the component dependency graph.

Tracked upstream: camunda/camunda-bpm-platform-maintenance#3108.

The separate code-conversion npm alert for `brace-expansion` is already resolved at 5.0.7 on `maintenance/0.2`; its lockfile reports zero vulnerabilities and needs no change.

## Validation

- `mvn clean install`
- dependency tree contains unshaded Spin modules, Jackson core 2.21.4, and Jackson databind 2.22.1
- Grype 0.116.0 scan of the rebuilt recipes JAR: 0 non-negligible findings
- code-conversion API mapping `npm audit --package-lock-only --audit-level=low`: 0 vulnerabilities

Baseline: `9fafed59b94bf92a70cb042abba49ef8eb72825a`