### PR TITLE
feat(core): prioritize lifecycle migration over jakarta patching

### DIFF
--- a/agentic-migration-skills/skills/migrate-c7-to-c8-code/SKILL.md
+++ b/agentic-migration-skills/skills/migrate-c7-to-c8-code/SKILL.md
@@ -170,7 +170,7 @@ Confirm each item before the next (commit policy: Shared rules). Tags mark what 
 - Remove `org.camunda.bpm.*`, `camunda-bom`, and embedded-engine deps (H2, JDBC starter).
 - Add the starter; add `io.camunda:camunda-process-test-spring` (test scope) if tests exist.
 - If removing Camunda 7 webapp/rest starters also removes your only SLF4J binding, add `org.springframework.boot:spring-boot-starter-logging` (or another SLF4J backend) so startup failures remain visible.
-- Ensure Spring Boot dependency management is set (parent or BOM); don't add `spring-boot-starter` just for jakarta.annotation.
+- Ensure Spring Boot dependency management is set (parent or BOM). If `@PostConstruct` is only used to start process instances, migrate that flow to `@EventListener(CamundaPostDeploymentEvent.class)` first instead of patching dependencies just to keep `jakarta.annotation`.
 - Replace `@EnableProcessApplication` with `@Deployment`. If the C7 app relied on implicit classpath auto-deployment (no `@EnableProcessApplication` present), still add explicit `@Deployment(resources = ...)` for BPMN/DMN files because C8 has no equivalent implicit deployment.
 - Replace `camunda.*` keys with `camunda.client.*` in `application.properties`/`.yaml` ([properties reference](https://docs.camunda.io/docs/apis-tools/camunda-spring-boot-starter/properties-reference/)).
 - Reference: "Maven dependency and configuration".

--- a/agentic-migration-skills/skills/migrate-c7-to-c8-code/SKILL.md
+++ b/agentic-migration-skills/skills/migrate-c7-to-c8-code/SKILL.md
@@ -170,7 +170,7 @@ Confirm each item before the next (commit policy: Shared rules). Tags mark what 
 - Remove `org.camunda.bpm.*`, `camunda-bom`, and embedded-engine deps (H2, JDBC starter).
 - Add the starter; add `io.camunda:camunda-process-test-spring` (test scope) if tests exist.
 - If removing Camunda 7 webapp/rest starters also removes your only SLF4J binding, add `org.springframework.boot:spring-boot-starter-logging` (or another SLF4J backend) so startup failures remain visible.
-- Ensure Spring Boot dependency management is set (parent or BOM). If `@PostConstruct` is only used to start process instances, migrate that flow to `@EventListener(CamundaPostDeploymentEvent.class)` first instead of patching dependencies just to keep `jakarta.annotation`.
+- Ensure Spring Boot dependency management is set (parent or BOM). If `@PostConstruct` is only used to start process instances, migrate that flow to `@EventListener(CamundaPostDeploymentEvent.class)` first instead of patching dependencies (for example adding `jakarta.annotation-api`) just to keep `jakarta.annotation`.
 - Replace `@EnableProcessApplication` with `@Deployment`. If the C7 app relied on implicit classpath auto-deployment (no `@EnableProcessApplication` present), still add explicit `@Deployment(resources = ...)` for BPMN/DMN files because C8 has no equivalent implicit deployment.
 - Replace `camunda.*` keys with `camunda.client.*` in `application.properties`/`.yaml` ([properties reference](https://docs.camunda.io/docs/apis-tools/camunda-spring-boot-starter/properties-reference/)).
 - Reference: "Maven dependency and configuration".

--- a/code-conversion/patterns/10-general/dependencies.md
+++ b/code-conversion/patterns/10-general/dependencies.md
@@ -25,3 +25,5 @@ Also, configure your connection to the Camunda 8 cluster in the `application.pro
 **Java client artifact**: Use `io.camunda:camunda-client-java`. The legacy `io.camunda:zeebe-client-java` artifact is deprecated and will be discontinued in Camunda 8.10.
 
 **Logging backend**: When removing Camunda 7 webapp/rest starters, keep an SLF4J binding. If those starters were your only logging source, add `org.springframework.boot:spring-boot-starter-logging` (or another SLF4J backend) so startup failures remain visible.
+
+**`jakarta.annotation` and process startup**: If `@PostConstruct` remains only to start process instances, migrate that startup to `@EventListener(CamundaPostDeploymentEvent.class)` first. Prefer fixing that lifecycle pattern over adding dependencies solely to keep `@PostConstruct`.

--- a/code-conversion/patterns/10-general/dependencies.md
+++ b/code-conversion/patterns/10-general/dependencies.md
@@ -26,4 +26,4 @@ Also, configure your connection to the Camunda 8 cluster in the `application.pro
 
 **Logging backend**: When removing Camunda 7 webapp/rest starters, keep an SLF4J binding. If those starters were your only logging source, add `org.springframework.boot:spring-boot-starter-logging` (or another SLF4J backend) so startup failures remain visible.
 
-**`jakarta.annotation` and process startup**: If `@PostConstruct` remains only to start process instances, migrate that startup to `@EventListener(CamundaPostDeploymentEvent.class)` first. Prefer fixing that lifecycle pattern over adding dependencies solely to keep `@PostConstruct`.
+**`jakarta.annotation` and process startup**: If `@PostConstruct` remains only to start process instances, migrate that startup to `@EventListener(CamundaPostDeploymentEvent.class)` first. Prefer fixing that lifecycle pattern over adding dependencies (for example `jakarta.annotation-api`) solely to keep `@PostConstruct`.

--- a/code-conversion/patterns/ALL_IN_ONE.md
+++ b/code-conversion/patterns/ALL_IN_ONE.md
@@ -83,7 +83,7 @@ Also, configure your connection to the Camunda 8 cluster in the `application.pro
 
 **Logging backend**: When removing Camunda 7 webapp/rest starters, keep an SLF4J binding. If those starters were your only logging source, add `org.springframework.boot:spring-boot-starter-logging` (or another SLF4J backend) so startup failures remain visible.
 
-**`jakarta.annotation` and process startup**: If `@PostConstruct` remains only to start process instances, migrate that startup to `@EventListener(CamundaPostDeploymentEvent.class)` first. Prefer fixing that lifecycle pattern over adding dependencies solely to keep `@PostConstruct`.
+**`jakarta.annotation` and process startup**: If `@PostConstruct` remains only to start process instances, migrate that startup to `@EventListener(CamundaPostDeploymentEvent.class)` first. Prefer fixing that lifecycle pattern over adding dependencies (for example `jakarta.annotation-api`) solely to keep `@PostConstruct`.
 
 ---
 

--- a/code-conversion/patterns/ALL_IN_ONE.md
+++ b/code-conversion/patterns/ALL_IN_ONE.md
@@ -83,6 +83,8 @@ Also, configure your connection to the Camunda 8 cluster in the `application.pro
 
 **Logging backend**: When removing Camunda 7 webapp/rest starters, keep an SLF4J binding. If those starters were your only logging source, add `org.springframework.boot:spring-boot-starter-logging` (or another SLF4J backend) so startup failures remain visible.
 
+**`jakarta.annotation` and process startup**: If `@PostConstruct` remains only to start process instances, migrate that startup to `@EventListener(CamundaPostDeploymentEvent.class)` first. Prefer fixing that lifecycle pattern over adding dependencies solely to keep `@PostConstruct`.
+
 ---
 
 ### Handling Process Variables


### PR DESCRIPTION
## Summary

- replace jakarta-annotation workaround guidance with lifecycle-first migration guidance
- instruct migrations to move process-startup `@PostConstruct` flows to `@EventListener(CamundaPostDeploymentEvent.class)` before adding dependency patches
- keep patterns catalog and migration skill checklist aligned on this lifecycle-first priority

## Changes

- `agentic-migration-skills/skills/migrate-c7-to-c8-code/SKILL.md`: replace jakarta workaround checklist line with lifecycle-first guidance
- `code-conversion/patterns/10-general/dependencies.md`: add explicit guidance to prefer lifecycle fix over dependency patching
- `code-conversion/patterns/ALL_IN_ONE.md`: regenerated from source pattern files

## Test plan

- [x] Regenerated pattern artifacts (`node generate-catalog.js`, `node generate-all-in-one.js`)
- [x] Documentation-only changes

## Baseline

Built from commit: 6a6fd181df96baefcb021b5f7349f1591352c0e4

closes #2022

🤖 Generated with [Claude Code](https://claude.com/claude-code)
