### PR TITLE
test(e2e): stabilize Cockpit Plugin login timeout for Firefox

### DIFF
--- a/data-migrator/qa/e2e-tests/tests/cockpit-plugin.spec.ts
+++ b/data-migrator/qa/e2e-tests/tests/cockpit-plugin.spec.ts
@@ -34,18 +34,28 @@ async function openProcessesPage(page: Page) {
 test.describe('Cockpit Plugin E2E', () => {
   test.describe.configure({ mode: 'serial' });
   // Cold CI containers need time for the login round-trip plus the Angular
-  // bootstrap; give each test a generous budget.
-  test.setTimeout(90000);
+  // bootstrap; give each test a generous budget. Firefox initialises the
+  // Angular runtime noticeably slower than Chromium on cold CI runners, so
+  // the budget is set high enough to accommodate the slowest browser.
+  test.setTimeout(120000);
 
   test.beforeEach(async ({ page }) => {
     // Playwright's default `page` fixture is function-scoped: every test gets a
     // fresh, cookie-less context, so we authenticate from scratch each time.
     await page.goto('/camunda/app/cockpit/default/');
 
+    // Ensure the browser has at least parsed the document before waiting for
+    // Angular-rendered elements. Firefox can take several extra seconds to
+    // reach DOMContentLoaded on cold CI runners compared to Chromium.
+    await page.waitForLoadState('domcontentloaded');
+
     // Log in with the Camunda 7 demo user. The login form is served by the same
     // Angular app, so wait for it explicitly rather than racing isVisible().
+    // Use a 60 s budget to accommodate Firefox's slower Angular bootstrap on
+    // cold CI containers (the previous 30 s budget caused intermittent failures
+    // in Firefox, see #1955).
     const usernameInput = page.locator('input[ng-model="username"]');
-    await usernameInput.waitFor({ state: 'visible', timeout: 30000 });
+    await usernameInput.waitFor({ state: 'visible', timeout: 60000 });
     await usernameInput.fill('demo');
     await page.fill('input[ng-model="password"]', 'demo');
     await page.click('button[type="submit"]');

--- a/data-migrator/qa/e2e-tests/tests/cockpit-plugin.spec.ts
+++ b/data-migrator/qa/e2e-tests/tests/cockpit-plugin.spec.ts
@@ -42,12 +42,10 @@ test.describe('Cockpit Plugin E2E', () => {
   test.beforeEach(async ({ page }) => {
     // Playwright's default `page` fixture is function-scoped: every test gets a
     // fresh, cookie-less context, so we authenticate from scratch each time.
-    await page.goto('/camunda/app/cockpit/default/');
-
-    // Ensure the browser has at least parsed the document before waiting for
-    // Angular-rendered elements. Firefox can take several extra seconds to
-    // reach DOMContentLoaded on cold CI runners compared to Chromium.
-    await page.waitForLoadState('domcontentloaded');
+    // Wait only for DOMContentLoaded (not the full `load` event) so that we
+    // start polling for the Angular-rendered login form as soon as the DOM is
+    // parsed, rather than waiting for every sub-resource to finish loading.
+    await page.goto('/camunda/app/cockpit/default/', { waitUntil: 'domcontentloaded' });
 
     // Log in with the Camunda 7 demo user. The login form is served by the same
     // Angular app, so wait for it explicitly rather than racing isVisible().

--- a/data-migrator/qa/e2e-tests/tests/cockpit-plugin.spec.ts
+++ b/data-migrator/qa/e2e-tests/tests/cockpit-plugin.spec.ts
@@ -36,8 +36,10 @@ test.describe('Cockpit Plugin E2E', () => {
   // Cold CI containers need time for the login round-trip plus the Angular
   // bootstrap; give each test a generous budget. Firefox initialises the
   // Angular runtime noticeably slower than Chromium on cold CI runners, so
-  // the budget is set high enough to accommodate the slowest browser.
-  test.setTimeout(120000);
+  // the budget must cover the worst-case beforeEach (up to 60 s for the login
+  // form + up to 60 s for the processes-link readiness gate + navigation
+  // overhead) and still leave meaningful headroom for the test body itself.
+  test.setTimeout(180000);
 
   test.beforeEach(async ({ page }) => {
     // Playwright's default `page` fixture is function-scoped: every test gets a


### PR DESCRIPTION
## Summary

- Firefox initialises the Angular runtime noticeably slower than Chromium on cold CI containers
- The previous 30 s `waitFor` on the login form input was insufficient and caused intermittent `TimeoutError` in the Firefox Playwright run (#1955)
- Changed `page.goto()` to use `waitUntil: 'domcontentloaded'` so navigation completes as soon as the DOM is parsed (rather than waiting for the full `load` event), letting the extended `usernameInput.waitFor` budget cover Angular's bootstrap
- Raised login form timeout (30 s → 60 s) and per-test budget (90 s → 180 s) — the worst-case `beforeEach` can consume up to 60 s (login form) + 60 s (processes-link readiness gate) + navigation overhead, so 120 s left no room for the test body itself

## Changes

- `data-migrator/qa/e2e-tests/tests/cockpit-plugin.spec.ts`: targeted changes in `beforeEach` / `test.setTimeout`

## Test plan

- [ ] `mvn verify -Pe2e` passes for all three browsers (Chromium, Firefox, Edge)
- [ ] The specific test `should display 6 skipped process instances with correct columns and data` passes consistently in Firefox
- [ ] No regressions in other tests

## Baseline

Built from commit: 6e1b16c3a86887d3d813340ca5d7db87bb37f0cc

Note: `mvn clean install -DskipTests` exits 1 locally due to a pre-existing license-check failure on files in the **untracked** `process-os/` directory (not committed to git, invisible to CI).

related to #1955

🤖 Generated with [Claude Code](https://claude.com/claude-code)