### PR TITLE
chore(ci): run full suite daily, remove post-merge re-run on main (#1948) [maintenance/0.2]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,5 @@
 name: CI
 on:
-  push:
-    branches:
-      - main
-      - maintenance/*
-      - "!maintenance/*-backport-*"
   pull_request:
     branches:
       - main
@@ -13,7 +8,7 @@ on:
     types: [opened, synchronize, reopened, labeled, unlabeled]
   workflow_dispatch:
   schedule:
-    - cron: "0 5 * * 1-5"  # Weekday mornings for general CI
+    - cron: "0 5 * * *"  # Daily mornings for general CI
 
 jobs:
   # Read Camunda 8 versions from pom.xml to avoid hard-coding in CI
@@ -870,7 +865,6 @@ jobs:
     timeout-minutes: 30
     if: |
       github.event_name == 'schedule' ||
-      (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'pull_request' &&
         contains(github.event.pull_request.labels.*.name, 'ci:previous-c8-version')
@@ -923,7 +917,6 @@ jobs:
     timeout-minutes: 30
     if: |
       github.event_name == 'schedule' ||
-      (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'pull_request' &&
         contains(github.event.pull_request.labels.*.name, 'ci:previous-c8-version')
@@ -969,7 +962,6 @@ jobs:
       contents: read
     if: |
       github.event_name == 'schedule' ||
-      (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'pull_request' &&
         contains(github.event.pull_request.labels.*.name, 'ci:previous-c8-version')
@@ -1043,7 +1035,6 @@ jobs:
       contents: read
     if: |
       github.event_name == 'schedule' ||
-      (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'pull_request' &&
         contains(github.event.pull_request.labels.*.name, 'ci:previous-c8-version')


### PR DESCRIPTION
Backport of #1948 to maintenance/0.2.

Includes only the CI workflow changes:
- remove post-merge push-triggered CI
- run the full suite daily via cron
- keep the detect-changes merge-base fetch fix

This is the same change set as main, backported for maintenance support.