### PR TITLE
fix(diagram-converter): handle engine resource output paths

### DIFF
--- a/diagram-converter/cli/src/main/java/io/camunda/migration/diagram/converter/cli/AbstractConvertCommand.java
+++ b/diagram-converter/cli/src/main/java/io/camunda/migration/diagram/converter/cli/AbstractConvertCommand.java
@@ -141,7 +141,7 @@ public abstract class AbstractConvertCommand implements Callable<Integer> {
       for (Entry<File, ModelInstance> modelInstance : modelInstances.entrySet()) {
         File file = prefixFileName(modelInstance.getKey());
         if (!override && file.exists()) {
-          LOG_CLI.error("File does already exist: {}", file);
+          LOG_CLI.error("File already exists: {}", file);
           returnCode = 1;
           continue;
         }

--- a/diagram-converter/cli/src/main/java/io/camunda/migration/diagram/converter/cli/AbstractConvertCommand.java
+++ b/diagram-converter/cli/src/main/java/io/camunda/migration/diagram/converter/cli/AbstractConvertCommand.java
@@ -137,11 +137,6 @@ public abstract class AbstractConvertCommand implements Callable<Integer> {
     if (!check) {
       for (Entry<File, ModelInstance> modelInstance : modelInstances.entrySet()) {
         File file = determineFileName(prefixFileName(modelInstance.getKey()));
-        if (!override && file.exists()) {
-          LOG_CLI.error("File does already exist: {}", file);
-          returnCode = 1;
-          continue;
-        }
         try (FileWriter fw = new FileWriter(file)) {
           converter.printXml(modelInstance.getValue().getDocument(), true, fw);
           fw.flush();

--- a/diagram-converter/cli/src/main/java/io/camunda/migration/diagram/converter/cli/AbstractConvertCommand.java
+++ b/diagram-converter/cli/src/main/java/io/camunda/migration/diagram/converter/cli/AbstractConvertCommand.java
@@ -140,6 +140,7 @@ public abstract class AbstractConvertCommand implements Callable<Integer> {
         if (!override && file.exists()) {
           LOG_CLI.error("File does already exist: {}", file);
           returnCode = 1;
+          continue;
         }
         try (FileWriter fw = new FileWriter(file)) {
           converter.printXml(modelInstance.getValue().getDocument(), true, fw);

--- a/diagram-converter/cli/src/main/java/io/camunda/migration/diagram/converter/cli/AbstractConvertCommand.java
+++ b/diagram-converter/cli/src/main/java/io/camunda/migration/diagram/converter/cli/AbstractConvertCommand.java
@@ -142,7 +142,7 @@ public abstract class AbstractConvertCommand implements Callable<Integer> {
           fw.flush();
           LOG_CLI.info("Created {}", file);
         } catch (IOException e) {
-          LOG_CLI.error("Error while creating BPMN file: {}", createMessage(e));
+          LOG_CLI.error("Error while creating diagram file: {}", createMessage(e));
           returnCode = 1;
         }
       }

--- a/diagram-converter/cli/src/main/java/io/camunda/migration/diagram/converter/cli/AbstractConvertCommand.java
+++ b/diagram-converter/cli/src/main/java/io/camunda/migration/diagram/converter/cli/AbstractConvertCommand.java
@@ -14,6 +14,7 @@ import io.camunda.migration.diagram.converter.DefaultConverterProperties;
 import io.camunda.migration.diagram.converter.DiagramCheckResult;
 import io.camunda.migration.diagram.converter.DiagramConverter;
 import io.camunda.migration.diagram.converter.DiagramConverterFactory;
+import io.camunda.migration.diagram.converter.DiagramType;
 import io.camunda.migration.diagram.converter.excel.ExcelWriter;
 import java.io.File;
 import java.io.FileOutputStream;
@@ -21,6 +22,8 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -136,7 +139,13 @@ public abstract class AbstractConvertCommand implements Callable<Integer> {
     }
     if (!check) {
       for (Entry<File, ModelInstance> modelInstance : modelInstances.entrySet()) {
-        File file = determineFileName(prefixFileName(modelInstance.getKey()));
+        File file = prefixFileName(modelInstance.getKey());
+        if (!override && file.exists()) {
+          LOG_CLI.error("File does already exist: {}", file);
+          returnCode = 1;
+          continue;
+        }
+        file = determineFileName(file);
         try (FileWriter fw = new FileWriter(file)) {
           converter.printXml(modelInstance.getValue().getDocument(), true, fw);
           fw.flush();
@@ -244,16 +253,30 @@ public abstract class AbstractConvertCommand implements Callable<Integer> {
     int counter = 0;
     while (!override && newFile.exists()) {
       counter++;
+      String fileName = file.getName();
+      String fileEnding = fileEnding(fileName);
       newFile =
           new File(
               file.getParentFile(),
-              FilenameUtils.getBaseName(file.getName())
+              fileName.substring(0, fileName.length() - fileEnding.length())
                   + " ("
                   + counter
-                  + ")."
-                  + FilenameUtils.getExtension(file.getName()));
+                  + ")"
+                  + fileEnding);
     }
     return newFile;
+  }
+
+  private String fileEnding(String fileName) {
+    return Arrays.stream(DiagramType.values())
+        .flatMap(diagramType -> diagramType.getFileEndings().stream())
+        .filter(fileName::endsWith)
+        .max(Comparator.comparingInt(String::length))
+        .orElseGet(
+            () -> {
+              String extension = FilenameUtils.getExtension(fileName);
+              return extension.isEmpty() ? "" : "." + extension;
+            });
   }
 
   protected String createMessage(Exception e) {

--- a/diagram-converter/cli/src/main/java/io/camunda/migration/diagram/converter/cli/AbstractConvertCommand.java
+++ b/diagram-converter/cli/src/main/java/io/camunda/migration/diagram/converter/cli/AbstractConvertCommand.java
@@ -19,6 +19,8 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -129,6 +131,9 @@ public abstract class AbstractConvertCommand implements Callable<Integer> {
 
   private void writeResults(
       Map<File, ModelInstance> modelInstances, List<DiagramCheckResult> results) {
+    if ((!check || csv || xlsx || markdown) && !createTargetDirectory()) {
+      return;
+    }
     if (!check) {
       for (Entry<File, ModelInstance> modelInstance : modelInstances.entrySet()) {
         File file = determineFileName(prefixFileName(modelInstance.getKey()));
@@ -136,10 +141,10 @@ public abstract class AbstractConvertCommand implements Callable<Integer> {
           LOG_CLI.error("File does already exist: {}", file);
           returnCode = 1;
         }
-        LOG_CLI.info("Created {}", file);
         try (FileWriter fw = new FileWriter(file)) {
           converter.printXml(modelInstance.getValue().getDocument(), true, fw);
           fw.flush();
+          LOG_CLI.info("Created {}", file);
         } catch (IOException e) {
           LOG_CLI.error("Error while creating BPMN file: {}", createMessage(e));
           returnCode = 1;
@@ -175,6 +180,19 @@ public abstract class AbstractConvertCommand implements Callable<Integer> {
         LOG_CLI.error("Error while creating markdown results: {}", createMessage(e));
         returnCode = 1;
       }
+    }
+  }
+
+  private boolean createTargetDirectory() {
+    File directory = targetDirectory();
+    Path path = directory == null ? Path.of(".") : directory.toPath();
+    try {
+      Files.createDirectories(path);
+      return true;
+    } catch (IOException e) {
+      LOG_CLI.error("Error while creating target directory {}: {}", path, createMessage(e));
+      returnCode = 1;
+      return false;
     }
   }
 

--- a/diagram-converter/cli/src/main/java/io/camunda/migration/diagram/converter/cli/ConvertEngineCommand.java
+++ b/diagram-converter/cli/src/main/java/io/camunda/migration/diagram/converter/cli/ConvertEngineCommand.java
@@ -10,6 +10,7 @@ package io.camunda.migration.diagram.converter.cli;
 import io.camunda.migration.diagram.converter.DiagramType;
 import java.io.ByteArrayInputStream;
 import java.io.File;
+import java.nio.charset.StandardCharsets;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
@@ -92,7 +93,8 @@ public class ConvertEngineCommand extends AbstractConvertCommand {
                   File outputFile = uniqueOutputFile(filename, diagramType, result);
                   result.put(
                       outputFile,
-                      diagramType.readDiagram(new ByteArrayInputStream(model.getBytes())));
+                      diagramType.readDiagram(
+                          new ByteArrayInputStream(model.getBytes(StandardCharsets.UTF_8))));
                 }));
   }
 

--- a/diagram-converter/cli/src/main/java/io/camunda/migration/diagram/converter/cli/ConvertEngineCommand.java
+++ b/diagram-converter/cli/src/main/java/io/camunda/migration/diagram/converter/cli/ConvertEngineCommand.java
@@ -67,10 +67,17 @@ public class ConvertEngineCommand extends AbstractConvertCommand {
 
   @Override
   protected Map<File, ModelInstance> modelInstances() {
-    Map<String, Map<String, Set<String>>> allLatestBpmnXml = getAllLatestBpmnXml();
-    allLatestBpmnXml.putAll(getAllLatestDmnXml());
     Map<File, ModelInstance> result = new LinkedHashMap<>();
-    allLatestBpmnXml.forEach(
+    addModelInstances(getAllLatestBpmnXml(), DiagramType.BPMN, result);
+    addModelInstances(getAllLatestDmnXml(), DiagramType.DMN, result);
+    return result;
+  }
+
+  private void addModelInstances(
+      Map<String, Map<String, Set<String>>> diagrams,
+      DiagramType diagramType,
+      Map<File, ModelInstance> result) {
+    diagrams.forEach(
         (resourceName, models) ->
             models.forEach(
                 (model, processDefinitionKeys) -> {
@@ -83,13 +90,19 @@ public class ConvertEngineCommand extends AbstractConvertCommand {
                               + ")."
                               + FilenameUtils.getExtension(resourceName);
                   filename = FilenameUtils.getName(filename);
+                  filename = safeFilename(filename, diagramType);
                   File outputFile = uniqueOutputFile(filename, result);
                   result.put(
                       outputFile,
-                      DiagramType.fromFileName(filename)
-                          .readDiagram(new ByteArrayInputStream(model.getBytes())));
+                      diagramType.readDiagram(new ByteArrayInputStream(model.getBytes())));
                 }));
-    return result;
+  }
+
+  static String safeFilename(String filename, DiagramType diagramType) {
+    if (filename.isBlank() || filename.equals(".") || filename.equals("..")) {
+      return "diagram" + diagramType.getFileEndings().get(0);
+    }
+    return filename;
   }
 
   private File uniqueOutputFile(String filename, Map<File, ModelInstance> existingFiles) {

--- a/diagram-converter/cli/src/main/java/io/camunda/migration/diagram/converter/cli/ConvertEngineCommand.java
+++ b/diagram-converter/cli/src/main/java/io/camunda/migration/diagram/converter/cli/ConvertEngineCommand.java
@@ -10,7 +10,7 @@ package io.camunda.migration.diagram.converter.cli;
 import io.camunda.migration.diagram.converter.DiagramType;
 import java.io.ByteArrayInputStream;
 import java.io.File;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -69,25 +69,44 @@ public class ConvertEngineCommand extends AbstractConvertCommand {
   protected Map<File, ModelInstance> modelInstances() {
     Map<String, Map<String, Set<String>>> allLatestBpmnXml = getAllLatestBpmnXml();
     allLatestBpmnXml.putAll(getAllLatestDmnXml());
-    Map<File, ModelInstance> result = new HashMap<>();
+    Map<File, ModelInstance> result = new LinkedHashMap<>();
     allLatestBpmnXml.forEach(
         (resourceName, models) ->
             models.forEach(
                 (model, processDefinitionKeys) -> {
                   String filename =
                       models.size() == 1
-                          ? resourceName
+                          ? FilenameUtils.getName(resourceName)
                           : FilenameUtils.getBaseName(resourceName)
                               + " ("
                               + String.join(", ", processDefinitionKeys)
                               + ")."
                               + FilenameUtils.getExtension(resourceName);
+                  filename = FilenameUtils.getName(filename);
+                  File outputFile = uniqueOutputFile(filename, result);
                   result.put(
-                      new File(targetDirectory, filename),
+                      outputFile,
                       DiagramType.fromFileName(filename)
                           .readDiagram(new ByteArrayInputStream(model.getBytes())));
                 }));
     return result;
+  }
+
+  private File uniqueOutputFile(String filename, Map<File, ModelInstance> existingFiles) {
+    File outputFile = new File(targetDirectory, filename);
+    int counter = 0;
+    while (existingFiles.containsKey(outputFile)) {
+      counter++;
+      outputFile =
+          new File(
+              targetDirectory,
+              FilenameUtils.getBaseName(filename)
+                  + " ("
+                  + counter
+                  + ")."
+                  + FilenameUtils.getExtension(filename));
+    }
+    return outputFile;
   }
 
   private Map<String, Map<String, Set<String>>> getAllLatestBpmnXml() {

--- a/diagram-converter/cli/src/main/java/io/camunda/migration/diagram/converter/cli/ConvertEngineCommand.java
+++ b/diagram-converter/cli/src/main/java/io/camunda/migration/diagram/converter/cli/ConvertEngineCommand.java
@@ -108,13 +108,17 @@ public class ConvertEngineCommand extends AbstractConvertCommand {
     String fileEnding = diagramEnding(resourceFilename, diagramType);
     if (fileEnding.isEmpty()) {
       return "diagram ("
-          + String.join(", ", processDefinitionKeys)
+          + processDefinitionKeys.stream().sorted().collect(Collectors.joining(", "))
           + ")"
           + diagramType.getFileEndings().get(0);
     }
     String baseName =
         resourceFilename.substring(0, resourceFilename.length() - fileEnding.length());
-    return baseName + " (" + String.join(", ", processDefinitionKeys) + ")" + fileEnding;
+    return baseName
+        + " ("
+        + processDefinitionKeys.stream().sorted().collect(Collectors.joining(", "))
+        + ")"
+        + fileEnding;
   }
 
   private String diagramEnding(String filename, DiagramType diagramType) {

--- a/diagram-converter/cli/src/main/java/io/camunda/migration/diagram/converter/cli/ConvertEngineCommand.java
+++ b/diagram-converter/cli/src/main/java/io/camunda/migration/diagram/converter/cli/ConvertEngineCommand.java
@@ -81,17 +81,15 @@ public class ConvertEngineCommand extends AbstractConvertCommand {
         (resourceName, models) ->
             models.forEach(
                 (model, processDefinitionKeys) -> {
+                  String resourceFilename = FilenameUtils.getName(resourceName);
                   String filename =
                       models.size() == 1
-                          ? FilenameUtils.getName(resourceName)
-                          : FilenameUtils.getBaseName(resourceName)
-                              + " ("
-                              + String.join(", ", processDefinitionKeys)
-                              + ")."
-                              + FilenameUtils.getExtension(resourceName);
+                          ? resourceFilename
+                          : multiModelFilename(
+                              resourceFilename, processDefinitionKeys, diagramType);
                   filename = FilenameUtils.getName(filename);
                   filename = safeFilename(filename, diagramType);
-                  File outputFile = uniqueOutputFile(filename, result);
+                  File outputFile = uniqueOutputFile(filename, diagramType, result);
                   result.put(
                       outputFile,
                       diagramType.readDiagram(new ByteArrayInputStream(model.getBytes())));
@@ -105,19 +103,46 @@ public class ConvertEngineCommand extends AbstractConvertCommand {
     return filename;
   }
 
-  private File uniqueOutputFile(String filename, Map<File, ModelInstance> existingFiles) {
+  private String multiModelFilename(
+      String resourceFilename, Set<String> processDefinitionKeys, DiagramType diagramType) {
+    String fileEnding = diagramEnding(resourceFilename, diagramType);
+    if (fileEnding.isEmpty()) {
+      return "diagram ("
+          + String.join(", ", processDefinitionKeys)
+          + ")"
+          + diagramType.getFileEndings().get(0);
+    }
+    String baseName =
+        resourceFilename.substring(0, resourceFilename.length() - fileEnding.length());
+    return baseName + " (" + String.join(", ", processDefinitionKeys) + ")" + fileEnding;
+  }
+
+  private String diagramEnding(String filename, DiagramType diagramType) {
+    return diagramType.getFileEndings().stream()
+        .filter(filename::endsWith)
+        .findFirst()
+        .orElseGet(
+            () -> {
+              String extension = FilenameUtils.getExtension(filename);
+              return extension.isEmpty() ? "" : "." + extension;
+            });
+  }
+
+  private File uniqueOutputFile(
+      String filename, DiagramType diagramType, Map<File, ModelInstance> existingFiles) {
     File outputFile = new File(targetDirectory, filename);
     int counter = 0;
     while (existingFiles.containsKey(outputFile)) {
       counter++;
+      String fileEnding = diagramEnding(filename, diagramType);
       outputFile =
           new File(
               targetDirectory,
-              FilenameUtils.getBaseName(filename)
+              filename.substring(0, filename.length() - fileEnding.length())
                   + " ("
                   + counter
-                  + ")."
-                  + FilenameUtils.getExtension(filename));
+                  + ")"
+                  + fileEnding);
     }
     return outputFile;
   }

--- a/diagram-converter/cli/src/test/java/io/camunda/migration/diagram/converter/cli/ConvertEngineCommandTest.java
+++ b/diagram-converter/cli/src/test/java/io/camunda/migration/diagram/converter/cli/ConvertEngineCommandTest.java
@@ -190,6 +190,45 @@ public class ConvertEngineCommandTest {
   }
 
   @Test
+  void shouldPreserveMultipartDiagramSuffixForMultipleModels(@TempDir File tempDir) {
+    BpmnModelInstance first =
+        Bpmn.createProcess("firstMultipartProcess")
+            .executable()
+            .startEvent("start")
+            .endEvent("end")
+            .done();
+    BpmnModelInstance second =
+        Bpmn.createProcess("secondMultipartProcess")
+            .executable()
+            .startEvent("start")
+            .endEvent("end")
+            .done();
+    processEngine
+        .getRepositoryService()
+        .createDeployment()
+        .name("first-multipart")
+        .addModelInstance("process.bpmn20.xml", first)
+        .deploy();
+    processEngine
+        .getRepositoryService()
+        .createDeployment()
+        .name("second-multipart")
+        .addModelInstance("process.bpmn20.xml", second)
+        .deploy();
+
+    File targetDirectory = new File(tempDir, "converted");
+    ConvertEngineCommand command = new ConvertEngineCommand();
+    command.targetDirectory = targetDirectory;
+    command.url = "http://localhost:" + randomServerPort + "/engine-rest";
+
+    assertThat(command.call()).isZero();
+    assertThat(targetDirectory.listFiles())
+        .hasSize(2)
+        .extracting(File::getName)
+        .allMatch(name -> name.endsWith(".bpmn20.xml"));
+  }
+
+  @Test
   void shouldUseSafeFilenamesForSpecialResourceNames() {
     assertThat(ConvertEngineCommand.safeFilename("", DiagramType.BPMN)).isEqualTo("diagram.bpmn");
     assertThat(ConvertEngineCommand.safeFilename(".", DiagramType.BPMN)).isEqualTo("diagram.bpmn");

--- a/diagram-converter/cli/src/test/java/io/camunda/migration/diagram/converter/cli/ConvertEngineCommandTest.java
+++ b/diagram-converter/cli/src/test/java/io/camunda/migration/diagram/converter/cli/ConvertEngineCommandTest.java
@@ -9,6 +9,7 @@ package io.camunda.migration.diagram.converter.cli;
 
 import static org.assertj.core.api.Assertions.*;
 
+import io.camunda.migration.diagram.converter.DiagramType;
 import io.camunda.migration.diagram.converter.cli.mock.App;
 import java.io.File;
 import java.io.InputStream;
@@ -186,5 +187,12 @@ public class ConvertEngineCommandTest {
     assertThat(targetDirectory.listFiles())
         .extracting(File::getName)
         .containsExactlyInAnyOrder("converted-c8-process.bpmn", "converted-c8-process (1).bpmn");
+  }
+
+  @Test
+  void shouldUseSafeFilenamesForSpecialResourceNames() {
+    assertThat(ConvertEngineCommand.safeFilename("", DiagramType.BPMN)).isEqualTo("diagram.bpmn");
+    assertThat(ConvertEngineCommand.safeFilename(".", DiagramType.BPMN)).isEqualTo("diagram.bpmn");
+    assertThat(ConvertEngineCommand.safeFilename("..", DiagramType.DMN)).isEqualTo("diagram.dmn");
   }
 }

--- a/diagram-converter/cli/src/test/java/io/camunda/migration/diagram/converter/cli/ConvertEngineCommandTest.java
+++ b/diagram-converter/cli/src/test/java/io/camunda/migration/diagram/converter/cli/ConvertEngineCommandTest.java
@@ -57,7 +57,9 @@ public class ConvertEngineCommandTest {
     command.targetDirectory = tempDir;
     command.url = "http://localhost:" + randomServerPort + "/engine-rest";
     command.call();
-    assertThat(tempDir.listFiles()).hasSize(1);
+    assertThat(tempDir.listFiles())
+        .extracting(File::getName)
+        .containsExactly("converted-c8-multiple-processes.bpmn");
   }
 
   @Test

--- a/diagram-converter/cli/src/test/java/io/camunda/migration/diagram/converter/cli/ConvertEngineCommandTest.java
+++ b/diagram-converter/cli/src/test/java/io/camunda/migration/diagram/converter/cli/ConvertEngineCommandTest.java
@@ -134,9 +134,8 @@ public class ConvertEngineCommandTest {
           .createDeployment()
           .name("path-based-resources")
           .addModelInstance(
-              "Users/peter.bojtos/projects/application/target/classes/process.bpmn", bpmn)
-          .addInputStream(
-              "Users/peter.bojtos/projects/application/target/classes/decision.dmn", dmn)
+              "Users/test-user/projects/application/target/classes/process.bpmn", bpmn)
+          .addInputStream("Users/test-user/projects/application/target/classes/decision.dmn", dmn)
           .deploy();
     }
 

--- a/diagram-converter/cli/src/test/java/io/camunda/migration/diagram/converter/cli/ConvertEngineCommandTest.java
+++ b/diagram-converter/cli/src/test/java/io/camunda/migration/diagram/converter/cli/ConvertEngineCommandTest.java
@@ -11,7 +11,9 @@ import static org.assertj.core.api.Assertions.*;
 
 import io.camunda.migration.diagram.converter.cli.mock.App;
 import java.io.File;
+import java.io.InputStream;
 import java.util.Arrays;
+import java.util.Objects;
 import org.camunda.bpm.engine.ProcessEngine;
 import org.camunda.bpm.model.bpmn.Bpmn;
 import org.camunda.bpm.model.bpmn.BpmnModelInstance;
@@ -113,5 +115,77 @@ public class ConvertEngineCommandTest {
     command.url = "http://localhost:" + randomServerPort + "/engine-rest";
     command.call();
     assertThat(tempDir.listFiles()).hasSize(3);
+  }
+
+  @Test
+  void shouldCreateTargetDirectoryForPathBasedBpmnAndDmnResources(@TempDir File tempDir)
+      throws Exception {
+    BpmnModelInstance bpmn =
+        Bpmn.createProcess("pathBasedProcess")
+            .executable()
+            .camundaHistoryTimeToLive(180)
+            .startEvent("start")
+            .endEvent("end")
+            .done();
+    try (InputStream dmn =
+        Objects.requireNonNull(getClass().getClassLoader().getResourceAsStream("first.dmn"))) {
+      processEngine
+          .getRepositoryService()
+          .createDeployment()
+          .name("path-based-resources")
+          .addModelInstance(
+              "Users/peter.bojtos/projects/application/target/classes/process.bpmn", bpmn)
+          .addInputStream(
+              "Users/peter.bojtos/projects/application/target/classes/decision.dmn", dmn)
+          .deploy();
+    }
+
+    File targetDirectory = new File(tempDir, "converted");
+    ConvertEngineCommand command = new ConvertEngineCommand();
+    command.targetDirectory = targetDirectory;
+    command.url = "http://localhost:" + randomServerPort + "/engine-rest";
+
+    assertThat(command.call()).isZero();
+    assertThat(targetDirectory.listFiles())
+        .extracting(File::getName)
+        .containsExactlyInAnyOrder("converted-c8-process.bpmn", "converted-c8-decision.dmn");
+  }
+
+  @Test
+  void shouldKeepPathBasedResourcesWithSameFilename(@TempDir File tempDir) {
+    BpmnModelInstance first =
+        Bpmn.createProcess("firstPathBasedProcess")
+            .executable()
+            .startEvent("start")
+            .endEvent("end")
+            .done();
+    BpmnModelInstance second =
+        Bpmn.createProcess("secondPathBasedProcess")
+            .executable()
+            .startEvent("start")
+            .endEvent("end")
+            .done();
+    processEngine
+        .getRepositoryService()
+        .createDeployment()
+        .name("first-path")
+        .addModelInstance("first/application/process.bpmn", first)
+        .deploy();
+    processEngine
+        .getRepositoryService()
+        .createDeployment()
+        .name("second-path")
+        .addModelInstance("second/application/process.bpmn", second)
+        .deploy();
+
+    File targetDirectory = new File(tempDir, "converted");
+    ConvertEngineCommand command = new ConvertEngineCommand();
+    command.targetDirectory = targetDirectory;
+    command.url = "http://localhost:" + randomServerPort + "/engine-rest";
+
+    assertThat(command.call()).isZero();
+    assertThat(targetDirectory.listFiles())
+        .extracting(File::getName)
+        .containsExactlyInAnyOrder("converted-c8-process.bpmn", "converted-c8-process (1).bpmn");
   }
 }

--- a/diagram-converter/cli/src/test/java/io/camunda/migration/diagram/converter/cli/ConvertLocalCommandTest.java
+++ b/diagram-converter/cli/src/test/java/io/camunda/migration/diagram/converter/cli/ConvertLocalCommandTest.java
@@ -44,6 +44,31 @@ public class ConvertLocalCommandTest {
   }
 
   @Test
+  void shouldNotOverwriteExistingOutputWithoutOverride(@TempDir File tempDir) throws IOException {
+    setupDir("c7.bpmn", tempDir);
+    File input = new File(tempDir, "c7.bpmn");
+    File output = new File(tempDir, "converted-c8-c7.bpmn");
+
+    ConvertLocalCommand firstCommand = new ConvertLocalCommand();
+    firstCommand.file = input;
+    assertThat(firstCommand.call()).isZero();
+
+    Files.writeString(output.toPath(), "existing output");
+
+    ConvertLocalCommand secondCommand = new ConvertLocalCommand();
+    secondCommand.file = input;
+    assertThat(secondCommand.call()).isEqualTo(1);
+    assertThat(Files.readString(output.toPath())).isEqualTo("existing output");
+    assertThat(new File(tempDir, "converted-c8-c7 (1).bpmn")).doesNotExist();
+
+    ConvertLocalCommand overrideCommand = new ConvertLocalCommand();
+    overrideCommand.file = input;
+    overrideCommand.override = true;
+    assertThat(overrideCommand.call()).isZero();
+    assertThat(Files.readString(output.toPath())).isNotEqualTo("existing output");
+  }
+
+  @Test
   public void shouldConvertDmn(@TempDir File tempDir) {
     setupDir("first.dmn", tempDir);
     ConvertLocalCommand command = new ConvertLocalCommand();


### PR DESCRIPTION
## Summary

- Fix engine-mode conversion when Camunda 7 resource names contain filesystem paths.
- Create missing target directories before writing converted diagrams and reports.
- Keep distinct path-based resources that share a filename.

## Changes

- Treat engine resource names as filenames and prevent path segments from escaping the target directory.
- Create the configured output directory before writing.
- Add CLI integration coverage for missing output directories, path-based BPMN/DMN resources, and duplicate basenames.

## Test plan

- [x] `JAVA_HOME=/opt/homebrew/opt/openjdk@21 mvn test -pl cli -am` from `diagram-converter` (19 tests)
- [x] `JAVA_HOME=/opt/homebrew/opt/openjdk@21 mvn clean install -DskipTests` from `diagram-converter`
- [x] `JAVA_HOME=/opt/homebrew/opt/openjdk@21 mvn verify -Pdistro,checkFormat -DskipTests` from `diagram-converter`
- [ ] Full root build: blocked in the existing Camunda 8 code-example tests while Testcontainers fetches `registry.camunda.cloud/camunda/camunda:SNAPSHOT`.

## Baseline

Built from commit: `5c1c59e3fc5698328e8c7ccd25b6931d1e08775c`

related to #2065