### PR TITLE
fix(cli): honor --not-recursive in local conversion

### DIFF
--- a/diagram-converter/cli/src/main/java/io/camunda/migration/diagram/converter/cli/ConvertLocalCommand.java
+++ b/diagram-converter/cli/src/main/java/io/camunda/migration/diagram/converter/cli/ConvertLocalCommand.java
@@ -23,6 +23,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.apache.commons.io.file.PathVisitor;
 import org.camunda.bpm.model.xml.ModelInstance;
 import org.slf4j.Logger;
@@ -113,7 +114,17 @@ public class ConvertLocalCommand extends AbstractConvertCommand {
   private List<File> findFiles(File directory) {
     List<File> files = new ArrayList<>();
     try {
-      Files.walkFileTree(directory.toPath(), new FindFileBySuffixPathVisitor(files));
+      if (notRecursive) {
+        try (Stream<Path> stream = Files.list(directory.toPath())) {
+          stream
+              .filter(Files::isRegularFile)
+              .map(Path::toFile)
+              .filter(this::isValidFile)
+              .forEach(files::add);
+        }
+      } else {
+        Files.walkFileTree(directory.toPath(), new FindFileBySuffixPathVisitor(files));
+      }
     } catch (Exception e) {
       LOG_CLI.error("Error while finding files: {}", createMessage(e));
       returnCode = 1;

--- a/diagram-converter/cli/src/test/java/io/camunda/migration/diagram/converter/cli/ConvertLocalCommandTest.java
+++ b/diagram-converter/cli/src/test/java/io/camunda/migration/diagram/converter/cli/ConvertLocalCommandTest.java
@@ -15,6 +15,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Objects;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -107,5 +108,44 @@ public class ConvertLocalCommandTest {
     Integer call = command.call();
     assertEquals(0, call);
     assertThat(tempDir.listFiles()).hasSize(1).anyMatch(file -> file.getName().equals("c7.bpmn"));
+  }
+
+  @Test
+  void shouldSkipNestedDirectoriesWhenNotRecursive(@TempDir File tempDir) throws IOException {
+    setupDir("c7.bpmn", tempDir);
+    File nestedDir = new File(tempDir, "nested");
+    assertThat(nestedDir.mkdirs()).isTrue();
+    Path nestedSource = new File(tempDir, "c7.bpmn").toPath();
+    Path nestedTarget = new File(nestedDir, "nested.bpmn").toPath();
+    Files.copy(nestedSource, nestedTarget, REPLACE_EXISTING);
+
+    ConvertLocalCommand command = new ConvertLocalCommand();
+    command.file = tempDir;
+    command.notRecursive = true;
+
+    Integer call = command.call();
+
+    assertEquals(0, call);
+    assertThat(new File(tempDir, "converted-c8-c7.bpmn")).exists();
+    assertThat(new File(nestedDir, "converted-c8-nested.bpmn")).doesNotExist();
+  }
+
+  @Test
+  void shouldProcessNestedDirectoriesByDefault(@TempDir File tempDir) throws IOException {
+    setupDir("c7.bpmn", tempDir);
+    File nestedDir = new File(tempDir, "nested");
+    assertThat(nestedDir.mkdirs()).isTrue();
+    Path nestedSource = new File(tempDir, "c7.bpmn").toPath();
+    Path nestedTarget = new File(nestedDir, "nested.bpmn").toPath();
+    Files.copy(nestedSource, nestedTarget, REPLACE_EXISTING);
+
+    ConvertLocalCommand command = new ConvertLocalCommand();
+    command.file = tempDir;
+
+    Integer call = command.call();
+
+    assertEquals(0, call);
+    assertThat(new File(tempDir, "converted-c8-c7.bpmn")).exists();
+    assertThat(new File(nestedDir, "converted-c8-nested.bpmn")).exists();
   }
 }


### PR DESCRIPTION
## Summary

Fixes local CLI behavior so `--not-recursive` only processes files directly in the input directory.

related to #2028

## Changes

- Updated `ConvertLocalCommand.findFiles(...)`:
  - when `--not-recursive` is set, use `Files.list(...)` and process only regular files in the top-level directory
  - keep recursive traversal (`Files.walkFileTree(...)`) as the default behavior
- Added regression tests in `ConvertLocalCommandTest`:
  - `shouldSkipNestedDirectoriesWhenNotRecursive`
  - `shouldProcessNestedDirectoriesByDefault`

## Validation

- Ran `mvn test -pl diagram-converter/cli -am -Dtest=ConvertLocalCommandTest -Dsurefire.failIfNoSpecifiedTests=false -Dmaven.compiler.release=21 --no-transfer-progress`