### PR TITLE
feat(recipes): select Gradle starters by Spring Boot major

### DIFF
--- a/code-conversion/recipes/pom.xml
+++ b/code-conversion/recipes/pom.xml
@@ -111,6 +111,11 @@
     </dependency>
 
     <dependency>
+      <groupId>org.openrewrite</groupId>
+      <artifactId>rewrite-gradle</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.openrewrite.recipe</groupId>
       <artifactId>rewrite-java-dependencies</artifactId>
     </dependency>
@@ -124,6 +129,19 @@
     <dependency>
       <groupId>org.openrewrite</groupId>
       <artifactId>rewrite-java-21</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>dev.gradleplugins</groupId>
+      <artifactId>gradle-api</artifactId>
+      <version>8.11.1</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.openrewrite.gradle.tooling</groupId>
+      <artifactId>model</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/code-conversion/recipes/src/main/java/io/camunda/migration/code/recipes/sharedRecipes/ChangeGradleDependencyRecipe.java
+++ b/code-conversion/recipes/src/main/java/io/camunda/migration/code/recipes/sharedRecipes/ChangeGradleDependencyRecipe.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.migration.code.recipes.sharedRecipes;
+
+import java.util.Optional;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.gradle.trait.GradleDependency;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.tree.J;
+
+/**
+ * Changes Gradle dependency coordinates without requiring the target artifact to resolve first.
+ *
+ * <p>Gradle declarations can be migrated even when a Camunda snapshot is not present in the
+ * repositories configured by a test or by a partially migrated project.
+ */
+public class ChangeGradleDependencyRecipe extends Recipe {
+
+  private final String oldGroupId;
+  private final String oldArtifactId;
+  private final String newGroupId;
+  private final String newArtifactId;
+  private final String newVersion;
+
+  public ChangeGradleDependencyRecipe(
+      String oldGroupId,
+      String oldArtifactId,
+      String newGroupId,
+      String newArtifactId,
+      @Nullable String newVersion) {
+    this.oldGroupId = oldGroupId;
+    this.oldArtifactId = oldArtifactId;
+    this.newGroupId = newGroupId;
+    this.newArtifactId = newArtifactId;
+    this.newVersion = newVersion;
+  }
+
+  @Override
+  public @NonNull String getDisplayName() {
+    return "Change a Gradle dependency declaration";
+  }
+
+  @Override
+  public @NonNull String getDescription() {
+    return "Changes a Gradle dependency declaration by its group, artifact, and optional version.";
+  }
+
+  @Override
+  public @NonNull TreeVisitor<?, ExecutionContext> getVisitor() {
+    return new JavaIsoVisitor<>() {
+      private final GradleDependency.Matcher matcher =
+          new GradleDependency.Matcher().groupId(oldGroupId).artifactId(oldArtifactId);
+
+      @Override
+      public J.MethodInvocation visitMethodInvocation(
+          J.MethodInvocation method, ExecutionContext ctx) {
+        J.MethodInvocation visited = super.visitMethodInvocation(method, ctx);
+        Optional<GradleDependency> dependency = matcher.get(getCursor());
+        if (dependency.isEmpty()) {
+          return visited;
+        }
+
+        GradleDependency updated =
+            dependency
+                .get()
+                .withDeclaredGroupId(newGroupId)
+                .withDeclaredArtifactId(newArtifactId)
+                .withDeclaredVersion(newVersion);
+        return updated.getTree();
+      }
+    };
+  }
+}

--- a/code-conversion/recipes/src/main/java/io/camunda/migration/code/recipes/sharedRecipes/DoesNotDeclareGradleDependencyRecipe.java
+++ b/code-conversion/recipes/src/main/java/io/camunda/migration/code/recipes/sharedRecipes/DoesNotDeclareGradleDependencyRecipe.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.migration.code.recipes.sharedRecipes;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Recipe;
+import org.openrewrite.SourceFile;
+import org.openrewrite.Tree;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.gradle.trait.GradleDependency;
+import org.openrewrite.java.JavaVisitor;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.marker.SearchResult;
+
+/**
+ * Matches a Gradle build file that does not declare a specific dependency.
+ *
+ * <p>The built-in Gradle absence search inspects resolved dependencies. Migration artifacts may be
+ * unavailable in a user's configured repositories while the build is being migrated, so selection
+ * must also recognize unresolved direct declarations in the build script itself.
+ */
+public class DoesNotDeclareGradleDependencyRecipe extends Recipe {
+
+  private final String groupId;
+  private final String artifactId;
+
+  public DoesNotDeclareGradleDependencyRecipe(String groupId, String artifactId) {
+    this.groupId = groupId;
+    this.artifactId = artifactId;
+  }
+
+  @Override
+  public @NonNull String getDisplayName() {
+    return "Find a Gradle build without a declared dependency";
+  }
+
+  @Override
+  public @NonNull String getDescription() {
+    return "Matches Gradle build files that do not declare the requested direct dependency.";
+  }
+
+  @Override
+  public @NonNull TreeVisitor<?, ExecutionContext> getVisitor() {
+    return new JavaVisitor<>() {
+      @Override
+      public @Nullable J visit(@Nullable Tree tree, ExecutionContext ctx) {
+        if (tree instanceof J j && j instanceof SourceFile sourceFile) {
+          AtomicBoolean found = new AtomicBoolean();
+          new GradleDependency.Matcher()
+              .groupId(groupId)
+              .artifactId(artifactId)
+              .asVisitor(
+                  (GradleDependency dependency, AtomicBoolean state) -> {
+                    state.set(true);
+                    return dependency.getTree();
+                  })
+              .reduce(sourceFile, found);
+          if (!found.get()) {
+            return SearchResult.found(j);
+          }
+        }
+        return super.visit(tree, ctx);
+      }
+    };
+  }
+}

