### PR TITLE
feat(ci): optimize pr feedback workflow

### DIFF
--- a/.github/actions/setup-maven/action.yml
+++ b/.github/actions/setup-maven/action.yml
@@ -41,6 +41,10 @@ inputs:
   vault-secret-id:
     description: Vault Secret ID to use
     required: false
+outputs:
+  maven-cache-hit:
+    description: Whether setup-java restored Maven dependencies from cache
+    value: ${{ steps.setup-java.outputs.cache-hit }}
 runs:
   using: composite
   steps:
@@ -58,6 +62,7 @@ runs:
         secret/data/products/cambpm/ci/artifactory USER | ARTIFACTORY_USR;
         secret/data/products/cambpm/ci/artifactory TOKEN | ARTIFACTORY_PSW;
   - name: Setup Java
+    id: setup-java
     uses: actions/setup-java@v5
     with:
       java-version: ${{ inputs.java-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -394,6 +394,8 @@ jobs:
     # Split the runtime suite into 4 parallel shards (was 1 serial job, ~53 min).
     # Each shard name matches its Maven profile (runtime-<shard>) and describes
     # the sub-set of test packages it covers.
+    outputs:
+      maven-cache-hit: ${{ steps.setup-maven.outputs.maven-cache-hit }}
     strategy:
       fail-fast: false
       matrix:
@@ -1098,6 +1100,7 @@ jobs:
       CACHE_CODE_CONVERSION: ${{ needs.code-conversion.outputs.maven-cache-hit }}
       CACHE_DIAGRAM_CONVERTER: ${{ needs.diagram-converter.outputs.maven-cache-hit }}
       CACHE_COMPILE_PREVIOUS: ${{ needs.compile-previous-version.outputs.maven-cache-hit }}
+      CACHE_RUNTIME_H2: ${{ needs.it-runtime-h2.outputs.maven-cache-hit }}
       CACHE_HISTORY_H2: ${{ needs.it-history-h2.outputs.maven-cache-hit }}
       CACHE_HISTORY_H2_WINDOWS: ${{ needs.it-history-h2-windows.outputs.maven-cache-hit }}
       CACHE_IDENTITY_H2: ${{ needs.it-identity-h2.outputs.maven-cache-hit }}
@@ -1192,6 +1195,7 @@ jobs:
               process.env.CACHE_CODE_CONVERSION,
               process.env.CACHE_DIAGRAM_CONVERTER,
               process.env.CACHE_COMPILE_PREVIOUS,
+              process.env.CACHE_RUNTIME_H2,
               process.env.CACHE_HISTORY_H2,
               process.env.CACHE_HISTORY_H2_WINDOWS,
               process.env.CACHE_IDENTITY_H2,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1150,16 +1150,17 @@ jobs:
             };
             const median = (values) => percentile(values, 0.5);
 
-            const runs = await github.paginate(github.rest.actions.listWorkflowRuns, {
+            const runsResponse = await github.rest.actions.listWorkflowRuns({
               owner: context.repo.owner,
               repo: context.repo.repo,
               workflow_id: "ci.yml",
               event: "pull_request",
               status: "completed",
-              per_page: 100,
+              per_page: 30,
             });
+            const runs = runsResponse.data.workflow_runs ?? [];
 
-            const completedRuns = runs.slice(0, 30).filter((run) => run.created_at && run.updated_at);
+            const completedRuns = runs.filter((run) => run.created_at && run.updated_at);
             const feedbackDurations = completedRuns.map((run) => durationMinutes(run.created_at, run.updated_at));
 
             const run = await github.rest.actions.getWorkflowRun({

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
       - main
       - maintenance/*
   pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
   workflow_dispatch:
   schedule:
     - cron: "0 5 * * 1-5"  # Weekday mornings for general CI
@@ -61,21 +62,29 @@ jobs:
           echo "Camunda 8 current: ${CURRENT} (docker: ${CURRENT_DOCKER})"
           echo "Camunda 8 previous: ${PREVIOUS} (docker: ${PREVIOUS_DOCKER})"
 
-  # Detects whether data-migrator source changed so downstream jobs can skip
-  # expensive tests on PRs that only touch other modules. For non-PR events
-  # (push to main, schedule, workflow_dispatch) we always consider it changed.
+  # Detect changed module surfaces and derive default test scopes for PRs.
+  # For non-PR events we execute the full CI surface.
   detect-changes:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:
       data-migrator: ${{ steps.filter.outputs.data-migrator }}
+      code-conversion: ${{ steps.filter.outputs.code-conversion }}
+      diagram-converter: ${{ steps.filter.outputs.diagram-converter }}
+      shared: ${{ steps.filter.outputs.shared }}
+      run-runtime: ${{ steps.filter.outputs.run-runtime }}
+      run-history: ${{ steps.filter.outputs.run-history }}
+      run-identity: ${{ steps.filter.outputs.run-identity }}
+      run-e2e: ${{ steps.filter.outputs.run-e2e }}
+      run-compile-previous-version: ${{ steps.filter.outputs.run-compile-previous-version }}
+      run-db-default: ${{ steps.filter.outputs.run-db-default }}
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
 
-      - name: Check for data-migrator changes
+      - name: Detect changed scopes and default checks
         id: filter
         env:
           BASE_REF: ${{ github.base_ref }}
@@ -83,18 +92,73 @@ jobs:
         run: |
           if [[ "$EVENT" != "pull_request" ]]; then
             echo "data-migrator=true" >> "$GITHUB_OUTPUT"
+            echo "code-conversion=true" >> "$GITHUB_OUTPUT"
+            echo "diagram-converter=true" >> "$GITHUB_OUTPUT"
+            echo "shared=true" >> "$GITHUB_OUTPUT"
+            echo "run-runtime=true" >> "$GITHUB_OUTPUT"
+            echo "run-history=true" >> "$GITHUB_OUTPUT"
+            echo "run-identity=true" >> "$GITHUB_OUTPUT"
+            echo "run-e2e=true" >> "$GITHUB_OUTPUT"
+            echo "run-compile-previous-version=true" >> "$GITHUB_OUTPUT"
+            echo "run-db-default=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
           git fetch origin "${BASE_REF}" --depth=1
-          if git diff --name-only "origin/${BASE_REF}...HEAD" | grep -qE '^(data-migrator/|pom\.xml$)'; then
+          CHANGED_FILES=$(git diff --name-only "origin/${BASE_REF}...HEAD")
+          if echo "$CHANGED_FILES" | grep -qE '^(data-migrator/|pom\.xml$)'; then
             echo "data-migrator=true" >> "$GITHUB_OUTPUT"
           else
             echo "data-migrator=false" >> "$GITHUB_OUTPUT"
           fi
 
+          if echo "$CHANGED_FILES" | grep -qE '^(code-conversion/|pom\.xml$)'; then
+            echo "code-conversion=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "code-conversion=false" >> "$GITHUB_OUTPUT"
+          fi
+
+          if echo "$CHANGED_FILES" | grep -qE '^(diagram-converter/|pom\.xml$)'; then
+            echo "diagram-converter=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "diagram-converter=false" >> "$GITHUB_OUTPUT"
+          fi
+
+          if echo "$CHANGED_FILES" | grep -qE '^(\.github/|pom\.xml$)'; then
+            echo "shared=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "shared=false" >> "$GITHUB_OUTPUT"
+          fi
+
+          if echo "$CHANGED_FILES" | grep -qE '^(data-migrator/|\.github/|pom\.xml$)'; then
+            echo "run-runtime=true" >> "$GITHUB_OUTPUT"
+            echo "run-history=true" >> "$GITHUB_OUTPUT"
+            echo "run-identity=true" >> "$GITHUB_OUTPUT"
+            echo "run-e2e=true" >> "$GITHUB_OUTPUT"
+            echo "run-db-default=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run-runtime=false" >> "$GITHUB_OUTPUT"
+            echo "run-history=false" >> "$GITHUB_OUTPUT"
+            echo "run-identity=false" >> "$GITHUB_OUTPUT"
+            echo "run-e2e=false" >> "$GITHUB_OUTPUT"
+            echo "run-db-default=false" >> "$GITHUB_OUTPUT"
+          fi
+
+          if echo "$CHANGED_FILES" | grep -qE '^(data-migrator/|code-conversion/|diagram-converter/|\.github/|pom\.xml$)'; then
+            echo "run-compile-previous-version=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run-compile-previous-version=false" >> "$GITHUB_OUTPUT"
+          fi
+
   distro:
+    needs: [detect-changes]
     runs-on: ubuntu-latest
     timeout-minutes: 70
+    if: |
+      github.event_name != 'pull_request' ||
+      needs.detect-changes.outputs.data-migrator == 'true' ||
+      needs.detect-changes.outputs.shared == 'true'
+    outputs:
+      maven-cache-hit: ${{ steps.setup-maven.outputs.maven-cache-hit }}
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -114,36 +178,38 @@ jobs:
             secret/data/products/cambpm/ci/nexus PASSWORD | NEXUS_APP_CAMUNDA_COM_PSW;
 
       - name: Setup Maven
+        id: setup-maven
         uses: ./.github/actions/setup-maven
         with:
           vault-address: ${{ secrets.VAULT_ADDR }}
           vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
 
-      - name: Build and run default tests
+      - name: Build data-migrator distribution
         working-directory: data-migrator
         run: mvn clean install -Dmaven.test.skip --batch-mode
-
-      - name: Collect distro
-        id: distro
-        if: github.ref == 'refs/heads/main'
-        run: |
-          ARTIFACT_DIR=$(mktemp -d)
-          cp data-migrator/assembly/target/camunda-7-to-8-data-migrator-*.tar.gz "${ARTIFACT_DIR}/"
-          cp data-migrator/assembly/target/camunda-7-to-8-data-migrator-*.zip "${ARTIFACT_DIR}/"
-          echo "dir=${ARTIFACT_DIR}" >> $GITHUB_OUTPUT
 
       - name: Upload distro
         uses: actions/upload-artifact@v7
         if: github.ref == 'refs/heads/main'
         with:
           name: distro
-          path: ${{ steps.distro.outputs.dir }}
+          path: |
+            data-migrator/assembly/target/camunda-7-to-8-data-migrator-*.tar.gz
+            data-migrator/assembly/target/camunda-7-to-8-data-migrator-*.zip
+          if-no-files-found: error
           retention-days: 7
 
   code-conversion:
+    needs: [detect-changes]
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    if: |
+      github.event_name != 'pull_request' ||
+      needs.detect-changes.outputs.code-conversion == 'true' ||
+      needs.detect-changes.outputs.shared == 'true'
+    outputs:
+      maven-cache-hit: ${{ steps.setup-maven.outputs.maven-cache-hit }}
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -165,6 +231,7 @@ jobs:
             secret/data/products/cambpm/ci/harbor password | HARBOR_PASSWORD;
 
       - name: Setup Maven
+        id: setup-maven
         uses: ./.github/actions/setup-maven
         with:
           vault-address: ${{ secrets.VAULT_ADDR }}
@@ -211,25 +278,25 @@ jobs:
           npm ci
           npm run build
 
-      - name: Collect code-conversion artifacts
-        id: code-conversion-artifacts
-        if: github.ref == 'refs/heads/main'
-        run: |
-          ARTIFACT_DIR=$(mktemp -d)
-          cp code-conversion/recipes/target/camunda-7-to-8-code-conversion-recipes-*.jar "${ARTIFACT_DIR}/"
-          echo "dir=${ARTIFACT_DIR}" >> $GITHUB_OUTPUT
-
       - name: Upload code-conversion artifacts
         uses: actions/upload-artifact@v7
         if: github.ref == 'refs/heads/main'
         with:
           name: code-conversion
-          path: ${{ steps.code-conversion-artifacts.outputs.dir }}
+          path: code-conversion/recipes/target/camunda-7-to-8-code-conversion-recipes-*.jar
+          if-no-files-found: error
           retention-days: 7
 
   diagram-converter:
+    needs: [detect-changes]
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    if: |
+      github.event_name != 'pull_request' ||
+      needs.detect-changes.outputs.diagram-converter == 'true' ||
+      needs.detect-changes.outputs.shared == 'true'
+    outputs:
+      maven-cache-hit: ${{ steps.setup-maven.outputs.maven-cache-hit }}
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -249,6 +316,7 @@ jobs:
             secret/data/products/cambpm/ci/nexus PASSWORD | NEXUS_APP_CAMUNDA_COM_PSW;
 
       - name: Setup Maven
+        id: setup-maven
         uses: ./.github/actions/setup-maven
         with:
           vault-address: ${{ secrets.VAULT_ADDR }}
@@ -259,33 +327,30 @@ jobs:
         working-directory: diagram-converter
         run: mvn verify -Pdistro,checkFormat --batch-mode
 
-      - name: Collect diagram-converter artifacts
-        id: diagram-converter-artifacts
-        if: github.ref == 'refs/heads/main'
-        run: |
-          ARTIFACT_DIR=$(mktemp -d)
-          cp diagram-converter/core/target/camunda-7-to-8-diagram-converter-core-*.jar "${ARTIFACT_DIR}/"
-          cp diagram-converter/webapp/target/camunda-7-to-8-diagram-converter-webapp-*.jar "${ARTIFACT_DIR}/"
-          cp diagram-converter/cli/target/camunda-7-to-8-diagram-converter-cli-*.jar "${ARTIFACT_DIR}/"
-          echo "dir=${ARTIFACT_DIR}" >> $GITHUB_OUTPUT
-
       - name: Upload diagram-converter artifacts
         uses: actions/upload-artifact@v7
         if: github.ref == 'refs/heads/main'
         with:
           name: diagram-converter
-          path: ${{ steps.diagram-converter-artifacts.outputs.dir }}
+          path: |
+            diagram-converter/core/target/camunda-7-to-8-diagram-converter-core-*.jar
+            diagram-converter/webapp/target/camunda-7-to-8-diagram-converter-webapp-*.jar
+            diagram-converter/cli/target/camunda-7-to-8-diagram-converter-cli-*.jar
+          if-no-files-found: error
           retention-days: 7
 
   # Compile-check all modules against the previous Camunda 8 version
   # to catch API-level incompatibilities before merge.
   compile-previous-version:
-    needs: [read-versions]
+    needs: [read-versions, detect-changes]
     runs-on: ubuntu-latest
     timeout-minutes: 30
     if: |
-      github.event_name == 'pull_request' ||
-      github.event_name == 'workflow_dispatch'
+      github.event_name == 'workflow_dispatch' ||
+      github.event_name != 'pull_request' ||
+      needs.detect-changes.outputs.run-compile-previous-version == 'true'
+    outputs:
+      maven-cache-hit: ${{ steps.setup-maven.outputs.maven-cache-hit }}
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -305,6 +370,7 @@ jobs:
             secret/data/products/cambpm/ci/nexus PASSWORD | NEXUS_APP_CAMUNDA_COM_PSW;
 
       - name: Setup Maven
+        id: setup-maven
         uses: ./.github/actions/setup-maven
         with:
           vault-address: ${{ secrets.VAULT_ADDR }}
@@ -337,17 +403,19 @@ jobs:
           - jobtype       # runtime.jobtype + runtime.tenant
           - variables     # runtime.variables
     if: |
-      (github.event_name == 'pull_request' &&
-       (
-         contains(github.event.pull_request.labels.*.name, 'ci:runtime') ||
-         (
-           needs.detect-changes.outputs.data-migrator == 'true' &&
-           !contains(github.event.pull_request.labels.*.name, 'ci:history') &&
-           !contains(github.event.pull_request.labels.*.name, 'ci:identity')
-         )
-       )
-      ) ||
-      github.event_name == 'workflow_dispatch'
+      github.event_name == 'workflow_dispatch' ||
+      github.event_name != 'pull_request' ||
+      (
+        github.event_name == 'pull_request' &&
+        (
+          contains(github.event.pull_request.labels.*.name, 'ci:runtime') ||
+          (
+            needs.detect-changes.outputs.run-runtime == 'true' &&
+            !contains(github.event.pull_request.labels.*.name, 'ci:history') &&
+            !contains(github.event.pull_request.labels.*.name, 'ci:identity')
+          )
+        )
+      )
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -367,6 +435,7 @@ jobs:
             secret/data/products/cambpm/ci/nexus PASSWORD | NEXUS_APP_CAMUNDA_COM_PSW;
 
       - name: Setup Maven
+        id: setup-maven
         uses: ./.github/actions/setup-maven
         with:
           vault-address: ${{ secrets.VAULT_ADDR }}
@@ -378,14 +447,22 @@ jobs:
         run: mvn verify -Pintegration,runtime-${{ matrix.shard }}
 
   it-history-h2:
+    needs: [detect-changes]
     runs-on: ubuntu-latest
     timeout-minutes: 70
+    outputs:
+      maven-cache-hit: ${{ steps.setup-maven.outputs.maven-cache-hit }}
     if: |
+      github.event_name == 'workflow_dispatch' ||
+      github.event_name != 'pull_request' ||
       (github.event_name == 'pull_request' && (
         contains(github.event.pull_request.labels.*.name, 'ci:history') ||
-        (!contains(github.event.pull_request.labels.*.name, 'ci:runtime') && !contains(github.event.pull_request.labels.*.name, 'ci:history') && !contains(github.event.pull_request.labels.*.name, 'ci:identity'))
-      )) ||
-      github.event_name == 'workflow_dispatch'
+        (
+          needs.detect-changes.outputs.run-history == 'true' &&
+          !contains(github.event.pull_request.labels.*.name, 'ci:runtime') &&
+          !contains(github.event.pull_request.labels.*.name, 'ci:identity')
+        )
+      ))
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -405,6 +482,7 @@ jobs:
             secret/data/products/cambpm/ci/nexus PASSWORD | NEXUS_APP_CAMUNDA_COM_PSW;
 
       - name: Setup Maven
+        id: setup-maven
         uses: ./.github/actions/setup-maven
         with:
           vault-address: ${{ secrets.VAULT_ADDR }}
@@ -417,12 +495,14 @@ jobs:
 
   # Determine which databases to test based on PR labels
   prepare-db-matrix:
+    needs: [detect-changes]
     runs-on: ubuntu-latest
     permissions:
       contents: read
     if: |
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'pull_request' && (
+        needs.detect-changes.outputs.run-db-default == 'true' ||
         contains(github.event.pull_request.labels.*.name, 'ci:db:postgresql') ||
         contains(github.event.pull_request.labels.*.name, 'ci:db:oracle') ||
         contains(github.event.pull_request.labels.*.name, 'ci:db:mysql') ||
@@ -455,6 +535,9 @@ jobs:
             fi
             if [[ "${{ contains(github.event.pull_request.labels.*.name, 'ci:db:sqlserver') }}" == "true" ]]; then
               databases+=("sqlserver")
+            fi
+            if [[ ${#databases[@]} -eq 0 ]] && [[ "${{ needs.detect-changes.outputs.run-db-default }}" == "true" ]]; then
+              databases+=("postgresql")
             fi
             json=$(printf '%s\n' "${databases[@]}" | jq -R . | jq -sc .)
             echo "databases=$json" >> "$GITHUB_OUTPUT"
@@ -541,15 +624,21 @@ jobs:
         run: mvn verify -P${{ matrix.database }},integration,history-only
 
   it-history-h2-windows:
+    needs: [detect-changes]
     runs-on: windows-latest
     timeout-minutes: 70
+    outputs:
+      maven-cache-hit: ${{ steps.setup-maven.outputs.maven-cache-hit }}
     if: |
-      github.event_name == 'push' ||
-      github.event_name == 'schedule' ||
       github.event_name == 'workflow_dispatch' ||
+      github.event_name != 'pull_request' ||
       (github.event_name == 'pull_request' && (
         contains(github.event.pull_request.labels.*.name, 'ci:history') ||
-        (!contains(github.event.pull_request.labels.*.name, 'ci:runtime') && !contains(github.event.pull_request.labels.*.name, 'ci:history') && !contains(github.event.pull_request.labels.*.name, 'ci:identity'))
+        (
+          needs.detect-changes.outputs.run-history == 'true' &&
+          !contains(github.event.pull_request.labels.*.name, 'ci:runtime') &&
+          !contains(github.event.pull_request.labels.*.name, 'ci:identity')
+        )
       ))
     steps:
       - name: Enable long paths for Git on Windows
@@ -574,26 +663,35 @@ jobs:
             secret/data/products/cambpm/ci/nexus PASSWORD | NEXUS_APP_CAMUNDA_COM_PSW;
 
       - name: Setup Maven
+        id: setup-maven
         uses: ./.github/actions/setup-maven
         with:
           vault-address: ${{ secrets.VAULT_ADDR }}
           vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
 
-      - name: Build and run history tests on Windows
+      - name: Build and run integration tests on Windows
         working-directory: data-migrator
         run: mvn clean install -P'windows,integration' --batch-mode
 
 
   it-identity-h2:
+    needs: [detect-changes]
     runs-on: ubuntu-latest
     timeout-minutes: 70
+    outputs:
+      maven-cache-hit: ${{ steps.setup-maven.outputs.maven-cache-hit }}
     if: |
+      github.event_name == 'workflow_dispatch' ||
+      github.event_name != 'pull_request' ||
       (github.event_name == 'pull_request' && (
         contains(github.event.pull_request.labels.*.name, 'ci:identity') ||
-        (!contains(github.event.pull_request.labels.*.name, 'ci:runtime') && !contains(github.event.pull_request.labels.*.name, 'ci:history') && !contains(github.event.pull_request.labels.*.name, 'ci:identity'))
-      )) ||
-      github.event_name == 'workflow_dispatch'
+        (
+          needs.detect-changes.outputs.run-identity == 'true' &&
+          !contains(github.event.pull_request.labels.*.name, 'ci:runtime') &&
+          !contains(github.event.pull_request.labels.*.name, 'ci:history')
+        )
+      ))
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -613,6 +711,7 @@ jobs:
             secret/data/products/cambpm/ci/nexus PASSWORD | NEXUS_APP_CAMUNDA_COM_PSW;
 
       - name: Setup Maven
+        id: setup-maven
         uses: ./.github/actions/setup-maven
         with:
           vault-address: ${{ secrets.VAULT_ADDR }}
@@ -664,10 +763,20 @@ jobs:
         run: mvn verify -P${{ matrix.database }},integration,identity-only
 
   e2e:
+    needs: [detect-changes]
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
       contents: read
+    outputs:
+      maven-cache-hit: ${{ steps.setup-maven.outputs.maven-cache-hit }}
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      github.event_name != 'pull_request' ||
+      (github.event_name == 'pull_request' && (
+        contains(github.event.pull_request.labels.*.name, 'ci:e2e') ||
+        needs.detect-changes.outputs.run-e2e == 'true'
+      ))
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -689,6 +798,7 @@ jobs:
             secret/data/products/cambpm/ci/harbor password | HARBOR_PASSWORD;
 
       - name: Setup Maven
+        id: setup-maven
         uses: ./.github/actions/setup-maven
         with:
           vault-address: ${{ secrets.VAULT_ADDR }}
@@ -702,7 +812,7 @@ jobs:
           username: ${{ steps.secrets.outputs.HARBOR_USERNAME }}
           password: ${{ steps.secrets.outputs.HARBOR_PASSWORD }}
 
-      - name: Run E2E tests via Maven
+      - name: Build and run E2E tests via Maven
         working-directory: data-migrator
         run: mvn clean install -Pe2e -Dmaven.test.skip --batch-mode
         env:
@@ -956,9 +1066,161 @@ jobs:
           -Dc8.api=${{ matrix.c8-api }}
           -Dcamunda.process-test.camunda-docker-image-version=${{ matrix.camunda-docker-image-version }}
 
+  ci-summary:
+    name: CI Summary Gate
+    needs:
+      - detect-changes
+      - distro
+      - code-conversion
+      - diagram-converter
+      - compile-previous-version
+      - it-runtime-h2
+      - it-history-h2
+      - it-history-h2-windows
+      - it-identity-h2
+      - e2e
+    if: always()
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+    env:
+      EXPECT_DISTRO: ${{ github.event_name != 'pull_request' || needs.detect-changes.outputs.data-migrator == 'true' || needs.detect-changes.outputs.shared == 'true' }}
+      EXPECT_CODE_CONVERSION: ${{ github.event_name != 'pull_request' || needs.detect-changes.outputs.code-conversion == 'true' || needs.detect-changes.outputs.shared == 'true' }}
+      EXPECT_DIAGRAM_CONVERTER: ${{ github.event_name != 'pull_request' || needs.detect-changes.outputs.diagram-converter == 'true' || needs.detect-changes.outputs.shared == 'true' }}
+      EXPECT_COMPILE_PREVIOUS: ${{ github.event_name != 'pull_request' || github.event_name == 'workflow_dispatch' || needs.detect-changes.outputs.run-compile-previous-version == 'true' }}
+      EXPECT_RUNTIME_H2: ${{ github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'ci:runtime') || (needs.detect-changes.outputs.run-runtime == 'true' && !contains(github.event.pull_request.labels.*.name, 'ci:history') && !contains(github.event.pull_request.labels.*.name, 'ci:identity')) }}
+      EXPECT_HISTORY_H2: ${{ github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'ci:history') || (needs.detect-changes.outputs.run-history == 'true' && !contains(github.event.pull_request.labels.*.name, 'ci:runtime') && !contains(github.event.pull_request.labels.*.name, 'ci:identity')) }}
+      EXPECT_HISTORY_H2_WINDOWS: ${{ github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'ci:history') || (needs.detect-changes.outputs.run-history == 'true' && !contains(github.event.pull_request.labels.*.name, 'ci:runtime') && !contains(github.event.pull_request.labels.*.name, 'ci:identity')) }}
+      EXPECT_IDENTITY_H2: ${{ github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'ci:identity') || (needs.detect-changes.outputs.run-identity == 'true' && !contains(github.event.pull_request.labels.*.name, 'ci:runtime') && !contains(github.event.pull_request.labels.*.name, 'ci:history')) }}
+      EXPECT_E2E: ${{ github.event_name != 'pull_request' || needs.detect-changes.outputs.run-e2e == 'true' || contains(github.event.pull_request.labels.*.name, 'ci:e2e') }}
+      CACHE_DISTRO: ${{ needs.distro.outputs.maven-cache-hit }}
+      CACHE_CODE_CONVERSION: ${{ needs.code-conversion.outputs.maven-cache-hit }}
+      CACHE_DIAGRAM_CONVERTER: ${{ needs.diagram-converter.outputs.maven-cache-hit }}
+      CACHE_COMPILE_PREVIOUS: ${{ needs.compile-previous-version.outputs.maven-cache-hit }}
+      CACHE_HISTORY_H2: ${{ needs.it-history-h2.outputs.maven-cache-hit }}
+      CACHE_HISTORY_H2_WINDOWS: ${{ needs.it-history-h2-windows.outputs.maven-cache-hit }}
+      CACHE_IDENTITY_H2: ${{ needs.it-identity-h2.outputs.maven-cache-hit }}
+      CACHE_E2E: ${{ needs.e2e.outputs.maven-cache-hit }}
+    steps:
+      - name: Evaluate blocking checks and publish CI budget metrics
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const parseBool = (value) => `${value}`.toLowerCase() === "true";
+            const needsResults = ${{ toJSON(needs) }};
+
+            const requiredChecks = [
+              { key: "distro", label: "distro", expected: parseBool(process.env.EXPECT_DISTRO) },
+              { key: "code-conversion", label: "code-conversion", expected: parseBool(process.env.EXPECT_CODE_CONVERSION) },
+              { key: "diagram-converter", label: "diagram-converter", expected: parseBool(process.env.EXPECT_DIAGRAM_CONVERTER) },
+              { key: "compile-previous-version", label: "compile-previous-version", expected: parseBool(process.env.EXPECT_COMPILE_PREVIOUS) },
+              { key: "it-runtime-h2", label: "it-runtime-h2", expected: parseBool(process.env.EXPECT_RUNTIME_H2) },
+              { key: "it-history-h2", label: "it-history-h2", expected: parseBool(process.env.EXPECT_HISTORY_H2) },
+              { key: "it-history-h2-windows", label: "it-history-h2-windows", expected: parseBool(process.env.EXPECT_HISTORY_H2_WINDOWS) },
+              { key: "it-identity-h2", label: "it-identity-h2", expected: parseBool(process.env.EXPECT_IDENTITY_H2) },
+              { key: "e2e", label: "e2e", expected: parseBool(process.env.EXPECT_E2E) },
+            ];
+
+            const failing = [];
+            const rows = [];
+            for (const check of requiredChecks) {
+              const result = needsResults[check.key]?.result || "missing";
+              rows.push({
+                check: check.label,
+                expected: check.expected ? "yes" : "no",
+                result,
+              });
+              if (!check.expected) {
+                continue;
+              }
+              if (result === "skipped") {
+                failing.push(`${check.label} was expected to run but was skipped`);
+              } else if (result !== "success") {
+                failing.push(`${check.label} finished with '${result}'`);
+              }
+            }
+
+            const durationMinutes = (start, end) => (new Date(end) - new Date(start)) / 60000;
+            const percentile = (values, q) => {
+              if (!values.length) return null;
+              const sorted = [...values].sort((a, b) => a - b);
+              const idx = Math.ceil(q * sorted.length) - 1;
+              return sorted[Math.max(0, Math.min(sorted.length - 1, idx))];
+            };
+            const median = (values) => percentile(values, 0.5);
+
+            const runs = await github.paginate(github.rest.actions.listWorkflowRuns, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: "ci.yml",
+              event: "pull_request",
+              status: "completed",
+              per_page: 100,
+            });
+
+            const completedRuns = runs.slice(0, 30).filter((run) => run.created_at && run.updated_at);
+            const feedbackDurations = completedRuns.map((run) => durationMinutes(run.created_at, run.updated_at));
+
+            const run = await github.rest.actions.getWorkflowRun({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: context.runId,
+            });
+            const runStartedAt = run.data.run_started_at || run.data.created_at;
+
+            const jobsForCurrentRun = await github.paginate(github.rest.actions.listJobsForWorkflowRun, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: context.runId,
+              per_page: 100,
+            });
+            const firstRedCandidates = jobsForCurrentRun
+              .filter((job) => ["failure", "cancelled", "timed_out", "action_required"].includes(job.conclusion))
+              .map((job) => job.completed_at)
+              .filter(Boolean);
+
+            let firstRedMinutes = null;
+            if (firstRedCandidates.length > 0 && runStartedAt) {
+              const firstRedAt = firstRedCandidates.sort()[0];
+              firstRedMinutes = durationMinutes(runStartedAt, firstRedAt);
+            }
+
+            const cacheValues = [
+              process.env.CACHE_DISTRO,
+              process.env.CACHE_CODE_CONVERSION,
+              process.env.CACHE_DIAGRAM_CONVERTER,
+              process.env.CACHE_COMPILE_PREVIOUS,
+              process.env.CACHE_HISTORY_H2,
+              process.env.CACHE_HISTORY_H2_WINDOWS,
+              process.env.CACHE_IDENTITY_H2,
+              process.env.CACHE_E2E,
+            ].filter((value) => value === "true" || value === "false");
+            const cacheHits = cacheValues.filter((value) => value === "true").length;
+            const cacheHitRate = cacheValues.length === 0 ? null : (cacheHits / cacheValues.length) * 100;
+
+            await core.summary
+              .addHeading("CI summary gate")
+              .addRaw("Blocking checks are validated here. Broad compatibility jobs stay asynchronous.\n\n")
+              .addTable([
+                [{ data: "Check", header: true }, { data: "Expected", header: true }, { data: "Result", header: true }],
+                ...rows.map((row) => [row.check, row.expected, row.result]),
+              ])
+              .addHeading("Feedback budgets", 2)
+              .addRaw(`- PR feedback median (last ${feedbackDurations.length} runs): ${median(feedbackDurations)?.toFixed(1) ?? "n/a"} min\n`)
+              .addRaw(`- PR feedback p95 (last ${feedbackDurations.length} runs): ${percentile(feedbackDurations, 0.95)?.toFixed(1) ?? "n/a"} min\n`)
+              .addRaw(`- First red in this run: ${firstRedMinutes?.toFixed(1) ?? "n/a"} min\n`)
+              .addRaw(`- Maven cache hit rate (blocking jobs): ${cacheHitRate?.toFixed(1) ?? "n/a"}%\n`)
+              .write();
+
+            if (failing.length > 0) {
+              core.setFailed(`CI summary gate failed:\n- ${failing.join("\n- ")}`);
+            }
+
   # Rerun failed jobs running on self-hosted runners in case of network issues or node preemption
   rerun-failed-jobs:
     needs:
+      - ci-summary
       - distro
       - code-conversion
       - diagram-converter

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,13 +123,13 @@ jobs:
             echo "diagram-converter=false" >> "$GITHUB_OUTPUT"
           fi
 
-          if echo "$CHANGED_FILES" | grep -qE '^(\.github/|pom\.xml$)'; then
+          if echo "$CHANGED_FILES" | grep -qE '^(\.github/|\.mvn/|mvnw$|mvnw\.cmd$|pom\.xml$)'; then
             echo "shared=true" >> "$GITHUB_OUTPUT"
           else
             echo "shared=false" >> "$GITHUB_OUTPUT"
           fi
 
-          if echo "$CHANGED_FILES" | grep -qE '^(data-migrator/|\.github/|pom\.xml$)'; then
+          if echo "$CHANGED_FILES" | grep -qE '^(data-migrator/|\.github/|\.mvn/|mvnw$|mvnw\.cmd$|pom\.xml$)'; then
             echo "run-runtime=true" >> "$GITHUB_OUTPUT"
             echo "run-history=true" >> "$GITHUB_OUTPUT"
             echo "run-identity=true" >> "$GITHUB_OUTPUT"
@@ -143,7 +143,7 @@ jobs:
             echo "run-db-default=false" >> "$GITHUB_OUTPUT"
           fi
 
-          if echo "$CHANGED_FILES" | grep -qE '^(data-migrator/|code-conversion/|diagram-converter/|\.github/|pom\.xml$)'; then
+          if echo "$CHANGED_FILES" | grep -qE '^(data-migrator/|code-conversion/|diagram-converter/|\.github/|\.mvn/|mvnw$|mvnw\.cmd$|pom\.xml$)'; then
             echo "run-compile-previous-version=true" >> "$GITHUB_OUTPUT"
           else
             echo "run-compile-previous-version=false" >> "$GITHUB_OUTPUT"
@@ -1220,7 +1220,6 @@ jobs:
   # Rerun failed jobs running on self-hosted runners in case of network issues or node preemption
   rerun-failed-jobs:
     needs:
-      - ci-summary
       - distro
       - code-conversion
       - diagram-converter

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -185,6 +185,11 @@ Examples (with the `related to #<issue-number>` body line shown inline for brevi
 
 GitHub Actions CI (`.github/workflows/ci.yml`) runs on push to `main`/`maintenance/*`, PRs, and nightly (weekdays 5 AM).
 
+### Merge-blocking vs asynchronous checks
+
+- **Merge-blocking:** `CI Summary Gate` (`ci-summary`) is the single required check for PR merges. It validates that expected high-yield jobs ran and succeeded, and publishes CI feedback metrics.
+- **Asynchronous/non-blocking:** broad compatibility coverage (previous-version and large matrix jobs) runs on schedule/main or explicit PR label escalation and is monitored separately from the merge gate.
+
 ### Jobs per module
 
 | Module | CI Job | What it does |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -187,8 +187,8 @@ GitHub Actions CI (`.github/workflows/ci.yml`) runs on push to `main`/`maintenan
 
 ### Merge-blocking vs asynchronous checks
 
-- **Merge-blocking:** `CI Summary Gate` (`ci-summary`) is the single required check for PR merges. It validates that expected high-yield jobs ran and succeeded, and publishes CI feedback metrics.
-- **Asynchronous/non-blocking:** broad compatibility coverage (previous-version and large matrix jobs) runs on schedule/main or explicit PR label escalation and is monitored separately from the merge gate.
+- **Merge-blocking:** `CI Summary Gate` (`ci-summary`) is the single required check for PR merges. It validates that expected high-yield jobs ran and succeeded, and publishes CI feedback metrics. `compile-previous-version` is part of this blocking surface when in scope.
+- **Asynchronous/non-blocking:** broad compatibility coverage (`code-conversion-previous-version`, `diagram-converter-previous-version`, `e2e-previous-version`, and `it-database-camunda-matrix`) runs on schedule/main or explicit PR label escalation and is monitored separately from the merge gate.
 
 ### Jobs per module
 


### PR DESCRIPTION
## Summary

- add derived, path-based CI scope detection for all major modules so unrelated PRs skip expensive jobs
- add a single `CI Summary Gate` job that validates expected blocking checks and fails on unexpected skips
- publish CI feedback metrics (median/p95 PR duration, first-red timing) and blocking-job Maven cache hit rate in the run summary
- make artifact upload and step naming more accurate and document blocking vs asynchronous checks

## Changes

- `.github/workflows/ci.yml`
  - expanded `detect-changes` outputs (module and derived scope signals)
  - applied module-aware `if` conditions to distro/code-conversion/diagram-converter/compile/runtime-history-identity/e2e jobs
  - switched PR DB coverage from label-only to derived defaults + explicit label escalation
  - introduced `ci-summary` as the single merge-blocking gate and metrics publisher
  - replaced temporary artifact copy steps with direct artifact glob uploads
  - corrected misleading step labels about test execution
- `.github/actions/setup-maven/action.yml`
  - exposed `maven-cache-hit` output based on `actions/setup-java` cache result
- `AGENTS.md`
  - documented merge-blocking (`CI Summary Gate`) vs asynchronous compatibility checks

## Test plan

- [x] `docker run --rm -v /Users/peter.bojtos/projects/camunda-7-to-8-migration-tooling/.claude/worktrees/budget-ci-feedback:/repo -w /repo rhysd/actionlint:latest -ignore 'shellcheck reported issue in this script' .github/workflows/ci.yml`
- [x] `gh workflow view ci.yml --repo camunda/camunda-7-to-8-migration-tooling`
- [x] verify workflow logic keeps broad compatibility jobs outside the blocking gate while failing the gate if expected blocking checks are skipped unexpectedly

## Baseline

Built from commit: a7da8db88fb5b1c9fad5e778c5c37403cc6a16e9

closes #1877

🤖 Generated with [Claude Code](https://claude.com/claude-code)
