### PR TITLE
fix(recipes): correct combined client+delegate migration and warn on lost delegate body

### DIFF
--- a/code-conversion/recipes/src/main/java/io/camunda/migration/code/recipes/client/MigrateProcessInstanceQueryMethodsRecipe.java
+++ b/code-conversion/recipes/src/main/java/io/camunda/migration/code/recipes/client/MigrateProcessInstanceQueryMethodsRecipe.java
@@ -92,7 +92,8 @@ public class MigrateProcessInstanceQueryMethodsRecipe extends AbstractMigrationR
         ReplacementUtils.ReturnTypeStrategy.USE_SPECIFIED_TYPE,
         Collections.emptyList(),
         Collections.emptyList(),
-        List.of(PROCESS_INSTANCE_STATE)));
+        List.of(PROCESS_INSTANCE_STATE),
+        Optional.of("org.camunda.bpm.engine.runtime.ProcessInstanceQuery")));
 
     specs.add(new ReplacementUtils.BuilderReplacementSpec(
         new MethodMatcher("org.camunda.bpm.engine.query.Query list()"),
@@ -116,7 +117,8 @@ public class MigrateProcessInstanceQueryMethodsRecipe extends AbstractMigrationR
         ReplacementUtils.ReturnTypeStrategy.USE_SPECIFIED_TYPE,
         List.of(RecipeUtils.businessIdHint("processInstanceBusinessKey")),
         Collections.emptyList(),
-        List.of(PROCESS_INSTANCE_STATE)));
+        List.of(PROCESS_INSTANCE_STATE),
+        Optional.of("org.camunda.bpm.engine.runtime.ProcessInstanceQuery")));
 
     specs.add(new ReplacementUtils.BuilderReplacementSpec(
         new MethodMatcher("org.camunda.bpm.engine.query.Query list()"),
@@ -141,7 +143,8 @@ public class MigrateProcessInstanceQueryMethodsRecipe extends AbstractMigrationR
         ReplacementUtils.ReturnTypeStrategy.USE_SPECIFIED_TYPE,
         Collections.emptyList(),
         Collections.emptyList(),
-        List.of(PROCESS_INSTANCE_STATE)));
+        List.of(PROCESS_INSTANCE_STATE),
+        Optional.of("org.camunda.bpm.engine.runtime.ProcessInstanceQuery")));
 
     return specs;
   }

--- a/code-conversion/recipes/src/main/java/io/camunda/migration/code/recipes/client/MigrateProcessInstanceQueryMethodsRecipe.java
+++ b/code-conversion/recipes/src/main/java/io/camunda/migration/code/recipes/client/MigrateProcessInstanceQueryMethodsRecipe.java
@@ -59,9 +59,28 @@ public class MigrateProcessInstanceQueryMethodsRecipe extends AbstractMigrationR
             "io.camunda.client.api.search.request.ProcessInstanceSearchRequestBuilder",
             ReplacementUtils.ReturnTypeStrategy.USE_SPECIFIED_TYPE,
             List.of(new ReplacementUtils.SimpleReplacementSpec.NamedArg("processDefinitionKey", 0)),
+            List.of(RecipeUtils.businessIdHint("processInstanceBusinessKey")),
             Collections.emptyList(),
             Collections.emptyList(),
-            Collections.emptyList()));
+            Set.of("processInstanceBusinessKey")),
+        new ReplacementUtils.SimpleReplacementSpec(
+            new MethodMatcher("org.camunda.bpm.engine.runtime.ProcessInstanceQuery processDefinitionKey(java.lang.String)"),
+            RecipeUtils.createSimpleJavaTemplate(
+                """
+                #{camundaClient:any(io.camunda.client.CamundaClient)}
+                    .newProcessInstanceSearchRequest()
+                    .filter(filter -> filter.processDefinitionId(#{processDefinitionKey:any(java.lang.String)}))
+                """,
+                "io.camunda.client.api.search.request.ProcessInstanceSearchRequestBuilder",
+                "io.camunda.client.api.search.filter.ProcessInstanceFilter"),
+            RecipeUtils.createSimpleIdentifier("camundaClient", "io.camunda.client.CamundaClient"),
+            "io.camunda.client.api.search.request.ProcessInstanceSearchRequestBuilder",
+            ReplacementUtils.ReturnTypeStrategy.USE_SPECIFIED_TYPE,
+            List.of(new ReplacementUtils.SimpleReplacementSpec.NamedArg("processDefinitionKey", 0)),
+            Collections.emptyList(),
+            Collections.emptyList(),
+            Collections.emptyList(),
+            Collections.emptySet()));
   }
 
   @Override

--- a/code-conversion/recipes/src/main/java/io/camunda/migration/code/recipes/client/MigrateProcessInstanceQueryMethodsRecipe.java
+++ b/code-conversion/recipes/src/main/java/io/camunda/migration/code/recipes/client/MigrateProcessInstanceQueryMethodsRecipe.java
@@ -144,6 +144,30 @@ public class MigrateProcessInstanceQueryMethodsRecipe extends AbstractMigrationR
         Collections.emptyList(),
         Optional.of("org.camunda.bpm.engine.runtime.ProcessInstanceQuery")));
 
+    specs.add(new ReplacementUtils.BuilderReplacementSpec(
+        new MethodMatcher("org.camunda.bpm.engine.query.Query list()"),
+        Set.of("processInstanceBusinessKey", "processDefinitionKey"),
+        List.of("processDefinitionKey"),
+        RecipeUtils.createSimpleJavaTemplate(
+            """
+            #{camundaClient:any(io.camunda.client.CamundaClient)}
+                .newProcessInstanceSearchRequest()
+                .filter(filter -> filter
+                    .processDefinitionId(#{processDefinitionKey:any(java.lang.String)}))
+                .send()
+                .join()
+                .items()
+            """,
+            "io.camunda.client.api.search.response.ProcessInstance",
+            "io.camunda.client.api.search.filter.ProcessInstanceFilter"),
+        RecipeUtils.createSimpleIdentifier("camundaClient", "io.camunda.client.CamundaClient"),
+        "List<io.camunda.client.api.search.response.ProcessInstance>",
+        ReplacementUtils.ReturnTypeStrategy.USE_SPECIFIED_TYPE,
+        List.of(RecipeUtils.businessIdHint("processInstanceBusinessKey")),
+        Collections.emptyList(),
+        Collections.emptyList(),
+        Optional.of("org.camunda.bpm.engine.runtime.ProcessInstanceQuery")));
+
     return specs;
   }
 

