### PR TITLE
feat(core): add explicit deployment guidance for migrated models

### DIFF
--- a/agentic-migration-skills/skills/migrate-c7-to-c8-code/SKILL.md
+++ b/agentic-migration-skills/skills/migrate-c7-to-c8-code/SKILL.md
@@ -171,7 +171,7 @@ Confirm each item before the next (commit policy: Shared rules). Tags mark what 
 - Add the starter; add `io.camunda:camunda-process-test-spring` (test scope) if tests exist.
 - If removing Camunda 7 webapp/rest starters also removes your only SLF4J binding, add `org.springframework.boot:spring-boot-starter-logging` (or another SLF4J backend) so startup failures remain visible.
 - Ensure Spring Boot dependency management is set (parent or BOM); don't add `spring-boot-starter` just for jakarta.annotation.
-- Replace `@EnableProcessApplication` with `@Deployment`.
+- Replace `@EnableProcessApplication` with `@Deployment`. If the C7 app relied on implicit classpath auto-deployment (no `@EnableProcessApplication` present), still add explicit `@Deployment(resources = ...)` for BPMN/DMN files because C8 has no equivalent implicit deployment.
 - Replace `camunda.*` keys with `camunda.client.*` in `application.properties`/`.yaml` ([properties reference](https://docs.camunda.io/docs/apis-tools/camunda-spring-boot-starter/properties-reference/)).
 - Reference: "Maven dependency and configuration".
 

--- a/code-conversion/patterns/20-client-code/10-process-engine/handle-resources.md
+++ b/code-conversion/patterns/20-client-code/10-process-engine/handle-resources.md
@@ -34,6 +34,7 @@ public class ProcessPaymentsApplication {
 ```
 
 -   the annotation `@Deployment` can be used to specify specific files or multiple resources via a wildcard pattern to be deployed to the engine
+-   Camunda 8 has no implicit classpath auto-deployment equivalent to the Camunda 7 Spring Boot starter defaults. Even if your Camunda 7 app had no `@EnableProcessApplication`, you must still add explicit deployment wiring (`@Deployment` or deploy commands) for BPMN/DMN resources.
 -   for more information, see [the docs](https://docs.camunda.io/docs/next/apis-tools/spring-zeebe-sdk/getting-started/#deploy-process-models)
 
 ## Deploy BPMN Model

--- a/code-conversion/patterns/ALL_IN_ONE.md
+++ b/code-conversion/patterns/ALL_IN_ONE.md
@@ -788,6 +788,7 @@ public class ProcessPaymentsApplication {
 ```
 
 -   the annotation `@Deployment` can be used to specify specific files or multiple resources via a wildcard pattern to be deployed to the engine
+-   Camunda 8 has no implicit classpath auto-deployment equivalent to the Camunda 7 Spring Boot starter defaults. Even if your Camunda 7 app had no `@EnableProcessApplication`, you must still add explicit deployment wiring (`@Deployment` or deploy commands) for BPMN/DMN resources.
 -   for more information, see [the docs](https://docs.camunda.io/docs/next/apis-tools/spring-zeebe-sdk/getting-started/#deploy-process-models)
 
 ###### Deploy BPMN Model


### PR DESCRIPTION
## Summary

- add explicit guidance that Camunda 8 has no implicit classpath deployment equivalent to C7 starter defaults
- require explicit deployment wiring even when the original C7 app had no `@EnableProcessApplication`
- align this runtime requirement across both the patterns catalog and migration skill checklist

## Changes

- `code-conversion/patterns/20-client-code/10-process-engine/handle-resources.md`: add explicit no-implicit-deployment guidance
- `code-conversion/patterns/ALL_IN_ONE.md`: regenerated from source pattern files
- `agentic-migration-skills/skills/migrate-c7-to-c8-code/SKILL.md`: extend `@Deployment` checklist item with no-annotation C7 case

## Test plan

- [x] Regenerated pattern artifacts (`node generate-catalog.js`, `node generate-all-in-one.js`)
- [x] Documentation-only changes

## Baseline

Built from commit: 5ac428c7b95d9b537c3eaf1e1e70d69ef0082041

closes #2020

🤖 Generated with [Claude Code](https://claude.com/claude-code)
