### PR TITLE
test(e2e): set desktop viewport to reveal Operate called-instances link

### DIFF
--- a/data-migrator/qa/e2e-tests/playwright.config.ts
+++ b/data-migrator/qa/e2e-tests/playwright.config.ts
@@ -1,6 +1,13 @@
 import { defineConfig, devices } from '@playwright/test';
 
 /**
+ * Operate's process-instance header hides the "Called Instances" link below
+ * the Carbon xlg breakpoint (~1312px). Use a large desktop viewport so the
+ * full header is rendered consistently across browsers.
+ */
+const desktopViewport = { width: 1920, height: 1080 };
+
+/**
  * E2E test configuration for Cockpit Plugin
  * See https://playwright.dev/docs/test-configuration
  */
@@ -39,15 +46,19 @@ export default defineConfig({
   projects: [
     {
       name: 'chromium',
-      use: { ...devices['Desktop Chrome'] },
+      use: { ...devices['Desktop Chrome'], viewport: desktopViewport },
     },
     {
       name: 'firefox',
-      use: { ...devices['Desktop Firefox'] },
+      use: { ...devices['Desktop Firefox'], viewport: desktopViewport },
     },
     {
       name: 'edge',
-      use: { ...devices['Desktop Edge'], channel: 'msedge' },
+      use: {
+        ...devices['Desktop Edge'],
+        channel: 'msedge',
+        viewport: desktopViewport,
+      },
     },
   ],
 


### PR DESCRIPTION
## Problem

The scheduled CI run https://github.com/camunda/camunda-7-to-8-migration-tooling/actions/runs/31773292219 failed because the E2E test "should navigate from parent to child process via call activity" could not find the "View all called instances" / "View All" link.

The failure was consistent across chromium, firefox and edge after all retries.

## Root cause

Operate's process-instance header renders the **Called Instances** column inside a responsive table. When the viewport is narrower than the Carbon `xlg` breakpoint (~1312px), the column is removed from the DOM (`showReducedContent`).

Playwright's default / `Desktop Chrome` viewport is **1280x720**, which triggers that reduced layout. As a result the existing locator `[aria-label="View all called instances"], a:has-text("View All")` never matches.

## Fix

Set an explicit **1920x1080** viewport for every browser project in `playwright.config.ts` so the desktop layout is used and the existing selector remains valid.

## Verification

- `npm run typecheck` in `data-migrator/qa/e2e-tests` passes.

related to https://github.com/camunda/camunda-7-to-8-migration-tooling/actions/runs/31773292219