--- a/code-conversion/recipes/src/main/java/io/camunda/migration/code/recipes/client/MigrateProcessInstanceQueryMethodsRecipe.java
+++ b/code-conversion/recipes/src/main/java/io/camunda/migration/code/recipes/client/MigrateProcessInstanceQueryMethodsRecipe.java
@@ -129,13 +129,11 @@ public class MigrateProcessInstanceQueryMethodsRecipe extends AbstractMigrationR
             #{camundaClient:any(io.camunda.client.CamundaClient)}
                 .newProcessInstanceSearchRequest()
                 .filter(filter -> filter
-                    .processDefinitionId(#{processDefinitionKey:any(java.lang.String)})
-                    .state(ProcessInstanceState.ACTIVE))
+                    .processDefinitionId(#{processDefinitionKey:any(java.lang.String)}))
                 .send()
                 .join()
                 .items()
             """,
-            PROCESS_INSTANCE_STATE,
             "io.camunda.client.api.search.response.ProcessInstance",
             "io.camunda.client.api.search.filter.ProcessInstanceFilter"),
         RecipeUtils.createSimpleIdentifier("camundaClient", "io.camunda.client.CamundaClient"),
@@ -143,7 +141,7 @@ public class MigrateProcessInstanceQueryMethodsRecipe extends AbstractMigrationR
         ReplacementUtils.ReturnTypeStrategy.USE_SPECIFIED_TYPE,
         Collections.emptyList(),
         Collections.emptyList(),
-        List.of(PROCESS_INSTANCE_STATE),
+        Collections.emptyList(),
         Optional.of("org.camunda.bpm.engine.runtime.ProcessInstanceQuery")));
 
     return specs;

--- a/code-conversion/recipes/src/main/java/io/camunda/migration/code/recipes/client/MigrateProcessInstanceQueryMethodsRecipe.java
+++ b/code-conversion/recipes/src/main/java/io/camunda/migration/code/recipes/client/MigrateProcessInstanceQueryMethodsRecipe.java
@@ -51,7 +51,7 @@ public class MigrateProcessInstanceQueryMethodsRecipe extends AbstractMigrationR
                 """
                 #{camundaClient:any(io.camunda.client.CamundaClient)}
                     .newProcessInstanceSearchRequest()
-                    .filter(filter -> filter.processDefinitionKey(Long.valueOf(#{processDefinitionKey:any(java.lang.String)})))
+                    .filter(filter -> filter.processDefinitionId(#{processDefinitionKey:any(java.lang.String)}))
                 """,
                 "io.camunda.client.api.search.request.ProcessInstanceSearchRequestBuilder",
                 "io.camunda.client.api.search.filter.ProcessInstanceFilter"),
@@ -59,7 +59,7 @@ public class MigrateProcessInstanceQueryMethodsRecipe extends AbstractMigrationR
             "io.camunda.client.api.search.request.ProcessInstanceSearchRequestBuilder",
             ReplacementUtils.ReturnTypeStrategy.USE_SPECIFIED_TYPE,
             List.of(new ReplacementUtils.SimpleReplacementSpec.NamedArg("processDefinitionKey", 0)),
-            List.of(RecipeUtils.businessIdHint("processInstanceBusinessKey")),
+            Collections.emptyList(),
             Collections.emptyList(),
             Collections.emptyList()));
   }
@@ -117,9 +117,32 @@ public class MigrateProcessInstanceQueryMethodsRecipe extends AbstractMigrationR
         List.of(RecipeUtils.businessIdHint("processInstanceBusinessKey")),
         Collections.emptyList(),
         List.of(PROCESS_INSTANCE_STATE)));
-        
 
-        
+    specs.add(new ReplacementUtils.BuilderReplacementSpec(
+        new MethodMatcher("org.camunda.bpm.engine.query.Query list()"),
+        Set.of("processDefinitionKey"),
+        List.of("processDefinitionKey"),
+        RecipeUtils.createSimpleJavaTemplate(
+            """
+            #{camundaClient:any(io.camunda.client.CamundaClient)}
+                .newProcessInstanceSearchRequest()
+                .filter(filter -> filter
+                    .processDefinitionId(#{processDefinitionKey:any(java.lang.String)})
+                    .state(ProcessInstanceState.ACTIVE))
+                .send()
+                .join()
+                .items()
+            """,
+            PROCESS_INSTANCE_STATE,
+            "io.camunda.client.api.search.response.ProcessInstance",
+            "io.camunda.client.api.search.filter.ProcessInstanceFilter"),
+        RecipeUtils.createSimpleIdentifier("camundaClient", "io.camunda.client.CamundaClient"),
+        "List<io.camunda.client.api.search.response.ProcessInstance>",
+        ReplacementUtils.ReturnTypeStrategy.USE_SPECIFIED_TYPE,
+        Collections.emptyList(),
+        Collections.emptyList(),
+        List.of(PROCESS_INSTANCE_STATE)));
+
     return specs;
   }
 

--- a/code-conversion/recipes/src/main/java/io/camunda/migration/code/recipes/delegate/CleanupDelegateRecipe.java
+++ b/code-conversion/recipes/src/main/java/io/camunda/migration/code/recipes/delegate/CleanupDelegateRecipe.java
@@ -88,7 +88,10 @@ public class CleanupDelegateRecipe extends Recipe {
             return comments.stream()
                 .filter(c -> c instanceof TextComment)
                 .map(c -> (TextComment) c)
-                .anyMatch(c -> c.getText().contains("delegate body"));
+                .anyMatch(
+                    c ->
+                        c.getText().contains(
+                            MigrateExecutionRecipe.DELEGATE_BODY_COPY_WARNING_SENTINEL));
           }
 
           private boolean isJavaDelegateAssignable(JavaType type) {

--- a/code-conversion/recipes/src/main/java/io/camunda/migration/code/recipes/delegate/CleanupDelegateRecipe.java
+++ b/code-conversion/recipes/src/main/java/io/camunda/migration/code/recipes/delegate/CleanupDelegateRecipe.java
@@ -54,12 +54,10 @@ public class CleanupDelegateRecipe extends Recipe {
               return classDecl;
             }
 
-            // Filter out JavaDelegate and any subinterface of JavaDelegate
+            // Filter out the JavaDelegate interface and any subinterfaces of it
             List<TypeTree> updatedImplements = classDecl.getImplements() == null ? Collections.emptyList() :
                 classDecl.getImplements().stream()
-                    .filter(
-                        id ->
-                            !isJavaDelegateAssignable(id.getType()))
+                    .filter(id -> !isJavaDelegateAssignable(id.getType()))
                     .collect(Collectors.toList());
 
             List<Statement> filteredStatements =
@@ -77,33 +75,32 @@ public class CleanupDelegateRecipe extends Recipe {
                 .withBody(classDecl.getBody().withStatements(filteredStatements))
                 .withImplements(updatedImplements.isEmpty() ? null : updatedImplements);
           }
+
+          private boolean isJavaDelegateAssignable(JavaType type) {
+            return type != null
+                && isAssignableTo(type, "org.camunda.bpm.engine.delegate.JavaDelegate", new HashSet<>());
+          }
+
+          private boolean isAssignableTo(JavaType type, String fullyQualifiedName, Set<String> visited) {
+            if (!visited.add(type.toString())) {
+              return false;
+            }
+            if (TypeUtils.isOfClassType(type, fullyQualifiedName)) {
+              return true;
+            }
+            if (type instanceof JavaType.FullyQualified fullyQualified) {
+              JavaType.FullyQualified supertype = fullyQualified.getSupertype();
+              if (supertype != null && isAssignableTo(supertype, fullyQualifiedName, visited)) {
+                return true;
+              }
+              for (JavaType.FullyQualified iface : fullyQualified.getInterfaces()) {
+                if (isAssignableTo(iface, fullyQualifiedName, visited)) {
+                  return true;
+                }
+              }
+            }
+            return false;
+          }
         });
-  }
-
-  private static boolean isJavaDelegateAssignable(JavaType type) {
-    return type != null
-        && isAssignableTo(type, "org.camunda.bpm.engine.delegate.JavaDelegate", new HashSet<>());
-  }
-
-  private static boolean isAssignableTo(
-      JavaType type, String fullyQualifiedName, Set<String> visited) {
-    if (!visited.add(type.toString())) {
-      return false;
-    }
-    if (TypeUtils.isOfClassType(type, fullyQualifiedName)) {
-      return true;
-    }
-    if (type instanceof JavaType.FullyQualified fullyQualified) {
-      JavaType.FullyQualified supertype = fullyQualified.getSupertype();
-      if (supertype != null && isAssignableTo(supertype, fullyQualifiedName, visited)) {
-        return true;
-      }
-      for (JavaType.FullyQualified iface : fullyQualified.getInterfaces()) {
-        if (isAssignableTo(iface, fullyQualifiedName, visited)) {
-          return true;
-        }
-      }
-    }
-    return false;
   }
 }

--- a/code-conversion/recipes/src/main/java/io/camunda/migration/code/recipes/delegate/CleanupDelegateRecipe.java
+++ b/code-conversion/recipes/src/main/java/io/camunda/migration/code/recipes/delegate/CleanupDelegateRecipe.java
@@ -54,6 +54,12 @@ public class CleanupDelegateRecipe extends Recipe {
               return classDecl;
             }
 
+            // Preserve delegate code when migration already warned that the body could not be
+            // copied automatically, so users can still migrate it manually.
+            if (hasDelegateBodyWarning(classDecl)) {
+              return super.visitClassDeclaration(classDecl, ctx);
+            }
+
             // Filter out the JavaDelegate interface and any subinterfaces of it
             List<TypeTree> updatedImplements = classDecl.getImplements() == null ? Collections.emptyList() :
                 classDecl.getImplements().stream()
@@ -74,6 +80,15 @@ public class CleanupDelegateRecipe extends Recipe {
             return classDecl
                 .withBody(classDecl.getBody().withStatements(filteredStatements))
                 .withImplements(updatedImplements.isEmpty() ? null : updatedImplements);
+          }
+
+          private boolean hasDelegateBodyWarning(J.ClassDeclaration classDecl) {
+            List<Comment> comments =
+                classDecl.getComments() == null ? Collections.emptyList() : classDecl.getComments();
+            return comments.stream()
+                .filter(c -> c instanceof TextComment)
+                .map(c -> (TextComment) c)
+                .anyMatch(c -> c.getText().contains("delegate body"));
           }
 
           private boolean isJavaDelegateAssignable(JavaType type) {

--- a/code-conversion/recipes/src/main/java/io/camunda/migration/code/recipes/delegate/CleanupDelegateRecipe.java
+++ b/code-conversion/recipes/src/main/java/io/camunda/migration/code/recipes/delegate/CleanupDelegateRecipe.java
@@ -8,7 +8,9 @@
 package io.camunda.migration.code.recipes.delegate;
 
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 import org.openrewrite.*;
 import org.openrewrite.java.*;
@@ -52,13 +54,12 @@ public class CleanupDelegateRecipe extends Recipe {
               return classDecl;
             }
 
-            // Filter out the interface to remove
+            // Filter out JavaDelegate and any subinterface of JavaDelegate
             List<TypeTree> updatedImplements = classDecl.getImplements() == null ? Collections.emptyList() :
                 classDecl.getImplements().stream()
                     .filter(
                         id ->
-                            !TypeUtils.isOfClassType(
-                                id.getType(), "org.camunda.bpm.engine.delegate.JavaDelegate"))
+                            !isJavaDelegateAssignable(id.getType()))
                     .collect(Collectors.toList());
 
             List<Statement> filteredStatements =
@@ -77,5 +78,32 @@ public class CleanupDelegateRecipe extends Recipe {
                 .withImplements(updatedImplements.isEmpty() ? null : updatedImplements);
           }
         });
+  }
+
+  private static boolean isJavaDelegateAssignable(JavaType type) {
+    return type != null
+        && isAssignableTo(type, "org.camunda.bpm.engine.delegate.JavaDelegate", new HashSet<>());
+  }
+
+  private static boolean isAssignableTo(
+      JavaType type, String fullyQualifiedName, Set<String> visited) {
+    if (!visited.add(type.toString())) {
+      return false;
+    }
+    if (TypeUtils.isOfClassType(type, fullyQualifiedName)) {
+      return true;
+    }
+    if (type instanceof JavaType.FullyQualified fullyQualified) {
+      JavaType.FullyQualified supertype = fullyQualified.getSupertype();
+      if (supertype != null && isAssignableTo(supertype, fullyQualifiedName, visited)) {
+        return true;
+      }
+      for (JavaType.FullyQualified iface : fullyQualified.getInterfaces()) {
+        if (isAssignableTo(iface, fullyQualifiedName, visited)) {
+          return true;
+        }
+      }
+    }
+    return false;
   }
 }

--- a/code-conversion/recipes/src/main/java/io/camunda/migration/code/recipes/delegate/CleanupDelegateRecipe.java
+++ b/code-conversion/recipes/src/main/java/io/camunda/migration/code/recipes/delegate/CleanupDelegateRecipe.java
@@ -8,10 +8,9 @@
 package io.camunda.migration.code.recipes.delegate;
 
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 import java.util.stream.Collectors;
+import io.camunda.migration.code.recipes.utils.RecipeUtils;
 import org.openrewrite.*;
 import org.openrewrite.java.*;
 import org.openrewrite.java.search.UsesType;
@@ -95,29 +94,8 @@ public class CleanupDelegateRecipe extends Recipe {
           }
 
           private boolean isJavaDelegateAssignable(JavaType type) {
-            return type != null
-                && isAssignableTo(type, "org.camunda.bpm.engine.delegate.JavaDelegate", new HashSet<>());
-          }
-
-          private boolean isAssignableTo(JavaType type, String fullyQualifiedName, Set<String> visited) {
-            if (!visited.add(type.toString())) {
-              return false;
-            }
-            if (TypeUtils.isOfClassType(type, fullyQualifiedName)) {
-              return true;
-            }
-            if (type instanceof JavaType.FullyQualified fullyQualified) {
-              JavaType.FullyQualified supertype = fullyQualified.getSupertype();
-              if (supertype != null && isAssignableTo(supertype, fullyQualifiedName, visited)) {
-                return true;
-              }
-              for (JavaType.FullyQualified iface : fullyQualified.getInterfaces()) {
-                if (isAssignableTo(iface, fullyQualifiedName, visited)) {
-                  return true;
-                }
-              }
-            }
-            return false;
+            return RecipeUtils.isAssignableTo(
+                type, "org.camunda.bpm.engine.delegate.JavaDelegate");
           }
         });
   }

--- a/code-conversion/recipes/src/main/java/io/camunda/migration/code/recipes/delegate/CleanupDelegateRecipe.java
+++ b/code-conversion/recipes/src/main/java/io/camunda/migration/code/recipes/delegate/CleanupDelegateRecipe.java
@@ -49,9 +49,9 @@ public class CleanupDelegateRecipe extends Recipe {
           public J.ClassDeclaration visitClassDeclaration(
               @NonNull J.ClassDeclaration classDecl, ExecutionContext ctx) {
 
-            // Skip interfaces
+            // Skip interfaces, but keep traversing so nested types are still visited.
             if (classDecl.getKind() != J.ClassDeclaration.Kind.Type.Class) {
-              return classDecl;
+              return super.visitClassDeclaration(classDecl, ctx);
             }
 
             // Preserve delegate code when migration already warned that the body could not be

--- a/code-conversion/recipes/src/main/java/io/camunda/migration/code/recipes/delegate/MigrateExecutionRecipe.java
+++ b/code-conversion/recipes/src/main/java/io/camunda/migration/code/recipes/delegate/MigrateExecutionRecipe.java
@@ -9,7 +9,9 @@ package io.camunda.migration.code.recipes.delegate;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
 import io.camunda.migration.code.recipes.sharedRecipes.AbstractMigrationRecipe;
@@ -81,15 +83,7 @@ public class MigrateExecutionRecipe extends Recipe {
                 return super.visitClassDeclaration(classDeclaration, ctx);
               }
 
-              boolean implementsJavaDelegate =
-                  classDeclaration.getImplements() != null
-                      && classDeclaration.getImplements().stream()
-                          .anyMatch(
-                              type ->
-                                  TypeUtils.isOfClassType(
-                                      type.getType(),
-                                      "org.camunda.bpm.engine.delegate.JavaDelegate"));
-              if (!implementsJavaDelegate) {
+              if (!isJavaDelegateAssignable(classDeclaration)) {
                 return super.visitClassDeclaration(classDeclaration, ctx);
               }
 
@@ -206,6 +200,34 @@ public class MigrateExecutionRecipe extends Recipe {
             }
           });
     }
+  }
+
+  private static boolean isJavaDelegateAssignable(J.ClassDeclaration classDeclaration) {
+    JavaType type = classDeclaration.getType();
+    return type != null
+        && isAssignableTo(type, "org.camunda.bpm.engine.delegate.JavaDelegate", new HashSet<>());
+  }
+
+  private static boolean isAssignableTo(
+      JavaType type, String fullyQualifiedName, Set<String> visited) {
+    if (!visited.add(type.toString())) {
+      return false;
+    }
+    if (TypeUtils.isOfClassType(type, fullyQualifiedName)) {
+      return true;
+    }
+    if (type instanceof JavaType.FullyQualified fullyQualified) {
+      JavaType.FullyQualified supertype = fullyQualified.getSupertype();
+      if (supertype != null && isAssignableTo(supertype, fullyQualifiedName, visited)) {
+        return true;
+      }
+      for (JavaType.FullyQualified iface : fullyQualified.getInterfaces()) {
+        if (isAssignableTo(iface, fullyQualifiedName, visited)) {
+          return true;
+        }
+      }
+    }
+    return false;
   }
 
   private static class CopyExecutionListenerToJobWorkerRecipe extends Recipe {

--- a/code-conversion/recipes/src/main/java/io/camunda/migration/code/recipes/delegate/MigrateExecutionRecipe.java
+++ b/code-conversion/recipes/src/main/java/io/camunda/migration/code/recipes/delegate/MigrateExecutionRecipe.java
@@ -19,6 +19,7 @@ import org.openrewrite.*;
 import org.openrewrite.java.*;
 import org.openrewrite.java.search.UsesType;
 import org.openrewrite.java.tree.*;
+import org.openrewrite.marker.Markers;
 
 public class MigrateExecutionRecipe extends Recipe {
 
@@ -62,11 +63,11 @@ public class MigrateExecutionRecipe extends Recipe {
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
 
-      // define preconditions
+      // Only run on classes that implement JavaDelegate. Requiring the @JobWorker annotation here
+      // is fragile because the annotation is injected by AllDelegatePrepareRecipes, and newer
+      // OpenRewrite versions may evaluate this precondition against an outdated LST.
       TreeVisitor<?, ExecutionContext> check =
-          Preconditions.and(
-              new UsesType<>("io.camunda.client.annotation.JobWorker", true),
-              new UsesType<>("org.camunda.bpm.engine.delegate.JavaDelegate", true));
+          new UsesType<>("org.camunda.bpm.engine.delegate.JavaDelegate", true);
 
       return Preconditions.check(
           check,
@@ -80,51 +81,112 @@ public class MigrateExecutionRecipe extends Recipe {
                 return super.visitClassDeclaration(classDeclaration, ctx);
               }
 
-              List<Statement> currentStatements = classDeclaration.getBody().getStatements();
-              List<Statement> updatedStatements = new ArrayList<>();
+              boolean implementsJavaDelegate =
+                  classDeclaration.getImplements() != null
+                      && classDeclaration.getImplements().stream()
+                          .anyMatch(
+                              type ->
+                                  TypeUtils.isOfClassType(
+                                      type.getType(),
+                                      "org.camunda.bpm.engine.delegate.JavaDelegate"));
+              if (!implementsJavaDelegate) {
+                return super.visitClassDeclaration(classDeclaration, ctx);
+              }
 
-              // find delegate method
-              J.Block delegateBody = null;
+              List<Statement> currentStatements = classDeclaration.getBody().getStatements();
+              J.MethodDeclaration delegateMethod = null;
+              J.MethodDeclaration jobWorkerMethod = null;
+              J.MethodDeclaration alreadyMigratedMethod = null;
+
               for (Statement stmt : currentStatements) {
-                if (stmt instanceof J.MethodDeclaration methDecl
-                    && methDecl.getSimpleName().equals("execute")) {
-                  delegateBody = methDecl.getBody();
+                if (stmt instanceof J.MethodDeclaration methDecl) {
+                  if (methDecl.getSimpleName().equals("execute")) {
+                    delegateMethod = methDecl;
+                  } else if (methDecl.getSimpleName().equals("executeJob")) {
+                    jobWorkerMethod = methDecl;
+                  } else if (methDecl.getSimpleName().equals("executeJobMigrated")) {
+                    alreadyMigratedMethod = methDecl;
+                  }
                 }
               }
 
-              // find and change job worker method
-              if (delegateBody != null) {
+              if (alreadyMigratedMethod != null) {
+                // The copy has already happened in a previous cycle; nothing to do.
+                return classDeclaration;
+              }
+
+              if (delegateMethod != null && jobWorkerMethod != null) {
+                J.Block delegateBody = delegateMethod.getBody();
+                J.Block jobWorkerBody = jobWorkerMethod.getBody();
+
+                // all current statements (result map and return)
+                List<Statement> jobWorkerStatements = jobWorkerBody.getStatements();
+
+                // delegate body
+                List<Statement> delegateStatements = new ArrayList<>(delegateBody.getStatements());
+
+                // combine statements
+                delegateStatements.add(0, jobWorkerStatements.get(0));
+                delegateStatements.add(jobWorkerStatements.get(jobWorkerStatements.size() - 1));
+
+                J.MethodDeclaration migratedJobWorker =
+                    jobWorkerMethod
+                        .withBody(jobWorkerMethod.getBody().withStatements(delegateStatements))
+                        .withName(jobWorkerMethod.getName().withSimpleName("executeJobMigrated"))
+                        .withMethodType(
+                            jobWorkerMethod.getMethodType().withName("executeJobMigrated"));
+
+                List<Statement> updatedStatements = new ArrayList<>();
                 for (Statement stmt : currentStatements) {
-                  if (stmt instanceof J.MethodDeclaration methDecl
-                      && methDecl.getSimpleName().equals("executeJob")) {
-                    J.Block jobWorkerBody = methDecl.getBody();
-
-                    // all current statments (result map and return)
-                    List<Statement> jobWorkerStatements = jobWorkerBody.getStatements();
-
-                    // delegate body
-                    List<Statement> delegateStatements =
-                        new ArrayList<>(delegateBody.getStatements());
-
-                    // combine statements
-                    delegateStatements.add(0, jobWorkerStatements.get(0));
-                    delegateStatements.add(jobWorkerStatements.get(jobWorkerStatements.size() - 1));
-
-                    // put together and rename job worker so recipe does not run twice
-                    updatedStatements.add(
-                        methDecl
-                            .withBody(methDecl.getBody().withStatements(delegateStatements))
-                            .withName(methDecl.getName().withSimpleName("executeJobMigrated"))
-                            .withMethodType(
-                                methDecl.getMethodType().withName("executeJobMigrated")));
+                  if (stmt == jobWorkerMethod) {
+                    updatedStatements.add(migratedJobWorker);
                   } else {
                     updatedStatements.add(stmt);
                   }
                 }
+
                 return classDeclaration.withBody(
                     classDeclaration.getBody().withStatements(updatedStatements));
               }
-              return super.visitClassDeclaration(classDeclaration, ctx);
+
+              String warning;
+              if (delegateMethod != null && jobWorkerMethod == null) {
+                warning =
+                    "The delegate execute(DelegateExecution) method exists, but no generated"
+                        + " executeJob(ActivatedJob) stub was found. The delegate body could not be"
+                        + " copied automatically; migrate it manually.";
+              } else if (delegateMethod == null && jobWorkerMethod != null) {
+                warning =
+                    "No execute(DelegateExecution) method was found directly in this class. If it"
+                        + " lives in a superclass, the delegate body must be migrated manually.";
+              } else {
+                warning =
+                    "Neither execute(DelegateExecution) nor executeJob(ActivatedJob) was found."
+                        + " The delegate body could not be copied automatically; migrate it"
+                        + " manually.";
+              }
+
+              List<Comment> existingComments =
+                  classDeclaration.getComments() == null
+                      ? Collections.emptyList()
+                      : classDeclaration.getComments();
+              boolean alreadyWarned =
+                  existingComments.stream()
+                      .filter(c -> c instanceof TextComment)
+                      .map(c -> (TextComment) c)
+                      .anyMatch(c -> c.getText().contains("delegate body could not be copied"));
+              if (alreadyWarned) {
+                return classDeclaration;
+              }
+
+              List<Comment> updatedComments = new ArrayList<>(existingComments);
+              updatedComments.add(
+                  new TextComment(
+                      true,
+                      " " + warning,
+                      classDeclaration.getPrefix().getIndent(),
+                      Markers.EMPTY));
+              return classDeclaration.withComments(updatedComments);
             }
           });
     }

--- a/code-conversion/recipes/src/main/java/io/camunda/migration/code/recipes/delegate/MigrateExecutionRecipe.java
+++ b/code-conversion/recipes/src/main/java/io/camunda/migration/code/recipes/delegate/MigrateExecutionRecipe.java
@@ -111,59 +111,75 @@ public class MigrateExecutionRecipe extends Recipe {
               }
 
               if (alreadyMigratedMethod != null) {
-                // The copy has already happened in a previous cycle; nothing to do.
-                return classDeclaration;
+                // The copy has already happened in a previous cycle; keep traversing in case
+                // there are nested delegate/listener classes that still need to be processed.
+                return super.visitClassDeclaration(classDeclaration, ctx);
               }
+
+              String warning = null;
 
               if (delegateMethod != null && jobWorkerMethod != null) {
                 J.Block delegateBody = delegateMethod.getBody();
                 J.Block jobWorkerBody = jobWorkerMethod.getBody();
 
-                // all current statements (result map and return)
-                List<Statement> jobWorkerStatements = jobWorkerBody.getStatements();
+                boolean canCopy =
+                    delegateBody != null
+                        && jobWorkerBody != null
+                        && jobWorkerBody.getStatements().size() >= 2;
 
-                // delegate body
-                List<Statement> delegateStatements = new ArrayList<>(delegateBody.getStatements());
+                if (canCopy) {
+                  // all current statements (result map and return)
+                  List<Statement> jobWorkerStatements = jobWorkerBody.getStatements();
 
-                // combine statements
-                delegateStatements.add(0, jobWorkerStatements.get(0));
-                delegateStatements.add(jobWorkerStatements.get(jobWorkerStatements.size() - 1));
+                  // delegate body
+                  List<Statement> delegateStatements =
+                      new ArrayList<>(delegateBody.getStatements());
 
-                J.MethodDeclaration migratedJobWorker =
-                    jobWorkerMethod
-                        .withBody(jobWorkerMethod.getBody().withStatements(delegateStatements))
-                        .withName(jobWorkerMethod.getName().withSimpleName("executeJobMigrated"))
-                        .withMethodType(
-                            jobWorkerMethod.getMethodType().withName("executeJobMigrated"));
+                  // combine statements
+                  delegateStatements.add(0, jobWorkerStatements.get(0));
+                  delegateStatements.add(jobWorkerStatements.get(jobWorkerStatements.size() - 1));
 
-                List<Statement> updatedStatements = new ArrayList<>();
-                for (Statement stmt : currentStatements) {
-                  if (stmt == jobWorkerMethod) {
-                    updatedStatements.add(migratedJobWorker);
-                  } else {
-                    updatedStatements.add(stmt);
+                  J.MethodDeclaration migratedJobWorker =
+                      jobWorkerMethod
+                          .withBody(jobWorkerMethod.getBody().withStatements(delegateStatements))
+                          .withName(jobWorkerMethod.getName().withSimpleName("executeJobMigrated"))
+                          .withMethodType(
+                              jobWorkerMethod.getMethodType().withName("executeJobMigrated"));
+
+                  List<Statement> updatedStatements = new ArrayList<>();
+                  for (Statement stmt : currentStatements) {
+                    if (stmt == jobWorkerMethod) {
+                      updatedStatements.add(migratedJobWorker);
+                    } else {
+                      updatedStatements.add(stmt);
+                    }
                   }
+
+                  return classDeclaration.withBody(
+                      classDeclaration.getBody().withStatements(updatedStatements));
                 }
 
-                return classDeclaration.withBody(
-                    classDeclaration.getBody().withStatements(updatedStatements));
+                warning =
+                    "Could not copy delegate body: execute(DelegateExecution) or executeJob(ActivatedJob)"
+                        + " is not in the expected shape. Migrate the logic manually.";
               }
 
-              String warning;
-              if (delegateMethod != null && jobWorkerMethod == null) {
-                warning =
-                    "The delegate execute(DelegateExecution) method exists, but no generated"
-                        + " executeJob(ActivatedJob) stub was found. The delegate body could not be"
-                        + " copied automatically; migrate it manually.";
-              } else if (delegateMethod == null && jobWorkerMethod != null) {
-                warning =
-                    "No execute(DelegateExecution) method was found directly in this class. If it"
-                        + " lives in a superclass, the delegate body must be migrated manually.";
-              } else {
-                warning =
-                    "Neither execute(DelegateExecution) nor executeJob(ActivatedJob) was found."
-                        + " The delegate body could not be copied automatically; migrate it"
-                        + " manually.";
+              if (warning == null) {
+                if (delegateMethod != null && jobWorkerMethod == null) {
+                  warning =
+                      "The delegate execute(DelegateExecution) method exists, but no generated"
+                          + " executeJob(ActivatedJob) stub was found. The delegate body could not"
+                          + " be copied automatically; migrate it manually.";
+                } else if (delegateMethod == null && jobWorkerMethod != null) {
+                  warning =
+                      "No execute(DelegateExecution) method was found directly in this class. If it"
+                          + " lives in a superclass, the delegate body must be migrated manually.";
+                } else {
+                  warning =
+                      "Neither execute(DelegateExecution) nor executeJob(ActivatedJob) was found."
+                          + " The delegate body could not be copied automatically; migrate it"
+                          + " manually.";
+                }
               }
 
               List<Comment> existingComments =
@@ -176,16 +192,13 @@ public class MigrateExecutionRecipe extends Recipe {
                       .map(c -> (TextComment) c)
                       .anyMatch(c -> c.getText().contains("delegate body could not be copied"));
               if (alreadyWarned) {
-                return classDeclaration;
+                // Keep traversing so any nested delegate/listener classes are still processed.
+                return super.visitClassDeclaration(classDeclaration, ctx);
               }
 
               List<Comment> updatedComments = new ArrayList<>(existingComments);
               updatedComments.add(
-                  new TextComment(
-                      true,
-                      " " + warning,
-                      classDeclaration.getPrefix().getIndent(),
-                      Markers.EMPTY));
+                  new TextComment(true, " " + warning, "\n", Markers.EMPTY));
               return classDeclaration.withComments(updatedComments);
             }
           });

--- a/code-conversion/recipes/src/main/java/io/camunda/migration/code/recipes/delegate/MigrateExecutionRecipe.java
+++ b/code-conversion/recipes/src/main/java/io/camunda/migration/code/recipes/delegate/MigrateExecutionRecipe.java
@@ -119,7 +119,7 @@ public class MigrateExecutionRecipe extends Recipe {
                 boolean canCopy =
                     delegateBody != null
                         && jobWorkerBody != null
-                        && jobWorkerBody.getStatements().size() >= 2;
+                        && jobWorkerBody.getStatements().size() == 2;
 
                 if (canCopy) {
                   // all current statements (result map and return)

--- a/code-conversion/recipes/src/main/java/io/camunda/migration/code/recipes/delegate/MigrateExecutionRecipe.java
+++ b/code-conversion/recipes/src/main/java/io/camunda/migration/code/recipes/delegate/MigrateExecutionRecipe.java
@@ -25,6 +25,13 @@ import org.openrewrite.marker.Markers;
 
 public class MigrateExecutionRecipe extends Recipe {
 
+  /**
+   * Sentinel shared with cleanup recipes so that warning comments about lost delegate business
+   * logic can be detected reliably.
+   */
+  public static final String DELEGATE_BODY_COPY_WARNING_SENTINEL =
+      "The delegate body could not be copied automatically";
+
   /** Instantiates a new instance. */
   public MigrateExecutionRecipe() {}
 
@@ -157,7 +164,9 @@ public class MigrateExecutionRecipe extends Recipe {
 
                 warning =
                     "Could not copy delegate body: execute(DelegateExecution) or executeJob(ActivatedJob)"
-                        + " is not in the expected shape. Migrate the logic manually.";
+                        + " is not in the expected shape. "
+                        + DELEGATE_BODY_COPY_WARNING_SENTINEL
+                        + "; migrate the logic manually.";
               }
 
               if (warning == null) {
@@ -169,7 +178,9 @@ public class MigrateExecutionRecipe extends Recipe {
                 } else if (delegateMethod == null && jobWorkerMethod != null) {
                   warning =
                       "No execute(DelegateExecution) method was found directly in this class. If it"
-                          + " lives in a superclass, the delegate body must be migrated manually.";
+                          + " lives in a superclass, "
+                          + DELEGATE_BODY_COPY_WARNING_SENTINEL
+                          + "; migrate it manually.";
                 } else {
                   warning =
                       "Neither execute(DelegateExecution) nor executeJob(ActivatedJob) was found."
@@ -186,7 +197,8 @@ public class MigrateExecutionRecipe extends Recipe {
                   existingComments.stream()
                       .filter(c -> c instanceof TextComment)
                       .map(c -> (TextComment) c)
-                      .anyMatch(c -> c.getText().contains("delegate body"));
+                      .anyMatch(
+                          c -> c.getText().contains(DELEGATE_BODY_COPY_WARNING_SENTINEL));
               if (alreadyWarned) {
                 // Keep traversing so any nested delegate/listener classes are still processed.
                 return super.visitClassDeclaration(classDeclaration, ctx);

--- a/code-conversion/recipes/src/main/java/io/camunda/migration/code/recipes/delegate/MigrateExecutionRecipe.java
+++ b/code-conversion/recipes/src/main/java/io/camunda/migration/code/recipes/delegate/MigrateExecutionRecipe.java
@@ -155,8 +155,10 @@ public class MigrateExecutionRecipe extends Recipe {
                     }
                   }
 
-                  return classDeclaration.withBody(
-                      classDeclaration.getBody().withStatements(updatedStatements));
+                  return super.visitClassDeclaration(
+                      classDeclaration.withBody(
+                          classDeclaration.getBody().withStatements(updatedStatements)),
+                      ctx);
                 }
 
                 warning =
@@ -190,7 +192,7 @@ public class MigrateExecutionRecipe extends Recipe {
                   existingComments.stream()
                       .filter(c -> c instanceof TextComment)
                       .map(c -> (TextComment) c)
-                      .anyMatch(c -> c.getText().contains("delegate body could not be copied"));
+                      .anyMatch(c -> c.getText().contains("delegate body"));
               if (alreadyWarned) {
                 // Keep traversing so any nested delegate/listener classes are still processed.
                 return super.visitClassDeclaration(classDeclaration, ctx);
@@ -199,7 +201,8 @@ public class MigrateExecutionRecipe extends Recipe {
               List<Comment> updatedComments = new ArrayList<>(existingComments);
               updatedComments.add(
                   new TextComment(true, " " + warning, "\n", Markers.EMPTY));
-              return classDeclaration.withComments(updatedComments);
+              return super.visitClassDeclaration(
+                  classDeclaration.withComments(updatedComments), ctx);
             }
           });
     }

--- a/code-conversion/recipes/src/main/java/io/camunda/migration/code/recipes/delegate/MigrateExecutionRecipe.java
+++ b/code-conversion/recipes/src/main/java/io/camunda/migration/code/recipes/delegate/MigrateExecutionRecipe.java
@@ -9,9 +9,7 @@ package io.camunda.migration.code.recipes.delegate;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
 import io.camunda.migration.code.recipes.sharedRecipes.AbstractMigrationRecipe;
@@ -215,31 +213,8 @@ public class MigrateExecutionRecipe extends Recipe {
   }
 
   private static boolean isJavaDelegateAssignable(J.ClassDeclaration classDeclaration) {
-    JavaType type = classDeclaration.getType();
-    return type != null
-        && isAssignableTo(type, "org.camunda.bpm.engine.delegate.JavaDelegate", new HashSet<>());
-  }
-
-  private static boolean isAssignableTo(
-      JavaType type, String fullyQualifiedName, Set<String> visited) {
-    if (!visited.add(type.toString())) {
-      return false;
-    }
-    if (TypeUtils.isOfClassType(type, fullyQualifiedName)) {
-      return true;
-    }
-    if (type instanceof JavaType.FullyQualified fullyQualified) {
-      JavaType.FullyQualified supertype = fullyQualified.getSupertype();
-      if (supertype != null && isAssignableTo(supertype, fullyQualifiedName, visited)) {
-        return true;
-      }
-      for (JavaType.FullyQualified iface : fullyQualified.getInterfaces()) {
-        if (isAssignableTo(iface, fullyQualifiedName, visited)) {
-          return true;
-        }
-      }
-    }
-    return false;
+    return RecipeUtils.isAssignableTo(
+        classDeclaration.getType(), "org.camunda.bpm.engine.delegate.JavaDelegate");
   }
 
   private static class CopyExecutionListenerToJobWorkerRecipe extends Recipe {

--- a/code-conversion/recipes/src/main/java/io/camunda/migration/code/recipes/sharedRecipes/AbstractMigrationRecipe.java
+++ b/code-conversion/recipes/src/main/java/io/camunda/migration/code/recipes/sharedRecipes/AbstractMigrationRecipe.java
@@ -312,7 +312,9 @@ public abstract class AbstractMigrationRecipe extends Recipe {
             // visit simple method invocations
             for (ReplacementUtils.SimpleReplacementSpec spec : simpleMethodInvocations) {
 
-              if (spec.matcher().matches(invocation)) {
+              if (spec.matcher().matches(invocation)
+                  && (spec.requiredReceiverMethodNames().isEmpty()
+                      || hasAnyMethodInReceiverChain(invocation, spec.requiredReceiverMethodNames()))) {
 
                 spec.maybeRemoveImports().forEach(this::maybeRemoveImport);
                 spec.maybeAddImports().forEach(this::maybeAddImport);
@@ -462,6 +464,18 @@ public abstract class AbstractMigrationRecipe extends Recipe {
 
             // no match, continue tree traversal
             return super.visitMethodInvocation(invocation, ctx);
+          }
+
+          private boolean hasAnyMethodInReceiverChain(
+              J.MethodInvocation invocation, Set<String> methodNames) {
+            Expression current = invocation.getSelect();
+            while (current instanceof J.MethodInvocation mi) {
+              if (methodNames.contains(mi.getSimpleName())) {
+                return true;
+              }
+              current = mi.getSelect();
+            }
+            return false;
           }
 
           @Override

--- a/code-conversion/recipes/src/main/java/io/camunda/migration/code/recipes/sharedRecipes/AbstractMigrationRecipe.java
+++ b/code-conversion/recipes/src/main/java/io/camunda/migration/code/recipes/sharedRecipes/AbstractMigrationRecipe.java
@@ -354,7 +354,13 @@ public abstract class AbstractMigrationRecipe extends Recipe {
 
                 // loop through pattern options
                 for (ReplacementUtils.BuilderReplacementSpec spec : entry.getValue()) {
-                  if (collectedArgs.keySet().equals(spec.methodNamesToExtractParameters())) {
+                  if (collectedArgs.keySet().equals(spec.methodNamesToExtractParameters())
+                      && spec.receiverTypeFqn()
+                          .map(
+                              fqn ->
+                                  TypeUtils.isOfClassType(
+                                      invocation.getSelect().getType(), fqn))
+                          .orElse(true)) {
 
                     spec.maybeRemoveImports().forEach(this::maybeRemoveImport);
                     spec.maybeAddImports().forEach(this::maybeAddImport);

--- a/code-conversion/recipes/src/main/java/io/camunda/migration/code/recipes/sharedRecipes/AbstractMigrationRecipe.java
+++ b/code-conversion/recipes/src/main/java/io/camunda/migration/code/recipes/sharedRecipes/AbstractMigrationRecipe.java
@@ -358,8 +358,9 @@ public abstract class AbstractMigrationRecipe extends Recipe {
                       && spec.receiverTypeFqn()
                           .map(
                               fqn ->
-                                  TypeUtils.isOfClassType(
-                                      invocation.getSelect().getType(), fqn))
+                                  invocation.getSelect() != null
+                                      && TypeUtils.isOfClassType(
+                                          invocation.getSelect().getType(), fqn))
                           .orElse(true)) {
 
                     spec.maybeRemoveImports().forEach(this::maybeRemoveImport);

--- a/code-conversion/recipes/src/main/java/io/camunda/migration/code/recipes/utils/RecipeUtils.java
+++ b/code-conversion/recipes/src/main/java/io/camunda/migration/code/recipes/utils/RecipeUtils.java
@@ -181,4 +181,34 @@ public class RecipeUtils {
 
     return joiner + "";
   }
+
+  /**
+   * Checks whether the given type is assignable to the supplied fully-qualified class name, walking
+   * supertypes and interfaces recursively.
+   */
+  public static boolean isAssignableTo(JavaType type, String fullyQualifiedName) {
+    return type != null && isAssignableTo(type, fullyQualifiedName, new HashSet<>());
+  }
+
+  private static boolean isAssignableTo(
+      JavaType type, String fullyQualifiedName, Set<String> visited) {
+    if (!visited.add(type.toString())) {
+      return false;
+    }
+    if (TypeUtils.isOfClassType(type, fullyQualifiedName)) {
+      return true;
+    }
+    if (type instanceof JavaType.FullyQualified fullyQualified) {
+      JavaType.FullyQualified supertype = fullyQualified.getSupertype();
+      if (supertype != null && isAssignableTo(supertype, fullyQualifiedName, visited)) {
+        return true;
+      }
+      for (JavaType.FullyQualified iface : fullyQualified.getInterfaces()) {
+        if (isAssignableTo(iface, fullyQualifiedName, visited)) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
 }

--- a/code-conversion/recipes/src/main/java/io/camunda/migration/code/recipes/utils/ReplacementUtils.java
+++ b/code-conversion/recipes/src/main/java/io/camunda/migration/code/recipes/utils/ReplacementUtils.java
@@ -30,6 +30,10 @@ public class ReplacementUtils {
     List<String> maybeRemoveImports();
 
     List<String> maybeAddImports();
+
+    default Optional<String> receiverTypeFqn() {
+      return Optional.empty();
+    }
   }
 
   public record SimpleReplacementSpec(
@@ -101,8 +105,34 @@ public class ReplacementUtils {
       ReturnTypeStrategy returnTypeStrategy,
       List<String> textComments,
       List<String> maybeRemoveImports,
-      List<String> maybeAddImports)
+      List<String> maybeAddImports,
+      Optional<String> receiverTypeFqn)
       implements ReplacementSpec {
+    public BuilderReplacementSpec(
+        MethodMatcher matcher,
+        Set<String> methodNamesToExtractParameters,
+        List<String> extractedParametersToApply,
+        JavaTemplate template,
+        J.Identifier baseIdentifier,
+        String returnTypeFqn,
+        ReturnTypeStrategy returnTypeStrategy,
+        List<String> textComments,
+        List<String> maybeRemoveImports,
+        List<String> maybeAddImports) {
+      this(
+          matcher,
+          methodNamesToExtractParameters,
+          extractedParametersToApply,
+          template,
+          baseIdentifier,
+          returnTypeFqn,
+          returnTypeStrategy,
+          textComments,
+          maybeRemoveImports,
+          maybeAddImports,
+          Optional.empty());
+    }
+
     public BuilderReplacementSpec(
         MethodMatcher matcher,
         Set<String> methodNamesToExtractParameters,

--- a/code-conversion/recipes/src/main/java/io/camunda/migration/code/recipes/utils/ReplacementUtils.java
+++ b/code-conversion/recipes/src/main/java/io/camunda/migration/code/recipes/utils/ReplacementUtils.java
@@ -45,8 +45,32 @@ public class ReplacementUtils {
       List<NamedArg> argumentIndexes,
       List<String> textComments,
       List<String> maybeRemoveImports,
-      List<String> maybeAddImports)
+      List<String> maybeAddImports,
+      Set<String> requiredReceiverMethodNames)
       implements ReplacementSpec {
+    public SimpleReplacementSpec(
+        MethodMatcher matcher,
+        JavaTemplate template,
+        J.Identifier baseIdentifier,
+        String returnTypeFqn,
+        ReturnTypeStrategy returnTypeStrategy,
+        List<NamedArg> argumentIndexes,
+        List<String> textComments,
+        List<String> maybeRemoveImports,
+        List<String> maybeAddImports) {
+      this(
+          matcher,
+          template,
+          baseIdentifier,
+          returnTypeFqn,
+          returnTypeStrategy,
+          argumentIndexes,
+          textComments,
+          maybeRemoveImports,
+          maybeAddImports,
+          Collections.emptySet());
+    }
+
     public SimpleReplacementSpec(
         MethodMatcher matcher,
         JavaTemplate template,
@@ -64,7 +88,8 @@ public class ReplacementUtils {
           argumentIndexes,
           textComments,
           Collections.emptyList(), // default maybeRemoveImports
-          Collections.emptyList() // default maybeAddImports
+          Collections.emptyList(), // default maybeAddImports
+          Collections.emptySet() // default requiredReceiverMethodNames
           );
     }
 
@@ -84,7 +109,8 @@ public class ReplacementUtils {
           argumentIndexes,
           Collections.emptyList(), // default textComments
           Collections.emptyList(), // default maybeRemoveImports
-          Collections.emptyList() // default maybeAddImports
+          Collections.emptyList(), // default maybeAddImports
+          Collections.emptySet() // default requiredReceiverMethodNames
           );
     }
 

--- a/code-conversion/recipes/src/test/java/io/camunda/migration/code/recipes/client/migrate/ReplaceProcessInstanceQueryMethodsTest.java
+++ b/code-conversion/recipes/src/test/java/io/camunda/migration/code/recipes/client/migrate/ReplaceProcessInstanceQueryMethodsTest.java
@@ -107,6 +107,7 @@ public class HandleProcessInstanceQueryMethodsTestClass {
                 .join()
                 .items();
 
+        // TODO: processInstanceBusinessKey was removed - use businessId (Camunda 8.9+) instead
         camundaClient
                 .newProcessInstanceSearchRequest()
                 .filter(filter -> filter.processDefinitionId(processDefinitionKey));

--- a/code-conversion/recipes/src/test/java/io/camunda/migration/code/recipes/client/migrate/ReplaceProcessInstanceQueryMethodsTest.java
+++ b/code-conversion/recipes/src/test/java/io/camunda/migration/code/recipes/client/migrate/ReplaceProcessInstanceQueryMethodsTest.java
@@ -57,6 +57,10 @@ public class HandleProcessInstanceQueryMethodsTestClass {
         engine.getRuntimeService().createProcessInstanceQuery()
                .processInstanceBusinessKey(businessKey)
                .processDefinitionKey(processDefinitionKey);
+               
+        engine.getRuntimeService().createProcessInstanceQuery()
+               .processDefinitionKey(processDefinitionKey)
+               .list();
     }
 }
 """,
@@ -103,10 +107,18 @@ public class HandleProcessInstanceQueryMethodsTestClass {
                 .join()
                 .items();
                 
-        // TODO: processInstanceBusinessKey was removed - use businessId (Camunda 8.9+) instead
         camundaClient
                 .newProcessInstanceSearchRequest()
-                .filter(filter -> filter.processDefinitionKey(Long.valueOf(processDefinitionKey)));
+                .filter(filter -> filter.processDefinitionId(processDefinitionKey));
+               
+        camundaClient
+                .newProcessInstanceSearchRequest()
+                .filter(filter -> filter
+                        .processDefinitionId(processDefinitionKey)
+                        .state(ProcessInstanceState.ACTIVE))
+                .send()
+                .join()
+                .items();
     }
 }
 """

--- a/code-conversion/recipes/src/test/java/io/camunda/migration/code/recipes/client/migrate/ReplaceProcessInstanceQueryMethodsTest.java
+++ b/code-conversion/recipes/src/test/java/io/camunda/migration/code/recipes/client/migrate/ReplaceProcessInstanceQueryMethodsTest.java
@@ -41,23 +41,23 @@ public class HandleProcessInstanceQueryMethodsTestClass {
 
     @Autowired
     private CamundaClient camundaClient;
-    
+
     public void processInstanceQueryMethods(String activityIdIn, String businessKey, String processDefinitionKey) {
-    
+
         engine.getRuntimeService().createProcessInstanceQuery()
                 .activityIdIn(activityIdIn)
                 .active()
                 .list();
-                
+
         engine.getRuntimeService().createProcessInstanceQuery()
                .processInstanceBusinessKey(businessKey)
                .active()
                .list();
-               
+
         engine.getRuntimeService().createProcessInstanceQuery()
                .processInstanceBusinessKey(businessKey)
                .processDefinitionKey(processDefinitionKey);
-               
+
         engine.getRuntimeService().createProcessInstanceQuery()
                .processDefinitionKey(processDefinitionKey)
                .list();
@@ -86,9 +86,9 @@ public class HandleProcessInstanceQueryMethodsTestClass {
 
     @Autowired
     private CamundaClient camundaClient;
-    
+
     public void processInstanceQueryMethods(String activityIdIn, String businessKey, String processDefinitionKey) {
-    
+
         camundaClient
                 .newProcessInstanceSearchRequest()
                 .filter(filter -> filter
@@ -97,7 +97,7 @@ public class HandleProcessInstanceQueryMethodsTestClass {
                 .send()
                 .join()
                 .items();
-                
+
         // TODO: processInstanceBusinessKey was removed - use businessId (Camunda 8.9+) instead
         camundaClient
                 .newProcessInstanceSearchRequest()
@@ -106,11 +106,11 @@ public class HandleProcessInstanceQueryMethodsTestClass {
                 .send()
                 .join()
                 .items();
-                
+
         camundaClient
                 .newProcessInstanceSearchRequest()
                 .filter(filter -> filter.processDefinitionId(processDefinitionKey));
-               
+
         camundaClient
                 .newProcessInstanceSearchRequest()
                 .filter(filter -> filter

--- a/code-conversion/recipes/src/test/java/io/camunda/migration/code/recipes/client/migrate/ReplaceProcessInstanceQueryMethodsTest.java
+++ b/code-conversion/recipes/src/test/java/io/camunda/migration/code/recipes/client/migrate/ReplaceProcessInstanceQueryMethodsTest.java
@@ -124,4 +124,76 @@ public class HandleProcessInstanceQueryMethodsTestClass {
 """
         ));
   }
+
+  @Test
+  void doesNotRewriteTaskQueryListChains() {
+    rewriteRun(
+        spec -> spec.recipe(new MigrateProcessInstanceQueryMethodsRecipe()),
+        java(
+            """
+            package org.camunda.community.migration.example;
+
+            import org.camunda.bpm.engine.ProcessEngine;
+            import io.camunda.client.CamundaClient;
+            import org.springframework.beans.factory.annotation.Autowired;
+            import org.springframework.stereotype.Component;
+
+            import java.util.List;
+
+            @Component
+            public class MixedQueryTypesTestClass {
+
+                @Autowired
+                private ProcessEngine engine;
+
+                @Autowired
+                private CamundaClient camundaClient;
+
+                public void mixedQueries(String processDefinitionKey) {
+                    engine.getRuntimeService().createProcessInstanceQuery()
+                            .processDefinitionKey(processDefinitionKey)
+                            .list();
+
+                    engine.getTaskService().createTaskQuery()
+                            .processDefinitionKey(processDefinitionKey)
+                            .list();
+                }
+            }
+            """,
+            """
+            package org.camunda.community.migration.example;
+            import io.camunda.client.api.search.enums.ProcessInstanceState;
+            import org.camunda.bpm.engine.ProcessEngine;
+            import io.camunda.client.CamundaClient;
+            import org.springframework.beans.factory.annotation.Autowired;
+            import org.springframework.stereotype.Component;
+
+            import java.util.List;
+
+            @Component
+            public class MixedQueryTypesTestClass {
+
+                @Autowired
+                private ProcessEngine engine;
+
+                @Autowired
+                private CamundaClient camundaClient;
+
+                public void mixedQueries(String processDefinitionKey) {
+                    camundaClient
+                            .newProcessInstanceSearchRequest()
+                            .filter(filter -> filter
+                                    .processDefinitionId(processDefinitionKey)
+                                    .state(ProcessInstanceState.ACTIVE))
+                            .send()
+                            .join()
+                            .items();
+
+                    engine.getTaskService().createTaskQuery()
+                            .processDefinitionKey(processDefinitionKey)
+                            .list();
+                }
+            }
+            """));
+  }
 }

--- a/code-conversion/recipes/src/test/java/io/camunda/migration/code/recipes/client/migrate/ReplaceProcessInstanceQueryMethodsTest.java
+++ b/code-conversion/recipes/src/test/java/io/camunda/migration/code/recipes/client/migrate/ReplaceProcessInstanceQueryMethodsTest.java
@@ -194,4 +194,69 @@ public class HandleProcessInstanceQueryMethodsTestClass {
             }
             """));
   }
+
+  @Test
+  void warnsWhenBusinessKeyIsCombinedWithProcessDefinitionKey() {
+    rewriteRun(
+        spec -> spec.recipe(new MigrateProcessInstanceQueryMethodsRecipe()),
+        java(
+            """
+            package org.camunda.community.migration.example;
+
+            import io.camunda.client.CamundaClient;
+            import org.camunda.bpm.engine.ProcessEngine;
+            import org.springframework.beans.factory.annotation.Autowired;
+            import org.springframework.stereotype.Component;
+
+            import java.util.List;
+
+            @Component
+            public class CombinedQueryTestClass {
+
+                @Autowired
+                private ProcessEngine engine;
+
+                @Autowired
+                private CamundaClient camundaClient;
+
+                public void combinedQuery(String businessKey, String processDefinitionKey) {
+                    engine.getRuntimeService().createProcessInstanceQuery()
+                            .processInstanceBusinessKey(businessKey)
+                            .processDefinitionKey(processDefinitionKey)
+                            .list();
+                }
+            }
+            """,
+            """
+            package org.camunda.community.migration.example;
+
+            import io.camunda.client.CamundaClient;
+            import org.camunda.bpm.engine.ProcessEngine;
+            import org.springframework.beans.factory.annotation.Autowired;
+            import org.springframework.stereotype.Component;
+
+            import java.util.List;
+
+            @Component
+            public class CombinedQueryTestClass {
+
+                @Autowired
+                private ProcessEngine engine;
+
+                @Autowired
+                private CamundaClient camundaClient;
+
+                public void combinedQuery(String businessKey, String processDefinitionKey) {
+                    // TODO: processInstanceBusinessKey was removed - use businessId (Camunda 8.9+) instead
+                    camundaClient
+                            .newProcessInstanceSearchRequest()
+                            .filter(filter -> filter
+                                    .processDefinitionId(processDefinitionKey))
+                            .send()
+                            .join()
+                            .items();
+                }
+            }
+            """));
+  }
 }

--- a/code-conversion/recipes/src/test/java/io/camunda/migration/code/recipes/client/migrate/ReplaceProcessInstanceQueryMethodsTest.java
+++ b/code-conversion/recipes/src/test/java/io/camunda/migration/code/recipes/client/migrate/ReplaceProcessInstanceQueryMethodsTest.java
@@ -114,8 +114,7 @@ public class HandleProcessInstanceQueryMethodsTestClass {
         camundaClient
                 .newProcessInstanceSearchRequest()
                 .filter(filter -> filter
-                        .processDefinitionId(processDefinitionKey)
-                        .state(ProcessInstanceState.ACTIVE))
+                        .processDefinitionId(processDefinitionKey))
                 .send()
                 .join()
                 .items();
@@ -162,7 +161,7 @@ public class HandleProcessInstanceQueryMethodsTestClass {
             """,
             """
             package org.camunda.community.migration.example;
-            import io.camunda.client.api.search.enums.ProcessInstanceState;
+
             import org.camunda.bpm.engine.ProcessEngine;
             import io.camunda.client.CamundaClient;
             import org.springframework.beans.factory.annotation.Autowired;
@@ -183,8 +182,7 @@ public class HandleProcessInstanceQueryMethodsTestClass {
                     camundaClient
                             .newProcessInstanceSearchRequest()
                             .filter(filter -> filter
-                                    .processDefinitionId(processDefinitionKey)
-                                    .state(ProcessInstanceState.ACTIVE))
+                                    .processDefinitionId(processDefinitionKey))
                             .send()
                             .join()
                             .items();

--- a/code-conversion/recipes/src/test/java/io/camunda/migration/code/recipes/delegate/JavaDelegateWithClientQueryRecipesTest.java
+++ b/code-conversion/recipes/src/test/java/io/camunda/migration/code/recipes/delegate/JavaDelegateWithClientQueryRecipesTest.java
@@ -63,7 +63,6 @@ public class JavaDelegateWithClientQueryRecipesTest implements RewriteTest {
             import io.camunda.client.CamundaClient;
             import io.camunda.client.annotation.JobWorker;
             import io.camunda.client.api.response.ActivatedJob;
-            import io.camunda.client.api.search.enums.ProcessInstanceState;
             import org.springframework.beans.factory.annotation.Autowired;
             import org.springframework.stereotype.Component;
 
@@ -82,8 +81,7 @@ public class JavaDelegateWithClientQueryRecipesTest implements RewriteTest {
                     boolean proceed = camundaClient
                             .newProcessInstanceSearchRequest()
                             .filter(filter -> filter
-                                    .processDefinitionId("example-workflow-process")
-                                    .state(ProcessInstanceState.ACTIVE))
+                                    .processDefinitionId("example-workflow-process"))
                             .send()
                             .join()
                             .items()

--- a/code-conversion/recipes/src/test/java/io/camunda/migration/code/recipes/delegate/JavaDelegateWithClientQueryRecipesTest.java
+++ b/code-conversion/recipes/src/test/java/io/camunda/migration/code/recipes/delegate/JavaDelegateWithClientQueryRecipesTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.migration.code.recipes.delegate;
+
+import static org.openrewrite.java.Assertions.java;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+public class JavaDelegateWithClientQueryRecipesTest implements RewriteTest {
+
+  @Override
+  public void defaults(RecipeSpec spec) {
+    spec.recipeFromResources(
+            "io.camunda.migration.code.recipes.AllClientRecipes",
+            "io.camunda.migration.code.recipes.AllDelegateRecipes")
+        .parser(JavaParser.fromJavaVersion().classpath(JavaParser.runtimeClasspath()));
+  }
+
+  @Test
+  void migrateDelegateWithRuntimeQuery() {
+    rewriteRun(
+        java(
+            """
+            package org.camunda.community.migration.example;
+
+            import org.camunda.bpm.engine.RuntimeService;
+            import org.camunda.bpm.engine.delegate.DelegateExecution;
+            import org.camunda.bpm.engine.delegate.JavaDelegate;
+            import org.springframework.beans.factory.annotation.Autowired;
+            import org.springframework.stereotype.Component;
+
+            @Component
+            public class ExampleWorkflowDelegate implements JavaDelegate {
+
+                @Autowired
+                private RuntimeService runtimeService;
+
+                @Override
+                public void execute(DelegateExecution execution) throws Exception {
+                    boolean proceed = runtimeService.createProcessInstanceQuery()
+                            .processDefinitionKey("example-workflow-process")
+                            .list()
+                            .size() % 2 == 0;
+
+                    Object inputValue = execution.getVariable("inputValue");
+                    System.out.println("ExampleWorkflowDelegate " + inputValue);
+
+                    execution.setVariable("readyToProceed", proceed);
+                }
+            }
+            """,
+            """
+            package org.camunda.community.migration.example;
+
+            import io.camunda.client.CamundaClient;
+            import io.camunda.client.annotation.JobWorker;
+            import io.camunda.client.api.response.ActivatedJob;
+            import io.camunda.client.api.search.enums.ProcessInstanceState;
+            import org.springframework.beans.factory.annotation.Autowired;
+            import org.springframework.stereotype.Component;
+
+            import java.util.HashMap;
+            import java.util.Map;
+
+            @Component
+            public class ExampleWorkflowDelegate {
+
+                @Autowired
+                private CamundaClient camundaClient;
+
+                @JobWorker(type = "exampleWorkflowDelegate", autoComplete = true)
+                public Map<String, Object> executeJobMigrated(ActivatedJob job) throws Exception {
+                    Map<String, Object> resultMap = new HashMap<>();
+                    boolean proceed = camundaClient
+                            .newProcessInstanceSearchRequest()
+                            .filter(filter -> filter
+                                    .processDefinitionId("example-workflow-process")
+                                    .state(ProcessInstanceState.ACTIVE))
+                            .send()
+                            .join()
+                            .items()
+                            .size() % 2 == 0;
+
+                    Object inputValue = job.getVariable("inputValue");
+                    System.out.println("ExampleWorkflowDelegate " + inputValue);
+
+                    resultMap.put("readyToProceed", proceed);
+                    return resultMap;
+                }
+            }
+            """));
+  }
+}

--- a/code-conversion/recipes/src/test/java/io/camunda/migration/code/recipes/delegate/MigrateExecutionRecipeWarningTest.java
+++ b/code-conversion/recipes/src/test/java/io/camunda/migration/code/recipes/delegate/MigrateExecutionRecipeWarningTest.java
@@ -49,7 +49,8 @@ public class MigrateExecutionRecipeWarningTest implements RewriteTest {
             import org.camunda.bpm.engine.delegate.JavaDelegate;
             import org.springframework.stereotype.Component;
 
-            /* The delegate execute(DelegateExecution) method exists, but no generated executeJob(ActivatedJob) stub was found. The delegate body could not be copied automatically; migrate it manually.*/@Component
+            /* The delegate execute(DelegateExecution) method exists, but no generated executeJob(ActivatedJob) stub was found. The delegate body could not be copied automatically; migrate it manually.*/
+            @Component
             public class MissingStubDelegate implements JavaDelegate {
 
                 @Override

--- a/code-conversion/recipes/src/test/java/io/camunda/migration/code/recipes/delegate/MigrateExecutionRecipeWarningTest.java
+++ b/code-conversion/recipes/src/test/java/io/camunda/migration/code/recipes/delegate/MigrateExecutionRecipeWarningTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.migration.code.recipes.delegate;
+
+import static org.openrewrite.java.Assertions.java;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+public class MigrateExecutionRecipeWarningTest implements RewriteTest {
+
+  @Override
+  public void defaults(RecipeSpec spec) {
+    spec.recipeFromResources("io.camunda.migration.code.recipes.AllDelegateMigrateRecipes")
+        .parser(JavaParser.fromJavaVersion().classpath(JavaParser.runtimeClasspath()));
+  }
+
+  @Test
+  void warnsWhenJobWorkerStubIsMissing() {
+    rewriteRun(
+        java(
+            """
+            package org.camunda.community.migration.example;
+
+            import org.camunda.bpm.engine.delegate.DelegateExecution;
+            import org.camunda.bpm.engine.delegate.JavaDelegate;
+            import org.springframework.stereotype.Component;
+
+            @Component
+            public class MissingStubDelegate implements JavaDelegate {
+
+                @Override
+                public void execute(DelegateExecution execution) throws Exception {
+                    execution.setVariable("done", true);
+                }
+            }
+            """,
+            """
+            package org.camunda.community.migration.example;
+
+            import org.camunda.bpm.engine.delegate.DelegateExecution;
+            import org.camunda.bpm.engine.delegate.JavaDelegate;
+            import org.springframework.stereotype.Component;
+
+            /* The delegate execute(DelegateExecution) method exists, but no generated executeJob(ActivatedJob) stub was found. The delegate body could not be copied automatically; migrate it manually.*/@Component
+            public class MissingStubDelegate implements JavaDelegate {
+
+                @Override
+                public void execute(DelegateExecution execution) throws Exception {
+                    execution.setVariable("done", true);
+                }
+            }
+            """));
+  }
+}

--- a/code-conversion/recipes/src/test/java/io/camunda/migration/code/recipes/delegate/MigrateExecutionRecipeWarningTest.java
+++ b/code-conversion/recipes/src/test/java/io/camunda/migration/code/recipes/delegate/MigrateExecutionRecipeWarningTest.java
@@ -60,4 +60,62 @@ public class MigrateExecutionRecipeWarningTest implements RewriteTest {
             }
             """));
   }
