### PR TITLE
fix(e2e): replace fixed sleeps and snapshot count in cockpit skipped-instances test

### DIFF
--- a/data-migrator/qa/e2e-tests/tests/cockpit-plugin.spec.ts
+++ b/data-migrator/qa/e2e-tests/tests/cockpit-plugin.spec.ts
@@ -138,15 +138,10 @@ test.describe('Cockpit Plugin E2E', () => {
   test('should display 6 skipped process instances with correct columns and data', async ({ page }) => {
     await openProcessesPage(page);
 
-    // Wait for plugin to load
-    await page.waitForTimeout(2000);
-
     // Select "Skipped" radio button (should be selected by default, but ensure it)
     const skippedRadio = page.locator('input[type="radio"][value="skipped"]');
+    await expect(skippedRadio).toBeVisible({ timeout: 10000 });
     await skippedRadio.click();
-
-    // Wait for data to load
-    await page.waitForTimeout(2000);
 
     // Find the table
     const table = page.locator('view[data-plugin-id="camunda-7-to-8-data-migrator"] table');
@@ -158,15 +153,12 @@ test.describe('Cockpit Plugin E2E', () => {
     await expect(headerRow.locator('th:has-text("Process Definition Key")')).toBeVisible();
     await expect(headerRow.locator('th:has-text("Skip Reason")')).toBeVisible();
 
-    // Get all data rows (excluding header)
+    // Get all data rows (excluding header) — toHaveCount retries until all 6 rows are rendered
     const dataRows = table.locator('tbody tr');
-    const rowCount = await dataRows.count();
-
-    // Verify we have exactly 6 rows
-    expect(rowCount).toBe(6);
+    await expect(dataRows).toHaveCount(6, { timeout: 15000 });
 
     // Verify each row has the expected data
-    for (let i = 0; i < rowCount; i++) {
+    for (let i = 0; i < 6; i++) {
       const row = dataRows.nth(i);
 
       // Get cells in the row

--- a/data-migrator/qa/e2e-tests/tests/cockpit-plugin.spec.ts
+++ b/data-migrator/qa/e2e-tests/tests/cockpit-plugin.spec.ts
@@ -153,12 +153,12 @@ test.describe('Cockpit Plugin E2E', () => {
     await expect(headerRow.locator('th:has-text("Process Definition Key")')).toBeVisible();
     await expect(headerRow.locator('th:has-text("Skip Reason")')).toBeVisible();
 
-    // Get all data rows (excluding header) — toHaveCount retries until all 6 rows are rendered
+    const expectedSkippedCount = 6;
     const dataRows = table.locator('tbody tr');
-    await expect(dataRows).toHaveCount(6, { timeout: 15000 });
+    await expect(dataRows).toHaveCount(expectedSkippedCount, { timeout: 15000 });
 
     // Verify each row has the expected data
-    for (let i = 0; i < 6; i++) {
+    for (let i = 0; i < expectedSkippedCount; i++) {
       const row = dataRows.nth(i);
 
       // Get cells in the row


### PR DESCRIPTION
## Summary

- Removes two `waitForTimeout(2000)` calls from the cockpit "should display 6 skipped process instances" test
- Replaces the first sleep with `expect(skippedRadio).toBeVisible()` — waits for the radio button to be ready before clicking
- Replaces the second sleep + snapshot count (`count() + toBe(6)`) with `toHaveCount(6, { timeout: 15000 })` — retries until all 6 rows are present

## Changes

- `data-migrator/qa/e2e-tests/tests/cockpit-plugin.spec.ts` — deterministic waits replace fixed sleeps and snapshot count

## Test plan

- [ ] TypeScript typecheck passes (`npm run typecheck`)
- [ ] E2E test `should display 6 skipped process instances with correct columns and data` no longer races on plugin load

## Baseline

Built from commit: 5ff45322

related to #1881

🤖 Generated with [Claude Code](https://claude.com/claude-code)