### PR TITLE
chore(ci): run full suite daily, remove post-merge re-run on main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,15 +1,10 @@
 name: CI
 on:
-  push:
-    branches:
-      - main
-      - maintenance/*
-      - "!maintenance/*-backport-*"
   pull_request:
     types: [opened, synchronize, reopened, labeled, unlabeled]
   workflow_dispatch:
   schedule:
-    - cron: "0 5 * * 1-5"  # Weekday mornings for general CI
+    - cron: "0 5 * * *"  # Daily mornings for general CI
 
 jobs:
   # Read Camunda 8 versions from pom.xml to avoid hard-coding in CI
@@ -844,7 +839,6 @@ jobs:
     timeout-minutes: 30
     if: |
       github.event_name == 'schedule' ||
-      (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'pull_request' &&
         contains(github.event.pull_request.labels.*.name, 'ci:previous-c8-version')
@@ -897,7 +891,6 @@ jobs:
     timeout-minutes: 30
     if: |
       github.event_name == 'schedule' ||
-      (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'pull_request' &&
         contains(github.event.pull_request.labels.*.name, 'ci:previous-c8-version')
@@ -943,7 +936,6 @@ jobs:
       contents: read
     if: |
       github.event_name == 'schedule' ||
-      (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'pull_request' &&
         contains(github.event.pull_request.labels.*.name, 'ci:previous-c8-version')
@@ -1017,7 +1009,6 @@ jobs:
       contents: read
     if: |
       github.event_name == 'schedule' ||
-      (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'pull_request' &&
         contains(github.event.pull_request.labels.*.name, 'ci:previous-c8-version')


### PR DESCRIPTION
## Summary

Eliminates the wasteful double-run that happens after every merge.

### Changes

- **Remove `push:` trigger** — CI no longer re-runs all jobs after merge to `main`
- **Daily cron** — changed from weekdays-only (`1-5`) to every day (`* * *`) so the full suite (including the DB/Camunda matrix) runs daily on main
- **Clean up dead conditions** — removed the `push && refs/heads/main` clauses from the 4 nightly jobs (`code-conversion-previous-version`, `diagram-converter-previous-version`, `e2e-previous-version`, `it-database-camunda-matrix`) since that trigger no longer fires

### Behavior after this change

| Event | What runs |
|---|---|
| PR | Changed-module jobs only (unchanged) |
| Merge to main | Nothing — CI already passed on PR |
| Daily 5 AM | Full suite including DB matrix, previous-version jobs, artifacts upload |
| Manual dispatch | Full suite |

### Artifact uploads

Artifact upload conditions (`if: github.ref == 'refs/heads/main'`) are unchanged — they still fire correctly on the daily scheduled run, which executes on the `main` branch.

related to #ci