### PR TITLE
fix(cli): clarify engine help labels

### DIFF
--- a/diagram-converter/cli/src/main/java/io/camunda/migration/diagram/converter/cli/ConvertEngineCommand.java
+++ b/diagram-converter/cli/src/main/java/io/camunda/migration/diagram/converter/cli/ConvertEngineCommand.java
@@ -43,17 +43,20 @@ public class ConvertEngineCommand extends AbstractConvertCommand {
 
   @Option(
       names = {"-u", "--username"},
-      description = "Username for basic auth")
+      description = "Username for Basic authentication",
+      paramLabel = "<username>")
   String username;
 
   @Option(
       names = {"-p", "--password"},
-      description = "Password for basic auth")
+      description = "Password for Basic authentication",
+      paramLabel = "<password>")
   String password;
 
   @Option(
       names = {"-t", "--target-directory"},
       description = "The directory to save the .bpmn files",
+      paramLabel = "<targetDirectory>",
       defaultValue = ".")
   File targetDirectory = new File(".");
 

--- a/diagram-converter/cli/src/test/java/io/camunda/migration/diagram/converter/cli/ConvertEngineCommandHelpTest.java
+++ b/diagram-converter/cli/src/test/java/io/camunda/migration/diagram/converter/cli/ConvertEngineCommandHelpTest.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.migration.diagram.converter.cli;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import picocli.CommandLine;
+
+class ConvertEngineCommandHelpTest {
+
+  @Test
+  void shouldRenderPasswordAndAuthenticationLabelsInHelp() {
+    String help = new CommandLine(new ConvertEngineCommand()).getUsageMessage();
+
+    assertThat(help).contains("-p, --password=<password>");
+    assertThat(help).contains("Password for Basic authentication");
+    assertThat(help).contains("-u, --username=<username>");
+    assertThat(help).contains("Username for Basic authentication");
+    assertThat(help).contains("-t, --target-directory=<targetDirectory>");
+  }
+}


### PR DESCRIPTION
## Summary

Clarifies the Diagram Converter engine CLI help output so the authentication options render with explicit labels and glossary-correct wording.

## Changes

- Uses `Basic authentication` in the username and password descriptions
- Sets explicit help labels for `username`, `password`, and `target-directory`
- Adds a regression test that checks the rendered usage message

## Validation

- Ran `mvn test -pl diagram-converter/cli -am -Dtest=ConvertEngineCommandHelpTest -Dsurefire.failIfNoSpecifiedTests=false -Dmaven.compiler.release=21`
