### PR TITLE
docs(core): document Spring Boot 3.5 HttpClient conflict

### DIFF
--- a/agentic-migration-skills/skills/migrate-c7-to-c8-code/SKILL.md
+++ b/agentic-migration-skills/skills/migrate-c7-to-c8-code/SKILL.md
@@ -169,6 +169,7 @@ Confirm each item before the next (commit policy: Shared rules). Tags mark what 
   - Gradle: `maven { url "https://artifacts.camunda.com/artifactory/public/" }`
 - Remove `org.camunda.bpm.*`, `camunda-bom`, and embedded-engine deps (H2, JDBC starter).
 - Add the starter; add `io.camunda:camunda-process-test-spring` (test scope) if tests exist.
+- For Spring Boot 3.5.x with Camunda 8.9.13, check the resolved `org.apache.httpcomponents.client5:httpclient5` version. If the Spring Boot BOM selects 5.5.2, override it to 5.6.1 or later in the application dependency management until upstream dependency alignment is fixed; verify with `mvn dependency:tree -Dincludes=org.apache.httpcomponents.client5:httpclient5`.
 - If removing Camunda 7 webapp/rest starters also removes your only SLF4J binding, add `org.springframework.boot:spring-boot-starter-logging` (or another SLF4J backend) so startup failures remain visible.
 - Ensure Spring Boot dependency management is set (parent or BOM). If `@PostConstruct` is only used to start process instances, migrate that flow to `@EventListener(CamundaPostDeploymentEvent.class)` first instead of patching dependencies (for example adding `jakarta.annotation-api`) just to keep `jakarta.annotation`.
 - Replace `@EnableProcessApplication` with `@Deployment`. If the C7 app relied on implicit classpath auto-deployment (no `@EnableProcessApplication` present), still add explicit `@Deployment(resources = ...)` for BPMN/DMN files because C8 has no equivalent implicit deployment.

--- a/code-conversion/patterns/10-general/dependencies.md
+++ b/code-conversion/patterns/10-general/dependencies.md
@@ -24,6 +24,22 @@ Also, configure your connection to the Camunda 8 cluster in the `application.pro
 
 **Java client artifact**: Use `io.camunda:camunda-client-java`. The legacy `io.camunda:zeebe-client-java` artifact is deprecated and will be discontinued in Camunda 8.10.
 
+**Spring Boot 3.5.x and Apache HttpClient**: Spring Boot 3.5.x may manage `org.apache.httpcomponents.client5:httpclient5` to `5.5.2`, while `io.camunda:camunda-client-java` 8.9.13 requires `5.6.1` or later. This mismatch can prevent the `CamundaClient` bean from starting with a `NoSuchMethodError`. Until the upstream dependency alignment is fixed, override the managed version in the application:
+
+```
+<dependencyManagement>
+	<dependencies>
+		<dependency>
+			<groupId>org.apache.httpcomponents.client5</groupId>
+			<artifactId>httpclient5</artifactId>
+			<version>5.6.1</version>
+		</dependency>
+	</dependencies>
+</dependencyManagement>
+```
+
+Verify the version required by the selected Camunda client release with `mvn dependency:tree -Dincludes=org.apache.httpcomponents.client5:httpclient5` before choosing the override.
+
 **Logging backend**: When removing Camunda 7 webapp/rest starters, keep an SLF4J binding. If those starters were your only logging source, add `org.springframework.boot:spring-boot-starter-logging` (or another SLF4J backend) so startup failures remain visible.
 
 **`jakarta.annotation` and process startup**: If `@PostConstruct` remains only to start process instances, migrate that startup to `@EventListener(CamundaPostDeploymentEvent.class)` first. Prefer fixing that lifecycle pattern over adding dependencies (for example `jakarta.annotation-api`) solely to keep `@PostConstruct`.

--- a/code-conversion/patterns/ALL_IN_ONE.md
+++ b/code-conversion/patterns/ALL_IN_ONE.md
@@ -81,6 +81,22 @@ Also, configure your connection to the Camunda 8 cluster in the `application.pro
 
 **Java client artifact**: Use `io.camunda:camunda-client-java`. The legacy `io.camunda:zeebe-client-java` artifact is deprecated and will be discontinued in Camunda 8.10.
 
+**Spring Boot 3.5.x and Apache HttpClient**: Spring Boot 3.5.x may manage `org.apache.httpcomponents.client5:httpclient5` to `5.5.2`, while `io.camunda:camunda-client-java` 8.9.13 requires `5.6.1` or later. This mismatch can prevent the `CamundaClient` bean from starting with a `NoSuchMethodError`. Until the upstream dependency alignment is fixed, override the managed version in the application:
+
+```
+<dependencyManagement>
+	<dependencies>
+		<dependency>
+			<groupId>org.apache.httpcomponents.client5</groupId>
+			<artifactId>httpclient5</artifactId>
+			<version>5.6.1</version>
+		</dependency>
+	</dependencies>
+</dependencyManagement>
+```
+
+Verify the version required by the selected Camunda client release with `mvn dependency:tree -Dincludes=org.apache.httpcomponents.client5:httpclient5` before choosing the override.
+
 **Logging backend**: When removing Camunda 7 webapp/rest starters, keep an SLF4J binding. If those starters were your only logging source, add `org.springframework.boot:spring-boot-starter-logging` (or another SLF4J backend) so startup failures remain visible.
 
 **`jakarta.annotation` and process startup**: If `@PostConstruct` remains only to start process instances, migrate that startup to `@EventListener(CamundaPostDeploymentEvent.class)` first. Prefer fixing that lifecycle pattern over adding dependencies (for example `jakarta.annotation-api`) solely to keep `@PostConstruct`.


### PR DESCRIPTION
## Summary

- Document the Spring Boot 3.5.x BOM conflict that resolves `httpclient5` to 5.5.2 for Camunda 8.9.13 clients requiring 5.6.1 or later.
- Provide the explicit Maven dependency-management override and dependency-tree verification command.
- Mirror the guidance in the migration skill and regenerated pattern catalog.

## Changes

- Update `code-conversion/patterns/10-general/dependencies.md`.
- Regenerate `code-conversion/patterns/ALL_IN_ONE.md`.
- Update `agentic-migration-skills/skills/migrate-c7-to-c8-code/SKILL.md`.

## Test plan

- [x] `node generate-catalog.js`
- [x] `node generate-all-in-one.js`
- [x] `git diff --check`
- [x] `JAVA_HOME=/opt/homebrew/opt/openjdk@21 mvn test -pl code-conversion/recipes`
- [x] `JAVA_HOME=/opt/homebrew/opt/openjdk@21 mvn clean install -DskipTests`
- Full `mvn clean install` reached the recipe tests but the two Camunda 8 code-example tests could not start Docker in this environment.

## Baseline

Built from commit: `5c1c59e3fc5698328e8c7ccd25b6931d1e08775c`

related to #2018