### PR TITLE
[Backport maintenance/0.3] fix(e2e): expose flaky-green outcomes in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -792,6 +792,9 @@ jobs:
       contents: read
     outputs:
       maven-cache-hit: ${{ steps.setup-maven.outputs.maven-cache-hit }}
+      e2e_first_pass_rate: ${{ steps.analyze-e2e-retries.outputs.first_pass_rate }}
+      e2e_retried_green_count: ${{ steps.analyze-e2e-retries.outputs.retried_green_count }}
+      e2e_first_attempt_failure_count: ${{ steps.analyze-e2e-retries.outputs.first_attempt_failure_count }}
     if: |
       github.event_name == 'workflow_dispatch' ||
       github.event_name != 'pull_request' ||
@@ -839,6 +842,15 @@ jobs:
         run: mvn clean install -Pe2e -Dmaven.test.skip --batch-mode
         env:
           CI: true
+
+      - name: Analyze Playwright first-pass reliability
+        id: analyze-e2e-retries
+        if: always()
+        working-directory: data-migrator/qa/e2e-tests
+        run: node scripts/analyze-playwright-results.mjs
+        env:
+          PLAYWRIGHT_RESULTS_PATH: test-results/playwright-report.json
+          FAIL_ON_RETRIED_GREEN: true
 
       - name: Upload test results
         uses: actions/upload-artifact@v7
@@ -1124,12 +1136,20 @@ jobs:
       CACHE_HISTORY_H2_WINDOWS: ${{ needs.it-history-h2-windows.outputs.maven-cache-hit }}
       CACHE_IDENTITY_H2: ${{ needs.it-identity-h2.outputs.maven-cache-hit }}
       CACHE_E2E: ${{ needs.e2e.outputs.maven-cache-hit }}
+      E2E_FIRST_PASS_RATE: ${{ needs.e2e.outputs.e2e_first_pass_rate }}
+      E2E_RETRIED_GREEN_COUNT: ${{ needs.e2e.outputs.e2e_retried_green_count }}
+      E2E_FIRST_ATTEMPT_FAILURE_COUNT: ${{ needs.e2e.outputs.e2e_first_attempt_failure_count }}
     steps:
       - name: Evaluate blocking checks and publish CI budget metrics
         uses: actions/github-script@v9
         with:
           script: |
             const parseBool = (value) => `${value}`.toLowerCase() === "true";
+            const parseNumber = (value) => {
+              if (value === '' || value === null || value === undefined) return null;
+              const parsed = Number(value);
+              return Number.isFinite(parsed) ? parsed : null;
+            };
             const needsResults = ${{ toJSON(needs) }};
 
             const requiredChecks = [
@@ -1221,6 +1241,13 @@ jobs:
             ].filter((value) => value === "true" || value === "false");
             const cacheHits = cacheValues.filter((value) => value === "true").length;
             const cacheHitRate = cacheValues.length === 0 ? null : (cacheHits / cacheValues.length) * 100;
+            const e2eFirstPassRate = parseNumber(process.env.E2E_FIRST_PASS_RATE);
+            const e2eRetriedGreenCount = parseNumber(process.env.E2E_RETRIED_GREEN_COUNT);
+            const e2eFirstAttemptFailureCount = parseNumber(process.env.E2E_FIRST_ATTEMPT_FAILURE_COUNT);
+
+            if (parseBool(process.env.EXPECT_E2E) && e2eRetriedGreenCount !== null && e2eRetriedGreenCount > 0) {
+              failing.push(`e2e reported ${e2eRetriedGreenCount} retried-green test(s)`);
+            }
 
             await core.summary
               .addHeading("CI summary gate")
@@ -1234,6 +1261,10 @@ jobs:
               .addRaw(`- PR feedback p95 (last ${feedbackDurations.length} runs): ${percentile(feedbackDurations, 0.95)?.toFixed(1) ?? "n/a"} min\n`)
               .addRaw(`- First red in this run: ${firstRedMinutes?.toFixed(1) ?? "n/a"} min\n`)
               .addRaw(`- Maven cache hit rate (blocking jobs): ${cacheHitRate?.toFixed(1) ?? "n/a"}%\n`)
