### PR TITLE
feat(core): add logging-backend preservation migration guidance

### DIFF
--- a/agentic-migration-skills/skills/migrate-c7-to-c8-code/SKILL.md
+++ b/agentic-migration-skills/skills/migrate-c7-to-c8-code/SKILL.md
@@ -169,6 +169,7 @@ Confirm each item before the next (commit policy: Shared rules). Tags mark what 
   - Gradle: `maven { url "https://artifacts.camunda.com/artifactory/public/" }`
 - Remove `org.camunda.bpm.*`, `camunda-bom`, and embedded-engine deps (H2, JDBC starter).
 - Add the starter; add `io.camunda:camunda-process-test-spring` (test scope) if tests exist.
+- If removing Camunda 7 webapp/rest starters also removes your only SLF4J binding, add `org.springframework.boot:spring-boot-starter-logging` (or another SLF4J backend) so startup failures remain visible.
 - Ensure Spring Boot dependency management is set (parent or BOM); don't add `spring-boot-starter` just for jakarta.annotation.
 - Replace `@EnableProcessApplication` with `@Deployment`.
 - Replace `camunda.*` keys with `camunda.client.*` in `application.properties`/`.yaml` ([properties reference](https://docs.camunda.io/docs/apis-tools/camunda-spring-boot-starter/properties-reference/)).

--- a/code-conversion/patterns/10-general/dependencies.md
+++ b/code-conversion/patterns/10-general/dependencies.md
@@ -23,3 +23,5 @@ Also, configure your connection to the Camunda 8 cluster in the `application.pro
 ```
 
 **Java client artifact**: Use `io.camunda:camunda-client-java`. The legacy `io.camunda:zeebe-client-java` artifact is deprecated and will be discontinued in Camunda 8.10.
+
+**Logging backend**: When removing Camunda 7 webapp/rest starters, keep an SLF4J binding. If those starters were your only logging source, add `org.springframework.boot:spring-boot-starter-logging` (or another SLF4J backend) so startup failures remain visible.

--- a/code-conversion/patterns/ALL_IN_ONE.md
+++ b/code-conversion/patterns/ALL_IN_ONE.md
@@ -81,6 +81,8 @@ Also, configure your connection to the Camunda 8 cluster in the `application.pro
 
 **Java client artifact**: Use `io.camunda:camunda-client-java`. The legacy `io.camunda:zeebe-client-java` artifact is deprecated and will be discontinued in Camunda 8.10.
 
+**Logging backend**: When removing Camunda 7 webapp/rest starters, keep an SLF4J binding. If those starters were your only logging source, add `org.springframework.boot:spring-boot-starter-logging` (or another SLF4J backend) so startup failures remain visible.
+
 ---
 
 ### Handling Process Variables


### PR DESCRIPTION
## Summary

- add migration guidance to preserve an SLF4J binding when removing Camunda 7 webapp/rest starters
- recommend adding `spring-boot-starter-logging` (or another SLF4J backend) when those starters were the only logging backend
- keep this guidance aligned across both the pattern catalog and the agentic migration skill checklist

## Changes

- `code-conversion/patterns/10-general/dependencies.md`: add logging-backend preservation guidance
- `code-conversion/patterns/ALL_IN_ONE.md`: regenerated from source pattern files
- `agentic-migration-skills/skills/migrate-c7-to-c8-code/SKILL.md`: add checklist bullet for SLF4J backend preservation

## Test plan

- [x] Regenerated pattern artifacts (`node generate-catalog.js`, `node generate-all-in-one.js`)
- [x] Documentation-only changes

## Baseline

Built from commit: b8d1442bbbbc5bcdaac46b50d03aaee7a36685d7

closes #2019

🤖 Generated with [Claude Code](https://claude.com/claude-code)
