### PR TITLE
fix(deps): update vulnerable brace-expansion (maintenance/0.2)

### DIFF
--- a/diagram-converter/webapp/src/main/javascript/package-lock.json
+++ b/diagram-converter/webapp/src/main/javascript/package-lock.json
@@ -2241,9 +2241,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
## Summary

Update the diagram-converter webapp lockfile from `brace-expansion` 1.1.15 to 1.1.16, resolving CVE-2026-13149 in the npm manifest embedded in the release artifact.

## Validation

- `npm audit --audit-level=low`: 0 vulnerabilities
- production frontend build
- `mvn clean install -pl diagram-converter/webapp -am`
- Grype 0.116.0 scan of the rebuilt diagram-converter webapp JAR: 0 non-negligible findings

Baseline: `9fafed59b94bf92a70cb042abba49ef8eb72825a`