--- a/code-conversion/recipes/src/main/java/io/camunda/migration/code/recipes/sharedRecipes/FindSpringBootMajorRecipe.java
+++ b/code-conversion/recipes/src/main/java/io/camunda/migration/code/recipes/sharedRecipes/FindSpringBootMajorRecipe.java
@@ -31,9 +31,9 @@ import org.openrewrite.marker.SearchResult;
 /**
  * Matches Gradle build files that resolve a specific Spring Boot major version.
  *
- * <p>The resolved Spring Boot platform is authoritative. When it is not available, the recipe
- * falls back to the version declared by the Spring Boot plugin and then to a
- * {@code dependencyManagement} BOM entry.
+ * <p>Detection uses the following precedence: resolved Spring Boot platform, declared platform,
+ * declared Spring Boot plugin, resolved plugin artifacts, and finally a {@code dependencyManagement}
+ * BOM entry. An ambiguous signal stops fallback and is not treated as a missing major.
  */
 public class FindSpringBootMajorRecipe extends Recipe {
 
@@ -57,8 +57,9 @@ public class FindSpringBootMajorRecipe extends Recipe {
 
   @Override
   public @NonNull String getDescription() {
-    return "Matches Gradle build files whose resolved Spring Boot platform, Spring Boot plugin, or "
-        + "Spring dependency management BOM uses the requested major version.";
+    return "Matches Gradle build files whose resolved or declared Spring Boot platform, declared or "
+        + "resolved Spring Boot plugin, or Spring dependency management BOM uses the requested major "
+        + "version.";
   }
 
   @Override
@@ -79,35 +80,35 @@ public class FindSpringBootMajorRecipe extends Recipe {
   }
 
   private boolean matchesMajor(SourceFile sourceFile, @Nullable GradleProject gradleProject) {
-    Optional<String> detectedMajor = detectMajor(sourceFile, gradleProject);
+    MajorDetection detectedMajor = detectMajor(sourceFile, gradleProject);
     if (NO_DETECTED_MAJOR.equals(major)) {
-      return detectedMajor.isEmpty();
+      return !detectedMajor.hasSignal();
     }
-    return detectedMajor.filter(major::equals).isPresent();
+    return detectedMajor.major().filter(major::equals).isPresent();
   }
 
-  private Optional<String> detectMajor(
+  private MajorDetection detectMajor(
       SourceFile sourceFile, @Nullable GradleProject gradleProject) {
     if (gradleProject != null) {
-      Optional<String> resolvedPlatformMajor = resolvedPlatformMajor(gradleProject);
-      if (resolvedPlatformMajor.isPresent()) {
+      MajorDetection resolvedPlatformMajor = resolvedPlatformMajor(gradleProject);
+      if (resolvedPlatformMajor.hasSignal()) {
         return resolvedPlatformMajor;
       }
     }
 
-    Optional<String> declaredPlatformMajor = declaredPlatformMajor(sourceFile);
-    if (declaredPlatformMajor.isPresent()) {
+    MajorDetection declaredPlatformMajor = declaredPlatformMajor(sourceFile);
+    if (declaredPlatformMajor.hasSignal()) {
       return declaredPlatformMajor;
     }
 
-    Optional<String> pluginMajor = pluginMajor(sourceFile);
-    if (pluginMajor.isPresent()) {
+    MajorDetection pluginMajor = pluginMajor(sourceFile);
+    if (pluginMajor.hasSignal()) {
       return pluginMajor;
     }
 
     if (gradleProject != null) {
-      Optional<String> resolvedPluginMajor = resolvedPluginMajor(gradleProject);
-      if (resolvedPluginMajor.isPresent()) {
+      MajorDetection resolvedPluginMajor = resolvedPluginMajor(gradleProject);
+      if (resolvedPluginMajor.hasSignal()) {
         return resolvedPluginMajor;
       }
     }
@@ -115,7 +116,7 @@ public class FindSpringBootMajorRecipe extends Recipe {
     return dependencyManagementMajor(sourceFile);
   }
 
-  private Optional<String> declaredPlatformMajor(SourceFile sourceFile) {
+  private MajorDetection declaredPlatformMajor(SourceFile sourceFile) {
     AtomicReference<Set<String>> majors = new AtomicReference<>(new HashSet<>());
     new GradleDependency.Matcher()
         .groupId(SPRING_BOOT_GROUP)
@@ -126,19 +127,19 @@ public class FindSpringBootMajorRecipe extends Recipe {
               return dependency.getTree();
             })
         .reduce(sourceFile, majors);
-    return singleMajor(majors.get());
+    return majorDetection(majors.get());
   }
 
-  private Optional<String> resolvedPlatformMajor(GradleProject gradleProject) {
+  private MajorDetection resolvedPlatformMajor(GradleProject gradleProject) {
     Set<String> majors = new HashSet<>();
     addResolvedMajors(gradleProject.getConfigurations(), majors, false);
-    return singleMajor(majors);
+    return majorDetection(majors);
   }
 
-  private Optional<String> resolvedPluginMajor(GradleProject gradleProject) {
+  private MajorDetection resolvedPluginMajor(GradleProject gradleProject) {
     Set<String> majors = new HashSet<>();
     addResolvedMajors(gradleProject.getBuildscript().getConfigurations(), majors, true);
-    return singleMajor(majors);
+    return majorDetection(majors);
   }
 
   private void addResolvedMajors(
@@ -157,7 +158,7 @@ public class FindSpringBootMajorRecipe extends Recipe {
     }
   }
 
-  private Optional<String> pluginMajor(SourceFile sourceFile) {
+  private MajorDetection pluginMajor(SourceFile sourceFile) {
     AtomicReference<Set<String>> majors = new AtomicReference<>(new HashSet<>());
     new GradlePlugin.Matcher()
         .pluginIdPattern(SPRING_BOOT_PLUGIN)
@@ -167,10 +168,10 @@ public class FindSpringBootMajorRecipe extends Recipe {
               return plugin.getTree();
             })
         .reduce(sourceFile, majors);
-    return singleMajor(majors.get());
+    return majorDetection(majors.get());
   }
 
-  private Optional<String> dependencyManagementMajor(SourceFile sourceFile) {
+  private MajorDetection dependencyManagementMajor(SourceFile sourceFile) {
     AtomicReference<Set<String>> majors = new AtomicReference<>(new HashSet<>());
     new SpringDependencyManagementPluginEntry.Matcher()
         .groupId(SPRING_BOOT_GROUP)
@@ -182,7 +183,7 @@ public class FindSpringBootMajorRecipe extends Recipe {
               return entry.getTree();
             })
         .reduce(sourceFile, majors);
-    return singleMajor(majors.get());
+    return majorDetection(majors.get());
   }
 
   private static boolean isSpringBootDependency(
@@ -205,7 +206,18 @@ public class FindSpringBootMajorRecipe extends Recipe {
     majors.add(separator < 0 ? version : version.substring(0, separator));
   }
 
-  private static Optional<String> singleMajor(Set<String> majors) {
-    return majors.size() == 1 ? Optional.of(majors.iterator().next()) : Optional.empty();
+  private static MajorDetection majorDetection(Set<String> majors) {
+    return switch (majors.size()) {
+      case 0 -> new MajorDetection(Optional.empty(), false);
+      case 1 -> new MajorDetection(Optional.of(majors.iterator().next()), false);
+      default -> new MajorDetection(Optional.empty(), true);
+    };
+  }
+
+  private record MajorDetection(Optional<String> major, boolean ambiguous) {
+
+    private boolean hasSignal() {
+      return ambiguous || major.isPresent();
+    }
   }
 }

--- a/code-conversion/recipes/src/main/java/io/camunda/migration/code/recipes/sharedRecipes/FindSpringBootMajorRecipe.java
+++ b/code-conversion/recipes/src/main/java/io/camunda/migration/code/recipes/sharedRecipes/FindSpringBootMajorRecipe.java
@@ -67,9 +67,9 @@ public class FindSpringBootMajorRecipe extends Recipe {
       @Override
       public @Nullable J visit(@Nullable Tree tree, ExecutionContext ctx) {
         if (tree instanceof J j && j instanceof SourceFile sourceFile) {
-          Optional<GradleProject> gradleProject =
-              sourceFile.getMarkers().findFirst(GradleProject.class);
-          if (gradleProject.isPresent() && matchesMajor(sourceFile, gradleProject.get())) {
+          GradleProject gradleProject =
+              sourceFile.getMarkers().findFirst(GradleProject.class).orElse(null);
+          if (matchesMajor(sourceFile, gradleProject)) {
             return SearchResult.found(j);
           }
         }
@@ -78,7 +78,7 @@ public class FindSpringBootMajorRecipe extends Recipe {
     };
   }
 
-  private boolean matchesMajor(SourceFile sourceFile, GradleProject gradleProject) {
+  private boolean matchesMajor(SourceFile sourceFile, @Nullable GradleProject gradleProject) {
     Optional<String> detectedMajor = detectMajor(sourceFile, gradleProject);
     if (NO_DETECTED_MAJOR.equals(major)) {
       return detectedMajor.isEmpty();
@@ -86,10 +86,13 @@ public class FindSpringBootMajorRecipe extends Recipe {
     return detectedMajor.filter(major::equals).isPresent();
   }
 
-  private Optional<String> detectMajor(SourceFile sourceFile, GradleProject gradleProject) {
-    Optional<String> resolvedPlatformMajor = resolvedPlatformMajor(gradleProject);
-    if (resolvedPlatformMajor.isPresent()) {
-      return resolvedPlatformMajor;
+  private Optional<String> detectMajor(
+      SourceFile sourceFile, @Nullable GradleProject gradleProject) {
+    if (gradleProject != null) {
+      Optional<String> resolvedPlatformMajor = resolvedPlatformMajor(gradleProject);
+      if (resolvedPlatformMajor.isPresent()) {
+        return resolvedPlatformMajor;
+      }
     }
 
     Optional<String> declaredPlatformMajor = declaredPlatformMajor(sourceFile);
@@ -102,9 +105,11 @@ public class FindSpringBootMajorRecipe extends Recipe {
       return pluginMajor;
     }
 
-    Optional<String> resolvedPluginMajor = resolvedPluginMajor(gradleProject);
-    if (resolvedPluginMajor.isPresent()) {
-      return resolvedPluginMajor;
+    if (gradleProject != null) {
+      Optional<String> resolvedPluginMajor = resolvedPluginMajor(gradleProject);
+      if (resolvedPluginMajor.isPresent()) {
+        return resolvedPluginMajor;
+      }
     }
 
     return dependencyManagementMajor(sourceFile);

--- a/code-conversion/recipes/src/main/java/io/camunda/migration/code/recipes/sharedRecipes/FindSpringBootMajorRecipe.java
+++ b/code-conversion/recipes/src/main/java/io/camunda/migration/code/recipes/sharedRecipes/FindSpringBootMajorRecipe.java
@@ -1,0 +1,206 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.migration.code.recipes.sharedRecipes;
+
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Recipe;
+import org.openrewrite.SourceFile;
+import org.openrewrite.Tree;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.gradle.marker.GradleDependencyConfiguration;
+import org.openrewrite.gradle.marker.GradleProject;
+import org.openrewrite.gradle.trait.GradleDependency;
+import org.openrewrite.gradle.trait.GradlePlugin;
+import org.openrewrite.gradle.trait.SpringDependencyManagementPluginEntry;
+import org.openrewrite.java.JavaVisitor;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.maven.tree.ResolvedDependency;
+import org.openrewrite.marker.SearchResult;
+
+/**
+ * Matches Gradle build files that resolve a specific Spring Boot major version.
+ *
+ * <p>The resolved Spring Boot platform is authoritative. When it is not available, the recipe
+ * falls back to the version declared by the Spring Boot plugin and then to a
+ * {@code dependencyManagement} BOM entry.
+ */
+public class FindSpringBootMajorRecipe extends Recipe {
+
+  private static final String SPRING_BOOT_GROUP = "org.springframework.boot";
+  private static final String SPRING_BOOT_PLATFORM = "spring-boot-dependencies";
+  private static final String SPRING_BOOT_PLUGIN = "org.springframework.boot";
+  private static final String SPRING_BOOT_GRADLE_PLUGIN = "spring-boot-gradle-plugin";
+  private static final String SPRING_BOOT_PLUGIN_MARKER = "org.springframework.boot.gradle.plugin";
+  private static final String NO_DETECTED_MAJOR = "none";
+
+  private final String major;
+
+  public FindSpringBootMajorRecipe(String major) {
+    this.major = major;
+  }
+
+  @Override
+  public @NonNull String getDisplayName() {
+    return "Find a Gradle project using a Spring Boot major version";
+  }
+
+  @Override
+  public @NonNull String getDescription() {
+    return "Matches Gradle build files whose resolved Spring Boot platform, Spring Boot plugin, or "
+        + "Spring dependency management BOM uses the requested major version.";
+  }
+
+  @Override
+  public @NonNull TreeVisitor<?, ExecutionContext> getVisitor() {
+    return new JavaVisitor<>() {
+      @Override
+      public @Nullable J visit(@Nullable Tree tree, ExecutionContext ctx) {
+        if (tree instanceof J j && j instanceof SourceFile sourceFile) {
+          Optional<GradleProject> gradleProject =
+              sourceFile.getMarkers().findFirst(GradleProject.class);
+          if (gradleProject.isPresent() && matchesMajor(sourceFile, gradleProject.get())) {
+            return SearchResult.found(j);
+          }
+        }
+        return super.visit(tree, ctx);
+      }
+    };
+  }
+
+  private boolean matchesMajor(SourceFile sourceFile, GradleProject gradleProject) {
+    Optional<String> detectedMajor = detectMajor(sourceFile, gradleProject);
+    if (NO_DETECTED_MAJOR.equals(major)) {
+      return detectedMajor.isEmpty();
+    }
+    return detectedMajor.filter(major::equals).isPresent();
+  }
+
+  private Optional<String> detectMajor(SourceFile sourceFile, GradleProject gradleProject) {
+    Optional<String> resolvedPlatformMajor = resolvedPlatformMajor(gradleProject);
+    if (resolvedPlatformMajor.isPresent()) {
+      return resolvedPlatformMajor;
+    }
+
+    Optional<String> declaredPlatformMajor = declaredPlatformMajor(sourceFile);
+    if (declaredPlatformMajor.isPresent()) {
+      return declaredPlatformMajor;
+    }
+
+    Optional<String> pluginMajor = pluginMajor(sourceFile);
+    if (pluginMajor.isPresent()) {
+      return pluginMajor;
+    }
+
+    Optional<String> resolvedPluginMajor = resolvedPluginMajor(gradleProject);
+    if (resolvedPluginMajor.isPresent()) {
+      return resolvedPluginMajor;
+    }
+
+    return dependencyManagementMajor(sourceFile);
+  }
+
+  private Optional<String> declaredPlatformMajor(SourceFile sourceFile) {
+    AtomicReference<Set<String>> majors = new AtomicReference<>(new HashSet<>());
+    new GradleDependency.Matcher()
+        .groupId(SPRING_BOOT_GROUP)
+        .artifactId(SPRING_BOOT_PLATFORM)
+        .asVisitor(
+            (GradleDependency dependency, AtomicReference<Set<String>> foundMajors) -> {
+              addMajor(foundMajors.get(), dependency.getDeclaredVersion());
+              return dependency.getTree();
+            })
+        .reduce(sourceFile, majors);
+    return singleMajor(majors.get());
+  }
+
+  private Optional<String> resolvedPlatformMajor(GradleProject gradleProject) {
+    Set<String> majors = new HashSet<>();
+    addResolvedMajors(gradleProject.getConfigurations(), majors, false);
+    return singleMajor(majors);
+  }
+
+  private Optional<String> resolvedPluginMajor(GradleProject gradleProject) {
+    Set<String> majors = new HashSet<>();
+    addResolvedMajors(gradleProject.getBuildscript().getConfigurations(), majors, true);
+    return singleMajor(majors);
+  }
+
+  private void addResolvedMajors(
+      Iterable<GradleDependencyConfiguration> configurations,
+      Set<String> majors,
+      boolean pluginArtifacts) {
+    for (GradleDependencyConfiguration configuration : configurations) {
+      if (!configuration.isCanBeResolved()) {
+        continue;
+      }
+      for (ResolvedDependency dependency : configuration.getResolved()) {
+        if (isSpringBootDependency(dependency, pluginArtifacts)) {
+          addMajor(majors, dependency.getVersion());
+        }
+      }
+    }
+  }
+
+  private Optional<String> pluginMajor(SourceFile sourceFile) {
+    AtomicReference<Set<String>> majors = new AtomicReference<>(new HashSet<>());
+    new GradlePlugin.Matcher()
+        .pluginIdPattern(SPRING_BOOT_PLUGIN)
+        .asVisitor(
+            (GradlePlugin plugin, AtomicReference<Set<String>> foundMajors) -> {
+              addMajor(foundMajors.get(), plugin.getVersion());
+              return plugin.getTree();
+            })
+        .reduce(sourceFile, majors);
+    return singleMajor(majors.get());
+  }
+
+  private Optional<String> dependencyManagementMajor(SourceFile sourceFile) {
+    AtomicReference<Set<String>> majors = new AtomicReference<>(new HashSet<>());
+    new SpringDependencyManagementPluginEntry.Matcher()
+        .groupId(SPRING_BOOT_GROUP)
+        .artifactId(SPRING_BOOT_PLATFORM)
+        .asVisitor(
+            (SpringDependencyManagementPluginEntry entry,
+                AtomicReference<Set<String>> foundMajors) -> {
+              addMajor(foundMajors.get(), entry.getVersion());
+              return entry.getTree();
+            })
+        .reduce(sourceFile, majors);
+    return singleMajor(majors.get());
+  }
+
+  private static boolean isSpringBootDependency(
+      ResolvedDependency dependency, boolean pluginArtifacts) {
+    if (!SPRING_BOOT_GROUP.equals(dependency.getGroupId())) {
+      return false;
+    }
+    if (pluginArtifacts) {
+      return SPRING_BOOT_GRADLE_PLUGIN.equals(dependency.getArtifactId())
+          || SPRING_BOOT_PLUGIN_MARKER.equals(dependency.getArtifactId());
+    }
+    return SPRING_BOOT_PLATFORM.equals(dependency.getArtifactId());
+  }
+
+  private static void addMajor(Set<String> majors, @Nullable String version) {
+    if (version == null || version.isBlank()) {
+      return;
+    }
+    int separator = version.indexOf('.');
+    majors.add(separator < 0 ? version : version.substring(0, separator));
+  }
+
+  private static Optional<String> singleMajor(Set<String> majors) {
+    return majors.size() == 1 ? Optional.of(majors.iterator().next()) : Optional.empty();
+  }
+}

--- a/code-conversion/recipes/src/main/java/io/camunda/migration/code/recipes/sharedRecipes/FindSpringBootMajorRecipe.java
+++ b/code-conversion/recipes/src/main/java/io/camunda/migration/code/recipes/sharedRecipes/FindSpringBootMajorRecipe.java
@@ -59,7 +59,7 @@ public class FindSpringBootMajorRecipe extends Recipe {
   public @NonNull String getDescription() {
     return "Matches Gradle build files whose resolved or declared Spring Boot platform, declared or "
         + "resolved Spring Boot plugin, or Spring dependency management BOM uses the requested major "
-        + "version.";
+        + "version; `none` matches only when no Spring Boot signal can be detected.";
   }
 
   @Override

--- a/code-conversion/recipes/src/main/resources/META-INF/rewrite/dependencyRecipes.yml
+++ b/code-conversion/recipes/src/main/resources/META-INF/rewrite/dependencyRecipes.yml
@@ -60,11 +60,9 @@ preconditions:
   - io.camunda.migration.code.recipes.sharedRecipes.DoesNotDeclareGradleDependencyRecipe:
       groupId: io.camunda
       artifactId: camunda-spring-boot-starter
-      onlyDirect: true
   - io.camunda.migration.code.recipes.sharedRecipes.DoesNotDeclareGradleDependencyRecipe:
       groupId: io.camunda
       artifactId: camunda-spring-boot-3-starter
-      onlyDirect: true
 recipeList:
   - org.openrewrite.gradle.AddDependency:
       groupId: io.camunda
@@ -82,11 +80,9 @@ preconditions:
   - io.camunda.migration.code.recipes.sharedRecipes.DoesNotDeclareGradleDependencyRecipe:
       groupId: io.camunda
       artifactId: camunda-spring-boot-starter
-      onlyDirect: true
   - io.camunda.migration.code.recipes.sharedRecipes.DoesNotDeclareGradleDependencyRecipe:
       groupId: io.camunda
       artifactId: camunda-spring-boot-3-starter
-      onlyDirect: true
 recipeList:
   - org.openrewrite.gradle.AddDependency:
       groupId: io.camunda
@@ -111,11 +107,9 @@ preconditions:
   - io.camunda.migration.code.recipes.sharedRecipes.DoesNotDeclareGradleDependencyRecipe:
       groupId: io.camunda
       artifactId: camunda-spring-boot-starter
-      onlyDirect: true
   - io.camunda.migration.code.recipes.sharedRecipes.DoesNotDeclareGradleDependencyRecipe:
       groupId: io.camunda
       artifactId: camunda-spring-boot-3-starter
-      onlyDirect: true
 recipeList:
   - org.openrewrite.gradle.AddDependency:
       groupId: io.camunda
@@ -135,11 +129,9 @@ preconditions:
   - io.camunda.migration.code.recipes.sharedRecipes.DoesNotDeclareGradleDependencyRecipe:
       groupId: io.camunda
       artifactId: camunda-process-test-spring
-      onlyDirect: true
   - io.camunda.migration.code.recipes.sharedRecipes.DoesNotDeclareGradleDependencyRecipe:
       groupId: io.camunda
       artifactId: camunda-process-test-spring-boot-3
-      onlyDirect: true
 recipeList:
   - org.openrewrite.gradle.AddDependency:
       groupId: io.camunda
@@ -157,11 +149,9 @@ preconditions:
   - io.camunda.migration.code.recipes.sharedRecipes.DoesNotDeclareGradleDependencyRecipe:
       groupId: io.camunda
       artifactId: camunda-process-test-spring
-      onlyDirect: true
   - io.camunda.migration.code.recipes.sharedRecipes.DoesNotDeclareGradleDependencyRecipe:
       groupId: io.camunda
       artifactId: camunda-process-test-spring-boot-3
-      onlyDirect: true
 recipeList:
   - org.openrewrite.gradle.AddDependency:
       groupId: io.camunda
@@ -181,11 +171,9 @@ preconditions:
   - io.camunda.migration.code.recipes.sharedRecipes.DoesNotDeclareGradleDependencyRecipe:
       groupId: io.camunda
       artifactId: camunda-process-test-spring
-      onlyDirect: true
   - io.camunda.migration.code.recipes.sharedRecipes.DoesNotDeclareGradleDependencyRecipe:
       groupId: io.camunda
       artifactId: camunda-process-test-spring-boot-3
-      onlyDirect: true
 recipeList:
   - org.openrewrite.gradle.AddDependency:
       groupId: io.camunda

--- a/code-conversion/recipes/src/main/resources/META-INF/rewrite/dependencyRecipes.yml
+++ b/code-conversion/recipes/src/main/resources/META-INF/rewrite/dependencyRecipes.yml
@@ -188,6 +188,9 @@ description: Renames the Camunda Spring Boot 3 starter to the Spring Boot 4 star
 preconditions:
   - io.camunda.migration.code.recipes.sharedRecipes.FindSpringBootMajorRecipe:
       major: "4"
+  - io.camunda.migration.code.recipes.sharedRecipes.DoesNotDeclareGradleDependencyRecipe:
+      groupId: io.camunda
+      artifactId: camunda-spring-boot-starter
 recipeList:
   - io.camunda.migration.code.recipes.sharedRecipes.ChangeGradleDependencyRecipe:
       oldGroupId: io.camunda
@@ -203,6 +206,9 @@ description: Renames the Camunda Spring Boot 4 starter to the Spring Boot 3 star
 preconditions:
   - io.camunda.migration.code.recipes.sharedRecipes.FindSpringBootMajorRecipe:
       major: "3"
+  - io.camunda.migration.code.recipes.sharedRecipes.DoesNotDeclareGradleDependencyRecipe:
+      groupId: io.camunda
+      artifactId: camunda-spring-boot-3-starter
 recipeList:
   - io.camunda.migration.code.recipes.sharedRecipes.ChangeGradleDependencyRecipe:
       oldGroupId: io.camunda
@@ -218,6 +224,9 @@ description: Renames the Spring Boot 3 Camunda process test module to the Spring
 preconditions:
   - io.camunda.migration.code.recipes.sharedRecipes.FindSpringBootMajorRecipe:
       major: "4"
+  - io.camunda.migration.code.recipes.sharedRecipes.DoesNotDeclareGradleDependencyRecipe:
+      groupId: io.camunda
+      artifactId: camunda-process-test-spring
 recipeList:
   - io.camunda.migration.code.recipes.sharedRecipes.ChangeGradleDependencyRecipe:
       oldGroupId: io.camunda
@@ -233,6 +242,9 @@ description: Renames the Spring Boot 4 Camunda process test module to the Spring
 preconditions:
   - io.camunda.migration.code.recipes.sharedRecipes.FindSpringBootMajorRecipe:
       major: "3"
+  - io.camunda.migration.code.recipes.sharedRecipes.DoesNotDeclareGradleDependencyRecipe:
+      groupId: io.camunda
+      artifactId: camunda-process-test-spring-boot-3
 recipeList:
   - io.camunda.migration.code.recipes.sharedRecipes.ChangeGradleDependencyRecipe:
       oldGroupId: io.camunda

--- a/code-conversion/recipes/src/main/resources/META-INF/rewrite/dependencyRecipes.yml
+++ b/code-conversion/recipes/src/main/resources/META-INF/rewrite/dependencyRecipes.yml
@@ -9,9 +9,9 @@ description: >-
   `spring-boot-dependencies` BOM or from `spring-boot-starter-parent`, with the parent winning
   when the two disagree. Both are resolved values, so a `spring-boot.version` property is
   honoured wherever it actually versions the BOM or the parent. Gradle projects use the
-  resolved Spring Boot platform when available, then the Spring Boot plugin version or a
-  dependency-management BOM entry; projects without a detectable major keep the Spring Boot 3
-  default.
+  resolved Spring Boot platform, declared platform, declared or resolved Spring Boot plugin, and
+  finally a dependency-management BOM entry; projects without a detectable major keep the Spring
+  Boot 3 default.
 recipeList:
   # Maven and Gradle need separate branches: a Maven-model precondition never matches a Gradle
   # build file, and vice versa, and YAML preconditions are AND-ed.

--- a/code-conversion/recipes/src/main/resources/META-INF/rewrite/dependencyRecipes.yml
+++ b/code-conversion/recipes/src/main/resources/META-INF/rewrite/dependencyRecipes.yml
@@ -8,14 +8,19 @@ description: >-
   then corrects the choice from the Spring Boot major resolved from the imported
   `spring-boot-dependencies` BOM or from `spring-boot-starter-parent`, with the parent winning
   when the two disagree. Both are resolved values, so a `spring-boot.version` property is
-  honoured wherever it actually versions the BOM or the parent. Gradle builds keep the Spring
-  Boot 3 starter default, because the Spring Boot major is not resolvable from the Gradle model
-  available here.
+  honoured wherever it actually versions the BOM or the parent. Gradle projects use the
+  resolved Spring Boot platform when available, then the Spring Boot plugin version or a
+  dependency-management BOM entry; projects without a detectable major keep the Spring Boot 3
+  default.
 recipeList:
   # Maven and Gradle need separate branches: a Maven-model precondition never matches a Gradle
   # build file, and vice versa, and YAML preconditions are AND-ed.
+  - io.camunda.migration.code.recipes.sharedRecipes.AddCamundaStarterWhenAbsentGradleBoot4
+  - io.camunda.migration.code.recipes.sharedRecipes.AddCamundaStarterWhenAbsentGradleBoot3
   - io.camunda.migration.code.recipes.sharedRecipes.AddCamundaStarterWhenAbsentGradle
   - io.camunda.migration.code.recipes.sharedRecipes.AddCamundaStarterWhenAbsent
+  - io.camunda.migration.code.recipes.sharedRecipes.UseSpringBoot4CamundaStarterWhenGradle
+  - io.camunda.migration.code.recipes.sharedRecipes.UseSpringBoot3CamundaStarterWhenGradle
   - io.camunda.migration.code.recipes.sharedRecipes.UseSpringBoot4CamundaStarterWhenBomIsBoot4
   - io.camunda.migration.code.recipes.sharedRecipes.UseSpringBoot3CamundaStarterWhenBomIsBoot3
   - io.camunda.migration.code.recipes.sharedRecipes.UseSpringBoot4CamundaStarterWhenParentIsBoot4
@@ -31,31 +36,54 @@ description: >-
   `ConfigureCamundaStarterRecipe` so the process test module always matches the starter.
 recipeList:
   # See ConfigureCamundaStarterRecipe for why Maven and Gradle need separate branches.
+  - io.camunda.migration.code.recipes.sharedRecipes.AddCamundaProcessTestDependencyWhenAbsentGradleBoot4
+  - io.camunda.migration.code.recipes.sharedRecipes.AddCamundaProcessTestDependencyWhenAbsentGradleBoot3
   - io.camunda.migration.code.recipes.sharedRecipes.AddCamundaProcessTestDependencyWhenAbsentGradle
   - io.camunda.migration.code.recipes.sharedRecipes.AddCamundaProcessTestDependencyWhenAbsent
+  - io.camunda.migration.code.recipes.sharedRecipes.UseSpringBoot4ProcessTestWhenGradle
+  - io.camunda.migration.code.recipes.sharedRecipes.UseSpringBoot3ProcessTestWhenGradle
   - io.camunda.migration.code.recipes.sharedRecipes.UseSpringBoot4ProcessTestWhenBomIsBoot4
   - io.camunda.migration.code.recipes.sharedRecipes.UseSpringBoot3ProcessTestWhenBomIsBoot3
   - io.camunda.migration.code.recipes.sharedRecipes.UseSpringBoot4ProcessTestWhenParentIsBoot4
   - io.camunda.migration.code.recipes.sharedRecipes.UseSpringBoot3ProcessTestWhenParentIsBoot3
 ---
-# Gradle counterpart of AddCamundaStarterWhenAbsent. The Spring Boot major is not resolvable from
-# the Gradle model available to these recipes, so Gradle builds keep the Spring Boot 3 default that
-# applied before this selector existed; the `Use...` rename recipes below are Maven only. The
-# precondition still matters: `AddDependency` on its own only skips the artifact it adds, so
-# without it a Gradle project that already declares the Spring Boot 4 starter would end up with
-# both starters on the classpath.
+# A Gradle build with a detected Spring Boot major must receive the matching artifact on the first
+# cycle. Adding the default Spring Boot 3 artifact and renaming it afterwards causes Gradle's
+# model-backed precondition to see the original dependency graph again on the next cycle.
 type: specs.openrewrite.org/v1beta/recipe
-name: io.camunda.migration.code.recipes.sharedRecipes.AddCamundaStarterWhenAbsentGradle
-displayName: Add the Camunda Spring Boot 3 starter to a Gradle build that declares no Camunda starter
-description: >-
-  Adds `camunda-spring-boot-3-starter` to the `implementation` configuration when the Gradle build
-  declares neither Camunda starter.
+name: io.camunda.migration.code.recipes.sharedRecipes.AddCamundaStarterWhenAbsentGradleBoot4
+displayName: Add the Camunda Spring Boot 4 starter to a Gradle build that resolves Spring Boot 4
+description: Adds the Spring Boot 4 Camunda starter when a Gradle build resolves Spring Boot 4 and declares no Camunda starter.
 preconditions:
-  - org.openrewrite.gradle.search.DoesNotIncludeDependency:
+  - io.camunda.migration.code.recipes.sharedRecipes.FindSpringBootMajorRecipe:
+      major: "4"
+  - io.camunda.migration.code.recipes.sharedRecipes.DoesNotDeclareGradleDependencyRecipe:
       groupId: io.camunda
       artifactId: camunda-spring-boot-starter
       onlyDirect: true
-  - org.openrewrite.gradle.search.DoesNotIncludeDependency:
+  - io.camunda.migration.code.recipes.sharedRecipes.DoesNotDeclareGradleDependencyRecipe:
+      groupId: io.camunda
+      artifactId: camunda-spring-boot-3-starter
+      onlyDirect: true
+recipeList:
+  - org.openrewrite.gradle.AddDependency:
+      groupId: io.camunda
+      artifactId: camunda-spring-boot-starter
+      version: ${version.camunda-8}
+      configuration: implementation
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: io.camunda.migration.code.recipes.sharedRecipes.AddCamundaStarterWhenAbsentGradleBoot3
+displayName: Add the Camunda Spring Boot 3 starter to a Gradle build that resolves Spring Boot 3
+description: Adds the Spring Boot 3 Camunda starter when a Gradle build resolves Spring Boot 3 and declares no Camunda starter.
+preconditions:
+  - io.camunda.migration.code.recipes.sharedRecipes.FindSpringBootMajorRecipe:
+      major: "3"
+  - io.camunda.migration.code.recipes.sharedRecipes.DoesNotDeclareGradleDependencyRecipe:
+      groupId: io.camunda
+      artifactId: camunda-spring-boot-starter
+      onlyDirect: true
+  - io.camunda.migration.code.recipes.sharedRecipes.DoesNotDeclareGradleDependencyRecipe:
       groupId: io.camunda
       artifactId: camunda-spring-boot-3-starter
       onlyDirect: true
@@ -66,18 +94,71 @@ recipeList:
       version: ${version.camunda-8}
       configuration: implementation
 ---
+# Gradle counterpart of AddCamundaStarterWhenAbsent. The precondition still matters:
+# `AddDependency` on its own only skips the artifact it adds, so it happily adds the Spring Boot 3
+# artifact to a build that already declares the mutually exclusive Spring Boot 4 one. Every Gradle
+# add therefore has to sit behind `DoesNotDeclareGradleDependencyRecipe` preconditions for both
+# artifacts of its pair.
 type: specs.openrewrite.org/v1beta/recipe
-name: io.camunda.migration.code.recipes.sharedRecipes.AddCamundaProcessTestDependencyWhenAbsentGradle
-displayName: Add the Camunda Spring Boot 3 process test module to a Gradle build that declares no process test module
+name: io.camunda.migration.code.recipes.sharedRecipes.AddCamundaStarterWhenAbsentGradle
+displayName: Add the Camunda Spring Boot 3 starter to a Gradle build that declares no Camunda starter
 description: >-
-  Adds `camunda-process-test-spring-boot-3` to the `testImplementation` configuration when the
-  Gradle build declares neither process test module.
+  Adds `camunda-spring-boot-3-starter` to the `implementation` configuration when the Gradle build
+  declares neither Camunda starter.
 preconditions:
-  - org.openrewrite.gradle.search.DoesNotIncludeDependency:
+  - io.camunda.migration.code.recipes.sharedRecipes.FindSpringBootMajorRecipe:
+      major: "none"
+  - io.camunda.migration.code.recipes.sharedRecipes.DoesNotDeclareGradleDependencyRecipe:
+      groupId: io.camunda
+      artifactId: camunda-spring-boot-starter
+      onlyDirect: true
+  - io.camunda.migration.code.recipes.sharedRecipes.DoesNotDeclareGradleDependencyRecipe:
+      groupId: io.camunda
+      artifactId: camunda-spring-boot-3-starter
+      onlyDirect: true
+recipeList:
+  - org.openrewrite.gradle.AddDependency:
+      groupId: io.camunda
+      artifactId: camunda-spring-boot-3-starter
+      version: ${version.camunda-8}
+      configuration: implementation
+---
+# As with the starter, add the artifact selected by the detected major directly so the
+# model-backed Gradle precondition does not cause a rename-and-add cycle.
+type: specs.openrewrite.org/v1beta/recipe
+name: io.camunda.migration.code.recipes.sharedRecipes.AddCamundaProcessTestDependencyWhenAbsentGradleBoot4
+displayName: Add the Camunda Spring Boot 4 process test module to a Gradle build that resolves Spring Boot 4
+description: Adds the Spring Boot 4 Camunda process test module when a Gradle build resolves Spring Boot 4 and declares no process test module.
+preconditions:
+  - io.camunda.migration.code.recipes.sharedRecipes.FindSpringBootMajorRecipe:
+      major: "4"
+  - io.camunda.migration.code.recipes.sharedRecipes.DoesNotDeclareGradleDependencyRecipe:
       groupId: io.camunda
       artifactId: camunda-process-test-spring
       onlyDirect: true
-  - org.openrewrite.gradle.search.DoesNotIncludeDependency:
+  - io.camunda.migration.code.recipes.sharedRecipes.DoesNotDeclareGradleDependencyRecipe:
+      groupId: io.camunda
+      artifactId: camunda-process-test-spring-boot-3
+      onlyDirect: true
+recipeList:
+  - org.openrewrite.gradle.AddDependency:
+      groupId: io.camunda
+      artifactId: camunda-process-test-spring
+      version: ${version.camunda-8}
+      configuration: testImplementation
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: io.camunda.migration.code.recipes.sharedRecipes.AddCamundaProcessTestDependencyWhenAbsentGradleBoot3
+displayName: Add the Camunda Spring Boot 3 process test module to a Gradle build that resolves Spring Boot 3
+description: Adds the Spring Boot 3 Camunda process test module when a Gradle build resolves Spring Boot 3 and declares no process test module.
+preconditions:
+  - io.camunda.migration.code.recipes.sharedRecipes.FindSpringBootMajorRecipe:
+      major: "3"
+  - io.camunda.migration.code.recipes.sharedRecipes.DoesNotDeclareGradleDependencyRecipe:
+      groupId: io.camunda
+      artifactId: camunda-process-test-spring
+      onlyDirect: true
+  - io.camunda.migration.code.recipes.sharedRecipes.DoesNotDeclareGradleDependencyRecipe:
       groupId: io.camunda
       artifactId: camunda-process-test-spring-boot-3
       onlyDirect: true
@@ -87,6 +168,90 @@ recipeList:
       artifactId: camunda-process-test-spring-boot-3
       version: ${version.camunda-8}
       configuration: testImplementation
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: io.camunda.migration.code.recipes.sharedRecipes.AddCamundaProcessTestDependencyWhenAbsentGradle
+displayName: Add the Camunda Spring Boot 3 process test module to a Gradle build that declares no process test module
+description: >-
+  Adds `camunda-process-test-spring-boot-3` to the `testImplementation` configuration when the
+  Gradle build declares neither process test module.
+preconditions:
+  - io.camunda.migration.code.recipes.sharedRecipes.FindSpringBootMajorRecipe:
+      major: "none"
+  - io.camunda.migration.code.recipes.sharedRecipes.DoesNotDeclareGradleDependencyRecipe:
+      groupId: io.camunda
+      artifactId: camunda-process-test-spring
+      onlyDirect: true
+  - io.camunda.migration.code.recipes.sharedRecipes.DoesNotDeclareGradleDependencyRecipe:
+      groupId: io.camunda
+      artifactId: camunda-process-test-spring-boot-3
+      onlyDirect: true
+recipeList:
+  - org.openrewrite.gradle.AddDependency:
+      groupId: io.camunda
+      artifactId: camunda-process-test-spring-boot-3
+      version: ${version.camunda-8}
+      configuration: testImplementation
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: io.camunda.migration.code.recipes.sharedRecipes.UseSpringBoot4CamundaStarterWhenGradle
+displayName: Use the Spring Boot 4 Camunda starter for a Gradle project
+description: Renames the Camunda Spring Boot 3 starter to the Spring Boot 4 starter when the Gradle project resolves Spring Boot 4.
+preconditions:
+  - io.camunda.migration.code.recipes.sharedRecipes.FindSpringBootMajorRecipe:
+      major: "4"
+recipeList:
+  - io.camunda.migration.code.recipes.sharedRecipes.ChangeGradleDependencyRecipe:
+      oldGroupId: io.camunda
+      oldArtifactId: camunda-spring-boot-3-starter
+      newGroupId: io.camunda
+      newArtifactId: camunda-spring-boot-starter
+      newVersion: ${version.camunda-8}
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: io.camunda.migration.code.recipes.sharedRecipes.UseSpringBoot3CamundaStarterWhenGradle
+displayName: Use the Spring Boot 3 Camunda starter for a Gradle project
+description: Renames the Camunda Spring Boot 4 starter to the Spring Boot 3 starter when the Gradle project resolves Spring Boot 3.
+preconditions:
+  - io.camunda.migration.code.recipes.sharedRecipes.FindSpringBootMajorRecipe:
+      major: "3"
+recipeList:
+  - io.camunda.migration.code.recipes.sharedRecipes.ChangeGradleDependencyRecipe:
+      oldGroupId: io.camunda
+      oldArtifactId: camunda-spring-boot-starter
+      newGroupId: io.camunda
+      newArtifactId: camunda-spring-boot-3-starter
+      newVersion: ${version.camunda-8}
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: io.camunda.migration.code.recipes.sharedRecipes.UseSpringBoot4ProcessTestWhenGradle
+displayName: Use the Spring Boot 4 Camunda process test module for a Gradle project
+description: Renames the Spring Boot 3 Camunda process test module to the Spring Boot 4 module when the Gradle project resolves Spring Boot 4.
+preconditions:
+  - io.camunda.migration.code.recipes.sharedRecipes.FindSpringBootMajorRecipe:
+      major: "4"
+recipeList:
+  - io.camunda.migration.code.recipes.sharedRecipes.ChangeGradleDependencyRecipe:
+      oldGroupId: io.camunda
+      oldArtifactId: camunda-process-test-spring-boot-3
+      newGroupId: io.camunda
+      newArtifactId: camunda-process-test-spring
+      newVersion: ${version.camunda-8}
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: io.camunda.migration.code.recipes.sharedRecipes.UseSpringBoot3ProcessTestWhenGradle
+displayName: Use the Spring Boot 3 Camunda process test module for a Gradle project
+description: Renames the Spring Boot 4 Camunda process test module to the Spring Boot 3 module when the Gradle project resolves Spring Boot 3.
+preconditions:
+  - io.camunda.migration.code.recipes.sharedRecipes.FindSpringBootMajorRecipe:
+      major: "3"
+recipeList:
+  - io.camunda.migration.code.recipes.sharedRecipes.ChangeGradleDependencyRecipe:
+      oldGroupId: io.camunda
+      oldArtifactId: camunda-process-test-spring
+      newGroupId: io.camunda
+      newArtifactId: camunda-process-test-spring-boot-3
+      newVersion: ${version.camunda-8}
 ---
 # The Spring Boot 3 starter is the default landing spot for a migrated Camunda 7 application; the
 # `UseSpringBoot4...` recipes below upgrade it when the project actually resolves Spring Boot 4.

--- a/code-conversion/recipes/src/main/resources/META-INF/rewrite/dependencyRecipes.yml
+++ b/code-conversion/recipes/src/main/resources/META-INF/rewrite/dependencyRecipes.yml
@@ -100,7 +100,7 @@ name: io.camunda.migration.code.recipes.sharedRecipes.AddCamundaStarterWhenAbsen
 displayName: Add the Camunda Spring Boot 3 starter to a Gradle build that declares no Camunda starter
 description: >-
   Adds `camunda-spring-boot-3-starter` to the `implementation` configuration when the Gradle build
-  declares neither Camunda starter.
+  declares neither Camunda starter and no Spring Boot major can be detected.
 preconditions:
   - io.camunda.migration.code.recipes.sharedRecipes.FindSpringBootMajorRecipe:
       major: "none"
@@ -164,7 +164,7 @@ name: io.camunda.migration.code.recipes.sharedRecipes.AddCamundaProcessTestDepen
 displayName: Add the Camunda Spring Boot 3 process test module to a Gradle build that declares no process test module
 description: >-
   Adds `camunda-process-test-spring-boot-3` to the `testImplementation` configuration when the
-  Gradle build declares neither process test module.
+  Gradle build declares neither process test module and no Spring Boot major can be detected.
 preconditions:
   - io.camunda.migration.code.recipes.sharedRecipes.FindSpringBootMajorRecipe:
       major: "none"

--- a/code-conversion/recipes/src/test/java/io/camunda/migration/code/recipes/RecipeDependencyConfigTest.java
+++ b/code-conversion/recipes/src/test/java/io/camunda/migration/code/recipes/RecipeDependencyConfigTest.java
@@ -9,6 +9,8 @@ package io.camunda.migration.code.recipes;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
+import static org.openrewrite.gradle.Assertions.buildGradle;
+import static org.openrewrite.gradle.toolingapi.Assertions.withToolingApi;
 import static org.openrewrite.maven.Assertions.pomXml;
 
 import java.io.BufferedReader;
@@ -42,6 +44,7 @@ class RecipeDependencyConfigTest implements RewriteTest {
   private static final String SB4_STARTER = "camunda-spring-boot-starter";
   private static final String SB3_PROCESS_TEST = "camunda-process-test-spring-boot-3";
   private static final String SB4_PROCESS_TEST = "camunda-process-test-spring";
+  private static final String GRADLE_TEST_CAMUNDA_VERSION = "8.9.0";
 
   /** The two artifacts of each pair are mutually exclusive - a project must declare exactly one. */
   private static final Map<String, String> MUTUALLY_EXCLUSIVE_PAIRS =
@@ -102,6 +105,265 @@ class RecipeDependencyConfigTest implements RewriteTest {
             SB4_STARTER,
             SB4_PROCESS_TEST),
         arguments("no detectable Spring Boot major", "", SB3_STARTER, SB3_PROCESS_TEST));
+  }
+
+  /**
+   * Gradle exposes the Spring Boot major through the resolved platform, the Boot plugin, or the
+   * Spring dependency management plugin. These are separate rows so a future detection change
+   * cannot silently drop one of the supported Gradle project shapes.
+   */
+  static List<Arguments> gradleSpringBootMajorSignals() {
+    return List.of(
+        arguments(
+            "resolved Spring Boot 3 platform",
+            gradleBuild(
+                """
+                plugins {
+                    id 'java'
+                }
+
+                repositories {
+                    mavenCentral()
+                }
+
+                dependencies {
+                    implementation platform('org.springframework.boot:spring-boot-dependencies:3.5.4')
+                }
+                """),
+            SB3_STARTER,
+            SB3_PROCESS_TEST),
+        arguments(
+            "resolved Spring Boot 4 platform",
+            gradleBuild(
+                """
+                plugins {
+                    id 'java'
+                }
+
+                repositories {
+                    mavenCentral()
+                }
+
+                dependencies {
+                    implementation platform('org.springframework.boot:spring-boot-dependencies:4.0.0')
+                }
+                """),
+            SB4_STARTER,
+            SB4_PROCESS_TEST),
+        arguments(
+            "Spring Boot 3 plugin",
+            gradleBuild(
+                """
+                plugins {
+                    id 'java'
+                    id 'org.springframework.boot' version '3.5.4'
+                }
+
+                repositories {
+                    mavenCentral()
+                }
+                """),
+            SB3_STARTER,
+            SB3_PROCESS_TEST),
+        arguments(
+            "Spring Boot 4 plugin",
+            gradleBuild(
+                """
+                plugins {
+                    id 'java'
+                    id 'org.springframework.boot' version '4.0.0'
+                }
+
+                repositories {
+                    mavenCentral()
+                }
+                """),
+            SB4_STARTER,
+            SB4_PROCESS_TEST),
+        arguments(
+            "Spring dependency management imports Boot 4",
+            gradleBuild(
+                """
+                plugins {
+                    id 'java'
+                    id 'io.spring.dependency-management' version '1.1.7'
+                }
+
+                repositories {
+                    mavenCentral()
+                }
+
+                dependencyManagement {
+                    imports {
+                        mavenBom 'org.springframework.boot:spring-boot-dependencies:4.0.0'
+                    }
+                }
+                """),
+            SB4_STARTER,
+            SB4_PROCESS_TEST),
+        arguments(
+            "Spring dependency management imports Boot 3",
+            gradleBuild(
+                """
+                plugins {
+                    id 'java'
+                    id 'io.spring.dependency-management' version '1.1.7'
+                }
+
+                repositories {
+                    mavenCentral()
+                }
+
+                dependencyManagement {
+                    imports {
+                        mavenBom 'org.springframework.boot:spring-boot-dependencies:3.5.4'
+                    }
+                }
+                """),
+            SB3_STARTER,
+            SB3_PROCESS_TEST),
+        arguments(
+            "no detectable Spring Boot major",
+            gradleBuild(
+                """
+                plugins {
+                    id 'java'
+                }
+
+                repositories {
+                    mavenCentral()
+                }
+                """),
+            SB3_STARTER,
+            SB3_PROCESS_TEST));
+  }
+
+  @ParameterizedTest(name = "selects Gradle dependencies when {0}")
+  @MethodSource("gradleSpringBootMajorSignals")
+  void selectsDependenciesMatchingGradleSpringBootMajor(
+      String signalName, String buildScript, String expectedStarter, String expectedProcessTest) {
+    rewriteRun(
+        spec -> spec.beforeRecipe(withToolingApi()),
+        buildGradle(
+            buildScript,
+            spec ->
+                spec.path("build.gradle")
+                    .after(
+                        after ->
+                            assertGradleDependencies(after, expectedStarter, expectedProcessTest))));
+  }
+
+  static List<Arguments> gradleDetectedSpringBootMajorSignals() {
+    return gradleSpringBootMajorSignals().stream()
+        .filter(arguments -> !"no detectable Spring Boot major".equals(arguments.get()[0]))
+        .toList();
+  }
+
+  @ParameterizedTest(name = "repairs Gradle dependencies when {0}")
+  @MethodSource("gradleDetectedSpringBootMajorSignals")
+  void repairsMismatchedGradleDependencyChoice(
+      String signalName, String buildScript, String expectedStarter, String expectedProcessTest) {
+    String wrongStarter = SB3_STARTER.equals(expectedStarter) ? SB4_STARTER : SB3_STARTER;
+    String wrongProcessTest =
+        SB3_PROCESS_TEST.equals(expectedProcessTest) ? SB4_PROCESS_TEST : SB3_PROCESS_TEST;
+
+    rewriteRun(
+        spec -> spec.beforeRecipe(withToolingApi()),
+        buildGradle(
+            buildScript + gradleDependencies(wrongStarter, wrongProcessTest),
+            spec ->
+                spec.path("build.gradle")
+                    .after(
+                        after ->
+                            assertGradleDependencies(after, expectedStarter, expectedProcessTest))));
+  }
+
+  @Test
+  void leavesExplicitGradleChoiceAloneWithoutSpringBootSignal() {
+    rewriteRun(
+        spec -> spec.beforeRecipe(withToolingApi()),
+        buildGradle(
+            gradleBuild(
+                """
+                plugins {
+                    id 'java'
+                }
+
+                repositories {
+                    mavenCentral()
+                }
+                """
+                    + gradleDependencies(SB4_STARTER, SB4_PROCESS_TEST)),
+            spec -> spec.path("build.gradle")));
+  }
+
+  @Test
+  void changesUnresolvedGradleDependencyDeclaration() {
+    String before =
+        gradleBuild(
+            """
+            plugins {
+                id 'java'
+            }
+
+            repositories {
+                mavenCentral()
+            }
+
+            dependencies {
+                implementation platform('org.springframework.boot:spring-boot-dependencies:4.0.0')
+                implementation "io.camunda:camunda-spring-boot-3-starter:8.10.0-SNAPSHOT"
+            }
+
+            dependencies {
+                testImplementation "io.camunda:camunda-process-test-spring-boot-3:8.10.0-SNAPSHOT"
+            }
+            """);
+    String after =
+        before.replace(SB3_STARTER + ":8.10.0-SNAPSHOT", SB4_STARTER + ":8.10.0-SNAPSHOT");
+
+    rewriteRun(
+        spec ->
+            spec.recipe(
+                    new io.camunda.migration.code.recipes.sharedRecipes
+                        .ChangeGradleDependencyRecipe(
+                        "io.camunda",
+                        SB3_STARTER,
+                        "io.camunda",
+                        SB4_STARTER,
+                        "8.10.0-SNAPSHOT"))
+                .beforeRecipe(withToolingApi()),
+        buildGradle(before, after));
+  }
+
+  @Test
+  void configuresPlatformBackedGradleDependenciesWithTheSharedRecipe() {
+    String before =
+        gradleBuild(
+            """
+            plugins {
+                id 'java'
+            }
+
+            repositories {
+                mavenCentral()
+            }
+
+            dependencies {
+                implementation platform('org.springframework.boot:spring-boot-dependencies:4.0.0')
+            }
+            """)
+            + gradleDependencies(SB3_STARTER, SB3_PROCESS_TEST);
+
+    rewriteRun(
+        spec -> spec.beforeRecipe(withToolingApi()),
+        buildGradle(
+            before,
+            spec ->
+                spec.path("build.gradle")
+                    .after(
+                        after ->
+                            assertGradleDependencies(after, SB4_STARTER, SB4_PROCESS_TEST))));
   }
 
   /**
@@ -268,8 +530,8 @@ class RecipeDependencyConfigTest implements RewriteTest {
    *
    * <p>{@code org.openrewrite.gradle.AddDependency} only skips the artifact it adds, so on its own
    * it happily adds the Spring Boot 3 artifact to a build that already declares the mutually
-   * exclusive Spring Boot 4 one. Every Gradle add therefore has to sit behind {@code
-   * DoesNotIncludeDependency} preconditions for both artifacts of its pair.
+   * exclusive Spring Boot 4 one. Every Gradle add therefore has to sit behind
+   * {@code DoesNotDeclareGradleDependencyRecipe} preconditions for both artifacts of its pair.
    *
    * <p>This is asserted on the descriptor rather than by running the recipe because executing a
    * Gradle branch requires a {@code GradleProject} marker, which in turn needs {@code
@@ -304,7 +566,8 @@ class RecipeDependencyConfigTest implements RewriteTest {
             .as("Gradle add of %s must be preconditioned on %s being absent", added, artifactId)
             .containsPattern(
                 Pattern.compile(
-                    "- org\\.openrewrite\\.gradle\\.search\\.DoesNotIncludeDependency:\\s*\\n"
+                    "- io\\.camunda\\.migration\\.code\\.recipes\\.sharedRecipes\\."
+                        + "DoesNotDeclareGradleDependencyRecipe:\\s*\\n"
                         + "\\s*groupId: io\\.camunda\\s*\\n"
                         + "\\s*artifactId: "
                         + Pattern.quote(artifactId)
@@ -314,7 +577,7 @@ class RecipeDependencyConfigTest implements RewriteTest {
 
     assertThat(guarded)
         .as("Gradle builds must still get a starter and a process test module")
-        .containsExactlyInAnyOrder(SB3_STARTER, SB3_PROCESS_TEST);
+        .contains(SB3_STARTER, SB4_STARTER, SB3_PROCESS_TEST, SB4_PROCESS_TEST);
   }
 
   private static String assertOnly(String pom, String expectedStarter, String expectedProcessTest) {
@@ -388,6 +651,36 @@ class RecipeDependencyConfigTest implements RewriteTest {
              </dependencies>
            """
         .formatted(starter, camundaVersion(), processTest, camundaVersion());
+  }
+
+  private static String gradleBuild(String script) {
+    return script;
+  }
+
+  private static String gradleDependencies(String starter, String processTest) {
+    return """
+
+           dependencies {
+             implementation "io.camunda:%s:%s"
+             testImplementation "io.camunda:%s:%s"
+           }
+           """
+        .formatted(
+            starter, GRADLE_TEST_CAMUNDA_VERSION, processTest, GRADLE_TEST_CAMUNDA_VERSION);
+  }
+
+  private static String assertGradleDependencies(
+      String build, String expectedStarter, String expectedProcessTest) {
+    String unexpectedStarter = SB3_STARTER.equals(expectedStarter) ? SB4_STARTER : SB3_STARTER;
+    String unexpectedProcessTest =
+        SB3_PROCESS_TEST.equals(expectedProcessTest) ? SB4_PROCESS_TEST : SB3_PROCESS_TEST;
+
+    assertThat(build)
+        .contains("io.camunda:" + expectedStarter + ":")
+        .contains("io.camunda:" + expectedProcessTest + ":")
+        .doesNotContain("io.camunda:" + unexpectedStarter + ":")
+        .doesNotContain("io.camunda:" + unexpectedProcessTest + ":");
+    return build;
   }
 
   private static String pom(String springBootSignal, String dependencies) {

--- a/code-conversion/recipes/src/test/java/io/camunda/migration/code/recipes/RecipeDependencyConfigTest.java
+++ b/code-conversion/recipes/src/test/java/io/camunda/migration/code/recipes/RecipeDependencyConfigTest.java
@@ -28,6 +28,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
@@ -371,6 +372,30 @@ class RecipeDependencyConfigTest implements RewriteTest {
     rewriteRun(
         spec -> spec.recipe(new FindSpringBootMajorRecipe("3")),
         buildGradle(build, "/*~~>*/" + build));
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"none", "3", "4"})
+  void doesNotMatchConflictingGradleSignals(String major) {
+    String build =
+        """
+        plugins {
+            id 'java'
+        }
+
+        repositories {
+            mavenCentral()
+        }
+
+        dependencies {
+            implementation platform('org.springframework.boot:spring-boot-dependencies:3.5.4')
+            implementation platform('org.springframework.boot:spring-boot-dependencies:4.0.0')
+        }
+        """;
+
+    rewriteRun(
+        spec -> spec.recipe(new FindSpringBootMajorRecipe(major)),
+        buildGradle(build));
   }
 
   @Test

--- a/code-conversion/recipes/src/test/java/io/camunda/migration/code/recipes/RecipeDependencyConfigTest.java
+++ b/code-conversion/recipes/src/test/java/io/camunda/migration/code/recipes/RecipeDependencyConfigTest.java
@@ -354,6 +354,20 @@ class RecipeDependencyConfigTest implements RewriteTest {
   }
 
   @Test
+  void ignoresSimilarGradlePluginId() {
+    String build =
+        """
+        plugins {
+            id 'orgxspringframeworkxboot' version '4.0.0'
+        }
+        """;
+
+    rewriteRun(
+        spec -> spec.recipe(new FindSpringBootMajorRecipe("none")),
+        buildGradle(build, "/*~~>*/" + build));
+  }
+
+  @Test
   void detectsDependencyManagementBomWithoutGradleModel() {
     String build =
         """
@@ -426,6 +440,28 @@ class RecipeDependencyConfigTest implements RewriteTest {
                     .after(
                         after ->
                             assertGradleDependencies(after, SB4_STARTER, SB4_PROCESS_TEST))));
+  }
+
+  @Test
+  void leavesGradleDependencyPairsAloneWhenBothArtifactsAreDeclared() {
+    String before =
+        gradleBuild(
+            """
+            plugins {
+                id 'java'
+            }
+
+            repositories {
+                mavenCentral()
+            }
+
+            dependencies {
+                implementation platform('org.springframework.boot:spring-boot-dependencies:4.0.0')
+            }
+            """)
+            + gradleDependenciesWithBothArtifacts();
+
+    rewriteRun(buildGradle(before, spec -> spec.path("build.gradle")));
   }
 
   /**
@@ -642,6 +678,47 @@ class RecipeDependencyConfigTest implements RewriteTest {
         .contains(SB3_STARTER, SB4_STARTER, SB3_PROCESS_TEST, SB4_PROCESS_TEST);
   }
 
+  @Test
+  void everyGradleRenameIsGuardedAgainstTheTargetArtifact() {
+    String yaml = resourceText("/META-INF/rewrite/dependencyRecipes.yml");
+
+    List<String> renamed = new ArrayList<>();
+    for (String document : yaml.split("(?m)^---$")) {
+      if (!document.contains("ChangeGradleDependencyRecipe")) {
+        continue;
+      }
+      Matcher targetMatcher =
+          Pattern.compile(
+                  "- io\\.camunda\\.migration\\.code\\.recipes\\.sharedRecipes\\."
+                      + "ChangeGradleDependencyRecipe:\\s*\\n"
+                      + "\\s*oldGroupId: \\S+\\s*\\n"
+                      + "\\s*oldArtifactId: \\S+\\s*\\n"
+                      + "\\s*newGroupId: \\S+\\s*\\n"
+                      + "\\s*newArtifactId: (\\S+)\\s*\\n")
+              .matcher(document);
+      assertThat(targetMatcher.find())
+          .as("Gradle rename must name its target artifact:\n%s", document)
+          .isTrue();
+      String target = targetMatcher.group(1);
+      renamed.add(target);
+
+      assertThat(document)
+          .as("Gradle rename to %s must be preconditioned on the target being absent", target)
+          .containsPattern(
+              Pattern.compile(
+                  "- io\\.camunda\\.migration\\.code\\.recipes\\.sharedRecipes\\."
+                      + "DoesNotDeclareGradleDependencyRecipe:\\s*\\n"
+                      + "\\s*groupId: io\\.camunda\\s*\\n"
+                      + "\\s*artifactId: "
+                      + Pattern.quote(target)
+                      + "\\s*\\n"));
+    }
+
+    assertThat(renamed)
+        .as("Gradle builds must guard every mutually exclusive rename target")
+        .containsExactlyInAnyOrder(SB3_STARTER, SB4_STARTER, SB3_PROCESS_TEST, SB4_PROCESS_TEST);
+  }
+
   private static String assertOnly(String pom, String expectedStarter, String expectedProcessTest) {
     String unexpectedStarter = SB3_STARTER.equals(expectedStarter) ? SB4_STARTER : SB3_STARTER;
     String unexpectedProcessTest =
@@ -729,6 +806,27 @@ class RecipeDependencyConfigTest implements RewriteTest {
            """
         .formatted(
             starter, GRADLE_TEST_CAMUNDA_VERSION, processTest, GRADLE_TEST_CAMUNDA_VERSION);
+  }
+
+  private static String gradleDependenciesWithBothArtifacts() {
+    return """
+
+           dependencies {
+             implementation "io.camunda:%s:%s"
+             implementation "io.camunda:%s:%s"
+             testImplementation "io.camunda:%s:%s"
+             testImplementation "io.camunda:%s:%s"
+           }
+           """
+        .formatted(
+            SB3_STARTER,
+            GRADLE_TEST_CAMUNDA_VERSION,
+            SB4_STARTER,
+            GRADLE_TEST_CAMUNDA_VERSION,
+            SB3_PROCESS_TEST,
+            GRADLE_TEST_CAMUNDA_VERSION,
+            SB4_PROCESS_TEST,
+            GRADLE_TEST_CAMUNDA_VERSION);
   }
 
   private static String assertGradleDependencies(

--- a/code-conversion/recipes/src/test/java/io/camunda/migration/code/recipes/RecipeDependencyConfigTest.java
+++ b/code-conversion/recipes/src/test/java/io/camunda/migration/code/recipes/RecipeDependencyConfigTest.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import io.camunda.migration.code.recipes.sharedRecipes.FindSpringBootMajorRecipe;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -334,6 +335,42 @@ class RecipeDependencyConfigTest implements RewriteTest {
                         "8.10.0-SNAPSHOT"))
                 .beforeRecipe(withToolingApi()),
         buildGradle(before, after));
+  }
+
+  @Test
+  void detectsSpringBootPluginWithoutGradleModel() {
+    String build =
+        """
+        plugins {
+            id 'java'
+            id 'org.springframework.boot' version '4.0.0'
+        }
+        """;
+
+    rewriteRun(
+        spec -> spec.recipe(new FindSpringBootMajorRecipe("4")),
+        buildGradle(build, "/*~~>*/" + build));
+  }
+
+  @Test
+  void detectsDependencyManagementBomWithoutGradleModel() {
+    String build =
+        """
+        plugins {
+            id 'java'
+            id 'io.spring.dependency-management' version '1.1.7'
+        }
+
+        dependencyManagement {
+            imports {
+                mavenBom 'org.springframework.boot:spring-boot-dependencies:3.5.4'
+            }
+        }
+        """;
+
+    rewriteRun(
+        spec -> spec.recipe(new FindSpringBootMajorRecipe("3")),
+        buildGradle(build, "/*~~>*/" + build));
   }
 
   @Test

--- a/code-conversion/recipes/src/test/java/io/camunda/migration/code/recipes/RecipeDependencyConfigTest.java
+++ b/code-conversion/recipes/src/test/java/io/camunda/migration/code/recipes/RecipeDependencyConfigTest.java
@@ -327,14 +327,12 @@ class RecipeDependencyConfigTest implements RewriteTest {
     rewriteRun(
         spec ->
             spec.recipe(
-                    new io.camunda.migration.code.recipes.sharedRecipes
-                        .ChangeGradleDependencyRecipe(
-                        "io.camunda",
-                        SB3_STARTER,
-                        "io.camunda",
-                        SB4_STARTER,
-                        "8.10.0-SNAPSHOT"))
-                .beforeRecipe(withToolingApi()),
+                new io.camunda.migration.code.recipes.sharedRecipes.ChangeGradleDependencyRecipe(
+                    "io.camunda",
+                    SB3_STARTER,
+                    "io.camunda",
+                    SB4_STARTER,
+                    "8.10.0-SNAPSHOT")),
         buildGradle(before, after));
   }
 


### PR DESCRIPTION
## Summary

- Detect Spring Boot 3/4 in Gradle projects from the resolved platform, Boot plugin, or dependency-management BOM.
- Select and repair the matching Camunda Spring Boot starter and process-test dependency.
- Add real Gradle Tooling API coverage for the signal matrix and unresolved migration declarations.

## Changes

- Added shared Gradle major detection and AST-aware dependency presence/change recipes.
- Added Boot 3/4 Gradle branches to the shared dependency selector recipes.
- Added Gradle/OpenRewrite test dependencies and category-scoped selection and repair tests.

## Test plan

- [x] JAVA_HOME=/opt/homebrew/opt/openjdk@21 mvn test -pl code-conversion/recipes -Dtest=RecipeDependencyConfigTest
- [x] JAVA_HOME=/opt/homebrew/opt/openjdk@21 mvn test -pl code-conversion/recipes
- [x] JAVA_HOME=/opt/homebrew/opt/openjdk@21 mvn verify -pl code-conversion/recipes -DskipTests

## Baseline

Built from commit: 5c1c59e3fc5698328e8c7ccd25b6931d1e08775c

related to #2051

🤖 Generated with [Claude Code](https://claude.com/claude-code)