### PR TITLE
fix(core): map Execution.getId in start-instance recipe

### DIFF
--- a/code-conversion/recipes/src/main/java/io/camunda/migration/code/recipes/client/MigrateStartProcessInstanceMethodsRecipe.java
+++ b/code-conversion/recipes/src/main/java/io/camunda/migration/code/recipes/client/MigrateStartProcessInstanceMethodsRecipe.java
@@ -746,6 +746,10 @@ public class MigrateStartProcessInstanceMethodsRecipe extends AbstractMigrationR
   protected List<ReplacementUtils.ReturnReplacementSpec> returnMethodInvocations() {
     return List.of(
         new ReplacementUtils.ReturnReplacementSpec(
+            new MethodMatcher("org.camunda.bpm.engine.runtime.Execution getId()"),
+            RecipeUtils.createSimpleJavaTemplate(
+                "String.valueOf(#{any()}.getProcessInstanceKey())")),
+        new ReplacementUtils.ReturnReplacementSpec(
             new MethodMatcher("org.camunda.bpm.engine.runtime.Execution getProcessInstanceId()"),
             RecipeUtils.createSimpleJavaTemplate(
                 "String.valueOf(#{any()}.getProcessInstanceKey())")),

--- a/code-conversion/recipes/src/test/java/io/camunda/migration/code/recipes/client/migrate/ReplaceStartProcessInstanceMethodsTest.java
+++ b/code-conversion/recipes/src/test/java/io/camunda/migration/code/recipes/client/migrate/ReplaceStartProcessInstanceMethodsTest.java
@@ -588,4 +588,64 @@ class ReplaceStartProcessInstanceMethodsTest implements RewriteTest {
                     }
                     """));
   }
+
+  @Test
+  void migratesExecutionGetIdToProcessInstanceKey() {
+    rewriteRun(
+        spec -> spec.recipe(new MigrateStartProcessInstanceMethodsRecipe()),
+        java(
+            """
+                    package org.camunda.community.migration.example;
+
+                    import io.camunda.client.CamundaClient;
+                    import org.camunda.bpm.engine.RuntimeService;
+                    import org.camunda.bpm.engine.runtime.ProcessInstance;
+                    import org.springframework.beans.factory.annotation.Autowired;
+                    import org.springframework.stereotype.Component;
+
+                    @Component
+                    class ExecutionGetIdMigrationTestClass {
+
+                        @Autowired
+                        private CamundaClient camundaClient;
+
+                        @Autowired
+                        private RuntimeService runtimeService;
+
+                        void starts() {
+                            ProcessInstance instance = runtimeService.startProcessInstanceByKey("myProcess");
+                            String id = instance.getId();
+                        }
+                    }
+                    """,
+            """
+                    package org.camunda.community.migration.example;
+
+                    import io.camunda.client.CamundaClient;
+                    import io.camunda.client.api.response.ProcessInstanceEvent;
+                    import org.camunda.bpm.engine.RuntimeService;
+                    import org.springframework.beans.factory.annotation.Autowired;
+                    import org.springframework.stereotype.Component;
+
+                    @Component
+                    class ExecutionGetIdMigrationTestClass {
+
+                        @Autowired
+                        private CamundaClient camundaClient;
+
+                        @Autowired
+                        private RuntimeService runtimeService;
+
+                        void starts() {
+                            ProcessInstanceEvent instance = camundaClient
+                                    .newCreateInstanceCommand()
+                                    .bpmnProcessId("myProcess")
+                                    .latestVersion()
+                                    .send()
+                                    .join();
+                            String id = String.valueOf(instance.getProcessInstanceKey());
+                        }
+                    }
+                    """));
+  }
 }


### PR DESCRIPTION
## Summary

- add missing `Execution.getId()` return mapping in `MigrateStartProcessInstanceMethodsRecipe`
- map `getId()` to `String.valueOf(...getProcessInstanceKey())` consistently with existing process-instance ID mappings
- add targeted regression coverage for `startProcessInstanceByKey(...).getId()` migration output

## Changes

- `code-conversion/recipes/src/main/java/io/camunda/migration/code/recipes/client/MigrateStartProcessInstanceMethodsRecipe.java`: add `Execution getId()` return-method replacement
- `code-conversion/recipes/src/test/java/io/camunda/migration/code/recipes/client/migrate/ReplaceStartProcessInstanceMethodsTest.java`: add `migratesExecutionGetIdToProcessInstanceKey` test

## Test plan

- [x] `mvn -pl code-conversion/recipes -Dtest=ReplaceStartProcessInstanceMethodsTest#migratesExecutionGetIdToProcessInstanceKey test`
- [x] `mvn -pl code-conversion/recipes -Dtest=ReplaceStartProcessInstanceMethodsTest test`

## Baseline

Built from commit: 30a9cb1758cb22879a811624f59cad3ca4f1e497

closes #2023

🤖 Generated with [Claude Code](https://claude.com/claude-code)
