### PR TITLE
test(core): enforce documented architecture rules

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -27,7 +27,8 @@
 
 Run architecture tests to ensure compliance:
 ```bash
-mvn test -Dtest=ArchitectureTest
+mvn install -DskipTests -pl data-migrator/distro -am && \
+  mvn test -Pintegration -pl data-migrator/qa/integration-tests -Dtest=ArchitectureTest
 ```
 
 If architecture tests fail, refactor your tests to use:
@@ -49,4 +50,3 @@ If architecture tests fail, refactor your tests to use:
 
 ## Related Issues
 <!-- Link to related issues: Fixes #123, Related to #456 -->
-

--- a/data-migrator/AGENTS.md
+++ b/data-migrator/AGENTS.md
@@ -100,7 +100,8 @@ These rules are enforced by ArchUnit tests in `qa/integration-tests` (scans `io.
 - Use SLF4J for logging - no `System.out`/`System.err`
 - Error Prone enabled for compile-time checks
 
-Run architecture validation: `mvn test -Dtest=ArchitectureTest -pl data-migrator/qa`
+Run architecture validation from the repository root:
+`mvn install -DskipTests -pl data-migrator/distro -am && mvn test -Pintegration -pl data-migrator/qa/integration-tests -Dtest=ArchitectureTest`
 
 ## Always-Green Policy
 

--- a/data-migrator/core/src/main/java/io/camunda/migration/data/impl/logging/EntityConversionServiceLogs.java
+++ b/data-migrator/core/src/main/java/io/camunda/migration/data/impl/logging/EntityConversionServiceLogs.java
@@ -19,10 +19,10 @@ public class EntityConversionServiceLogs {
   protected static final Logger LOGGER = LoggerFactory.getLogger(EntityConversionServiceLogs.class);
 
   // Log message templates
-  protected static final String EXECUTING_INTERCEPTOR_LOG = "Executing interceptor {} for entity type: {}";
+  public static final String EXECUTING_INTERCEPTOR_LOG = "Executing interceptor {} for entity type: {}";
 
   // Error message templates
-  protected static final String ENTITY_INTERCEPTOR_FAILED_MSG = "%s failed for entity type '%s'";
+  public static final String ENTITY_INTERCEPTOR_FAILED_MSG = "%s failed for entity type '%s'";
 
   /**
    * Logs the execution of an interceptor for a specific entity type.
@@ -45,4 +45,3 @@ public class EntityConversionServiceLogs {
     return String.format(ENTITY_INTERCEPTOR_FAILED_MSG, interceptorName, entityType);
   }
 }
-

--- a/data-migrator/qa/integration-tests/pom.xml
+++ b/data-migrator/qa/integration-tests/pom.xml
@@ -222,8 +222,13 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <version>3.5.6</version>
         <configuration>
+          <failIfNoSpecifiedTests>true</failIfNoSpecifiedTests>
+          <failIfNoTests>true</failIfNoTests>
           <forkedProcessTimeoutInSeconds>3900</forkedProcessTimeoutInSeconds>
           <forkedProcessExitTimeoutInSeconds>300</forkedProcessExitTimeoutInSeconds>
+          <systemPropertyVariables>
+            <repositoryRoot>${maven.multiModuleProjectDirectory}</repositoryRoot>
+          </systemPropertyVariables>
         </configuration>
       </plugin>
       <plugin>
@@ -583,4 +588,3 @@
   </profiles>
 
 </project>
-

--- a/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/architecturefixture/InvalidArchitectureFixtures.java
+++ b/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/architecturefixture/InvalidArchitectureFixtures.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.migration.data.architecturefixture;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.stereotype.Component;
+
+public class InvalidArchitectureFixtures {
+
+  public static class InvalidVisibility {
+
+    private String mutableState;
+
+    private InvalidVisibility() {
+    }
+
+    private void mutate() {
+      mutableState = "changed";
+    }
+  }
+
+  @Component
+  public static class MisplacedComponent {
+  }
+
+  @Configuration
+  public static class MisplacedConfiguration {
+  }
+
+  public static class SystemOutAccess {
+
+    public void print() {
+      System.out.println("invalid");
+    }
+  }
+
+  public static class PrintStackTraceCall {
+
+    public void print(Throwable throwable) {
+      throwable.printStackTrace();
+    }
+  }
+}

--- a/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/impl/logging/architecturefixture/InvalidLoggingFixtures.java
+++ b/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/impl/logging/architecturefixture/InvalidLoggingFixtures.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.migration.data.impl.logging.architecturefixture;
+
+public class InvalidLoggingFixtures {
+
+  public static class NonFinalLogs {
+
+    public static String STATIC_MESSAGE = "mutable";
+  }
+
+  public static class NonStaticLogs {
+
+    public String instanceMessage = "instance";
+  }
+
+  public static class NonPublicConstantsLogs {
+
+    protected static final String MESSAGE = "hidden";
+  }
+}

--- a/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/ArchitectureTest.java
+++ b/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/ArchitectureTest.java
@@ -47,6 +47,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Consumer;
@@ -71,10 +72,15 @@ import org.junit.jupiter.params.provider.MethodSource;
  */
 class ArchitectureTest {
 
-  protected static final ImportOption EXCLUDE_ARCHITECTURE_FIXTURES =
-      location -> !location.contains("/architecturefixture/");
+  protected static final Pattern ARCHITECTURE_FIXTURE_PATH =
+      Pattern.compile(".*[/\\\\]architecturefixture[/\\\\].*");
 
-  protected static final Path REPOSITORY_ROOT = Path.of(System.getProperty("repositoryRoot"));
+  protected static final ImportOption EXCLUDE_ARCHITECTURE_FIXTURES =
+      location -> !location.matches(ARCHITECTURE_FIXTURE_PATH);
+
+  protected static final Path REPOSITORY_ROOT = Path.of(Objects.requireNonNull(
+      System.getProperty("repositoryRoot"),
+      "repositoryRoot system property must be configured by the test runner"));
 
   protected static final JavaClasses CLASSES = new ClassFileImporter()
       .withImportOption(EXCLUDE_ARCHITECTURE_FIXTURES)
@@ -121,8 +127,19 @@ class ArchitectureTest {
         .should(notAccessCamundaBpmEngineImplPackage())
         .allowEmptyShould(true)
         .because("Tests should not use internal Camunda BPM engine implementation classes. " +
-            "Exception: ClockUtil from org.camunda.bpm.engine.impl.util is allowed for time manipulation in tests.")
+            "ClockUtil is allowed for time manipulation, ProcessEngineConfigurationImpl is allowed " +
+            "from test lifecycle and test methods, and @WhiteBox classes and methods are exempt.")
         .check(classesToCheck);
+  }
+
+  @Test
+  void shouldRecognizeArchitectureFixturePathsAcrossOperatingSystems() {
+    assertThat(ARCHITECTURE_FIXTURE_PATH.matcher(
+        "file:/workspace/io/camunda/migration/data/architecturefixture/Invalid.class").matches())
+        .isTrue();
+    assertThat(ARCHITECTURE_FIXTURE_PATH.matcher(
+        "C:\\workspace\\io\\camunda\\migration\\data\\architecturefixture\\Invalid.class").matches())
+        .isTrue();
   }
 
   @Test

--- a/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/ArchitectureTest.java
+++ b/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/ArchitectureTest.java
@@ -10,16 +10,54 @@ package io.camunda.migration.data.qa;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.fields;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
+import static io.camunda.migration.data.architecturefixture.InvalidArchitectureFixtures.InvalidVisibility;
+import static io.camunda.migration.data.architecturefixture.InvalidArchitectureFixtures.MisplacedComponent;
+import static io.camunda.migration.data.architecturefixture.InvalidArchitectureFixtures.MisplacedConfiguration;
+import static io.camunda.migration.data.architecturefixture.InvalidArchitectureFixtures.PrintStackTraceCall;
+import static io.camunda.migration.data.architecturefixture.InvalidArchitectureFixtures.SystemOutAccess;
+import static io.camunda.migration.data.impl.logging.architecturefixture.InvalidLoggingFixtures.NonFinalLogs;
+import static io.camunda.migration.data.impl.logging.architecturefixture.InvalidLoggingFixtures.NonPublicConstantsLogs;
+import static io.camunda.migration.data.impl.logging.architecturefixture.InvalidLoggingFixtures.NonStaticLogs;
+import static io.camunda.migration.data.qa.architecturefixture.InvalidTestingFixtures.BadMethodNameTest;
+import static io.camunda.migration.data.qa.architecturefixture.InvalidTestingFixtures.BadParameterizedMethodNameTest;
+import static io.camunda.migration.data.qa.architecturefixture.InvalidTestingFixtures.EngineImplAccessTest;
+import static io.camunda.migration.data.qa.architecturefixture.InvalidTestingFixtures.ImplementationAccessTest;
+import static io.camunda.migration.data.qa.architecturefixture.InvalidTestingFixtures.MissingSuffix;
+import static io.camunda.migration.data.qa.architecturefixture.InvalidTestingFixtures.MissingParameterizedSuffix;
+import static io.camunda.migration.data.qa.architecturefixture.InvalidTestingFixtures.StandaloneMigrationTest;
+import static io.camunda.migration.data.qa.architecturefixture.InvalidTestingFixtures.StandaloneParameterizedMigrationTest;
+import static io.camunda.migration.data.qa.architecturefixture.InvalidTestingFixtures.StaticNestedContainerTest.StaticNestedMigrationTest;
+import static io.camunda.migration.data.qa.architecturefixture.InvalidTestingFixtures.packagePrivateMissingSuffix;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.tngtech.archunit.core.domain.JavaClass;
 import com.tngtech.archunit.core.domain.JavaClasses;
 import com.tngtech.archunit.core.domain.JavaModifier;
 import com.tngtech.archunit.core.importer.ClassFileImporter;
 import com.tngtech.archunit.core.importer.ImportOption;
+import com.tngtech.archunit.core.importer.Location;
+import com.tngtech.archunit.core.importer.Locations;
 import com.tngtech.archunit.lang.ArchCondition;
 import com.tngtech.archunit.lang.ConditionEvents;
 import com.tngtech.archunit.lang.SimpleConditionEvent;
+import java.io.IOException;
+import java.lang.reflect.Method;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Consumer;
+import java.util.regex.Pattern;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  * Architecture tests to enforce design principles and prevent anti-patterns.
@@ -33,11 +71,30 @@ import org.junit.jupiter.api.Test;
  */
 class ArchitectureTest {
 
+  protected static final ImportOption EXCLUDE_ARCHITECTURE_FIXTURES =
+      location -> !location.contains("/architecturefixture/");
+
+  protected static final Path REPOSITORY_ROOT = Path.of(System.getProperty("repositoryRoot"));
+
   protected static final JavaClasses CLASSES = new ClassFileImporter()
-      .importPackages("io.camunda.migration.data");
+      .withImportOption(EXCLUDE_ARCHITECTURE_FIXTURES)
+      .importLocations(productionAndTestLocations());
+
+  protected static final Pattern RULE_HEADING =
+      Pattern.compile("^###\\s+((?:VR|PO|LR|TR)-\\d+):.*$");
+
+  protected static final Pattern ENFORCEMENT =
+      Pattern.compile("^\\*\\*Enforcement:\\*\\*\\s+`ArchitectureTest\\.(\\w+)\\(\\)`$");
+
+  protected static final Pattern DOCUMENTED_RULE_ROW =
+      Pattern.compile("^\\|\\s*((?:VR|PO|LR|TR)-\\d+)\\s*\\|.*\\|\\s*`(\\w+)\\(\\)`\\s*\\|$");
 
   @Test
   void shouldNotAccessImplClasses() {
+    checkShouldNotAccessImplClasses(CLASSES);
+  }
+
+  protected static void checkShouldNotAccessImplClasses(JavaClasses classesToCheck) {
     classes()
         .that().resideInAPackage("..qa..")
         .and().areNotAnnotatedWith("io.camunda.migration.data.qa.util.WhiteBox")
@@ -49,11 +106,15 @@ class ArchitectureTest {
             "(2) ConverterUtil.prefixDefinitionId and ConverterUtil.convertDate are allowed for data conversion in tests (including method references like ConverterUtil::prefixDefinitionId), " +
             "(3) Methods annotated with @BeforeEach or @AfterEach can access impl classes for test setup/cleanup, " +
             "(4) Classes or methods annotated with @WhiteBox are allowed to access impl classes for white-box testing.")
-        .check(CLASSES);
+        .check(classesToCheck);
   }
 
   @Test
   void shouldNotAccessCamundaBpmEngineImplClasses() {
+    checkShouldNotAccessCamundaBpmEngineImplClasses(CLASSES);
+  }
+
+  protected static void checkShouldNotAccessCamundaBpmEngineImplClasses(JavaClasses classesToCheck) {
     classes()
         .that().resideInAPackage("..qa..")
         .and().haveSimpleNameEndingWith("Test")
@@ -61,11 +122,15 @@ class ArchitectureTest {
         .allowEmptyShould(true)
         .because("Tests should not use internal Camunda BPM engine implementation classes. " +
             "Exception: ClockUtil from org.camunda.bpm.engine.impl.util is allowed for time manipulation in tests.")
-        .check(CLASSES);
+        .check(classesToCheck);
   }
 
   @Test
   void shouldNotHavePrivateMethods() {
+    checkShouldNotHavePrivateMethods(CLASSES);
+  }
+
+  protected static void checkShouldNotHavePrivateMethods(JavaClasses classesToCheck) {
     classes()
         .that().resideInAPackage("io.camunda.migration.data..")
         .and().resideOutsideOfPackage("..qa..") // Exclude test code
@@ -74,11 +139,15 @@ class ArchitectureTest {
         .because("Methods should use protected or package-protected visibility instead of private " +
             "to allow for testing and extensibility. Use protected for methods that might be " +
             "overridden and package-protected for internal methods that tests might need to access.")
-        .check(CLASSES);
+        .check(classesToCheck);
   }
 
   @Test
   void shouldNotHavePrivateFields() {
+    checkShouldNotHavePrivateFields(CLASSES);
+  }
+
+  protected static void checkShouldNotHavePrivateFields(JavaClasses classesToCheck) {
     classes()
         .that().resideInAPackage("io.camunda.migration.data..")
         .and().resideOutsideOfPackage("..qa..") // Exclude test code
@@ -88,11 +157,15 @@ class ArchitectureTest {
         .because("Fields should use protected or package-protected visibility instead of private " +
             "to allow for testing and extensibility. Use protected for fields that might be " +
             "accessed by subclasses and package-protected for fields that tests might need to access.")
-        .check(CLASSES);
+        .check(classesToCheck);
   }
 
   @Test
   void shouldNotHavePrivateConstructors() {
+    checkShouldNotHavePrivateConstructors(CLASSES);
+  }
+
+  protected static void checkShouldNotHavePrivateConstructors(JavaClasses classesToCheck) {
     classes()
         .that().resideInAPackage("io.camunda.migration.data..")
         .and().resideOutsideOfPackage("..qa..") // Exclude test code
@@ -100,23 +173,30 @@ class ArchitectureTest {
         .allowEmptyShould(true)
         .because("Classes should use protected or package-protected constructors to allow for " +
             "testing and extensibility.")
-        .check(CLASSES);
+        .check(classesToCheck);
   }
 
   @Test
   void shouldOnlyHaveStaticFinalFieldsInLogClasses() {
+    checkShouldOnlyHaveStaticFinalFieldsInLogClasses(CLASSES);
+  }
+
+  protected static void checkShouldOnlyHaveStaticFinalFieldsInLogClasses(JavaClasses classesToCheck) {
     classes()
         .that().haveSimpleNameEndingWith("Logs")
         .and().resideInAPackage("..impl.logging..")
         .should(onlyHaveStaticFinalFields())
         .allowEmptyShould(true)
-        .because("Log classes should only contain public static final String constants " +
-            "for centralized log message management.")
-        .check(CLASSES);
+        .because("Log classes should only contain static final fields")
+        .check(classesToCheck);
   }
 
   @Test
   void shouldFollowNamingConventionForTestMethods() {
+    checkShouldFollowNamingConventionForTestMethods(CLASSES);
+  }
+
+  protected static void checkShouldFollowNamingConventionForTestMethods(JavaClasses classesToCheck) {
     classes()
         .that().resideInAPackage("..qa..")
         .and().haveSimpleNameEndingWith("Test")
@@ -124,11 +204,15 @@ class ArchitectureTest {
         .allowEmptyShould(true)
         .because("Test methods should follow the naming convention: 'should' prefix for behavior tests " +
             "to clearly express what the test verifies (e.g., shouldSkipProcessInstanceWhenDefinitionMissing).")
-        .check(CLASSES);
+        .check(classesToCheck);
   }
 
   @Test
   void shouldResideInImplPackageForComponents() {
+    checkShouldResideInImplPackageForComponents(CLASSES);
+  }
+
+  protected static void checkShouldResideInImplPackageForComponents(JavaClasses classesToCheck) {
     classes()
         .that().areAnnotatedWith("org.springframework.stereotype.Component")
         .or().areAnnotatedWith("org.springframework.stereotype.Service")
@@ -138,11 +222,31 @@ class ArchitectureTest {
         .allowEmptyShould(true)
         .because("Components and services should reside in the 'impl' package (for internal implementations) " +
             "or at the top level of io.camunda.migration.data (for public APIs like HistoryMigrator, RuntimeMigrator).")
-        .check(CLASSES);
+        .check(classesToCheck);
+  }
+
+  @Test
+  void shouldResideInConfigPackageForConfigurations() {
+    checkShouldResideInConfigPackageForConfigurations(CLASSES);
+  }
+
+  protected static void checkShouldResideInConfigPackageForConfigurations(JavaClasses classesToCheck) {
+    classes()
+        .that().areAnnotatedWith("org.springframework.context.annotation.Configuration")
+        .and().resideInAPackage("io.camunda.migration.data..")
+        .and().resideOutsideOfPackage("..qa..")
+        .should().resideInAPackage("..config..")
+        .allowEmptyShould(true)
+        .because("@Configuration classes should be centralized in the config package")
+        .check(classesToCheck);
   }
 
   @Test
   void shouldBePublicStaticFinalForLogConstants() {
+    checkShouldBePublicStaticFinalForLogConstants(CLASSES);
+  }
+
+  protected static void checkShouldBePublicStaticFinalForLogConstants(JavaClasses classesToCheck) {
     classes()
         .that().haveSimpleNameEndingWith("Logs")
         .and().resideInAPackage("..impl.logging..")
@@ -150,7 +254,7 @@ class ArchitectureTest {
         .allowEmptyShould(true)
         .because("Log message constants should be public static final to prevent modification " +
             "and ensure consistent logging across the application.")
-        .check(CLASSES);
+        .check(classesToCheck);
   }
 
   @Test
@@ -179,29 +283,199 @@ class ArchitectureTest {
 
   @Test
   void shouldNotUseSystemOutOrPrintStackTrace() {
+    checkShouldNotUseSystemOutOrPrintStackTrace(CLASSES);
+  }
+
+  protected static void checkShouldNotUseSystemOutOrPrintStackTrace(JavaClasses classesToCheck) {
     noClasses()
         .that().resideInAPackage("io.camunda.migration.data..")
-        .should().callMethod(System.class, "out")
+        .and().resideOutsideOfPackage("..app..")
+        .should().accessField(System.class, "out")
         .orShould().callMethod("java.lang.Throwable", "printStackTrace")
         .allowEmptyShould(true)
         .because("Production code should use SLF4J logging instead of System.out.println() or printStackTrace(). " +
             "Use a Logger instance and appropriate log levels (debug, info, warn, error).")
-        .check(CLASSES);
+        .check(classesToCheck);
+  }
+
+  @Test
+  void shouldExtendAppropriateAbstractTestClass() {
+    checkShouldExtendAppropriateAbstractTestClass(CLASSES);
+  }
+
+  protected static void checkShouldExtendAppropriateAbstractTestClass(JavaClasses classesToCheck) {
+    classes()
+        .that().resideInAPackage("..qa..")
+        .and().haveSimpleNameEndingWith("Test")
+        .and().resideOutsideOfPackages("..persistence..", "..distribution..")
+        .and().doNotHaveSimpleName("ArchitectureTest")
+        .should(extendAppropriateAbstractTestClass())
+        .allowEmptyShould(true)
+        .because("Migration behavior tests should extend a shared abstract test class")
+        .check(classesToCheck);
   }
 
   @Test
   void shouldHaveTestSuffixForTestClasses() {
+    checkShouldHaveTestSuffixForTestClasses(CLASSES);
+  }
+
+  protected static void checkShouldHaveTestSuffixForTestClasses(JavaClasses classesToCheck) {
     classes()
         .that().resideInAPackage("..qa..")
-        .and().haveModifier(JavaModifier.PUBLIC)
         .and().areNotInterfaces()
         .and().areNotEnums()
         .and().areNotAnnotations()
+        .and().doNotHaveModifier(JavaModifier.ABSTRACT)
         .should(haveTestSuffixIfContainingTestMethods())
         .allowEmptyShould(true)
         .because("Test classes should end with 'Test' suffix to follow JUnit conventions and be " +
             "recognized by test runners and build tools.")
-        .check(CLASSES);
+        .check(classesToCheck);
+  }
+
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("documentedRuleFixtures")
+  @DisplayName("documented rules reject invalid fixtures")
+  void shouldRejectInvalidFixtures(
+      String ruleId, Consumer<JavaClasses> rule, Class<?> invalidFixture) {
+    JavaClasses fixtureClasses = new ClassFileImporter().importClasses(invalidFixture);
+
+    assertThatThrownBy(() -> rule.accept(fixtureClasses))
+        .as("Rule %s should reject %s", ruleId, invalidFixture.getSimpleName())
+        .isInstanceOf(AssertionError.class);
+  }
+
+  @Test
+  void shouldBindEveryDocumentedArchitectureRule() throws NoSuchMethodException {
+    List<DocumentedRule> documentedRules = Stream.of(
+            REPOSITORY_ROOT.resolve("docs/ARCHITECTURE_RULES.md"),
+            REPOSITORY_ROOT.resolve("docs/TESTING_GUIDELINES.md"))
+        .flatMap(path -> documentedRules(path).stream())
+        .toList();
+
+    assertThat(documentedRules).isNotEmpty();
+    for (DocumentedRule documentedRule : documentedRules) {
+      Method enforcementMethod = ArchitectureTest.class.getDeclaredMethod(documentedRule.enforcementMethod());
+      assertThat(enforcementMethod.isAnnotationPresent(Test.class))
+          .as("%s (%s) must be an executable @Test", documentedRule.id(), enforcementMethod.getName())
+          .isTrue();
+    }
+  }
+
+  protected static Stream<Arguments> documentedRuleFixtures() {
+    return Stream.of(
+        Arguments.of("TR-1", (Consumer<JavaClasses>) ArchitectureTest::checkShouldNotAccessImplClasses,
+            ImplementationAccessTest.class),
+        Arguments.of("TR-2",
+            (Consumer<JavaClasses>) ArchitectureTest::checkShouldNotAccessCamundaBpmEngineImplClasses,
+            EngineImplAccessTest.class),
+        Arguments.of("TR-3",
+            (Consumer<JavaClasses>) ArchitectureTest::checkShouldFollowNamingConventionForTestMethods,
+            BadMethodNameTest.class),
+        Arguments.of("TR-3 parameterized",
+            (Consumer<JavaClasses>) ArchitectureTest::checkShouldFollowNamingConventionForTestMethods,
+            BadParameterizedMethodNameTest.class),
+        Arguments.of("TR-4",
+            (Consumer<JavaClasses>) ArchitectureTest::checkShouldExtendAppropriateAbstractTestClass,
+            StandaloneMigrationTest.class),
+        Arguments.of("TR-4 parameterized",
+            (Consumer<JavaClasses>) ArchitectureTest::checkShouldExtendAppropriateAbstractTestClass,
+            StandaloneParameterizedMigrationTest.class),
+        Arguments.of("TR-4 static nested",
+            (Consumer<JavaClasses>) ArchitectureTest::checkShouldExtendAppropriateAbstractTestClass,
+            StaticNestedMigrationTest.class),
+        Arguments.of("TR-5",
+            (Consumer<JavaClasses>) ArchitectureTest::checkShouldHaveTestSuffixForTestClasses,
+            MissingSuffix.class),
+        Arguments.of("TR-5 parameterized",
+            (Consumer<JavaClasses>) ArchitectureTest::checkShouldHaveTestSuffixForTestClasses,
+            MissingParameterizedSuffix.class),
+        Arguments.of("TR-5 package-private",
+            (Consumer<JavaClasses>) ArchitectureTest::checkShouldHaveTestSuffixForTestClasses,
+            packagePrivateMissingSuffix()),
+        Arguments.of("VR-1", (Consumer<JavaClasses>) ArchitectureTest::checkShouldNotHavePrivateMethods,
+            InvalidVisibility.class),
+        Arguments.of("VR-2", (Consumer<JavaClasses>) ArchitectureTest::checkShouldNotHavePrivateFields,
+            InvalidVisibility.class),
+        Arguments.of("VR-3", (Consumer<JavaClasses>) ArchitectureTest::checkShouldNotHavePrivateConstructors,
+            InvalidVisibility.class),
+        Arguments.of("PO-1",
+            (Consumer<JavaClasses>) ArchitectureTest::checkShouldResideInImplPackageForComponents,
+            MisplacedComponent.class),
+        Arguments.of("PO-2",
+            (Consumer<JavaClasses>) ArchitectureTest::checkShouldResideInConfigPackageForConfigurations,
+            MisplacedConfiguration.class),
+        Arguments.of("LR-1 non-final",
+            (Consumer<JavaClasses>) ArchitectureTest::checkShouldOnlyHaveStaticFinalFieldsInLogClasses,
+            NonFinalLogs.class),
+        Arguments.of("LR-1 non-static",
+            (Consumer<JavaClasses>) ArchitectureTest::checkShouldOnlyHaveStaticFinalFieldsInLogClasses,
+            NonStaticLogs.class),
+        Arguments.of("LR-2",
+            (Consumer<JavaClasses>) ArchitectureTest::checkShouldBePublicStaticFinalForLogConstants,
+            NonPublicConstantsLogs.class),
+        Arguments.of("LR-3 System.out",
+            (Consumer<JavaClasses>) ArchitectureTest::checkShouldNotUseSystemOutOrPrintStackTrace,
+            SystemOutAccess.class),
+        Arguments.of("LR-3 printStackTrace",
+            (Consumer<JavaClasses>) ArchitectureTest::checkShouldNotUseSystemOutOrPrintStackTrace,
+            PrintStackTraceCall.class));
+  }
+
+  protected static Set<Location> productionAndTestLocations() {
+    Set<Location> locations = new HashSet<>(Locations.ofPackage("io.camunda.migration.data"));
+    Path distroClasses = REPOSITORY_ROOT.resolve("data-migrator/distro/target/classes");
+    assertThat(distroClasses)
+        .as("Build data-migrator/distro before running architecture tests")
+        .isDirectory();
+    locations.add(Location.of(distroClasses));
+    return locations;
+  }
+
+  protected static List<DocumentedRule> documentedRules(Path path) {
+    List<String> lines = readLines(path);
+    List<DocumentedRule> sectionRules = IntStream.range(0, lines.size())
+        .mapToObj(index -> documentedSectionRule(lines, index))
+        .flatMap(java.util.Optional::stream)
+        .toList();
+    List<DocumentedRule> tableRules = lines.stream()
+        .map(DOCUMENTED_RULE_ROW::matcher)
+        .filter(java.util.regex.Matcher::matches)
+        .map(matcher -> new DocumentedRule(matcher.group(1), matcher.group(2)))
+        .toList();
+
+    assertThat(tableRules)
+        .as("Summary table must match documented rule sections in %s", path)
+        .containsExactlyInAnyOrderElementsOf(sectionRules);
+    return sectionRules;
+  }
+
+  protected static Optional<DocumentedRule> documentedSectionRule(
+      List<String> lines, int headingIndex) {
+    var heading = RULE_HEADING.matcher(lines.get(headingIndex));
+    if (!heading.matches()) {
+      return Optional.empty();
+    }
+
+    Optional<DocumentedRule> documentedRule = IntStream.range(headingIndex + 1, lines.size())
+        .takeWhile(index -> !RULE_HEADING.matcher(lines.get(index)).matches())
+        .mapToObj(index -> ENFORCEMENT.matcher(lines.get(index)))
+        .filter(java.util.regex.Matcher::matches)
+        .findFirst()
+        .map(matcher -> new DocumentedRule(heading.group(1), matcher.group(1)));
+    assertThat(documentedRule)
+        .as("Rule %s must declare an ArchitectureTest enforcement method", heading.group(1))
+        .isPresent();
+    return documentedRule;
+  }
+
+  protected static List<String> readLines(Path path) {
+    try {
+      return Files.readAllLines(path);
+    } catch (IOException e) {
+      throw new IllegalStateException("Cannot read architecture documentation " + path, e);
+    }
   }
 
   // Custom ArchConditions
@@ -210,6 +484,9 @@ class ArchitectureTest {
     return new ArchCondition<JavaClass>("not access io.camunda.migration.data.impl package") {
       @Override
       public void check(JavaClass javaClass, ConditionEvents events) {
+        if (javaClass.isAnnotatedWith("io.camunda.migration.data.qa.util.WhiteBox")) {
+          return;
+        }
         javaClass.getAccessesFromSelf().forEach(access -> {
           JavaClass targetClass = access.getTargetOwner();
           String targetClassName = targetClass.getName();
@@ -318,15 +595,21 @@ class ArchitectureTest {
               return; // ClockUtil is allowed
             }
 
-            // Allow ProcessEngineConfigurationImpl from @BeforeEach/@AfterEach/@Test methods
+            if (access.getOrigin() instanceof com.tngtech.archunit.core.domain.JavaMethod originMethod &&
+                originMethod.isAnnotatedWith("io.camunda.migration.data.qa.util.WhiteBox")) {
+              return;
+            }
+
+            // Allow ProcessEngineConfigurationImpl from test lifecycle and test methods
             if (access.getOrigin() instanceof com.tngtech.archunit.core.domain.JavaMethod originMethod) {
-              boolean isTestMethod = originMethod.getAnnotations().stream()
+              boolean isTestInfrastructureMethod = isJUnitTestMethod(originMethod) ||
+                  originMethod.getAnnotations().stream()
                   .anyMatch(annotation ->
                       annotation.getRawType().getName().equals("org.junit.jupiter.api.BeforeEach") ||
-                      annotation.getRawType().getName().equals("org.junit.jupiter.api.AfterEach") ||
-                      annotation.getRawType().getName().equals("org.junit.jupiter.api.Test"));
+                      annotation.getRawType().getName().equals("org.junit.jupiter.api.AfterEach"));
 
-              if (isTestMethod && targetClassName.equals("org.camunda.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl")) {
+              if (isTestInfrastructureMethod &&
+                  targetClassName.equals("org.camunda.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl")) {
                 return; // ProcessEngineConfigurationImpl access from test methods is allowed
               }
             }
@@ -427,7 +710,7 @@ class ArchitectureTest {
   }
 
   protected static ArchCondition<JavaClass> onlyHaveStaticFinalFields() {
-    return new ArchCondition<JavaClass>("only have public static final fields") {
+    return new ArchCondition<JavaClass>("only have static final fields") {
       @Override
       public void check(JavaClass javaClass, ConditionEvents events) {
         javaClass.getFields().stream()
@@ -435,7 +718,7 @@ class ArchitectureTest {
                            !field.getModifiers().contains(JavaModifier.FINAL))
             .forEach(field -> {
               String message = String.format(
-                  "Field <%s.%s> should be public static final in Logs class",
+                  "Field <%s.%s> should be static final in Logs class",
                   javaClass.getName(), field.getName());
               events.add(SimpleConditionEvent.violated(field, message));
             });
@@ -448,7 +731,7 @@ class ArchitectureTest {
       @Override
       public void check(JavaClass javaClass, ConditionEvents events) {
         javaClass.getMethods().stream()
-            .filter(method -> method.isAnnotatedWith("org.junit.jupiter.api.Test"))
+            .filter(ArchitectureTest::isJUnitTestMethod)
             .filter(method -> !method.getName().startsWith("should"))
             .forEach(method -> {
               String message = String.format(
@@ -464,17 +747,13 @@ class ArchitectureTest {
     return new ArchCondition<JavaClass>("extend an appropriate abstract test class") {
       @Override
       public void check(JavaClass javaClass, ConditionEvents events) {
-        // Skip abstract classes themselves
-        if (javaClass.getModifiers().contains(JavaModifier.ABSTRACT)) {
+        boolean hasTestMethods = javaClass.getMethods().stream()
+            .anyMatch(ArchitectureTest::isJUnitTestMethod);
+        if (javaClass.getModifiers().contains(JavaModifier.ABSTRACT) || !hasTestMethods) {
           return;
         }
 
-        boolean extendsAbstractTest = javaClass.getAllRawSuperclasses().stream()
-            .anyMatch(superClass ->
-                superClass.getName().equals("io.camunda.migration.data.qa.AbstractMigratorTest") ||
-                superClass.getName().equals("io.camunda.migration.data.qa.history.HistoryMigrationAbstractTest") ||
-                superClass.getName().equals("io.camunda.migration.data.qa.runtime.RuntimeMigrationAbstractTest") ||
-                superClass.getSimpleName().endsWith("AbstractTest"));
+        boolean extendsAbstractTest = extendsAppropriateTestBase(javaClass);
 
         if (!extendsAbstractTest) {
           String message = String.format(
@@ -484,6 +763,27 @@ class ArchitectureTest {
         }
       }
     };
+  }
+
+  protected static boolean extendsAppropriateTestBase(JavaClass javaClass) {
+    boolean extendsBaseClass = javaClass.getAllRawSuperclasses().stream()
+        .anyMatch(superClass ->
+            superClass.getName().equals("io.camunda.migration.data.qa.AbstractMigratorTest") ||
+            superClass.getName().equals("io.camunda.migration.data.qa.history.HistoryMigrationAbstractTest") ||
+            superClass.getName().equals("io.camunda.migration.data.qa.runtime.RuntimeMigrationAbstractTest") ||
+            superClass.getSimpleName().endsWith("AbstractTest"));
+    boolean isNonStaticNestedTest = javaClass.isAnnotatedWith("org.junit.jupiter.api.Nested") &&
+        !javaClass.getModifiers().contains(JavaModifier.STATIC);
+    return extendsBaseClass || isNonStaticNestedTest &&
+        javaClass.getEnclosingClass().map(ArchitectureTest::extendsAppropriateTestBase).orElse(false);
+  }
+
+  protected static boolean isJUnitTestMethod(com.tngtech.archunit.core.domain.JavaMethod method) {
+    return method.isAnnotatedWith("org.junit.jupiter.api.Test") ||
+        method.isAnnotatedWith("org.junit.jupiter.params.ParameterizedTest");
+  }
+
+  protected record DocumentedRule(String id, String enforcementMethod) {
   }
 
   protected static ArchCondition<JavaClass> beInImplPackageOrTopLevel() {
@@ -515,15 +815,17 @@ class ArchitectureTest {
   }
 
   protected static ArchCondition<JavaClass> notHaveNonFinalStaticFields() {
-    return new ArchCondition<JavaClass>("not have mutable static fields") {
+    return new ArchCondition<JavaClass>("have public static final String constants") {
       @Override
       public void check(JavaClass javaClass, ConditionEvents events) {
         javaClass.getFields().stream()
-            .filter(field -> field.getModifiers().contains(JavaModifier.STATIC))
-            .filter(field -> !field.getModifiers().contains(JavaModifier.FINAL))
+            .filter(field -> field.getRawType().isEquivalentTo(String.class))
+            .filter(field -> !field.getModifiers().contains(JavaModifier.PUBLIC) ||
+                             !field.getModifiers().contains(JavaModifier.STATIC) ||
+                             !field.getModifiers().contains(JavaModifier.FINAL))
             .forEach(field -> {
               String message = String.format(
-                  "Static field <%s.%s> should be final to prevent modification",
+                  "Log constant <%s.%s> should be public static final",
                   javaClass.getName(), field.getName());
               events.add(SimpleConditionEvent.violated(field, message));
             });
@@ -587,7 +889,7 @@ class ArchitectureTest {
       @Override
       public void check(JavaClass javaClass, ConditionEvents events) {
         boolean hasTestMethods = javaClass.getMethods().stream()
-            .anyMatch(method -> method.isAnnotatedWith("org.junit.jupiter.api.Test"));
+            .anyMatch(ArchitectureTest::isJUnitTestMethod);
 
         if (hasTestMethods && !javaClass.getSimpleName().endsWith("Test")) {
           String message = String.format(
@@ -599,5 +901,3 @@ class ArchitectureTest {
     };
   }
 }
-
-

--- a/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/ArchitectureTest.java
+++ b/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/ArchitectureTest.java
@@ -306,7 +306,7 @@ class ArchitectureTest {
   protected static void checkShouldNotUseSystemOutOrPrintStackTrace(JavaClasses classesToCheck) {
     noClasses()
         .that().resideInAPackage("io.camunda.migration.data..")
-        .and().resideOutsideOfPackage("..app..")
+        .and().resideOutsideOfPackages("..app..", "..qa..")
         .should().accessField(System.class, "out")
         .orShould().callMethod("java.lang.Throwable", "printStackTrace")
         .allowEmptyShould(true)

--- a/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/ArchitectureTest.java
+++ b/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/ArchitectureTest.java
@@ -21,6 +21,7 @@ import static io.camunda.migration.data.impl.logging.architecturefixture.Invalid
 import static io.camunda.migration.data.qa.architecturefixture.InvalidTestingFixtures.BadMethodNameTest;
 import static io.camunda.migration.data.qa.architecturefixture.InvalidTestingFixtures.BadParameterizedMethodNameTest;
 import static io.camunda.migration.data.qa.architecturefixture.InvalidTestingFixtures.EngineImplAccessTest;
+import static io.camunda.migration.data.qa.architecturefixture.InvalidTestingFixtures.EngineImplLifecycleAccessTest;
 import static io.camunda.migration.data.qa.architecturefixture.InvalidTestingFixtures.ImplementationAccessTest;
 import static io.camunda.migration.data.qa.architecturefixture.InvalidTestingFixtures.MissingSuffix;
 import static io.camunda.migration.data.qa.architecturefixture.InvalidTestingFixtures.MissingParameterizedSuffix;
@@ -140,6 +141,13 @@ class ArchitectureTest {
     assertThat(ARCHITECTURE_FIXTURE_PATH.matcher(
         "C:\\workspace\\io\\camunda\\migration\\data\\architecturefixture\\Invalid.class").matches())
         .isTrue();
+  }
+
+  @Test
+  void shouldAllowEngineConfigurationAccessFromAllLifecycleMethods() {
+    JavaClasses fixtureClasses = new ClassFileImporter().importClasses(EngineImplLifecycleAccessTest.class);
+
+    checkShouldNotAccessCamundaBpmEngineImplClasses(fixtureClasses);
   }
 
   @Test
@@ -622,6 +630,8 @@ class ArchitectureTest {
               boolean isTestInfrastructureMethod = isJUnitTestMethod(originMethod) ||
                   originMethod.getAnnotations().stream()
                   .anyMatch(annotation ->
+                      annotation.getRawType().getName().equals("org.junit.jupiter.api.BeforeAll") ||
+                      annotation.getRawType().getName().equals("org.junit.jupiter.api.AfterAll") ||
                       annotation.getRawType().getName().equals("org.junit.jupiter.api.BeforeEach") ||
                       annotation.getRawType().getName().equals("org.junit.jupiter.api.AfterEach"));
 

--- a/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/architecturefixture/InvalidTestingFixtures.java
+++ b/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/architecturefixture/InvalidTestingFixtures.java
@@ -11,6 +11,8 @@ import io.camunda.migration.data.impl.VariableService;
 import io.camunda.migration.data.qa.AbstractMigratorTest;
 import java.util.List;
 import org.camunda.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -31,6 +33,19 @@ public class InvalidTestingFixtures {
   public static class EngineImplAccessTest {
 
     public void access(ProcessEngineConfigurationImpl configuration) {
+      configuration.getHistoryLevel();
+    }
+  }
+
+  public static class EngineImplLifecycleAccessTest {
+
+    @BeforeAll
+    static void beforeAll(ProcessEngineConfigurationImpl configuration) {
+      configuration.getHistoryLevel();
+    }
+
+    @AfterAll
+    static void afterAll(ProcessEngineConfigurationImpl configuration) {
       configuration.getHistoryLevel();
     }
   }

--- a/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/architecturefixture/InvalidTestingFixtures.java
+++ b/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/architecturefixture/InvalidTestingFixtures.java
@@ -12,7 +12,9 @@ import io.camunda.migration.data.qa.AbstractMigratorTest;
 import java.util.List;
 import org.camunda.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
 import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -46,6 +48,16 @@ public class InvalidTestingFixtures {
 
     @AfterAll
     static void afterAll(ProcessEngineConfigurationImpl configuration) {
+      configuration.getHistoryLevel();
+    }
+
+    @BeforeEach
+    void beforeEach(ProcessEngineConfigurationImpl configuration) {
+      configuration.getHistoryLevel();
+    }
+
+    @AfterEach
+    void afterEach(ProcessEngineConfigurationImpl configuration) {
       configuration.getHistoryLevel();
     }
   }

--- a/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/architecturefixture/InvalidTestingFixtures.java
+++ b/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/architecturefixture/InvalidTestingFixtures.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.migration.data.qa.architecturefixture;
+
+import io.camunda.migration.data.impl.VariableService;
+import io.camunda.migration.data.qa.AbstractMigratorTest;
+import java.util.List;
+import org.camunda.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+
+public class InvalidTestingFixtures {
+
+  public static Class<?> packagePrivateMissingSuffix() {
+    return PackagePrivateMissingSuffix.class;
+  }
+
+  public static class ImplementationAccessTest {
+
+    public void access(VariableService variableService) {
+      variableService.processVariablesToActivityGroups(List.of());
+    }
+  }
+
+  public static class EngineImplAccessTest {
+
+    public void access(ProcessEngineConfigurationImpl configuration) {
+      configuration.getHistoryLevel();
+    }
+  }
+
+  public static class BadMethodNameTest {
+
+    @Test
+    void invalidName() {
+    }
+  }
+
+  public static class BadParameterizedMethodNameTest {
+
+    @ParameterizedTest
+    void invalidParameterizedName(String value) {
+    }
+  }
+
+  public static class StandaloneMigrationTest {
+
+    @Test
+    void shouldRequireMigrationTestBaseClass() {
+    }
+  }
+
+  public static class StandaloneParameterizedMigrationTest {
+
+    @ParameterizedTest
+    void shouldRequireMigrationTestBaseClass(String value) {
+    }
+  }
+
+  public static class StaticNestedContainerTest extends AbstractMigratorTest {
+
+    @Nested
+    public static class StaticNestedMigrationTest {
+
+      @Test
+      void shouldNotInheritInfrastructureFromEnclosingClass() {
+      }
+    }
+  }
+
+  public static class MissingSuffix {
+
+    @Test
+    void shouldRequireTestClassSuffix() {
+    }
+  }
+
+  public static class MissingParameterizedSuffix {
+
+    @ParameterizedTest
+    void shouldRequireTestClassSuffix(String value) {
+    }
+  }
+
+  static class PackagePrivateMissingSuffix {
+
+    @Test
+    void shouldRequireTestClassSuffix() {
+    }
+  }
+}

--- a/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/history/element/HistoryAbstractElementMigrationTest.java
+++ b/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/history/element/HistoryAbstractElementMigrationTest.java
@@ -31,9 +31,10 @@ public abstract class HistoryAbstractElementMigrationTest extends HistoryMigrati
   @EnabledIf("hasScenarios_terminatedElementPostMigration")
   @MethodSource("elementScenarios_terminatedElementPostMigration")
   @ParameterizedTest
-  public void migrateSimpleElementScenarios_expectTerminatedElement(final String processFile,
-                                                                    final String processId,
-                                                                    final FlowNodeInstanceEntity.FlowNodeType elementType) {
+  public void shouldMigrateSimpleElementScenariosWithTerminatedElement(
+      final String processFile,
+      final String processId,
+      final FlowNodeInstanceEntity.FlowNodeType elementType) {
     // given
     deployer.deployCamunda7Process(processFile);
     runtimeService.startProcessInstanceByKey(processId);
@@ -55,9 +56,10 @@ public abstract class HistoryAbstractElementMigrationTest extends HistoryMigrati
   @EnabledIf("hasScenarios_completedElementPostMigration")
   @MethodSource("elementScenarios_completedElementPostMigration")
   @ParameterizedTest
-  public void migrateSimpleElementScenarios_expectCompletedElement(final String processFile,
-                                                                   final String processId,
-                                                                    final FlowNodeInstanceEntity.FlowNodeType elementType) {
+  public void shouldMigrateSimpleElementScenariosWithCompletedElement(
+      final String processFile,
+      final String processId,
+      final FlowNodeInstanceEntity.FlowNodeType elementType) {
     // given
     deployer.deployCamunda7Process(processFile);
     runtimeService.startProcessInstanceByKey(processId);
@@ -104,4 +106,3 @@ public abstract class HistoryAbstractElementMigrationTest extends HistoryMigrati
     return elementScenarios_completedElementPostMigration().findAny().isPresent();
   }
 }
-

--- a/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/runtime/element/AbstractElementMigrationTest.java
+++ b/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/runtime/element/AbstractElementMigrationTest.java
@@ -28,9 +28,10 @@ public abstract class AbstractElementMigrationTest extends RuntimeMigrationAbstr
   @EnabledIf("hasScenarios_activeElementPostMigration")
   @MethodSource("elementScenarios_activeElementPostMigration")
   @ParameterizedTest
-  public void migrateSimpleElementScenarios_expectActiveElement(final String processFile,
-                                                                final String processId,
-                                                                final String elementId) {
+  public void shouldMigrateSimpleElementScenariosWithActiveElement(
+      final String processFile,
+      final String processId,
+      final String elementId) {
     // given
     deployer.deployProcessInC7AndC8(processFile);
     ProcessInstance instance = runtimeService.startProcessInstanceByKey(processId);
@@ -47,9 +48,10 @@ public abstract class AbstractElementMigrationTest extends RuntimeMigrationAbstr
   @EnabledIf("hasScenarios_completedElementPostMigration")
   @MethodSource("elementScenarios_completedElementPostMigration")
   @ParameterizedTest
-  public void migrateSimpleElementScenarios_expectCompletedElement(final String processFile,
-                                                                   final String processId,
-                                                                   final String elementId) {
+  public void shouldMigrateSimpleElementScenariosWithCompletedElement(
+      final String processFile,
+      final String processId,
+      final String elementId) {
     // given
     deployer.deployProcessInC7AndC8(processFile);
     ProcessInstance instance = runtimeService.startProcessInstanceByKey(processId);

--- a/docs/ARCHITECTURE_RULES.md
+++ b/docs/ARCHITECTURE_RULES.md
@@ -125,15 +125,15 @@ public class C7Client { ... }
 
 **Rationale:** Centralizing configuration classes provides clear separation of concerns.
 
-**Enforcement:** -
+**Enforcement:** `ArchitectureTest.shouldResideInConfigPackageForConfigurations()`
 
 ---
 
 ## Logging Rules
 
-### LR-1: Log Classes Must Only Contain Constants
+### LR-1: Log Classes Must Only Contain Immutable Fields
 
-**Rule:** Classes ending with "Logs" in `..impl.logging..` must only contain `public static final` fields.
+**Rule:** Classes ending with "Logs" in `..impl.logging..` must only contain `static final` fields.
 
 **Rationale:** Log classes serve as centralized message repositories and should only contain immutable string constants.
 
@@ -155,17 +155,18 @@ public class HistoryMigratorLogs {
 
 ---
 
-### LR-2: Log Constants Must Be Public Static Final
+### LR-2: String Log Constants Must Be Public Static Final
 
-**Rule:** Static fields in log classes must be `final`.
+**Rule:** String fields in log classes must be `public static final`.
 
 **Enforcement:** `ArchitectureTest.shouldBePublicStaticFinalForLogConstants()`
 
 ---
 
-### LR-3: No System.out or printStackTrace in Production Code
+### LR-3: No System.out or printStackTrace Outside CLI Output
 
-**Rule:** Production code (outside `..qa..` and `..test..` packages) must not use `System.out` or `Throwable.printStackTrace()`.
+**Rule:** Production code must not use `System.out` or `Throwable.printStackTrace()`. The
+`..app..` package is exempt because CLI usage text is intentionally written to standard output.
 
 **Rationale:** Production code should use proper logging frameworks (SLF4J) for consistent log management.
 
@@ -189,15 +190,18 @@ e.printStackTrace();
 
 Execute all architecture tests:
 ```bash
-mvn test -Dtest=ArchitectureTest -pl qa
+mvn install -DskipTests -pl data-migrator/distro -am && \
+  mvn test -Pintegration -pl data-migrator/qa/integration-tests -Dtest=ArchitectureTest
 ```
 
-Run with full build:
+Run with all integration tests:
 ```bash
-mvn verify
+mvn verify -Pintegration
 ```
 
-Architecture tests run automatically during the build and will fail if any rule is violated.
+Architecture tests run automatically in every integration-test shard. The targeted command fails
+when no tests are selected, so a successful result always reports a non-zero architecture-test
+count.
 
 ---
 
@@ -209,10 +213,10 @@ Architecture tests run automatically during the build and will fail if any rule 
 | VR-2 | Visibility | No private fields | `shouldNotHavePrivateFields()` |
 | VR-3 | Visibility | No private constructors | `shouldNotHavePrivateConstructors()` |
 | PO-1 | Package | Components in impl or top-level | `shouldResideInImplPackageForComponents()` |
-| PO-2 | Package | Converters end with "Converter" | `shouldFollowConverterNamingConvention()` |
-| LR-1 | Logging | Log classes only contain constants | `shouldOnlyHaveStaticFinalFieldsInLogClasses()` |
-| LR-2 | Logging | Log constants are final | `shouldBePublicStaticFinalForLogConstants()` |
-| LR-3 | Logging | No System.out or printStackTrace | `shouldNotUseSystemOutOrPrintStackTrace()` |
+| PO-2 | Package | Configuration classes in config package | `shouldResideInConfigPackageForConfigurations()` |
+| LR-1 | Logging | Log classes only contain static final fields | `shouldOnlyHaveStaticFinalFieldsInLogClasses()` |
+| LR-2 | Logging | String log constants are public static final | `shouldBePublicStaticFinalForLogConstants()` |
+| LR-3 | Logging | No System.out/printStackTrace outside CLI output | `shouldNotUseSystemOutOrPrintStackTrace()` |
 
 **Note:** Testing rules (TR-1 through TR-5) are documented in [TESTING_GUIDELINES.md](TESTING_GUIDELINES.md).
 
@@ -222,4 +226,3 @@ Architecture tests run automatically during the build and will fail if any rule 
 
 - [Testing Guidelines](TESTING_GUIDELINES.md) - Detailed testing philosophy and examples
 - [Code Review Checklist](CODE_REVIEW_CHECKLIST.md) - Review checklist for maintainers
-

--- a/docs/TESTING_GUIDELINES.md
+++ b/docs/TESTING_GUIDELINES.md
@@ -81,9 +81,12 @@ void shouldSaveSkipReasonToDatabase() {
 
 ### TR-2: No Direct Access to Camunda BPM Engine Implementation
 
-**Rule:** Test classes must not access `org.camunda.bpm.engine.impl` package classes, except `ClockUtil`.
+**Rule:** Test classes must not access `org.camunda.bpm.engine.impl` package classes, except
+`ClockUtil`, scenario-specific `ProcessEngineConfigurationImpl` access, and `@WhiteBox` tests.
 
-**Rationale:** Using internal Camunda BPM engine classes couples tests to implementation details. Only `ClockUtil` is permitted for time manipulation in tests.
+**Rationale:** Using internal Camunda BPM engine classes couples tests to implementation details.
+The limited exceptions support time manipulation, explicit engine-configuration scenarios, and
+tests that intentionally declare white-box access.
 
 **Exceptions:**
 - `org.camunda.bpm.engine.impl.util.ClockUtil` - allowed for time manipulation

--- a/docs/TESTING_GUIDELINES.md
+++ b/docs/TESTING_GUIDELINES.md
@@ -87,6 +87,8 @@ void shouldSaveSkipReasonToDatabase() {
 
 **Exceptions:**
 - `org.camunda.bpm.engine.impl.util.ClockUtil` - allowed for time manipulation
+- `org.camunda.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl` - allowed from test lifecycle
+  and test methods when engine configuration is part of the scenario
 - Classes or methods annotated with `@WhiteBox` are exempt
 
 **Enforcement:** `ArchitectureTest.shouldNotAccessCamundaBpmEngineImplClasses()`
@@ -104,7 +106,7 @@ EnsureUtil.ensureTrue("message", condition);
 
 ### TR-3: Test Method Naming Convention
 
-**Rule:** Test methods annotated with `@Test` must start with "should" prefix.
+**Rule:** Test methods annotated with `@Test` or `@ParameterizedTest` must start with "should" prefix.
 
 **Rationale:** The "should" prefix creates behavior-driven test names that clearly express expected behavior and improve test readability.
 
@@ -131,23 +133,26 @@ void migrateUserTask() { ... }
 
 ### TR-4: Tests Must Extend Appropriate Abstract Test Class
 
-**Rule:** Concrete test classes in the `..qa..` package must extend an appropriate abstract test class.
+**Rule:** Concrete migration behavior test classes in the `..qa..` package must extend an
+appropriate abstract test class. Architecture, persistence, and distribution tests are exempt
+because they provide their own infrastructure.
 
 **Rationale:** Extending abstract test classes ensures proper test setup, dependency injection, and access to required services.
 
 **Allowed Base Classes:**
-- `io.camunda.migration.data.AbstractMigratorTest`
-- `history.io.camunda.migration.data.HistoryMigrationAbstractTest`
-- `runtime.io.camunda.migration.data.RuntimeMigrationAbstractTest`
+- `io.camunda.migration.data.qa.AbstractMigratorTest`
+- `io.camunda.migration.data.qa.history.HistoryMigrationAbstractTest`
+- `io.camunda.migration.data.qa.runtime.RuntimeMigrationAbstractTest`
 - Any class ending with `AbstractTest`
 
-**Enforcement:** -
+**Enforcement:** `ArchitectureTest.shouldExtendAppropriateAbstractTestClass()`
 
 ---
 
 ### TR-5: Test Classes Must End with "Test" Suffix
 
-**Rule:** Classes in the `..qa..` package that contain methods annotated with `@Test` must have a simple name ending with "Test".
+**Rule:** Concrete classes in the `..qa..` package that contain methods annotated with `@Test`
+or `@ParameterizedTest` must have a simple name ending with "Test". Abstract test bases are exempt.
 
 **Rationale:** Following the standard JUnit naming convention ensures test classes are recognized by test runners and build tools.
 
@@ -576,7 +581,8 @@ The `ArchitectureTest` class automatically enforces these guidelines:
 
 Run architecture tests:
 ```bash
-mvn test -Dtest=ArchitectureTest -pl qa
+mvn install -DskipTests -pl data-migrator/distro -am && \
+  mvn test -Pintegration -pl data-migrator/qa/integration-tests -Dtest=ArchitectureTest
 ```
 
 ---
@@ -619,7 +625,7 @@ Remove imports of `DbClient`, `IdKeyMapper`, and other `..impl..` classes.
 | TR-1 | No access to impl package | `shouldNotAccessImplClasses()` |
 | TR-2 | No Camunda BPM impl access (except ClockUtil) | `shouldNotAccessCamundaBpmEngineImplClasses()` |
 | TR-3 | Test methods start with "should" | `shouldFollowNamingConventionForTestMethods()` |
-| TR-4 | Tests extend abstract test class | `testsShouldExtendAbstractTestClass()` |
+| TR-4 | Tests extend abstract test class | `shouldExtendAppropriateAbstractTestClass()` |
 | TR-5 | Test classes end with "Test" suffix | `shouldHaveTestSuffixForTestClasses()` |
 
 For non-testing architecture rules (visibility, package organization, logging), see [ARCHITECTURE_RULES.md](ARCHITECTURE_RULES.md).
@@ -639,4 +645,3 @@ Before submitting a test PR, verify:
 - [ ] Tests extend appropriate abstract base class
 - [ ] No imports of `DbClient`, `IdKeyMapper`, or other `..impl..` classes (unless `@WhiteBox`)
 - [ ] `ArchitectureTest` passes locally
-


### PR DESCRIPTION
## Summary

- turn every documented architecture rule into an executable guard with an explicit `@Test` binding
- add negative fixtures that prove visibility, package, logging, and testing rules reject violations
- cover current core and distro classes, including parameterized and nested test categories
- make the documented command build current production artifacts and fail when zero tests execute

## Changes

- adds PO-2 configuration placement and TR-4 test-base enforcement
- reconciles documented rule sections and summary tables with executable test methods
- configures Surefire to reject empty and unmatched test selections
- updates architecture commands in contributor guidance and the PR template

## Test plan

- [x] `mvn clean install -DskipTests`
- [x] `mvn install -DskipTests -pl data-migrator/distro -am && mvn test -Pintegration -pl data-migrator/qa/integration-tests -Dtest=ArchitectureTest` (36 tests)
- [x] nonexistent `-Dtest` selector exits non-zero

## Baseline

Built from commit: `a7da8db88fb5b1c9fad5e778c5c37403cc6a16e9`

related to #1880