### PR TITLE
fix(e2e): expose flaky-green outcomes in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -773,6 +773,9 @@ jobs:
       contents: read
     outputs:
       maven-cache-hit: ${{ steps.setup-maven.outputs.maven-cache-hit }}
+      e2e-first-pass-rate: ${{ steps.analyze-e2e-retries.outputs.first-pass-rate }}
+      e2e-retried-green-count: ${{ steps.analyze-e2e-retries.outputs.retried-green-count }}
+      e2e-first-attempt-failure-count: ${{ steps.analyze-e2e-retries.outputs.first-attempt-failure-count }}
     if: |
       github.event_name == 'workflow_dispatch' ||
       github.event_name != 'pull_request' ||
@@ -820,6 +823,15 @@ jobs:
         run: mvn clean install -Pe2e -Dmaven.test.skip --batch-mode
         env:
           CI: true
+
+      - name: Analyze Playwright first-pass reliability
+        id: analyze-e2e-retries
+        if: always()
+        working-directory: data-migrator/qa/e2e-tests
+        run: node scripts/analyze-playwright-results.mjs
+        env:
+          PLAYWRIGHT_RESULTS_PATH: test-results/playwright-report.json
+          FAIL_ON_RETRIED_GREEN: true
 
       - name: Upload test results
         uses: actions/upload-artifact@v7
@@ -1106,12 +1118,19 @@ jobs:
       CACHE_HISTORY_H2_WINDOWS: ${{ needs.it-history-h2-windows.outputs.maven-cache-hit }}
       CACHE_IDENTITY_H2: ${{ needs.it-identity-h2.outputs.maven-cache-hit }}
       CACHE_E2E: ${{ needs.e2e.outputs.maven-cache-hit }}
+      E2E_FIRST_PASS_RATE: ${{ needs.e2e.outputs.e2e-first-pass-rate }}
+      E2E_RETRIED_GREEN_COUNT: ${{ needs.e2e.outputs.e2e-retried-green-count }}
+      E2E_FIRST_ATTEMPT_FAILURE_COUNT: ${{ needs.e2e.outputs.e2e-first-attempt-failure-count }}
     steps:
       - name: Evaluate blocking checks and publish CI budget metrics
         uses: actions/github-script@v9
         with:
           script: |
             const parseBool = (value) => `${value}`.toLowerCase() === "true";
+            const parseNumber = (value) => {
+              const parsed = Number(value);
+              return Number.isFinite(parsed) ? parsed : null;
+            };
             const needsResults = ${{ toJSON(needs) }};
 
             const requiredChecks = [
@@ -1204,6 +1223,13 @@ jobs:
             ].filter((value) => value === "true" || value === "false");
             const cacheHits = cacheValues.filter((value) => value === "true").length;
             const cacheHitRate = cacheValues.length === 0 ? null : (cacheHits / cacheValues.length) * 100;
+            const e2eFirstPassRate = parseNumber(process.env.E2E_FIRST_PASS_RATE);
+            const e2eRetriedGreenCount = parseNumber(process.env.E2E_RETRIED_GREEN_COUNT);
+            const e2eFirstAttemptFailureCount = parseNumber(process.env.E2E_FIRST_ATTEMPT_FAILURE_COUNT);
+
+            if (parseBool(process.env.EXPECT_E2E) && e2eRetriedGreenCount !== null && e2eRetriedGreenCount > 0) {
+              failing.push(`e2e reported ${e2eRetriedGreenCount} retried-green test(s)`);
+            }
 
             await core.summary
               .addHeading("CI summary gate")
@@ -1217,6 +1243,10 @@ jobs:
               .addRaw(`- PR feedback p95 (last ${feedbackDurations.length} runs): ${percentile(feedbackDurations, 0.95)?.toFixed(1) ?? "n/a"} min\n`)
               .addRaw(`- First red in this run: ${firstRedMinutes?.toFixed(1) ?? "n/a"} min\n`)
               .addRaw(`- Maven cache hit rate (blocking jobs): ${cacheHitRate?.toFixed(1) ?? "n/a"}%\n`)
