### PR TITLE
fix(deps): secure data migrator dependencies (maintenance/0.2)

### DIFF
--- a/data-migrator/core/pom.xml
+++ b/data-migrator/core/pom.xml
@@ -79,14 +79,14 @@
 
     <dependency>
       <groupId>org.camunda.spin</groupId>
-      <artifactId>camunda-spin-dataformat-all</artifactId>
+      <artifactId>camunda-spin-dataformat-json-jackson</artifactId>
       <version>${version.camunda-7}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>org.slf4j</groupId>
-          <artifactId>slf4j-api</artifactId>
-        </exclusion>
-      </exclusions>
+    </dependency>
+
+    <dependency>
+      <groupId>org.camunda.spin</groupId>
+      <artifactId>camunda-spin-dataformat-xml-dom</artifactId>
+      <version>${version.camunda-7}</version>
     </dependency>
 
     <dependency>

--- a/data-migrator/plugins/cockpit/frontend/package-lock.json
+++ b/data-migrator/plugins/cockpit/frontend/package-lock.json
@@ -4501,9 +4501,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5236,9 +5236,9 @@
       }
     },
     "node_modules/immutable": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.5.tgz",
-      "integrity": "sha512-t7xcm2siw+hlUM68I+UEOK+z84RzmN59as9DZ7P1l0994DKUWV7UXBMQZVxaoMSRQ+PBZbHCOoBt7a2wxOMt+A==",
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.9.tgz",
+      "integrity": "sha512-m8nVez3rwrgmWxtLMt1ZYXB2Lv7OKYn/disyxAlSDYAlKSlFoPPfIAmAM/M5xqL4m4C/wAPw7S2/CNaUii1Hxg==",
       "dev": true,
       "license": "MIT"
     },

--- a/data-migrator/pom.xml
+++ b/data-migrator/pom.xml
@@ -52,5 +52,35 @@
     </profile>
   </profiles>
 
-</project>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>reject-shaded-spin-dataformat-all</id>
+            <phase>validate</phase>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <bannedDependencies>
+                  <excludes>
+                    <exclude>org.camunda.spin:camunda-spin-dataformat-all</exclude>
+                  </excludes>
+                  <message>
+                    camunda-spin-dataformat-all shades dependencies that cannot be secured through dependency management; use the individual Spin data-format artifacts.
+                  </message>
+                  <searchTransitive>true</searchTransitive>
+                </bannedDependencies>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
 
+</project>


### PR DESCRIPTION
## Summary

- replace `camunda-spin-dataformat-all` with the individual JSON/Jackson and XML/DOM Spin modules
- ensure the existing Jackson dependency management applies to Spin instead of shipping shaded Jackson 2.21.1
- ban `camunda-spin-dataformat-all` in all data-migrator modules to prevent the vulnerable shaded dependency from returning
- update Cockpit frontend `brace-expansion` to 1.1.16 and `immutable` to 5.1.9

## Root cause

The 0.2.6 archive contains both managed Jackson and a second, relocated Jackson copy inside `camunda-spin-dataformat-all`. Maven dependency management cannot override shaded classes, so earlier Jackson BOM fixes left scanner findings in the shipped data-migrator tarball. The current Camunda 7 7.24.11-ee artifact still shades Jackson 2.21.4, so a Camunda 7 patch bump alone does not clear all findings.

Tracked upstream: camunda/camunda-bpm-platform-maintenance#3108.

The frontend lockfile also retained vulnerable development dependencies even though `shell-quote` and the code-conversion lock had already moved to patched versions.

## Security coverage

This removes the remaining Jackson findings from the built data-migrator archive and resolves CVE-2026-59879, CVE-2026-59880, and CVE-2026-13149 in the embedded Cockpit npm manifest. The maintenance branch already contains the effective pins for the other CVEs reported against 0.2.6.

## Validation

- `mvn clean install`
- runtime and history Spin JSON/XML integration tests: 18 passed
- `npm audit --audit-level=low`: 0 vulnerabilities
- Grype 0.116.0 scan of the rebuilt data-migrator tarball and Cockpit plugin JAR: 0 non-negligible findings

Baseline: `9fafed59b94bf92a70cb042abba49ef8eb72825a`