### PR TITLE
fix(agentic-migration-skills): fix invalid skills field in plugin.json

### DIFF
--- a/agentic-migration-skills/plugin.json
+++ b/agentic-migration-skills/plugin.json
@@ -19,5 +19,7 @@
   ],
   "homepage": "https://docs.camunda.io/docs/next/guides/migrating-from-camunda-7/data-migrator/",
   "repository": "https://github.com/camunda/camunda-7-to-8-migration-tooling",
-  "skills": "skills/"
+  "skills": [
+    "./skills/migrate-c7-to-c8-code"
+  ]
 }


### PR DESCRIPTION
## Summary
- `plugin.json`'s `skills` field was a string (`"skills/"`) instead of an array of relative paths, which fails plugin manifest schema validation.
- Fixed to `"skills": ["./skills/migrate-c7-to-c8-code"]`, matching the format used by other Claude Code plugin manifests (e.g. AMD, Box, NetSuite skill plugins in the official marketplace).

Fixes install error:
```
Installing plugin "camunda-migration"...
✘ Failed to install plugin "camunda-migration": Plugin ... has an invalid manifest file at .../plugin.json.
Validation errors: skills: Invalid input
```

## Test plan
- [x] Confirmed via `claude plugin marketplace add` + `claude plugin install camunda-migration` reproduces the original error against the unfixed manifest.
- [x] Re-run install against this branch to confirm it succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)