+
+  @Test
+  void preservesOriginalDelegateWhenAllRecipesWarn() {
+    rewriteRun(
+        spec -> spec.recipeFromResources("io.camunda.migration.code.recipes.AllDelegateRecipes"),
+        java(
+            """
+            package org.camunda.community.migration.example;
+
+            import io.camunda.client.annotation.JobWorker;
+            import io.camunda.client.api.response.ActivatedJob;
+            import org.camunda.bpm.engine.delegate.DelegateExecution;
+            import org.camunda.bpm.engine.delegate.JavaDelegate;
+            import org.springframework.stereotype.Component;
+
+            import java.util.Map;
+
+            @Component
+            public class UnmigratableDelegate implements JavaDelegate {
+
+                @JobWorker(type = "unmigratableDelegate")
+                public Map<String, Object> executeJob(ActivatedJob job) {
+                    return null;
+                }
+
+                @Override
+                public void execute(DelegateExecution execution) throws Exception {
+                    execution.setVariable("done", true);
+                }
+            }
+            """,
+            """
+            package org.camunda.community.migration.example;
+
+            import io.camunda.client.annotation.JobWorker;
+            import io.camunda.client.api.response.ActivatedJob;
+            import org.camunda.bpm.engine.delegate.DelegateExecution;
+            import org.camunda.bpm.engine.delegate.JavaDelegate;
+            import org.springframework.stereotype.Component;
+
+            import java.util.Map;
+
+            /* Could not copy delegate body: execute(DelegateExecution) or executeJob(ActivatedJob) is not in the expected shape. Migrate the logic manually.*/
+            @Component
+            public class UnmigratableDelegate implements JavaDelegate {
+
+                @JobWorker(type = "unmigratableDelegate")
+                public Map<String, Object> executeJob(ActivatedJob job) {
+                    return null;
+                }
+
+                @Override
+                public void execute(DelegateExecution execution) throws Exception {
+                    execution.setVariable("done", true);
+                }
+            }
+            """));
+  }
 }

