### PR TITLE
fix(runtime): harden distribution process teardown (maintenance/0.3)

### DIFF
--- a/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/distribution/DistributionSmokeTest.java
+++ b/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/distribution/DistributionSmokeTest.java
@@ -623,9 +623,19 @@ public class DistributionSmokeTest {
       }
       waitForDescendantsToExit(descendants, 5, TimeUnit.SECONDS);
     } catch (final InterruptedException e) {
-      Thread.currentThread().interrupt();
       descendants.forEach(ProcessHandle::destroyForcibly);
       proc.destroyForcibly();
+      // Best-effort wait for descendants before restoring the interrupt flag so that
+      // file locks are released before @TempDir cleanup. The interrupt flag is clear
+      // here, so onExit().get() can block normally.
+      for (final ProcessHandle child : descendants) {
+        try {
+          child.onExit().get(1, TimeUnit.SECONDS);
+        } catch (ExecutionException | TimeoutException | InterruptedException ignored) {
+          // best effort
+        }
+      }
+      Thread.currentThread().interrupt();
     }
   }
 

--- a/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/distribution/DistributionSmokeTest.java
+++ b/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/distribution/DistributionSmokeTest.java
@@ -18,6 +18,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
@@ -610,16 +611,33 @@ public class DistributionSmokeTest {
     if (proc == null) {
       return;
     }
-    proc.descendants().forEach(ProcessHandle::destroyForcibly);
+    final List<ProcessHandle> descendants = proc.descendants().toList();
+    descendants.forEach(ProcessHandle::destroyForcibly);
     proc.destroy();
     try {
       if (!proc.waitFor(5, TimeUnit.SECONDS)) {
         proc.destroyForcibly();
         proc.waitFor(5, TimeUnit.SECONDS);
       }
+      waitForDescendantsToExit(descendants, 5, TimeUnit.SECONDS);
     } catch (final InterruptedException e) {
       Thread.currentThread().interrupt();
+      descendants.forEach(ProcessHandle::destroyForcibly);
       proc.destroyForcibly();
+    }
+  }
+
+  protected void waitForDescendantsToExit(
+      final List<ProcessHandle> descendants, final long timeout, final TimeUnit unit)
+      throws InterruptedException {
+    final long deadlineNanos = System.nanoTime() + unit.toNanos(timeout);
+    for (final ProcessHandle child : descendants) {
+      while (child.isAlive() && System.nanoTime() < deadlineNanos) {
+        Thread.sleep(50);
+      }
+      if (child.isAlive()) {
+        child.destroyForcibly();
+      }
     }
   }
 }

--- a/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/distribution/DistributionSmokeTest.java
+++ b/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/distribution/DistributionSmokeTest.java
@@ -19,7 +19,9 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.util.List;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 import org.junit.jupiter.api.AfterEach;
@@ -637,6 +639,11 @@ public class DistributionSmokeTest {
       }
       if (child.isAlive()) {
         child.destroyForcibly();
+        try {
+          child.onExit().get(1, TimeUnit.SECONDS);
+        } catch (ExecutionException | TimeoutException ignored) {
+          // best effort: process termination was already requested
+        }
       }
     }
   }

--- a/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/distribution/DistributionSmokeTest.java
+++ b/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/distribution/DistributionSmokeTest.java
@@ -639,8 +639,11 @@ public class DistributionSmokeTest {
       }
       if (child.isAlive()) {
         child.destroyForcibly();
+        final long remainingNanos = deadlineNanos - System.nanoTime();
         try {
-          child.onExit().get(1, TimeUnit.SECONDS);
+          if (remainingNanos > 0) {
+            child.onExit().get(remainingNanos, TimeUnit.NANOSECONDS);
+          }
         } catch (ExecutionException | TimeoutException ignored) {
           // best effort: process termination was already requested
         }


### PR DESCRIPTION
related to #1895

Fixes the Windows CI failure in DistributionSmokeTest where JUnit cannot delete @TempDir because child JVMs from start.bat still hold locks on extracted JARs.

- snapshot and forcibly terminate descendant processes
- wait for descendants to exit before teardown returns
- keep forcible fallback on interruption