+              .addHeading("E2E first-pass reliability", 2)
+              .addRaw(`- First-pass rate: ${e2eFirstPassRate?.toFixed(2) ?? "n/a"}%\n`)
+              .addRaw(`- First-attempt failures: ${e2eFirstAttemptFailureCount ?? "n/a"}\n`)
+              .addRaw(`- Retried-green tests: ${e2eRetriedGreenCount ?? "n/a"}\n`)
               .write();
 
             if (failing.length > 0) {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -773,9 +773,9 @@ jobs:
       contents: read
     outputs:
       maven-cache-hit: ${{ steps.setup-maven.outputs.maven-cache-hit }}
-      e2e-first-pass-rate: ${{ steps.analyze-e2e-retries.outputs.first-pass-rate }}
-      e2e-retried-green-count: ${{ steps.analyze-e2e-retries.outputs.retried-green-count }}
-      e2e-first-attempt-failure-count: ${{ steps.analyze-e2e-retries.outputs.first-attempt-failure-count }}
+      e2e_first_pass_rate: ${{ steps.analyze-e2e-retries.outputs.first_pass_rate }}
+      e2e_retried_green_count: ${{ steps.analyze-e2e-retries.outputs.retried_green_count }}
+      e2e_first_attempt_failure_count: ${{ steps.analyze-e2e-retries.outputs.first_attempt_failure_count }}
     if: |
       github.event_name == 'workflow_dispatch' ||
       github.event_name != 'pull_request' ||
@@ -1118,9 +1118,9 @@ jobs:
       CACHE_HISTORY_H2_WINDOWS: ${{ needs.it-history-h2-windows.outputs.maven-cache-hit }}
       CACHE_IDENTITY_H2: ${{ needs.it-identity-h2.outputs.maven-cache-hit }}
       CACHE_E2E: ${{ needs.e2e.outputs.maven-cache-hit }}
-      E2E_FIRST_PASS_RATE: ${{ needs.e2e.outputs.e2e-first-pass-rate }}
-      E2E_RETRIED_GREEN_COUNT: ${{ needs.e2e.outputs.e2e-retried-green-count }}
-      E2E_FIRST_ATTEMPT_FAILURE_COUNT: ${{ needs.e2e.outputs.e2e-first-attempt-failure-count }}
+      E2E_FIRST_PASS_RATE: ${{ needs.e2e.outputs.e2e_first_pass_rate }}
+      E2E_RETRIED_GREEN_COUNT: ${{ needs.e2e.outputs.e2e_retried_green_count }}
+      E2E_FIRST_ATTEMPT_FAILURE_COUNT: ${{ needs.e2e.outputs.e2e_first_attempt_failure_count }}
     steps:
       - name: Evaluate blocking checks and publish CI budget metrics
         uses: actions/github-script@v9
@@ -1128,6 +1128,7 @@ jobs:
           script: |
             const parseBool = (value) => `${value}`.toLowerCase() === "true";
             const parseNumber = (value) => {
+              if (value === '' || value === null || value === undefined) return null;
               const parsed = Number(value);
               return Number.isFinite(parsed) ? parsed : null;
             };

--- a/data-migrator/qa/e2e-tests/playwright.config.ts
+++ b/data-migrator/qa/e2e-tests/playwright.config.ts
@@ -12,17 +12,27 @@ export default defineConfig({
   forbidOnly: !!process.env.CI,
   /* Retry on CI only */
   retries: process.env.CI ? 2 : 0,
+  /* Retries that eventually pass are still defects and should fail CI */
+  failOnFlakyTests: !!process.env.CI,
   /* Opt out of parallel tests on CI. */
   workers: 1,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-  reporter: process.env.CI ? [['html'], ['github'], ['list']] : 'html',
+  reporter: process.env.CI
+    ? [
+        ['html'],
+        ['github'],
+        ['list'],
+        ['json', { outputFile: 'test-results/playwright-report.json' }],
+      ]
+    : 'html',
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */
     baseURL: 'http://localhost:8090',
-    /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
-    trace: 'on-first-retry',
+    /* Collect traces for every retry attempt to preserve flaky diagnostics */
+    trace: 'on-all-retries',
     screenshot: 'only-on-failure',
+    video: 'retain-on-failure',
   },
 
   /* Configure projects for major browsers */

--- a/data-migrator/qa/e2e-tests/scripts/analyze-playwright-results.mjs
+++ b/data-migrator/qa/e2e-tests/scripts/analyze-playwright-results.mjs
@@ -1,0 +1,150 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const scriptFilePath = fileURLToPath(import.meta.url);
+const scriptDirectory = path.dirname(scriptFilePath);
+const projectRoot = path.resolve(scriptDirectory, '..');
+
+const resultsPath = path.resolve(
+  projectRoot,
+  process.env.PLAYWRIGHT_RESULTS_PATH ?? 'test-results/playwright-report.json',
+);
+const failOnRetriedGreen = `${process.env.FAIL_ON_RETRIED_GREEN ?? 'true'}`.toLowerCase() === 'true';
+
+const appendOutput = (key, value) => {
+  if (!process.env.GITHUB_OUTPUT) {
+    return;
+  }
+  fs.appendFileSync(process.env.GITHUB_OUTPUT, `${key}=${value}\n`);
+};
+
+const appendSummary = (line) => {
+  if (process.env.GITHUB_STEP_SUMMARY) {
+    fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, `${line}\n`);
+    return;
+  }
+  console.log(line);
+};
+
+const writeDefaultOutputs = () => {
+  appendOutput('total-tests', 0);
+  appendOutput('first-pass-count', 0);
+  appendOutput('first-attempt-failure-count', 0);
+  appendOutput('retried-green-count', 0);
+  appendOutput('failed-after-retry-count', 0);
+  appendOutput('first-pass-rate', '0.00');
+};
+
+if (!fs.existsSync(resultsPath)) {
+  appendSummary('### Playwright first-pass reliability');
+  appendSummary(`No JSON report found at \`${resultsPath}\`.`);
+  writeDefaultOutputs();
+  process.exit(0);
+}
+
+const report = JSON.parse(fs.readFileSync(resultsPath, 'utf8'));
+const tests = [];
+
+const collectFromSuite = (suite, parents = []) => {
+  const suiteTitle = suite.title?.trim();
+  const nextParents = suiteTitle ? [...parents, suiteTitle] : parents;
+
+  for (const spec of suite.specs ?? []) {
+    const specTitle = spec.title?.trim() ?? '';
+    const titleParts = [...nextParents, specTitle].filter(Boolean);
+    const location = spec.file
+      ? `${spec.file}${spec.line ? `:${spec.line}` : ''}`
+      : titleParts.join(' › ');
+    for (const testCase of spec.tests ?? []) {
+      tests.push({
+        title: titleParts.join(' › '),
+        location,
+        results: testCase.results ?? [],
+      });
+    }
+  }
+
+  for (const child of suite.suites ?? []) {
+    collectFromSuite(child, nextParents);
+  }
+};
+
+for (const suite of report.suites ?? []) {
+  collectFromSuite(suite, []);
+}
+
+let firstPassCount = 0;
+let firstAttemptFailureCount = 0;
+let retriedGreenCount = 0;
+let failedAfterRetryCount = 0;
+const retriedGreenDiagnostics = [];
+
+for (const testCase of tests) {
+  const attemptStatuses = testCase.results
+    .map((result) => result.status)
+    .filter(Boolean);
+
+  if (attemptStatuses.length === 0) {
+    continue;
+  }
+
+  const firstStatus = attemptStatuses[0];
+  const finalStatus = attemptStatuses[attemptStatuses.length - 1];
+  const hasRetry = attemptStatuses.length > 1;
+  const firstAttemptPassed = firstStatus === 'passed';
+  const retriedGreen = !firstAttemptPassed && hasRetry && finalStatus === 'passed';
+  const failedAfterRetry =
+    !firstAttemptPassed && finalStatus !== 'passed' && finalStatus !== 'skipped';
+
+  if (firstAttemptPassed) {
+    firstPassCount += 1;
+  } else {
+    firstAttemptFailureCount += 1;
+  }
+
+  if (retriedGreen) {
+    retriedGreenCount += 1;
+    retriedGreenDiagnostics.push(
+      `${testCase.location} — ${testCase.title} (${attemptStatuses.join(' -> ')})`,
+    );
+  }
+
+  if (failedAfterRetry) {
+    failedAfterRetryCount += 1;
+  }
+}
+
+const totalTests = firstPassCount + firstAttemptFailureCount;
+const firstPassRate =
+  totalTests === 0 ? 0 : (firstPassCount / totalTests) * 100;
+
+appendSummary('### Playwright first-pass reliability');
+appendSummary(`- Total tests: ${totalTests}`);
+appendSummary(`- First-pass green: ${firstPassCount}`);
+appendSummary(`- First-attempt failures: ${firstAttemptFailureCount}`);
+appendSummary(`- Retried-green tests: ${retriedGreenCount}`);
+appendSummary(`- Failed after retries: ${failedAfterRetryCount}`);
+appendSummary(`- First-pass rate: ${firstPassRate.toFixed(2)}%`);
+
+if (retriedGreenDiagnostics.length > 0) {
+  appendSummary('');
+  appendSummary('#### Retried-green diagnostics');
+  for (const diagnostic of retriedGreenDiagnostics) {
+    appendSummary(`- ${diagnostic}`);
+  }
+}
+
+appendOutput('total-tests', totalTests);
+appendOutput('first-pass-count', firstPassCount);
+appendOutput('first-attempt-failure-count', firstAttemptFailureCount);
+appendOutput('retried-green-count', retriedGreenCount);
+appendOutput('failed-after-retry-count', failedAfterRetryCount);
+appendOutput('first-pass-rate', firstPassRate.toFixed(2));
+
+if (failOnRetriedGreen && retriedGreenCount > 0) {
+  console.error(
+    `Found ${retriedGreenCount} retried-green test(s). Flaky-green outcomes fail CI by policy.`,
+  );
+  process.exit(1);
+}

--- a/data-migrator/qa/e2e-tests/scripts/analyze-playwright-results.mjs
+++ b/data-migrator/qa/e2e-tests/scripts/analyze-playwright-results.mjs
@@ -28,12 +28,12 @@ const appendSummary = (line) => {
 };
 
 const writeDefaultOutputs = () => {
-  appendOutput('total_tests', 0);
-  appendOutput('first_pass_count', 0);
-  appendOutput('first_attempt_failure_count', 0);
-  appendOutput('retried_green_count', 0);
-  appendOutput('failed_after_retry_count', 0);
-  appendOutput('first_pass_rate', '0.00');
+  appendOutput('total_tests', '');
+  appendOutput('first_pass_count', '');
+  appendOutput('first_attempt_failure_count', '');
+  appendOutput('retried_green_count', '');
+  appendOutput('failed_after_retry_count', '');
+  appendOutput('first_pass_rate', '');
 };
 
 if (!fs.existsSync(resultsPath)) {

--- a/data-migrator/qa/e2e-tests/scripts/analyze-playwright-results.mjs
+++ b/data-migrator/qa/e2e-tests/scripts/analyze-playwright-results.mjs
@@ -28,18 +28,24 @@ const appendSummary = (line) => {
 };
 
 const writeDefaultOutputs = () => {
-  appendOutput('total-tests', 0);
-  appendOutput('first-pass-count', 0);
-  appendOutput('first-attempt-failure-count', 0);
-  appendOutput('retried-green-count', 0);
-  appendOutput('failed-after-retry-count', 0);
-  appendOutput('first-pass-rate', '0.00');
+  appendOutput('total_tests', 0);
+  appendOutput('first_pass_count', 0);
+  appendOutput('first_attempt_failure_count', 0);
+  appendOutput('retried_green_count', 0);
+  appendOutput('failed_after_retry_count', 0);
+  appendOutput('first_pass_rate', '0.00');
 };
 
 if (!fs.existsSync(resultsPath)) {
   appendSummary('### Playwright first-pass reliability');
   appendSummary(`No JSON report found at \`${resultsPath}\`.`);
   writeDefaultOutputs();
+  if (process.env.GITHUB_ACTIONS && failOnRetriedGreen) {
+    console.error(
+      'Missing Playwright JSON report on CI; flaky-green enforcement cannot run.',
+    );
+    process.exit(1);
+  }
   process.exit(0);
 }
 
@@ -90,6 +96,9 @@ for (const testCase of tests) {
   }
 
   const firstStatus = attemptStatuses[0];
+  if (firstStatus === 'skipped') {
+    continue;
+  }
   const finalStatus = attemptStatuses[attemptStatuses.length - 1];
   const hasRetry = attemptStatuses.length > 1;
   const firstAttemptPassed = firstStatus === 'passed';
@@ -135,12 +144,12 @@ if (retriedGreenDiagnostics.length > 0) {
   }
 }
 
-appendOutput('total-tests', totalTests);
-appendOutput('first-pass-count', firstPassCount);
-appendOutput('first-attempt-failure-count', firstAttemptFailureCount);
-appendOutput('retried-green-count', retriedGreenCount);
-appendOutput('failed-after-retry-count', failedAfterRetryCount);
-appendOutput('first-pass-rate', firstPassRate.toFixed(2));
+appendOutput('total_tests', totalTests);
+appendOutput('first_pass_count', firstPassCount);
+appendOutput('first_attempt_failure_count', firstAttemptFailureCount);
+appendOutput('retried_green_count', retriedGreenCount);
+appendOutput('failed_after_retry_count', failedAfterRetryCount);
+appendOutput('first_pass_rate', firstPassRate.toFixed(2));
 
 if (failOnRetriedGreen && retriedGreenCount > 0) {
   console.error(

--- a/data-migrator/qa/e2e-tests/tests/cockpit-plugin.spec.ts
+++ b/data-migrator/qa/e2e-tests/tests/cockpit-plugin.spec.ts
@@ -87,12 +87,10 @@ test.describe('Cockpit Plugin E2E', () => {
   test('should display migrated and skipped entity tabs', async ({ page }) => {
     await openProcessesPage(page);
 
-    // Wait for the plugin to render
-    await page.waitForTimeout(2000); // Give React time to render
-
     // Look for the radio buttons for skipped/migrated
     const skippedRadio = page.locator('input[type="radio"][value="skipped"]');
     const migratedRadio = page.locator('input[type="radio"][value="migrated"]');
+    await skippedRadio.waitFor({ state: 'visible', timeout: 10000 });
 
     // Verify both radio buttons are visible
     await expect(skippedRadio).toBeVisible();
@@ -109,15 +107,9 @@ test.describe('Cockpit Plugin E2E', () => {
   test('should be able to switch between entity types', async ({ page }) => {
     await openProcessesPage(page);
 
-    // Wait for plugin to load
-    await page.waitForTimeout(2000);
-
     // Switch to History mode to access the entity type selector
     const historyRadio = page.locator('input[type="radio"][value="history"]');
     await historyRadio.click();
-
-    // Wait for the dropdown to appear
-    await page.waitForTimeout(500);
 
     // Look for the entity type selector dropdown
     const entityTypeSelector = page.locator('select#type-selector');
@@ -138,19 +130,14 @@ test.describe('Cockpit Plugin E2E', () => {
   test('should display 6 skipped process instances with correct columns and data', async ({ page }) => {
     await openProcessesPage(page);
 
-    // Wait for plugin to load
-    await page.waitForTimeout(2000);
-
     // Select "Skipped" radio button (should be selected by default, but ensure it)
     const skippedRadio = page.locator('input[type="radio"][value="skipped"]');
     await skippedRadio.click();
 
-    // Wait for data to load
-    await page.waitForTimeout(2000);
-
     // Find the table
     const table = page.locator('view[data-plugin-id="camunda-7-to-8-data-migrator"] table');
     await expect(table).toBeVisible();
+    await table.locator('tbody tr').first().waitFor({ state: 'visible', timeout: 10000 });
 
     // Verify table headers contain the expected columns
     const headerRow = table.locator('thead tr');
@@ -202,7 +189,9 @@ test.describe('Cockpit Plugin E2E', () => {
 
     // Wait for plugin to fully render
     await page.locator('h1:has-text("Camunda 7 to 8 Data Migrator")').waitFor({ timeout: 10000 });
-    await page.waitForTimeout(2000);
+    await page
+      .locator('input[type="radio"][value="skipped"]')
+      .waitFor({ state: 'visible', timeout: 10000 });
 
     // Take final screenshot
     await page.screenshot({ path: 'test-results/plugin-loaded.png', fullPage: true });

--- a/data-migrator/qa/e2e-tests/tests/cockpit-plugin.spec.ts
+++ b/data-migrator/qa/e2e-tests/tests/cockpit-plugin.spec.ts
@@ -115,7 +115,7 @@ test.describe('Cockpit Plugin E2E', () => {
     const entityTypeSelector = page.locator('select#type-selector');
 
     // Verify the selector is visible
-    await expect(entityTypeSelector).toBeVisible();
+    await expect(entityTypeSelector).toBeVisible({ timeout: 10000 });
 
     // Take screenshot of the dropdown
     await page.screenshot({ path: 'test-results/entity-type-selector.png', fullPage: true });

--- a/data-migrator/qa/e2e-tests/tests/operate-decisions.spec.ts
+++ b/data-migrator/qa/e2e-tests/tests/operate-decisions.spec.ts
@@ -117,10 +117,6 @@ test.describe('Operate - Decision Instances', () => {
 
     // Wait for the decisions page to load
     await page.waitForURL('**/decisions**', { timeout: 10000 });
-    await page
-      .locator('[data-testid="data-list"] > div, table tbody tr')
-      .first()
-      .waitFor({ state: 'visible', timeout: 10000 });
 
     // Take screenshot of decisions page
     await page.screenshot({ path: 'test-results/operate-decisions-page.png', fullPage: true });
@@ -135,16 +131,10 @@ test.describe('Operate - Decision Instances', () => {
       '[role="row"]'
     );
 
-    // Wait for results to be visible
-    await decisionRows.first().waitFor({ state: 'visible', timeout: 10000 });
+    // Wait until all 12 rows are rendered (toHaveCount retries until stable)
+    await expect(decisionRows).toHaveCount(12, { timeout: 15000 });
 
-    // Count the number of decision instances displayed
-    const count = await decisionRows.count();
-
-    // Verify we have exactly 12 decision instances
-    expect(count).toBe(12);
-
-    console.log(`Found ${count} decision instances on the decisions page`);
+    console.log(`Found 12 decision instances on the decisions page`);
   });
 
   test('should open first decision instance and display details page', async ({ page }) => {

--- a/data-migrator/qa/e2e-tests/tests/operate-decisions.spec.ts
+++ b/data-migrator/qa/e2e-tests/tests/operate-decisions.spec.ts
@@ -93,9 +93,9 @@ test.describe('Operate - Decision Instances', () => {
 
       await submitButton.click();
 
-      await page
-        .locator('input[name="username"]')
-        .waitFor({ state: 'hidden', timeout: 15000 });
+      await page.waitForURL((url) => !url.pathname.endsWith('/login'), {
+        timeout: 15000,
+      });
 
       // Take screenshot after login
       await page.screenshot({ path: 'test-results/operate-after-login.png', fullPage: true });

--- a/data-migrator/qa/e2e-tests/tests/operate-decisions.spec.ts
+++ b/data-migrator/qa/e2e-tests/tests/operate-decisions.spec.ts
@@ -19,7 +19,10 @@ async function navigateToDecisionByName(page: Page, decisionName: string) {
 
   // Wait for the decisions page to load
   await page.waitForURL('**/decisions**', { timeout: 10000 });
-  await page.waitForTimeout(3000);
+  await page
+    .locator('[data-testid="data-list"] > div, table tbody tr')
+    .first()
+    .waitFor({ state: 'visible', timeout: 10000 });
 
   // Find the decision row containing the specified decision name
   // Look for a row that contains the decision name and then find the link within it
@@ -33,7 +36,9 @@ async function navigateToDecisionByName(page: Page, decisionName: string) {
 
   // Wait for the decision instance detail page to load
   await page.waitForURL('**/decisions/**', { timeout: 10000 });
-  await page.waitForTimeout(3000);
+  await page
+    .locator('[data-testid="instance-header"]')
+    .waitFor({ state: 'visible', timeout: 10000 });
 }
 
 /**
@@ -88,8 +93,9 @@ test.describe('Operate - Decision Instances', () => {
 
       await submitButton.click();
 
-      // Wait for the dashboard to load
-      await page.waitForTimeout(2000);
+      await page
+        .locator('input[name="username"]')
+        .waitFor({ state: 'hidden', timeout: 15000 });
 
       // Take screenshot after login
       await page.screenshot({ path: 'test-results/operate-after-login.png', fullPage: true });
@@ -111,7 +117,10 @@ test.describe('Operate - Decision Instances', () => {
 
     // Wait for the decisions page to load
     await page.waitForURL('**/decisions**', { timeout: 10000 });
-    await page.waitForTimeout(3000); // Give time for data to load
+    await page
+      .locator('[data-testid="data-list"] > div, table tbody tr')
+      .first()
+      .waitFor({ state: 'visible', timeout: 10000 });
 
     // Take screenshot of decisions page
     await page.screenshot({ path: 'test-results/operate-decisions-page.png', fullPage: true });
@@ -146,7 +155,10 @@ test.describe('Operate - Decision Instances', () => {
 
     // Wait for the decisions page to load
     await page.waitForURL('**/decisions**', { timeout: 10000 });
-    await page.waitForTimeout(3000);
+    await page
+      .locator('[data-testid="data-list"] > div, table tbody tr')
+      .first()
+      .waitFor({ state: 'visible', timeout: 10000 });
 
     // Find the first decision instance and click on its key/ID to open details
     const firstDecisionLink = page.locator(
@@ -164,7 +176,9 @@ test.describe('Operate - Decision Instances', () => {
 
     // Wait for the decision instance detail page to load
     await page.waitForURL('**/decisions/**', { timeout: 10000 });
-    await page.waitForTimeout(3000);
+    await page
+      .locator('[data-testid="instance-header"]')
+      .waitFor({ state: 'visible', timeout: 10000 });
 
     // Take screenshot of decision instance details
     await page.screenshot({ path: 'test-results/operate-decision-details.png', fullPage: true });
@@ -351,7 +365,7 @@ test.describe('Operate - Decision Instances', () => {
     await invoiceClassificationNode.click();
 
     // Wait for navigation to occur
-    await page.waitForTimeout(3000);
+    await expect(page).not.toHaveURL(currentUrl, { timeout: 10000 });
 
     // Take screenshot after clicking decision in DRD
     await page.screenshot({ path: 'test-results/operate-after-drd-navigation.png', fullPage: true });
@@ -384,7 +398,11 @@ test.describe('Operate - Decision Instances', () => {
     await decisionsLink.click();
 
     // Wait for the page to load
-    await page.waitForTimeout(3000);
+    await page.waitForURL('**/decisions**', { timeout: 10000 });
+    await page
+      .locator('[data-testid="data-list"] > div, table tbody tr')
+      .first()
+      .waitFor({ state: 'visible', timeout: 10000 });
 
     // Open first decision
     const firstDecisionLink = page.locator(
@@ -396,7 +414,10 @@ test.describe('Operate - Decision Instances', () => {
     await firstDecisionLink.click();
 
     // Wait for details to fully render
-    await page.waitForTimeout(3000);
+    await page.waitForURL('**/decisions/**', { timeout: 10000 });
+    await page
+      .locator('[data-testid="instance-header"]')
+      .waitFor({ state: 'visible', timeout: 10000 });
 
     // Take final screenshot
     await page.screenshot({ path: 'test-results/operate-decision-rendered.png', fullPage: true });

--- a/data-migrator/qa/e2e-tests/tests/operate-processes.spec.ts
+++ b/data-migrator/qa/e2e-tests/tests/operate-processes.spec.ts
@@ -64,7 +64,12 @@ async function goToProcesses(page: Page) {
   await processesLink.waitFor({ state: 'visible', timeout: 10000 });
   await processesLink.click();
   await page.waitForURL('**/processes**', { timeout: 10000 });
-  await page.waitForTimeout(3000);
+  await page
+    .locator(
+      '[data-testid="data-list"], [data-testid="data-table-container"], table tbody tr',
+    )
+    .first()
+    .waitFor({ state: 'visible', timeout: 10000 });
 }
 
 /**
@@ -83,7 +88,9 @@ async function openProcessInstance(page: Page, processName: string) {
   await instanceLink.click();
 
   await page.waitForURL('**/processes/**', { timeout: 10000 });
-  await page.waitForTimeout(3000);
+  await page
+    .locator('[data-testid="instance-header"]')
+    .waitFor({ state: 'visible', timeout: 10000 });
 }
 
 /**
@@ -328,8 +335,10 @@ test.describe('Operate - Process Instances & Audit Logs', () => {
     ).first();
     await viewAllLink.waitFor({ state: 'visible', timeout: 10000 });
     await viewAllLink.click();
-
-    await page.waitForTimeout(3000);
+    await page
+      .locator('a[href*="/processes/"]')
+      .first()
+      .waitFor({ state: 'visible', timeout: 10000 });
 
     await page.screenshot({
       path: 'test-results/operate-called-instances.png',
@@ -342,8 +351,7 @@ test.describe('Operate - Process Instances & Audit Logs', () => {
       .first();
     await miProcessLink.waitFor({ state: 'visible', timeout: 10000 });
     await miProcessLink.click();
-
-    await page.waitForTimeout(3000);
+    await page.waitForURL('**/processes/**', { timeout: 10000 });
 
     await page.screenshot({
       path: 'test-results/operate-child-process.png',
@@ -441,8 +449,9 @@ test.describe('Operate - Process Instances & Audit Logs', () => {
     await goToProcesses(page);
     await openProcessInstance(page, 'callingProcessId');
 
-    // Wait for full render
-    await page.waitForTimeout(3000);
+    await expect(page.locator('[data-testid="diagram"]')).toBeVisible({
+      timeout: 10000,
+    });
 
     await page.screenshot({
       path: 'test-results/operate-process-no-errors.png',


### PR DESCRIPTION
## Summary

- fail CI when a Playwright test only passes after retry (flaky-green)
- publish first-pass vs retried outcome metrics for the e2e job in CI summary output
- preserve retry diagnostics with JSON reporting and per-retry traces
- replace fixed sleeps in e2e Playwright specs with state-based waits

## Changes

- `.github/workflows/ci.yml`
  - added a first-pass reliability analysis step for the `e2e` job
  - exported e2e retry metrics as job outputs and surfaced them in `ci-summary`
  - enforced CI failure when retried-green outcomes are detected
- `data-migrator/qa/e2e-tests/playwright.config.ts`
  - enabled `failOnFlakyTests` on CI
  - added JSON reporter output (`test-results/playwright-report.json`)
  - changed tracing to `on-all-retries` and retained failure videos
- `data-migrator/qa/e2e-tests/scripts/analyze-playwright-results.mjs`
  - new analyzer that computes first-pass/retry metrics, writes job outputs, and fails on retried-green tests
- `data-migrator/qa/e2e-tests/tests/*.spec.ts`
  - removed fixed `waitForTimeout(...)` sleeps from cockpit/process/decision suites
  - replaced them with URL/locator/state waits

## Backports

- #1943 — backport to `maintenance/0.3`
- #1944 — backport to `maintenance/0.2`

## Test plan

- [x] `cd data-migrator/qa/e2e-tests && npm run typecheck`
- [x] `cd data-migrator/qa/e2e-tests && npm run check:type-escapes`
- [x] `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/ci.yml'); puts 'ok'"`
- [x] `cd data-migrator/qa/e2e-tests && node scripts/analyze-playwright-results.mjs`
- [x] `JAVA_HOME=/opt/homebrew/opt/openjdk@21 PATH=/opt/homebrew/opt/openjdk@21/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/pkg/env/global/bin:/usr/local/share/dotnet:~/.dotnet/tools:/Users/peter.bojtos/.lmstudio/bin:/Applications/Warp.app/Contents/Resources/bin mvn clean install -DskipTests -pl data-migrator/qa -Pe2e -am -f pom.xml`

## Baseline

Built from commit: 5ff45322beaccfec178584a785a89873cc926b92

related to #1881

🤖 Generated with [Claude Code](https://claude.com/claude-code)