### PR TITLE
feat(core): add deployment wiring prompt for converted models

### DIFF
--- a/agentic-migration-skills/skills/migrate-c7-to-c8-code/SKILL.md
+++ b/agentic-migration-skills/skills/migrate-c7-to-c8-code/SKILL.md
@@ -406,7 +406,7 @@ When the scope is **Code + models**:
 - Keep both inventories and both sets of results in `MIGRATION_REPORT.md`.
 - After both complete, cross-check: job types emitted by the Diagram Converter should match the `@JobWorker(type = ...)` values produced by the code migration. Flag mismatches for the user.
 - After both complete, ask whether to wire deployment of converted files in application code via `AskUserQuestion`:
-  - **Yes, add/update `@Deployment` for converted files** *(recommended when code scope includes a Spring Boot app)* — add or update `@Deployment(resources = ...)` so it targets only converted resources with explicit classpath patterns (for example, `@Deployment(resources = {"classpath*:converted-c8-*.bpmn", "classpath*:converted-c8-*.dmn"})`) and never the original diagrams.
+  - **Yes, add/update `@Deployment` for converted files** *(recommended when code scope includes a Spring Boot app)* — add or update `@Deployment(resources = ...)` so it targets only converted resources with explicit recursive classpath patterns (for example, `@Deployment(resources = {"classpath*:**/converted-c8-*.bpmn", "classpath*:**/converted-c8-*.dmn"})`) and never the original diagrams.
   - **No, I will handle deployment outside app startup** — leave code unchanged and record this decision in `MIGRATION_REPORT.md`.
 
 ---

--- a/agentic-migration-skills/skills/migrate-c7-to-c8-code/SKILL.md
+++ b/agentic-migration-skills/skills/migrate-c7-to-c8-code/SKILL.md
@@ -405,6 +405,9 @@ When the scope is **Code + models**:
 - The two paths are independent — run each with its chosen approach. Order doesn't strictly matter; a reasonable default is **models first** (diagrams define the job types/listeners the code must implement), then code, but follow the user's preference.
 - Keep both inventories and both sets of results in `MIGRATION_REPORT.md`.
 - After both complete, cross-check: job types emitted by the Diagram Converter should match the `@JobWorker(type = ...)` values produced by the code migration. Flag mismatches for the user.
+- After both complete, ask whether to wire deployment of converted files in application code via `AskUserQuestion`:
+  - **Yes, add/update `@Deployment` for converted files** *(recommended when code scope includes a Spring Boot app)* — add or update `@Deployment(resources = ...)` so it targets only `converted-c8-*.bpmn` / `converted-c8-*.dmn` resources (never the original diagrams).
+  - **No, I will handle deployment outside app startup** — leave code unchanged and record this decision in `MIGRATION_REPORT.md`.
 
 ---
 

--- a/agentic-migration-skills/skills/migrate-c7-to-c8-code/SKILL.md
+++ b/agentic-migration-skills/skills/migrate-c7-to-c8-code/SKILL.md
@@ -406,7 +406,7 @@ When the scope is **Code + models**:
 - Keep both inventories and both sets of results in `MIGRATION_REPORT.md`.
 - After both complete, cross-check: job types emitted by the Diagram Converter should match the `@JobWorker(type = ...)` values produced by the code migration. Flag mismatches for the user.
 - After both complete, ask whether to wire deployment of converted files in application code via `AskUserQuestion`:
-  - **Yes, add/update `@Deployment` for converted files** *(recommended when code scope includes a Spring Boot app)* — add or update `@Deployment(resources = ...)` so it targets only `converted-c8-*.bpmn` / `converted-c8-*.dmn` resources (never the original diagrams).
+  - **Yes, add/update `@Deployment` for converted files** *(recommended when code scope includes a Spring Boot app)* — add or update `@Deployment(resources = ...)` so it targets only converted resources with explicit classpath patterns (for example, `@Deployment(resources = {"classpath*:converted-c8-*.bpmn", "classpath*:converted-c8-*.dmn"})`) and never the original diagrams.
   - **No, I will handle deployment outside app startup** — leave code unchanged and record this decision in `MIGRATION_REPORT.md`.
 
 ---


### PR DESCRIPTION
## Summary

- introduce an explicit Code+models composition prompt asking whether converted-c8 BPMN/DMN files should be wired for deployment at app startup
- provide a recommended opt-in path to add/update `@Deployment(resources=...)` for converted-c8 files only
- keep an explicit opt-out path that records manual deployment ownership in `MIGRATION_REPORT.md`

## Changes

- `agentic-migration-skills/skills/migrate-c7-to-c8-code/SKILL.md`: extend the "Composing code + model migration" section with deployment-wiring `AskUserQuestion` options and explicit `classpath*:` pattern guidance

## Test plan

- [x] Documentation-only change (no runnable module tests in this submodule)

## Baseline

Built from commit: 1b7564066371aa22e20ee3e79960201453155839

closes #2025

🤖 Generated with [Claude Code](https://claude.com/claude-code)
