### PR TITLE
feat(core): add post-deployment startup guidance

### DIFF
--- a/agentic-migration-skills/skills/migrate-c7-to-c8-code/SKILL.md
+++ b/agentic-migration-skills/skills/migrate-c7-to-c8-code/SKILL.md
@@ -178,6 +178,7 @@ Confirm each item before the next (commit policy: Shared rules). Tags mark what 
 **2. Client code** (`ProcessEngine` → `CamundaClient`)
 - Replace `ProcessEngine`/service autowiring (RuntimeService, TaskService, HistoryService, DecisionService, ManagementService) with `CamundaClient`.
 - Map: start instances (incl. `businessId`/tags), message correlation, signal broadcast, cancel, user tasks, variables, `HistoryService` → search requests, `DecisionService` → `newEvaluateDecisionCommand`, batch `...Async` → batch operations (8.8+).
+- If migrated code starts instances from `@PostConstruct` while using `@Deployment`, move that startup logic to `@EventListener(CamundaPostDeploymentEvent.class)` to avoid deployment-order races.
 - Reference: "Client code → ProcessEngine" (incl. Business Key, Batch Operations, Evaluate Decisions, Query History).
 
 **3. JavaDelegate → Job Worker** *(OpenRewrite covers this)*

--- a/code-conversion/patterns/20-client-code/10-process-engine/starting-process-instances.md
+++ b/code-conversion/patterns/20-client-code/10-process-engine/starting-process-instances.md
@@ -64,6 +64,7 @@ The following patterns focus on various methods to start process instances in Ca
 -   uniqueness enforcement is optional and configurable per cluster; when enabled, duplicate businessId for the same process definition is rejected with a conflict error
 -   on Camunda 8.8 (no businessId) use tags or a process variable instead — see the [Business Key pattern](business-key-and-tags.md)
 -   if you need a bounded wait for the command response, apply a timeout to the returned future (e.g. `send().orTimeout(...).join()` or `send().get(timeout, unit)`); `send()` itself does **not** wait for the process instance to complete
+-   if your app also uses `@Deployment`, do not start instances from `@PostConstruct`; use `@EventListener(CamundaPostDeploymentEvent.class)` so startup runs after deployment completes
 
 ## By Key Assigned on Deployment (specific version)
 

--- a/code-conversion/patterns/ALL_IN_ONE.md
+++ b/code-conversion/patterns/ALL_IN_ONE.md
@@ -1173,6 +1173,7 @@ The following patterns focus on various methods to start process instances in Ca
 -   uniqueness enforcement is optional and configurable per cluster; when enabled, duplicate businessId for the same process definition is rejected with a conflict error
 -   on Camunda 8.8 (no businessId) use tags or a process variable instead — see the [Business Key pattern](business-key-and-tags.md)
 -   if you need a bounded wait for the command response, apply a timeout to the returned future (e.g. `send().orTimeout(...).join()` or `send().get(timeout, unit)`); `send()` itself does **not** wait for the process instance to complete
+-   if your app also uses `@Deployment`, do not start instances from `@PostConstruct`; use `@EventListener(CamundaPostDeploymentEvent.class)` so startup runs after deployment completes
 
 ###### By Key Assigned on Deployment (specific version)
 


### PR DESCRIPTION
## Summary

- add explicit guidance to avoid starting process instances from `@PostConstruct` when `@Deployment` is used
- direct migrations to `@EventListener(CamundaPostDeploymentEvent.class)` to prevent startup race conditions
- keep the startup-order guidance aligned in both the patterns catalog and migration skill checklist

## Changes

- `code-conversion/patterns/20-client-code/10-process-engine/starting-process-instances.md`: add deployment-order race guidance and event-listener replacement
- `code-conversion/patterns/ALL_IN_ONE.md`: regenerated from source pattern files
- `agentic-migration-skills/skills/migrate-c7-to-c8-code/SKILL.md`: add client-code checklist item for `@PostConstruct` migration

## Test plan

- [x] Regenerated pattern artifacts (`node generate-catalog.js`, `node generate-all-in-one.js`)
- [x] Documentation-only changes

## Baseline

Built from commit: 655dd11bd4c2aa34d07c089a78748486ed3d42cb

closes #2021

🤖 Generated with [Claude Code](https://claude.com/claude-code)
