### PR TITLE
fix(skill): fix YAML frontmatter parse error in migrate-c7-to-c8-code skill

### DIFF
--- a/agentic-migration-skills/skills/migrate-c7-to-c8-code/SKILL.md
+++ b/agentic-migration-skills/skills/migrate-c7-to-c8-code/SKILL.md
@@ -1,8 +1,7 @@
 ---
 name: migrate-c7-to-c8-code
-description: Use this when migrating or converting a Camunda 7 / camunda-bpm project to Camunda 8 — both Java/Spring code (JavaDelegates, ExternalTaskWorkers, ProcessEngine/RuntimeService client code, execution/task listeners, application.properties/application.yaml with camunda.* keys) and BPMN/DMN models (diagrams with the camunda: namespace). Handles code migration, model migration, or both.
-argument-hint: Optional path to project root (defaults to current directory)
-allowed-tools: Bash, Read, Write, Edit, Glob, Grep, WebFetch, AskUserQuestion
+description: |-
+  Migrates Camunda 7 / camunda-bpm projects to Camunda 8. Handles Java/Spring code (JavaDelegates, ExternalTaskWorkers, ProcessEngine/RuntimeService client code, execution/task listeners, application.properties/application.yaml with camunda.* keys) and BPMN/DMN models (diagrams with the camunda: namespace). Use for code migration, model migration, or both.
 ---
 
 # Camunda 7 → 8 Migration


### PR DESCRIPTION
## Problem

The `description` field in `SKILL.md` contained `camunda: namespace`, which YAML interprets as a mapping value, causing:

```
failed to parse YAML frontmatter: mapping values are not allowed in this context
```

## Fix

- Convert `description` to a YAML block scalar (`|`) so the colon is safe
- Remove `allowed-tools` and `argument-hint` fields — these are not part of the Agent Skills format and break Claude Code / other tools

After the fix, the skill loads correctly in both Copilot CLI and Claude Code.