### PR TITLE
feat(core): add JDK compatibility gate for rewrite migration

### DIFF
--- a/agentic-migration-skills/skills/migrate-c7-to-c8-code/SKILL.md
+++ b/agentic-migration-skills/skills/migrate-c7-to-c8-code/SKILL.md
@@ -264,7 +264,7 @@ For Maven — add to `pom.xml`:
      - If the project already has a `.mvn` directory, prefer appending them temporarily to `.mvn/jvm.config` while preserving any existing content. Otherwise, use `JAVA_TOOL_OPTIONS` rather than creating repository configuration solely for this temporary step.
      - Arrange cleanup so it runs whether `mvn rewrite:run` succeeds or fails: restore the exact previous `.mvn/jvm.config` content or remove the file if this step created it, and restore the previous `JAVA_TOOL_OPTIONS` value if it was changed.
      - Do not stage or commit the temporary changes; preserve any legitimate pre-existing tracked configuration.
-   - If this still fails with a Spotless error, ask the user: "Spotless is incompatible with your current Java version. Would you like to skip it for now (`mvn rewrite:run -Dspotless.skip=true`) or switch to a Java version known to work with this project's Spotless setup (for example Java 11 or 17 if you're currently on a newer JDK)?"
+   - If this still fails with a Spotless error, ask the user: "Spotless is incompatible with your current Java version. Would you like to skip it for now (`mvn rewrite:run -Dspotless.skip=true`) or switch to another JDK that still stays inside the currently selected OpenRewrite+recipes compatibility window?"
 4. If Spotless is not present, or the selected Java major version < 17, run `mvn rewrite:run` directly.
 
 For Gradle — add to `build.gradle`:

--- a/agentic-migration-skills/skills/migrate-c7-to-c8-code/SKILL.md
+++ b/agentic-migration-skills/skills/migrate-c7-to-c8-code/SKILL.md
@@ -247,9 +247,9 @@ For Maven — add to `pom.xml`:
 **Before running**, check Java runtime compatibility for OpenRewrite itself, then check Spotless + Java compatibility:
 
 1. Detect installed JDKs and pick one compatible with the selected OpenRewrite + recipe versions.
-   - The current known-safe window for this migration flow is Java **21-23** (recipes require Java 21+, while current OpenRewrite plugin versions can fail on Java 24+).
+   - For the currently reported combination (`rewrite-maven-plugin` 6.12.0 + `camunda-7-to-8-code-conversion-recipes` 0.3.x), the known-safe window is Java **21-23** (recipes require Java 21+, while this rewrite plugin line can fail on Java 24+).
    - Detect installed JDKs with a platform-appropriate method (for example `/usr/libexec/java_home -V` on macOS), then choose a compatible one and scope `JAVA_HOME`/`PATH` to that JDK only for the rewrite step.
-   - If no compatible JDK is installed, ask via `AskUserQuestion` to install one (for example `brew install openjdk@21` on macOS), wait for confirmation, then continue.
+   - If no compatible JDK is installed, ask via `AskUserQuestion` to install one (for example `brew install openjdk@21` on macOS), wait for confirmation, then re-detect installed JDKs and select a compatible one before continuing.
 2. Inspect the Maven/Gradle build files to determine whether Spotless is configured.
 3. If Spotless is present **and** the selected Java major version ≥ 17:
    - Run the OpenRewrite Maven goal with the JVM flags Spotless needs on Java 17+:

--- a/agentic-migration-skills/skills/migrate-c7-to-c8-code/SKILL.md
+++ b/agentic-migration-skills/skills/migrate-c7-to-c8-code/SKILL.md
@@ -244,11 +244,14 @@ For Maven — add to `pom.xml`:
 </plugin>
 ```
 
-**Before running**, check for Spotless + Java version incompatibility and fix proactively:
+**Before running**, check Java runtime compatibility for OpenRewrite itself, then check Spotless + Java compatibility:
 
-1. Detect whether Java is installed and record its major version.
+1. Detect installed JDKs and pick one compatible with the selected OpenRewrite + recipe versions.
+   - The current known-safe window for this migration flow is Java **21-23** (recipes require Java 21+, while current OpenRewrite plugin versions can fail on Java 24+).
+   - Detect installed JDKs with a platform-appropriate method (for example `/usr/libexec/java_home -V` on macOS), then choose a compatible one and scope `JAVA_HOME`/`PATH` to that JDK only for the rewrite step.
+   - If no compatible JDK is installed, ask via `AskUserQuestion` to install one (for example `brew install openjdk@21` on macOS), wait for confirmation, then continue.
 2. Inspect the Maven/Gradle build files to determine whether Spotless is configured.
-3. If Spotless is present **and** Java major version ≥ 17:
+3. If Spotless is present **and** the selected Java major version ≥ 17:
    - Run the OpenRewrite Maven goal with the JVM flags Spotless needs on Java 17+:
      - `--add-opens=java.base/java.lang=ALL-UNNAMED`
      - `--add-opens=java.base/java.util=ALL-UNNAMED`
@@ -262,7 +265,7 @@ For Maven — add to `pom.xml`:
      - Arrange cleanup so it runs whether `mvn rewrite:run` succeeds or fails: restore the exact previous `.mvn/jvm.config` content or remove the file if this step created it, and restore the previous `JAVA_TOOL_OPTIONS` value if it was changed.
      - Do not stage or commit the temporary changes; preserve any legitimate pre-existing tracked configuration.
    - If this still fails with a Spotless error, ask the user: "Spotless is incompatible with your current Java version. Would you like to skip it for now (`mvn rewrite:run -Dspotless.skip=true`) or switch to a Java version known to work with this project's Spotless setup (for example Java 11 or 17 if you're currently on a newer JDK)?"
-4. If Spotless is not present, or Java < 17, run `mvn rewrite:run` directly.
+4. If Spotless is not present, or the selected Java major version < 17, run `mvn rewrite:run` directly.
 
 For Gradle — add to `build.gradle`:
 ```groovy


### PR DESCRIPTION
## Summary

- add a feature-gated OpenRewrite runtime JDK compatibility check before Spotless handling
- require detection/selection of a compatible installed JDK with scoped `JAVA_HOME`/`PATH` for rewrite execution
- add an `AskUserQuestion` install flow when no compatible JDK exists, then re-detect/select before continuing

## Changes

- `agentic-migration-skills/skills/migrate-c7-to-c8-code/SKILL.md`: update OpenRewrite pre-run guidance to handle JDK compatibility independently from Spotless and scope the known-safe range to the reported plugin/recipe combination

## Test plan

- [x] Documentation-only change (no runnable module tests in this submodule)

## Baseline

Built from commit: d8aaf0e72b4d2dcc90959a9146e0957f4017f554

closes #2026

🤖 Generated with [Claude Code](https://claude.com/claude-code)
