### PR TITLE
feat(ci): avoid duplicate CI on backport branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,8 @@ on:
   push:
     branches:
       - main
-      - maintenance/*
+      - maintenance/0.3
+      - maintenance/0.2
   pull_request:
     types: [opened, synchronize, reopened, labeled, unlabeled]
   workflow_dispatch:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,8 @@ on:
   push:
     branches:
       - main
-      - maintenance/0.3
-      - maintenance/0.2
+      - maintenance/*
+      - "!maintenance/*-backport-*"
   pull_request:
     types: [opened, synchronize, reopened, labeled, unlabeled]
   workflow_dispatch:


### PR DESCRIPTION
What changed:
- updated CI push trigger branch filters in .github/workflows/ci.yml
- kept push CI for main and maintenance/*
- excluded maintenance/*-backport-* branches from push-triggered CI

Why:
Backport PRs were getting duplicate CI runs (push + pull_request) with different/skipped job sets in the checks UI. Excluding backport branches from push keeps one authoritative PR run while preserving push CI on long-lived branches.

related to #1895
related to #1894
