### PR TITLE
feat(core): use direct Maven metadata for dependency versions

### DIFF
--- a/agentic-migration-skills/skills/migrate-c7-to-c8-code/SKILL.md
+++ b/agentic-migration-skills/skills/migrate-c7-to-c8-code/SKILL.md
@@ -162,9 +162,9 @@ Both approaches apply the same **Transform checklist** below. Approach A runs Op
 Confirm each item before the next (commit policy: Shared rules). Tags mark what OpenRewrite already handles.
 
 **1. Dependencies & configuration**
-- Resolve the latest Camunda version via WebFetch: `https://search.maven.org/solrsearch/select?q=g:io.camunda+AND+a:camunda-spring-boot-starter&rows=1&wt=json` → `response.docs[0].latestVersion`. For 8.8 targets use the latest `8.8.x`; for 8.9+ use it as-is.
+- Resolve the latest released GA Camunda version from Maven Central's artifact metadata, not its search API. Query `https://repo.maven.apache.org/maven2/io/camunda/<artifact-id>/maven-metadata.xml` (the equivalent `repo1.maven.org` path is also available) for the starter artifact selected below. From `<versions>`, choose the highest version matching the target Camunda minor (`8.8.x`, `8.9.x`, etc.) and exclude `-SNAPSHOT`, `-alpha`, `-beta`, and `-rc` versions. If no GA version exists for the target, ask before using a pre-release.
 - Pick the starter by Spring Boot version: 3.x → `io.camunda:camunda-spring-boot-3-starter`; 4.x → `io.camunda:camunda-spring-boot-starter`.
-- Add the Camunda public repo if artifacts aren't on Maven Central:
+- Add the Camunda public repository only if the selected artifact/version is not available on Maven Central. Do not use its metadata to select a GA version, because its public feed can list snapshots without the corresponding GA releases:
   - Maven: `<repository><id>camunda-public</id><url>https://artifacts.camunda.com/artifactory/public/</url></repository>`
   - Gradle: `maven { url "https://artifacts.camunda.com/artifactory/public/" }`
 - Remove `org.camunda.bpm.*`, `camunda-bom`, and embedded-engine deps (H2, JDBC starter).
@@ -215,7 +215,7 @@ Confirm each item before the next (commit policy: Shared rules). Tags mark what 
 RECIPES_VERSION by Camunda target, use the latest from these minor versions: 8.8 → `0.2.x`; 8.9 and 8.10 → `0.3.x`.
 
 REWRITE_VERSION: Before adding the plugin, resolve the latest released version via WebFetch:
-- `rewrite-maven-plugin` (OpenRewrite): `https://search.maven.org/solrsearch/select?q=g:org.openrewrite.maven+AND+a:rewrite-maven-plugin&rows=1&wt=json` → read `response.docs[0].latestVersion`
+- `rewrite-maven-plugin` (OpenRewrite): `https://repo.maven.apache.org/maven2/org/openrewrite/maven/rewrite-maven-plugin/maven-metadata.xml` → select the highest stable version from `<versions>`, excluding snapshots and pre-releases.
 
 
 Use those resolved versions in the snippets below (replacing `REWRITE_VERSION` and `RECIPES_VERSION`).

--- a/code-conversion/patterns/10-general/dependencies.md
+++ b/code-conversion/patterns/10-general/dependencies.md
@@ -22,6 +22,8 @@ Also, configure your connection to the Camunda 8 cluster in the `application.pro
 </dependency>
 ```
 
+**Version resolution**: Resolve the latest released GA version from Maven Central's direct artifact metadata, for example `https://repo.maven.apache.org/maven2/io/camunda/<artifact-id>/maven-metadata.xml` (the equivalent `repo1.maven.org` path is also available). From `<versions>`, select the highest version matching the target Camunda minor (`8.8.x`, `8.9.x`, etc.) and exclude `-SNAPSHOT`, `-alpha`, `-beta`, and `-rc` versions. If no GA version exists for the target, ask before using a pre-release. Do not use `search.maven.org`'s search API or the Camunda public repository metadata for this lookup.
+
 **Java client artifact**: Use `io.camunda:camunda-client-java`. The legacy `io.camunda:zeebe-client-java` artifact is deprecated and will be discontinued in Camunda 8.10.
 
 **Logging backend**: When removing Camunda 7 webapp/rest starters, keep an SLF4J binding. If those starters were your only logging source, add `org.springframework.boot:spring-boot-starter-logging` (or another SLF4J backend) so startup failures remain visible.

--- a/code-conversion/patterns/ALL_IN_ONE.md
+++ b/code-conversion/patterns/ALL_IN_ONE.md
@@ -79,6 +79,8 @@ Also, configure your connection to the Camunda 8 cluster in the `application.pro
 </dependency>
 ```
 
+**Version resolution**: Resolve the latest released GA version from Maven Central's direct artifact metadata, for example `https://repo.maven.apache.org/maven2/io/camunda/<artifact-id>/maven-metadata.xml` (the equivalent `repo1.maven.org` path is also available). From `<versions>`, select the highest version matching the target Camunda minor (`8.8.x`, `8.9.x`, etc.) and exclude `-SNAPSHOT`, `-alpha`, `-beta`, and `-rc` versions. If no GA version exists for the target, ask before using a pre-release. Do not use `search.maven.org`'s search API or the Camunda public repository metadata for this lookup.
+
 **Java client artifact**: Use `io.camunda:camunda-client-java`. The legacy `io.camunda:zeebe-client-java` artifact is deprecated and will be discontinued in Camunda 8.10.
 
 **Logging backend**: When removing Camunda 7 webapp/rest starters, keep an SLF4J binding. If those starters were your only logging source, add `org.springframework.boot:spring-boot-starter-logging` (or another SLF4J backend) so startup failures remain visible.


### PR DESCRIPTION
## Summary

- Replace the unreliable search.maven.org Solr lookup with direct Maven Central artifact metadata.
- Select the highest GA version matching the requested Camunda minor and reject snapshots or prereleases unless explicitly approved.
- Keep the Camunda public repository as an artifact fallback, not a GA version-resolution source.

## Changes

- Updated the migration skill Camunda starter and OpenRewrite plugin version-resolution instructions.
- Updated the dependency migration pattern and regenerated ALL_IN_ONE.md.

## Test plan

- [x] Regenerated pattern catalogs with node generate-catalog.js && node generate-all-in-one.js.
- [x] Confirmed no obsolete Solr URL remains in the migration guidance.
- [x] Java 21 mvn clean install -DskipTests passes in an isolated clean worktree.

## Baseline

Built from commit: 5c1c59e3fc5698328e8c7ccd25b6931d1e08775c

closes #2024

🤖 Generated with Claude Code