+              .addHeading("E2E first-pass reliability", 2)
+              .addRaw(`- First-pass rate: ${e2eFirstPassRate?.toFixed(2) ?? "n/a"}%\n`)
+              .addRaw(`- First-attempt failures: ${e2eFirstAttemptFailureCount ?? "n/a"}\n`)
+              .addRaw(`- Retried-green tests: ${e2eRetriedGreenCount ?? "n/a"}\n`)
               .write();
 
             if (failing.length > 0) {

--- a/data-migrator/qa/e2e-tests/playwright.config.ts
+++ b/data-migrator/qa/e2e-tests/playwright.config.ts
@@ -12,17 +12,27 @@ export default defineConfig({
   forbidOnly: !!process.env.CI,
   /* Retry on CI only */
   retries: process.env.CI ? 2 : 0,
+  /* Retries that eventually pass are still defects and should fail CI */
+  failOnFlakyTests: !!process.env.CI,
   /* Opt out of parallel tests on CI. */
   workers: 1,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-  reporter: process.env.CI ? [['html'], ['github'], ['list']] : 'html',
+  reporter: process.env.CI
+    ? [
+        ['html'],
+        ['github'],
+        ['list'],
+        ['json', { outputFile: 'test-results/playwright-report.json' }],
+      ]
+    : 'html',
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */
     baseURL: 'http://localhost:8090',
-    /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
-    trace: 'on-first-retry',
+    /* Collect traces for every retry attempt to preserve flaky diagnostics */
+    trace: 'on-all-retries',
     screenshot: 'only-on-failure',
+    video: 'retain-on-failure',
   },
 
   /* Configure projects for major browsers */

--- a/data-migrator/qa/e2e-tests/scripts/analyze-playwright-results.mjs
+++ b/data-migrator/qa/e2e-tests/scripts/analyze-playwright-results.mjs
@@ -1,0 +1,159 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const scriptFilePath = fileURLToPath(import.meta.url);
+const scriptDirectory = path.dirname(scriptFilePath);
+const projectRoot = path.resolve(scriptDirectory, '..');
+
+const resultsPath = path.resolve(
+  projectRoot,
+  process.env.PLAYWRIGHT_RESULTS_PATH ?? 'test-results/playwright-report.json',
+);
+const failOnRetriedGreen = `${process.env.FAIL_ON_RETRIED_GREEN ?? 'true'}`.toLowerCase() === 'true';
+
+const appendOutput = (key, value) => {
+  if (!process.env.GITHUB_OUTPUT) {
+    return;
+  }
+  fs.appendFileSync(process.env.GITHUB_OUTPUT, `${key}=${value}\n`);
+};
+
+const appendSummary = (line) => {
+  if (process.env.GITHUB_STEP_SUMMARY) {
+    fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, `${line}\n`);
+    return;
+  }
+  console.log(line);
+};
+
+const writeDefaultOutputs = () => {
+  appendOutput('total_tests', '');
+  appendOutput('first_pass_count', '');
+  appendOutput('first_attempt_failure_count', '');
+  appendOutput('retried_green_count', '');
+  appendOutput('failed_after_retry_count', '');
+  appendOutput('first_pass_rate', '');
+};
+
+if (!fs.existsSync(resultsPath)) {
+  appendSummary('### Playwright first-pass reliability');
+  appendSummary(`No JSON report found at \`${resultsPath}\`.`);
+  writeDefaultOutputs();
+  if (process.env.GITHUB_ACTIONS && failOnRetriedGreen) {
+    console.error(
+      'Missing Playwright JSON report on CI; flaky-green enforcement cannot run.',
+    );
+    process.exit(1);
+  }
+  process.exit(0);
+}
+
+const report = JSON.parse(fs.readFileSync(resultsPath, 'utf8'));
+const tests = [];
+
+const collectFromSuite = (suite, parents = []) => {
+  const suiteTitle = suite.title?.trim();
+  const nextParents = suiteTitle ? [...parents, suiteTitle] : parents;
+
+  for (const spec of suite.specs ?? []) {
+    const specTitle = spec.title?.trim() ?? '';
+    const titleParts = [...nextParents, specTitle].filter(Boolean);
+    const location = spec.file
+      ? `${spec.file}${spec.line ? `:${spec.line}` : ''}`
+      : titleParts.join(' › ');
+    for (const testCase of spec.tests ?? []) {
+      tests.push({
+        title: titleParts.join(' › '),
+        location,
+        results: testCase.results ?? [],
+      });
+    }
+  }
+
+  for (const child of suite.suites ?? []) {
+    collectFromSuite(child, nextParents);
+  }
+};
+
+for (const suite of report.suites ?? []) {
+  collectFromSuite(suite, []);
+}
+
+let firstPassCount = 0;
+let firstAttemptFailureCount = 0;
+let retriedGreenCount = 0;
+let failedAfterRetryCount = 0;
+const retriedGreenDiagnostics = [];
+
+for (const testCase of tests) {
+  const attemptStatuses = testCase.results
+    .map((result) => result.status)
+    .filter(Boolean);
+
+  if (attemptStatuses.length === 0) {
+    continue;
+  }
+
+  const firstStatus = attemptStatuses[0];
+  if (firstStatus === 'skipped') {
+    continue;
+  }
+  const finalStatus = attemptStatuses[attemptStatuses.length - 1];
+  const hasRetry = attemptStatuses.length > 1;
+  const firstAttemptPassed = firstStatus === 'passed';
+  const retriedGreen = !firstAttemptPassed && hasRetry && finalStatus === 'passed';
+  const failedAfterRetry =
+    !firstAttemptPassed && finalStatus !== 'passed' && finalStatus !== 'skipped';
+
+  if (firstAttemptPassed) {
+    firstPassCount += 1;
+  } else {
+    firstAttemptFailureCount += 1;
+  }
+
+  if (retriedGreen) {
+    retriedGreenCount += 1;
+    retriedGreenDiagnostics.push(
+      `${testCase.location} — ${testCase.title} (${attemptStatuses.join(' -> ')})`,
+    );
+  }
+
+  if (failedAfterRetry) {
+    failedAfterRetryCount += 1;
+  }
+}
+
+const totalTests = firstPassCount + firstAttemptFailureCount;
+const firstPassRate =
+  totalTests === 0 ? 0 : (firstPassCount / totalTests) * 100;
+
+appendSummary('### Playwright first-pass reliability');
+appendSummary(`- Total tests: ${totalTests}`);
+appendSummary(`- First-pass green: ${firstPassCount}`);
+appendSummary(`- First-attempt failures: ${firstAttemptFailureCount}`);
+appendSummary(`- Retried-green tests: ${retriedGreenCount}`);
+appendSummary(`- Failed after retries: ${failedAfterRetryCount}`);
+appendSummary(`- First-pass rate: ${firstPassRate.toFixed(2)}%`);
+
+if (retriedGreenDiagnostics.length > 0) {
+  appendSummary('');
+  appendSummary('#### Retried-green diagnostics');
+  for (const diagnostic of retriedGreenDiagnostics) {
+    appendSummary(`- ${diagnostic}`);
+  }
+}
+
+appendOutput('total_tests', totalTests);
+appendOutput('first_pass_count', firstPassCount);
+appendOutput('first_attempt_failure_count', firstAttemptFailureCount);
+appendOutput('retried_green_count', retriedGreenCount);
+appendOutput('failed_after_retry_count', failedAfterRetryCount);
+appendOutput('first_pass_rate', firstPassRate.toFixed(2));
+
+if (failOnRetriedGreen && retriedGreenCount > 0) {
+  console.error(
+    `Found ${retriedGreenCount} retried-green test(s). Flaky-green outcomes fail CI by policy.`,
+  );
+  process.exit(1);
+}

--- a/data-migrator/qa/e2e-tests/tests/cockpit-plugin.spec.ts
+++ b/data-migrator/qa/e2e-tests/tests/cockpit-plugin.spec.ts
@@ -87,12 +87,10 @@ test.describe('Cockpit Plugin E2E', () => {
   test('should display migrated and skipped entity tabs', async ({ page }) => {
     await openProcessesPage(page);
 
-    // Wait for the plugin to render
-    await page.waitForTimeout(2000); // Give React time to render
-
     // Look for the radio buttons for skipped/migrated
     const skippedRadio = page.locator('input[type="radio"][value="skipped"]');
     const migratedRadio = page.locator('input[type="radio"][value="migrated"]');
+    await skippedRadio.waitFor({ state: 'visible', timeout: 10000 });
 
     // Verify both radio buttons are visible
     await expect(skippedRadio).toBeVisible();
@@ -109,21 +107,15 @@ test.describe('Cockpit Plugin E2E', () => {
   test('should be able to switch between entity types', async ({ page }) => {
     await openProcessesPage(page);
 
-    // Wait for plugin to load
-    await page.waitForTimeout(2000);
-
     // Switch to History mode to access the entity type selector
     const historyRadio = page.locator('input[type="radio"][value="history"]');
     await historyRadio.click();
-
-    // Wait for the dropdown to appear
-    await page.waitForTimeout(500);
 
     // Look for the entity type selector dropdown
     const entityTypeSelector = page.locator('select#type-selector');
 
     // Verify the selector is visible
-    await expect(entityTypeSelector).toBeVisible();
+    await expect(entityTypeSelector).toBeVisible({ timeout: 10000 });
 
     // Take screenshot of the dropdown
     await page.screenshot({ path: 'test-results/entity-type-selector.png', fullPage: true });
@@ -151,6 +143,7 @@ test.describe('Cockpit Plugin E2E', () => {
     // Find the table
     const table = page.locator('view[data-plugin-id="camunda-7-to-8-data-migrator"] table');
     await expect(table).toBeVisible();
+    await table.locator('tbody tr').first().waitFor({ state: 'visible', timeout: 10000 });
 
     // Verify table headers contain the expected columns
     const headerRow = table.locator('thead tr');
@@ -202,7 +195,9 @@ test.describe('Cockpit Plugin E2E', () => {
 
     // Wait for plugin to fully render
     await page.locator('h1:has-text("Camunda 7 to 8 Data Migrator")').waitFor({ timeout: 10000 });
-    await page.waitForTimeout(2000);
+    await page
+      .locator('input[type="radio"][value="skipped"]')
+      .waitFor({ state: 'visible', timeout: 10000 });
 
     // Take final screenshot
     await page.screenshot({ path: 'test-results/plugin-loaded.png', fullPage: true });

--- a/data-migrator/qa/e2e-tests/tests/operate-decisions.spec.ts
+++ b/data-migrator/qa/e2e-tests/tests/operate-decisions.spec.ts
@@ -19,7 +19,10 @@ async function navigateToDecisionByName(page: Page, decisionName: string) {
 
   // Wait for the decisions page to load
   await page.waitForURL('**/decisions**', { timeout: 10000 });
-  await page.waitForTimeout(3000);
+  await page
+    .locator('[data-testid="data-list"] > div, table tbody tr')
+    .first()
+    .waitFor({ state: 'visible', timeout: 10000 });
 
   // Find the decision row containing the specified decision name
   // Look for a row that contains the decision name and then find the link within it
@@ -33,7 +36,9 @@ async function navigateToDecisionByName(page: Page, decisionName: string) {
 
   // Wait for the decision instance detail page to load
   await page.waitForURL('**/decisions/**', { timeout: 10000 });
-  await page.waitForTimeout(3000);
+  await page
+    .locator('[data-testid="instance-header"]')
+    .waitFor({ state: 'visible', timeout: 10000 });
 }
 
 /**
@@ -88,8 +93,9 @@ test.describe('Operate - Decision Instances', () => {
 
       await submitButton.click();
 
-      // Wait for the dashboard to load
-      await page.waitForTimeout(2000);
+      await page.waitForURL((url) => !url.pathname.endsWith('/login'), {
+        timeout: 15000,
+      });
 
       // Take screenshot after login
       await page.screenshot({ path: 'test-results/operate-after-login.png', fullPage: true });
@@ -111,7 +117,6 @@ test.describe('Operate - Decision Instances', () => {
 
     // Wait for the decisions page to load
     await page.waitForURL('**/decisions**', { timeout: 10000 });
-    await page.waitForTimeout(3000); // Give time for data to load
 
     // Take screenshot of decisions page
     await page.screenshot({ path: 'test-results/operate-decisions-page.png', fullPage: true });
@@ -126,16 +131,10 @@ test.describe('Operate - Decision Instances', () => {
       '[role="row"]'
     );
 
-    // Wait for results to be visible
-    await decisionRows.first().waitFor({ state: 'visible', timeout: 10000 });
+    // Wait until all 12 rows are rendered (toHaveCount retries until stable)
+    await expect(decisionRows).toHaveCount(12, { timeout: 15000 });
 
-    // Count the number of decision instances displayed
-    const count = await decisionRows.count();
-
-    // Verify we have exactly 12 decision instances
-    expect(count).toBe(12);
-
-    console.log(`Found ${count} decision instances on the decisions page`);
+    console.log(`Found 12 decision instances on the decisions page`);
   });
 
   test('should open first decision instance and display details page', async ({ page }) => {
@@ -146,7 +145,10 @@ test.describe('Operate - Decision Instances', () => {
 
     // Wait for the decisions page to load
     await page.waitForURL('**/decisions**', { timeout: 10000 });
-    await page.waitForTimeout(3000);
+    await page
+      .locator('[data-testid="data-list"] > div, table tbody tr')
+      .first()
+      .waitFor({ state: 'visible', timeout: 10000 });
 
     // Find the first decision instance and click on its key/ID to open details
     const firstDecisionLink = page.locator(
@@ -164,7 +166,9 @@ test.describe('Operate - Decision Instances', () => {
 
     // Wait for the decision instance detail page to load
     await page.waitForURL('**/decisions/**', { timeout: 10000 });
-    await page.waitForTimeout(3000);
+    await page
+      .locator('[data-testid="instance-header"]')
+      .waitFor({ state: 'visible', timeout: 10000 });
 
     // Take screenshot of decision instance details
     await page.screenshot({ path: 'test-results/operate-decision-details.png', fullPage: true });
@@ -351,7 +355,7 @@ test.describe('Operate - Decision Instances', () => {
     await invoiceClassificationNode.click();
 
     // Wait for navigation to occur
-    await page.waitForTimeout(3000);
+    await expect(page).not.toHaveURL(currentUrl, { timeout: 10000 });
 
     // Take screenshot after clicking decision in DRD
     await page.screenshot({ path: 'test-results/operate-after-drd-navigation.png', fullPage: true });
@@ -384,7 +388,11 @@ test.describe('Operate - Decision Instances', () => {
     await decisionsLink.click();
 
     // Wait for the page to load
-    await page.waitForTimeout(3000);
+    await page.waitForURL('**/decisions**', { timeout: 10000 });
+    await page
+      .locator('[data-testid="data-list"] > div, table tbody tr')
+      .first()
+      .waitFor({ state: 'visible', timeout: 10000 });
 
     // Open first decision
     const firstDecisionLink = page.locator(
@@ -396,7 +404,10 @@ test.describe('Operate - Decision Instances', () => {
     await firstDecisionLink.click();
 
     // Wait for details to fully render
-    await page.waitForTimeout(3000);
+    await page.waitForURL('**/decisions/**', { timeout: 10000 });
+    await page
+      .locator('[data-testid="instance-header"]')
+      .waitFor({ state: 'visible', timeout: 10000 });
 
     // Take final screenshot
     await page.screenshot({ path: 'test-results/operate-decision-rendered.png', fullPage: true });

--- a/data-migrator/qa/e2e-tests/tests/operate-processes.spec.ts
+++ b/data-migrator/qa/e2e-tests/tests/operate-processes.spec.ts
@@ -64,7 +64,12 @@ async function goToProcesses(page: Page) {
   await processesLink.waitFor({ state: 'visible', timeout: 10000 });
   await processesLink.click();
   await page.waitForURL('**/processes**', { timeout: 10000 });
-  await page.waitForTimeout(3000);
+  await page
+    .locator(
+      '[data-testid="data-list"], [data-testid="data-table-container"], table tbody tr',
+    )
+    .first()
+    .waitFor({ state: 'visible', timeout: 10000 });
 }
 
 /**
@@ -83,7 +88,9 @@ async function openProcessInstance(page: Page, processName: string) {
   await instanceLink.click();
 
   await page.waitForURL('**/processes/**', { timeout: 10000 });
-  await page.waitForTimeout(3000);
+  await page
+    .locator('[data-testid="instance-header"]')
+    .waitFor({ state: 'visible', timeout: 10000 });
 }
 
 /**
@@ -328,8 +335,10 @@ test.describe('Operate - Process Instances & Audit Logs', () => {
     ).first();
     await viewAllLink.waitFor({ state: 'visible', timeout: 10000 });
     await viewAllLink.click();
-
-    await page.waitForTimeout(3000);
+    await page
+      .locator('a[href*="/processes/"]')
+      .first()
+      .waitFor({ state: 'visible', timeout: 10000 });
 
     await page.screenshot({
       path: 'test-results/operate-called-instances.png',
@@ -342,8 +351,7 @@ test.describe('Operate - Process Instances & Audit Logs', () => {
       .first();
     await miProcessLink.waitFor({ state: 'visible', timeout: 10000 });
     await miProcessLink.click();
-
-    await page.waitForTimeout(3000);
+    await page.waitForURL('**/processes/**', { timeout: 10000 });
 
     await page.screenshot({
       path: 'test-results/operate-child-process.png',
@@ -441,8 +449,9 @@ test.describe('Operate - Process Instances & Audit Logs', () => {
     await goToProcesses(page);
     await openProcessInstance(page, 'callingProcessId');
 
-    // Wait for full render
-    await page.waitForTimeout(3000);
+    await expect(page.locator('[data-testid="diagram"]')).toBeVisible({
+      timeout: 10000,
+    });
 
     await page.screenshot({
       path: 'test-results/operate-process-no-errors.png',


### PR DESCRIPTION
# Description
Backport of camunda/camunda-7-to-8-migration-tooling#1932 to `maintenance/0.3`.

Cherry-picked cleanly with no conflicts.

related to #1932