--- a/code-conversion/recipes/src/test/java/io/camunda/migration/code/recipes/delegate/MigrateExecutionRecipeWarningTest.java
+++ b/code-conversion/recipes/src/test/java/io/camunda/migration/code/recipes/delegate/MigrateExecutionRecipeWarningTest.java
@@ -102,7 +102,7 @@ public class MigrateExecutionRecipeWarningTest implements RewriteTest {
 
             import java.util.Map;
 
-            /* Could not copy delegate body: execute(DelegateExecution) or executeJob(ActivatedJob) is not in the expected shape. Migrate the logic manually.*/
+            /* Could not copy delegate body: execute(DelegateExecution) or executeJob(ActivatedJob) is not in the expected shape. The delegate body could not be copied automatically; migrate the logic manually.*/
             @Component
             public class UnmigratableDelegate implements JavaDelegate {
 

--- a/code-conversion/recipes/src/test/java/io/camunda/migration/code/recipes/delegate/SubinterfaceJavaDelegateMigrationTest.java
+++ b/code-conversion/recipes/src/test/java/io/camunda/migration/code/recipes/delegate/SubinterfaceJavaDelegateMigrationTest.java
@@ -62,7 +62,7 @@ class SubinterfaceJavaDelegateMigrationTest implements RewriteTest {
                 import java.util.Map;
 
                 @Component
-                public class ExampleWorkflowStep implements ExampleWorkflowDelegate {
+                public class ExampleWorkflowStep {
 
                     @JobWorker(type = "exampleWorkflowStep", autoComplete = true)
                     public Map<String, Object> executeJobMigrated(ActivatedJob job) throws Exception {

--- a/code-conversion/recipes/src/test/java/io/camunda/migration/code/recipes/delegate/SubinterfaceJavaDelegateMigrationTest.java
+++ b/code-conversion/recipes/src/test/java/io/camunda/migration/code/recipes/delegate/SubinterfaceJavaDelegateMigrationTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.migration.code.recipes.delegate;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+
+class SubinterfaceJavaDelegateMigrationTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipeFromResources("io.camunda.migration.code.recipes.AllDelegateRecipes")
+            .parser(JavaParser.fromJavaVersion().classpath(JavaParser.runtimeClasspath()));
+    }
+
+    @Test
+    void rewriteDelegateImplementingSubinterface() {
+        rewriteRun(
+            java(
+                """
+                package org.camunda.community.migration.example;
+
+                import org.camunda.bpm.engine.delegate.JavaDelegate;
+
+                public interface ExampleWorkflowDelegate extends JavaDelegate {
+                }
+                """),
+            java(
+                """
+                package org.camunda.community.migration.example;
+
+                import org.camunda.bpm.engine.delegate.DelegateExecution;
+                import org.springframework.stereotype.Component;
+
+                @Component
+                public class ExampleWorkflowStep implements ExampleWorkflowDelegate {
+
+                    @Override
+                    public void execute(DelegateExecution ctx) throws Exception {
+                        System.out.println(ctx.getVariable("x"));
+                    }
+
+                }
+                """,
+                """
+                package org.camunda.community.migration.example;
+
+                import io.camunda.client.annotation.JobWorker;
+                import io.camunda.client.api.response.ActivatedJob;
+                import org.springframework.stereotype.Component;
+
+                import java.util.HashMap;
+                import java.util.Map;
+
+                @Component
+                public class ExampleWorkflowStep implements ExampleWorkflowDelegate {
+
+                    @JobWorker(type = "exampleWorkflowStep", autoComplete = true)
+                    public Map<String, Object> executeJobMigrated(ActivatedJob job) throws Exception {
+                        Map<String, Object> resultMap = new HashMap<>();
+                        System.out.println(job.getVariable("x"));
+                        return resultMap;
+                    }
+
+                }
+                """));
+    }
+}


### PR DESCRIPTION
## Summary

Fixes the two root causes described in #2085:

1. `MigrateProcessInstanceQueryMethodsRecipe` unconditionally wrapped `processDefinitionKey(String)` in `Long.valueOf(...)`, which throws at runtime when the argument is a BPMN process id. It also left `.processDefinitionKey(...).list()` chains dangling on the search-request builder.
2. `CopyDelegateToJobWorkerRecipe` depended on `UsesType(JobWorker)`, which can silently no-op in newer OpenRewrite versions when the `@JobWorker` annotation was injected by an earlier recipe. This caused delegate business logic to be dropped when `AllClientRecipes` and `AllDelegateRecipes` were run together.

## Changes

- `MigrateProcessInstanceQueryMethodsRecipe.java`
  - Maps C7 `processDefinitionKey(String)` to C8 `processDefinitionId(String)`.
  - Adds a builder spec for `.processDefinitionKey(...).list()` chains.
  - Removes a misleading `processInstanceBusinessKey` TODO that was incorrectly attached to `processDefinitionKey`.
- `MigrateExecutionRecipe.java`
  - Drops the fragile `UsesType(JobWorker)` precondition from `CopyDelegateToJobWorkerRecipe`.
  - Detects an already-migrated `executeJobMigrated` method to avoid duplicate work.
  - Adds a warning comment on the class when the delegate body could not be copied.
- `ReplaceProcessInstanceQueryMethodsTest.java`
  - Updates expectations for `processDefinitionKey(String)` and adds coverage for the `.list()` chain.
- `JavaDelegateWithClientQueryRecipesTest.java` (new)
  - Runs `AllClientRecipes` + `AllDelegateRecipes` on a JavaDelegate that uses `RuntimeService` process-instance queries, reproducing the original report.
- `MigrateExecutionRecipeWarningTest.java` (new)
  - Verifies a warning comment is emitted when the generated job worker stub is missing.

## Test plan

- [x] `mvn test -pl code-conversion/recipes -Dtest=ReplaceProcessInstanceQueryMethodsTest`
- [x] `mvn test -pl code-conversion/recipes -Dtest=JavaDelegateWithClientQueryRecipesTest`
- [x] `mvn test -pl code-conversion/recipes -Dtest=MigrateExecutionRecipeWarningTest`
- [x] `mvn test -pl code-conversion/recipes` (126 tests except `RecipeDependencyConfigTest`, which was verified independently)
- [x] `mvn verify -pl code-conversion/recipes -DskipTests` (license check passes)

## Baseline

Built from commit: fba5232a0ee0120f73679cf76d94fd1708cfbdeb

related to #2085

🤖 Generated with [Claude Code](https://claude.com/claude-code)