### PR TITLE
fix(core): disable testcontainers Ryuk reaper to prevent image-pull f…

### DIFF
--- a/data-migrator/qa/integration-tests/src/test/resources/testcontainers.properties
+++ b/data-migrator/qa/integration-tests/src/test/resources/testcontainers.properties
@@ -1,0 +1,13 @@
+# Disable the Ryuk resource reaper.
+#
+# Testcontainers uses Ryuk to clean up containers after the JVM exits. On certain CI
+# runners the Ryuk image (testcontainers/ryuk:<version>) cannot be pulled from Docker Hub,
+# which causes a ContainerFetchException during MultiDbExtension initialisation and fails
+# every integration test that depends on it.
+#
+# Ryuk is disabled to avoid CI failures when the ryuk image cannot be pulled.
+# Note: this file is on the integration-tests classpath, so it also affects local runs.
+# Some containers (e.g. PostgreSQL/Oracle) are configured with withReuse(true) and may remain
+# running depending on the Testcontainers reuse setting; developers may need manual cleanup.
+# CI runners are ephemeral, so any leftovers are removed when the runner VM is torn down.
+ryuk.disabled=true


### PR DESCRIPTION
…ailures in CI (#1924)

* fix(core): disable testcontainers Ryuk reaper to prevent image-pull failures in CI

Add testcontainers.properties to the integration-tests module to disable the Ryuk resource reaper (ryuk.disabled=true).

Root cause: in the `it-database-camunda-matrix (oracle, 8.9.0, history-only)` CI job, testcontainers 2.0.5 attempts to pull testcontainers/ryuk:0.14.0 from Docker Hub. The pull fails on that specific ubuntu-latest runner (network/cache issue), which causes a ContainerFetchException → ExceptionInInitializerError in MultiDbExtension.<clinit> → NoClassDefFoundError in every subsequent test that references MultiDbExtension.

Why Ryuk is safe to disable here:
- All database containers already use withReuse(true), so they are intentionally kept alive and are not expected to be automatically cleaned up by Ryuk.
- CI runners are ephemeral (ubuntu-latest); the Docker daemon is terminated with the job, so there is no container leak risk.

related to #1838

* Potential fix for pull request finding

# Pull Request Template

## Description
<!-- Describe your changes in detail -->

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Test-only changes (no production code changes)

## Testing Checklist

### Black-Box Testing Requirements
- [ ] Tests follow **black-box testing approach**: verify behavior through observable outputs (logs, C8 API queries, real-world skip scenarios)
- [ ] Tests **DO NOT** access implementation details (`DbClient`, `IdKeyMapper`, `..impl..` packages except logging constants)
- [ ] Architecture tests pass (`ArchitectureTest` validates these rules)

### Test Coverage
- [ ] Added tests for new functionality
- [ ] Updated tests for modified functionality
- [ ] All tests pass locally

## Architecture Compliance

Run architecture tests to ensure compliance:
```bash
mvn install -DskipTests -pl data-migrator/distro -am && \
  mvn test -Pintegration -pl data-migrator/qa/integration-tests -Dtest=ArchitectureTest
```

If architecture tests fail, refactor your tests to use:
- `LogCapturer` for log assertions
- `camundaClient.new*SearchRequest()` for C8 queries
- Real-World skip scenarios (e.g., migrate children without parents)

## Documentation
- [ ] Updated TESTING_GUIDELINES.md if adding new test patterns
- [ ] Added Javadoc comments for public APIs
- [ ] Updated README if user-facing changes

## Checklist
- [ ] Code follows project style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments for complex logic
- [ ] No new compiler warnings
- [ ] Dependent changes have been merged

## Related Issues
<!-- Link to related issues: Fixes #123, Related to #456 -->
