### PR TITLE
fix(ci): fetch full main history for detect-changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,7 +104,7 @@ jobs:
             echo "run-db-default=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          git fetch origin "${BASE_REF}" --depth=1
+          git fetch origin "${BASE_REF}"
           CHANGED_FILES=$(git diff --name-only "origin/${BASE_REF}...HEAD")
           if echo "$CHANGED_FILES" | grep -qE '^(data-migrator/|pom\.xml$)'; then
             echo "data-migrator=true" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
Summary:
- Fixes detect-changes so PRs can diff against main without requiring a rebase.
- Removes the shallow fetch that prevented Git from finding the merge base.

Test plan:
- Let CI run on this branch.
- Rebase the current CI PR onto this branch and confirm detect-changes no longer fails.

This PR contains only the detect-changes fix.