### PR TITLE
[Backport maintenance/0.2] fix(e2e): wait for history radio before switching entity type

### DIFF
--- a/data-migrator/qa/e2e-tests/tests/cockpit-plugin.spec.ts
+++ b/data-migrator/qa/e2e-tests/tests/cockpit-plugin.spec.ts
@@ -109,7 +109,7 @@ test.describe('Cockpit Plugin E2E', () => {
     // Switch to History mode to access the entity type selector
     const historyRadio = page.locator('input[type="radio"][value="history"]');
     await expect(historyRadio).toBeVisible({ timeout: 10000 });
-    await expect(historyRadio).toBeEnabled();
+    await expect(historyRadio).toBeEnabled({ timeout: 10000 });
     await historyRadio.click();
 
     // Look for the entity type selector dropdown


### PR DESCRIPTION
Backport of #1952 to `maintenance/0.2`.

The automated bot failed because commit `652224cc` had already been applied to this branch (adding `toBeVisible` guard), but left `toBeEnabled()` without a timeout. This PR adds the missing `{ timeout: 10000 }` to bring it in line with the full fix on `main`.

related to #1949