### PR TITLE
fix(recipes): correct combined client+delegate migration and warn on lost business logic (backport to 0.3)

### DIFF
--- a/code-conversion/recipes/src/main/java/io/camunda/migration/code/recipes/client/MigrateProcessInstanceQueryMethodsRecipe.java
+++ b/code-conversion/recipes/src/main/java/io/camunda/migration/code/recipes/client/MigrateProcessInstanceQueryMethodsRecipe.java
@@ -51,7 +51,7 @@ public class MigrateProcessInstanceQueryMethodsRecipe extends AbstractMigrationR
                 """
                 #{camundaClient:any(io.camunda.client.CamundaClient)}
                     .newProcessInstanceSearchRequest()
-                    .filter(filter -> filter.processDefinitionKey(Long.valueOf(#{processDefinitionKey:any(java.lang.String)})))
+                    .filter(filter -> filter.processDefinitionId(#{processDefinitionKey:any(java.lang.String)}))
                 """,
                 "io.camunda.client.api.search.request.ProcessInstanceSearchRequestBuilder",
                 "io.camunda.client.api.search.filter.ProcessInstanceFilter"),
@@ -59,9 +59,28 @@ public class MigrateProcessInstanceQueryMethodsRecipe extends AbstractMigrationR
             "io.camunda.client.api.search.request.ProcessInstanceSearchRequestBuilder",
             ReplacementUtils.ReturnTypeStrategy.USE_SPECIFIED_TYPE,
             List.of(new ReplacementUtils.SimpleReplacementSpec.NamedArg("processDefinitionKey", 0)),
-            List.of(" processInstanceBusinessKey was removed - business key concept changed in Camunda 8"),
+            List.of(RecipeUtils.businessIdHint("processInstanceBusinessKey")),
             Collections.emptyList(),
-            Collections.emptyList()));
+            Collections.emptyList(),
+            Set.of("processInstanceBusinessKey")),
+        new ReplacementUtils.SimpleReplacementSpec(
+            new MethodMatcher("org.camunda.bpm.engine.runtime.ProcessInstanceQuery processDefinitionKey(java.lang.String)"),
+            RecipeUtils.createSimpleJavaTemplate(
+                """
+                #{camundaClient:any(io.camunda.client.CamundaClient)}
+                    .newProcessInstanceSearchRequest()
+                    .filter(filter -> filter.processDefinitionId(#{processDefinitionKey:any(java.lang.String)}))
+                """,
+                "io.camunda.client.api.search.request.ProcessInstanceSearchRequestBuilder",
+                "io.camunda.client.api.search.filter.ProcessInstanceFilter"),
+            RecipeUtils.createSimpleIdentifier("camundaClient", "io.camunda.client.CamundaClient"),
+            "io.camunda.client.api.search.request.ProcessInstanceSearchRequestBuilder",
+            ReplacementUtils.ReturnTypeStrategy.USE_SPECIFIED_TYPE,
+            List.of(new ReplacementUtils.SimpleReplacementSpec.NamedArg("processDefinitionKey", 0)),
+            Collections.emptyList(),
+            Collections.emptyList(),
+            Collections.emptyList(),
+            Collections.emptySet()));
   }
 
   @Override
@@ -92,7 +111,8 @@ public class MigrateProcessInstanceQueryMethodsRecipe extends AbstractMigrationR
         ReplacementUtils.ReturnTypeStrategy.USE_SPECIFIED_TYPE,
         Collections.emptyList(),
         Collections.emptyList(),
-        List.of(PROCESS_INSTANCE_STATE)));
+        List.of(PROCESS_INSTANCE_STATE),
+        Optional.of("org.camunda.bpm.engine.runtime.ProcessInstanceQuery")));
 
     specs.add(new ReplacementUtils.BuilderReplacementSpec(
         new MethodMatcher("org.camunda.bpm.engine.query.Query list()"),
@@ -114,12 +134,59 @@ public class MigrateProcessInstanceQueryMethodsRecipe extends AbstractMigrationR
         RecipeUtils.createSimpleIdentifier("camundaClient", "io.camunda.client.CamundaClient"),
         "List<io.camunda.client.api.search.response.ProcessInstance>",
         ReplacementUtils.ReturnTypeStrategy.USE_SPECIFIED_TYPE,
-        List.of(" processInstanceBusinessKey was removed - business key concept changed in Camunda 8"),
+        List.of(RecipeUtils.businessIdHint("processInstanceBusinessKey")),
         Collections.emptyList(),
-        List.of(PROCESS_INSTANCE_STATE)));
-        
+        List.of(PROCESS_INSTANCE_STATE),
+        Optional.of("org.camunda.bpm.engine.runtime.ProcessInstanceQuery")));
 
-        
+    specs.add(new ReplacementUtils.BuilderReplacementSpec(
+        new MethodMatcher("org.camunda.bpm.engine.query.Query list()"),
+        Set.of("processDefinitionKey"),
+        List.of("processDefinitionKey"),
+        RecipeUtils.createSimpleJavaTemplate(
+            """
+            #{camundaClient:any(io.camunda.client.CamundaClient)}
+                .newProcessInstanceSearchRequest()
+                .filter(filter -> filter
+                    .processDefinitionId(#{processDefinitionKey:any(java.lang.String)}))
+                .send()
+                .join()
+                .items()
+            """,
+            "io.camunda.client.api.search.response.ProcessInstance",
+            "io.camunda.client.api.search.filter.ProcessInstanceFilter"),
+        RecipeUtils.createSimpleIdentifier("camundaClient", "io.camunda.client.CamundaClient"),
+        "List<io.camunda.client.api.search.response.ProcessInstance>",
+        ReplacementUtils.ReturnTypeStrategy.USE_SPECIFIED_TYPE,
+        Collections.emptyList(),
+        Collections.emptyList(),
+        Collections.emptyList(),
+        Optional.of("org.camunda.bpm.engine.runtime.ProcessInstanceQuery")));
+
+    specs.add(new ReplacementUtils.BuilderReplacementSpec(
+        new MethodMatcher("org.camunda.bpm.engine.query.Query list()"),
+        Set.of("processInstanceBusinessKey", "processDefinitionKey"),
+        List.of("processDefinitionKey"),
+        RecipeUtils.createSimpleJavaTemplate(
+            """
+            #{camundaClient:any(io.camunda.client.CamundaClient)}
+                .newProcessInstanceSearchRequest()
+                .filter(filter -> filter
+                    .processDefinitionId(#{processDefinitionKey:any(java.lang.String)}))
+                .send()
+                .join()
+                .items()
+            """,
+            "io.camunda.client.api.search.response.ProcessInstance",
+            "io.camunda.client.api.search.filter.ProcessInstanceFilter"),
+        RecipeUtils.createSimpleIdentifier("camundaClient", "io.camunda.client.CamundaClient"),
+        "List<io.camunda.client.api.search.response.ProcessInstance>",
+        ReplacementUtils.ReturnTypeStrategy.USE_SPECIFIED_TYPE,
+        List.of(RecipeUtils.businessIdHint("processInstanceBusinessKey")),
+        Collections.emptyList(),
+        Collections.emptyList(),
+        Optional.of("org.camunda.bpm.engine.runtime.ProcessInstanceQuery")));
+
     return specs;
   }
 

--- a/code-conversion/recipes/src/main/java/io/camunda/migration/code/recipes/delegate/CleanupDelegateRecipe.java
+++ b/code-conversion/recipes/src/main/java/io/camunda/migration/code/recipes/delegate/CleanupDelegateRecipe.java
@@ -10,6 +10,7 @@ package io.camunda.migration.code.recipes.delegate;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
+import io.camunda.migration.code.recipes.utils.RecipeUtils;
 import org.openrewrite.*;
 import org.openrewrite.java.*;
 import org.openrewrite.java.search.UsesType;
@@ -47,18 +48,21 @@ public class CleanupDelegateRecipe extends Recipe {
           public J.ClassDeclaration visitClassDeclaration(
               @NonNull J.ClassDeclaration classDecl, ExecutionContext ctx) {
 
-            // Skip interfaces
+            // Skip interfaces, but keep traversing so nested types are still visited.
             if (classDecl.getKind() != J.ClassDeclaration.Kind.Type.Class) {
-              return classDecl;
+              return super.visitClassDeclaration(classDecl, ctx);
             }
 
-            // Filter out the interface to remove
+            // Preserve delegate code when migration already warned that the body could not be
+            // copied automatically, so users can still migrate it manually.
+            if (hasDelegateBodyWarning(classDecl)) {
+              return super.visitClassDeclaration(classDecl, ctx);
+            }
+
+            // Filter out the JavaDelegate interface and any subinterfaces of it
             List<TypeTree> updatedImplements = classDecl.getImplements() == null ? Collections.emptyList() :
                 classDecl.getImplements().stream()
-                    .filter(
-                        id ->
-                            !TypeUtils.isOfClassType(
-                                id.getType(), "org.camunda.bpm.engine.delegate.JavaDelegate"))
+                    .filter(id -> !isJavaDelegateAssignable(id.getType()))
                     .collect(Collectors.toList());
 
             List<Statement> filteredStatements =
@@ -75,6 +79,23 @@ public class CleanupDelegateRecipe extends Recipe {
             return classDecl
                 .withBody(classDecl.getBody().withStatements(filteredStatements))
                 .withImplements(updatedImplements.isEmpty() ? null : updatedImplements);
+          }
+
+          private boolean hasDelegateBodyWarning(J.ClassDeclaration classDecl) {
+            List<Comment> comments =
+                classDecl.getComments() == null ? Collections.emptyList() : classDecl.getComments();
+            return comments.stream()
+                .filter(c -> c instanceof TextComment)
+                .map(c -> (TextComment) c)
+                .anyMatch(
+                    c ->
+                        c.getText().contains(
+                            MigrateExecutionRecipe.DELEGATE_BODY_COPY_WARNING_SENTINEL));
+          }
+
+          private boolean isJavaDelegateAssignable(JavaType type) {
+            return RecipeUtils.isAssignableTo(
+                type, "org.camunda.bpm.engine.delegate.JavaDelegate");
           }
         });
   }

--- a/code-conversion/recipes/src/main/java/io/camunda/migration/code/recipes/delegate/MigrateExecutionRecipe.java
+++ b/code-conversion/recipes/src/main/java/io/camunda/migration/code/recipes/delegate/MigrateExecutionRecipe.java
@@ -19,8 +19,16 @@ import org.openrewrite.*;
 import org.openrewrite.java.*;
 import org.openrewrite.java.search.UsesType;
 import org.openrewrite.java.tree.*;
+import org.openrewrite.marker.Markers;
 
 public class MigrateExecutionRecipe extends Recipe {
+
+  /**
+   * Sentinel shared with cleanup recipes so that warning comments about lost delegate business
+   * logic can be detected reliably.
+   */
+  public static final String DELEGATE_BODY_COPY_WARNING_SENTINEL =
+      "The delegate body could not be copied automatically";
 
   /** Instantiates a new instance. */
   public MigrateExecutionRecipe() {}
@@ -62,11 +70,11 @@ public class MigrateExecutionRecipe extends Recipe {
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
 
-      // define preconditions
+      // Only run on classes that implement JavaDelegate. Requiring the @JobWorker annotation here
+      // is fragile because the annotation is injected by AllDelegatePrepareRecipes, and newer
+      // OpenRewrite versions may evaluate this precondition against an outdated LST.
       TreeVisitor<?, ExecutionContext> check =
-          Preconditions.and(
-              new UsesType<>("io.camunda.client.annotation.JobWorker", true),
-              new UsesType<>("org.camunda.bpm.engine.delegate.JavaDelegate", true));
+          new UsesType<>("org.camunda.bpm.engine.delegate.JavaDelegate", true);
 
       return Preconditions.check(
           check,
@@ -80,54 +88,133 @@ public class MigrateExecutionRecipe extends Recipe {
                 return super.visitClassDeclaration(classDeclaration, ctx);
               }
 
-              List<Statement> currentStatements = classDeclaration.getBody().getStatements();
-              List<Statement> updatedStatements = new ArrayList<>();
-
-              // find delegate method
-              J.Block delegateBody = null;
-              for (Statement stmt : currentStatements) {
-                if (stmt instanceof J.MethodDeclaration methDecl
-                    && methDecl.getSimpleName().equals("execute")) {
-                  delegateBody = methDecl.getBody();
-                }
+              if (!isJavaDelegateAssignable(classDeclaration)) {
+                return super.visitClassDeclaration(classDeclaration, ctx);
               }
 
-              // find and change job worker method
-              if (delegateBody != null) {
-                for (Statement stmt : currentStatements) {
-                  if (stmt instanceof J.MethodDeclaration methDecl
-                      && methDecl.getSimpleName().equals("executeJob")) {
-                    J.Block jobWorkerBody = methDecl.getBody();
+              List<Statement> currentStatements = classDeclaration.getBody().getStatements();
+              J.MethodDeclaration delegateMethod = null;
+              J.MethodDeclaration jobWorkerMethod = null;
+              J.MethodDeclaration alreadyMigratedMethod = null;
 
-                    // all current statments (result map and return)
-                    List<Statement> jobWorkerStatements = jobWorkerBody.getStatements();
-
-                    // delegate body
-                    List<Statement> delegateStatements =
-                        new ArrayList<>(delegateBody.getStatements());
-
-                    // combine statements
-                    delegateStatements.add(0, jobWorkerStatements.get(0));
-                    delegateStatements.add(jobWorkerStatements.get(jobWorkerStatements.size() - 1));
-
-                    // put together and rename job worker so recipe does not run twice
-                    updatedStatements.add(
-                        methDecl
-                            .withBody(methDecl.getBody().withStatements(delegateStatements))
-                            .withName(methDecl.getName().withSimpleName("executeJobMigrated"))
-                            .withMethodType(
-                                methDecl.getMethodType().withName("executeJobMigrated")));
-                  } else {
-                    updatedStatements.add(stmt);
+              for (Statement stmt : currentStatements) {
+                if (stmt instanceof J.MethodDeclaration methDecl) {
+                  if (methDecl.getSimpleName().equals("execute")) {
+                    delegateMethod = methDecl;
+                  } else if (methDecl.getSimpleName().equals("executeJob")) {
+                    jobWorkerMethod = methDecl;
+                  } else if (methDecl.getSimpleName().equals("executeJobMigrated")) {
+                    alreadyMigratedMethod = methDecl;
                   }
                 }
-                return classDeclaration.withBody(
-                    classDeclaration.getBody().withStatements(updatedStatements));
               }
-              return super.visitClassDeclaration(classDeclaration, ctx);
+
+              if (alreadyMigratedMethod != null) {
+                // The copy has already happened in a previous cycle; keep traversing in case
+                // there are nested delegate/listener classes that still need to be processed.
+                return super.visitClassDeclaration(classDeclaration, ctx);
+              }
+
+              String warning = null;
+
+              if (delegateMethod != null && jobWorkerMethod != null) {
+                J.Block delegateBody = delegateMethod.getBody();
+                J.Block jobWorkerBody = jobWorkerMethod.getBody();
+
+                boolean canCopy =
+                    delegateBody != null
+                        && jobWorkerBody != null
+                        && jobWorkerBody.getStatements().size() == 2;
+
+                if (canCopy) {
+                  // all current statements (result map and return)
+                  List<Statement> jobWorkerStatements = jobWorkerBody.getStatements();
+
+                  // delegate body
+                  List<Statement> delegateStatements =
+                      new ArrayList<>(delegateBody.getStatements());
+
+                  // combine statements
+                  delegateStatements.add(0, jobWorkerStatements.get(0));
+                  delegateStatements.add(jobWorkerStatements.get(jobWorkerStatements.size() - 1));
+
+                  J.MethodDeclaration migratedJobWorker =
+                      jobWorkerMethod
+                          .withBody(jobWorkerMethod.getBody().withStatements(delegateStatements))
+                          .withName(jobWorkerMethod.getName().withSimpleName("executeJobMigrated"))
+                          .withMethodType(
+                              jobWorkerMethod.getMethodType().withName("executeJobMigrated"));
+
+                  List<Statement> updatedStatements = new ArrayList<>();
+                  for (Statement stmt : currentStatements) {
+                    if (stmt == jobWorkerMethod) {
+                      updatedStatements.add(migratedJobWorker);
+                    } else {
+                      updatedStatements.add(stmt);
+                    }
+                  }
+
+                  return super.visitClassDeclaration(
+                      classDeclaration.withBody(
+                          classDeclaration.getBody().withStatements(updatedStatements)),
+                      ctx);
+                }
+
+                warning =
+                    "Could not copy delegate body: execute(DelegateExecution) or executeJob(ActivatedJob)"
+                        + " is not in the expected shape. "
+                        + DELEGATE_BODY_COPY_WARNING_SENTINEL
+                        + "; migrate the logic manually.";
+              }
+
+              if (warning == null) {
+                if (delegateMethod != null && jobWorkerMethod == null) {
+                  warning =
+                      "The delegate execute(DelegateExecution) method exists, but no generated"
+                          + " executeJob(ActivatedJob) stub was found. The delegate body could not"
+                          + " be copied automatically; migrate it manually.";
+                } else if (delegateMethod == null && jobWorkerMethod != null) {
+                  warning =
+                      "No execute(DelegateExecution) method was found directly in this class. If it"
+                          + " lives in a superclass, "
+                          + DELEGATE_BODY_COPY_WARNING_SENTINEL
+                          + "; migrate it manually.";
+                } else {
+                  warning =
+                      "Neither execute(DelegateExecution) nor executeJob(ActivatedJob) was found."
+                          + " The delegate body could not be copied automatically; migrate it"
+                          + " manually.";
+                }
+              }
+
+              List<Comment> existingComments =
+                  classDeclaration.getComments() == null
+                      ? Collections.emptyList()
+                      : classDeclaration.getComments();
+              boolean alreadyWarned =
+                  existingComments.stream()
+                      .filter(c -> c instanceof TextComment)
+                      .map(c -> (TextComment) c)
+                      .anyMatch(
+                          c -> c.getText().contains(DELEGATE_BODY_COPY_WARNING_SENTINEL));
+              if (alreadyWarned) {
+                // Keep traversing so any nested delegate/listener classes are still processed.
+                return super.visitClassDeclaration(classDeclaration, ctx);
+              }
+
+              List<Comment> updatedComments = new ArrayList<>(existingComments);
+              updatedComments.add(
+                  new TextComment(true, " " + warning, "\n", Markers.EMPTY));
+              return super.visitClassDeclaration(
+                  classDeclaration.withComments(updatedComments), ctx);
             }
           });
     }
+  }
+
+  private static boolean isJavaDelegateAssignable(J.ClassDeclaration classDeclaration) {
+    return RecipeUtils.isAssignableTo(
+        classDeclaration.getType(), "org.camunda.bpm.engine.delegate.JavaDelegate");
   }
 
   private static class CopyExecutionListenerToJobWorkerRecipe extends Recipe {

--- a/code-conversion/recipes/src/main/java/io/camunda/migration/code/recipes/sharedRecipes/AbstractMigrationRecipe.java
+++ b/code-conversion/recipes/src/main/java/io/camunda/migration/code/recipes/sharedRecipes/AbstractMigrationRecipe.java
@@ -312,7 +312,9 @@ public abstract class AbstractMigrationRecipe extends Recipe {
             // visit simple method invocations
             for (ReplacementUtils.SimpleReplacementSpec spec : simpleMethodInvocations) {
 
-              if (spec.matcher().matches(invocation)) {
+              if (spec.matcher().matches(invocation)
+                  && (spec.requiredReceiverMethodNames().isEmpty()
+                      || hasAnyMethodInReceiverChain(invocation, spec.requiredReceiverMethodNames()))) {
 
                 spec.maybeRemoveImports().forEach(this::maybeRemoveImport);
                 spec.maybeAddImports().forEach(this::maybeAddImport);
@@ -354,7 +356,14 @@ public abstract class AbstractMigrationRecipe extends Recipe {
 
                 // loop through pattern options
                 for (ReplacementUtils.BuilderReplacementSpec spec : entry.getValue()) {
-                  if (collectedArgs.keySet().equals(spec.methodNamesToExtractParameters())) {
+                  if (collectedArgs.keySet().equals(spec.methodNamesToExtractParameters())
+                      && spec.receiverTypeFqn()
+                          .map(
+                              fqn ->
+                                  invocation.getSelect() != null
+                                      && TypeUtils.isOfClassType(
+                                          invocation.getSelect().getType(), fqn))
+                          .orElse(true)) {
 
                     spec.maybeRemoveImports().forEach(this::maybeRemoveImport);
                     spec.maybeAddImports().forEach(this::maybeAddImport);
@@ -455,6 +464,18 @@ public abstract class AbstractMigrationRecipe extends Recipe {
 
             // no match, continue tree traversal
             return super.visitMethodInvocation(invocation, ctx);
+          }
+
+          private boolean hasAnyMethodInReceiverChain(
+              J.MethodInvocation invocation, Set<String> methodNames) {
+            Expression current = invocation.getSelect();
+            while (current instanceof J.MethodInvocation mi) {
+              if (methodNames.contains(mi.getSimpleName())) {
+                return true;
+              }
+              current = mi.getSelect();
+            }
+            return false;
           }
 
           @Override

--- a/code-conversion/recipes/src/main/java/io/camunda/migration/code/recipes/utils/RecipeUtils.java
+++ b/code-conversion/recipes/src/main/java/io/camunda/migration/code/recipes/utils/RecipeUtils.java
@@ -163,4 +163,34 @@ public class RecipeUtils {
 
     return joiner + "";
   }
+
+  /**
+   * Checks whether the given type is assignable to the supplied fully-qualified class name, walking
+   * supertypes and interfaces recursively.
+   */
+  public static boolean isAssignableTo(JavaType type, String fullyQualifiedName) {
+    return type != null && isAssignableTo(type, fullyQualifiedName, new HashSet<>());
+  }
+
+  private static boolean isAssignableTo(
+      JavaType type, String fullyQualifiedName, Set<String> visited) {
+    if (!visited.add(type.toString())) {
+      return false;
+    }
+    if (TypeUtils.isOfClassType(type, fullyQualifiedName)) {
+      return true;
+    }
+    if (type instanceof JavaType.FullyQualified fullyQualified) {
+      JavaType.FullyQualified supertype = fullyQualified.getSupertype();
+      if (supertype != null && isAssignableTo(supertype, fullyQualifiedName, visited)) {
+        return true;
+      }
+      for (JavaType.FullyQualified iface : fullyQualified.getInterfaces()) {
+        if (isAssignableTo(iface, fullyQualifiedName, visited)) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
 }

--- a/code-conversion/recipes/src/main/java/io/camunda/migration/code/recipes/utils/ReplacementUtils.java
+++ b/code-conversion/recipes/src/main/java/io/camunda/migration/code/recipes/utils/ReplacementUtils.java
@@ -30,6 +30,10 @@ public class ReplacementUtils {
     List<String> maybeRemoveImports();
 
     List<String> maybeAddImports();
+
+    default Optional<String> receiverTypeFqn() {
+      return Optional.empty();
+    }
   }
 
   public record SimpleReplacementSpec(
@@ -41,8 +45,32 @@ public class ReplacementUtils {
       List<NamedArg> argumentIndexes,
       List<String> textComments,
       List<String> maybeRemoveImports,
-      List<String> maybeAddImports)
+      List<String> maybeAddImports,
+      Set<String> requiredReceiverMethodNames)
       implements ReplacementSpec {
+    public SimpleReplacementSpec(
+        MethodMatcher matcher,
+        JavaTemplate template,
+        J.Identifier baseIdentifier,
+        String returnTypeFqn,
+        ReturnTypeStrategy returnTypeStrategy,
+        List<NamedArg> argumentIndexes,
+        List<String> textComments,
+        List<String> maybeRemoveImports,
+        List<String> maybeAddImports) {
+      this(
+          matcher,
+          template,
+          baseIdentifier,
+          returnTypeFqn,
+          returnTypeStrategy,
+          argumentIndexes,
+          textComments,
+          maybeRemoveImports,
+          maybeAddImports,
+          Collections.emptySet());
+    }
+
     public SimpleReplacementSpec(
         MethodMatcher matcher,
         JavaTemplate template,
@@ -60,7 +88,8 @@ public class ReplacementUtils {
           argumentIndexes,
           textComments,
           Collections.emptyList(), // default maybeRemoveImports
-          Collections.emptyList() // default maybeAddImports
+          Collections.emptyList(), // default maybeAddImports
+          Collections.emptySet() // default requiredReceiverMethodNames
           );
     }
 
@@ -80,7 +109,8 @@ public class ReplacementUtils {
           argumentIndexes,
           Collections.emptyList(), // default textComments
           Collections.emptyList(), // default maybeRemoveImports
-          Collections.emptyList() // default maybeAddImports
+          Collections.emptyList(), // default maybeAddImports
+          Collections.emptySet() // default requiredReceiverMethodNames
           );
     }
 
@@ -101,8 +131,34 @@ public class ReplacementUtils {
       ReturnTypeStrategy returnTypeStrategy,
       List<String> textComments,
       List<String> maybeRemoveImports,
-      List<String> maybeAddImports)
+      List<String> maybeAddImports,
+      Optional<String> receiverTypeFqn)
       implements ReplacementSpec {
+    public BuilderReplacementSpec(
+        MethodMatcher matcher,
+        Set<String> methodNamesToExtractParameters,
+        List<String> extractedParametersToApply,
+        JavaTemplate template,
+        J.Identifier baseIdentifier,
+        String returnTypeFqn,
+        ReturnTypeStrategy returnTypeStrategy,
+        List<String> textComments,
+        List<String> maybeRemoveImports,
+        List<String> maybeAddImports) {
+      this(
+          matcher,
+          methodNamesToExtractParameters,
+          extractedParametersToApply,
+          template,
+          baseIdentifier,
+          returnTypeFqn,
+          returnTypeStrategy,
+          textComments,
+          maybeRemoveImports,
+          maybeAddImports,
+          Optional.empty());
+    }
+
     public BuilderReplacementSpec(
         MethodMatcher matcher,
         Set<String> methodNamesToExtractParameters,

--- a/code-conversion/recipes/src/test/java/io/camunda/migration/code/recipes/client/migrate/ReplaceProcessInstanceQueryMethodsTest.java
+++ b/code-conversion/recipes/src/test/java/io/camunda/migration/code/recipes/client/migrate/ReplaceProcessInstanceQueryMethodsTest.java
@@ -41,22 +41,26 @@ public class HandleProcessInstanceQueryMethodsTestClass {
 
     @Autowired
     private CamundaClient camundaClient;
-    
+
     public void processInstanceQueryMethods(String activityIdIn, String businessKey, String processDefinitionKey) {
-    
+
         engine.getRuntimeService().createProcessInstanceQuery()
                 .activityIdIn(activityIdIn)
                 .active()
                 .list();
-                
+
         engine.getRuntimeService().createProcessInstanceQuery()
                .processInstanceBusinessKey(businessKey)
                .active()
                .list();
-               
+
         engine.getRuntimeService().createProcessInstanceQuery()
                .processInstanceBusinessKey(businessKey)
                .processDefinitionKey(processDefinitionKey);
+
+        engine.getRuntimeService().createProcessInstanceQuery()
+               .processDefinitionKey(processDefinitionKey)
+               .list();
     }
 }
 """,
@@ -82,9 +86,9 @@ public class HandleProcessInstanceQueryMethodsTestClass {
 
     @Autowired
     private CamundaClient camundaClient;
-    
+
     public void processInstanceQueryMethods(String activityIdIn, String businessKey, String processDefinitionKey) {
-    
+
         camundaClient
                 .newProcessInstanceSearchRequest()
                 .filter(filter -> filter
@@ -93,8 +97,8 @@ public class HandleProcessInstanceQueryMethodsTestClass {
                 .send()
                 .join()
                 .items();
-                
-        // processInstanceBusinessKey was removed - business key concept changed in Camunda 8
+
+        // TODO: processInstanceBusinessKey was removed - use businessId (Camunda 8.9+) instead
         camundaClient
                 .newProcessInstanceSearchRequest()
                 .filter(filter -> filter
@@ -102,14 +106,158 @@ public class HandleProcessInstanceQueryMethodsTestClass {
                 .send()
                 .join()
                 .items();
-                
-        // processInstanceBusinessKey was removed - business key concept changed in Camunda 8
+
+        // TODO: processInstanceBusinessKey was removed - use businessId (Camunda 8.9+) instead
         camundaClient
                 .newProcessInstanceSearchRequest()
-                .filter(filter -> filter.processDefinitionKey(Long.valueOf(processDefinitionKey)));
+                .filter(filter -> filter.processDefinitionId(processDefinitionKey));
+
+        camundaClient
+                .newProcessInstanceSearchRequest()
+                .filter(filter -> filter
+                        .processDefinitionId(processDefinitionKey))
+                .send()
+                .join()
+                .items();
     }
 }
 """
         ));
+  }
+
+  @Test
+  void doesNotRewriteTaskQueryListChains() {
+    rewriteRun(
+        spec -> spec.recipe(new MigrateProcessInstanceQueryMethodsRecipe()),
+        java(
+            """
+            package org.camunda.community.migration.example;
+
+            import org.camunda.bpm.engine.ProcessEngine;
+            import io.camunda.client.CamundaClient;
+            import org.springframework.beans.factory.annotation.Autowired;
+            import org.springframework.stereotype.Component;
+
+            import java.util.List;
+
+            @Component
+            public class MixedQueryTypesTestClass {
+
+                @Autowired
+                private ProcessEngine engine;
+
+                @Autowired
+                private CamundaClient camundaClient;
+
+                public void mixedQueries(String processDefinitionKey) {
+                    engine.getRuntimeService().createProcessInstanceQuery()
+                            .processDefinitionKey(processDefinitionKey)
+                            .list();
+
+                    engine.getTaskService().createTaskQuery()
+                            .processDefinitionKey(processDefinitionKey)
+                            .list();
+                }
+            }
+            """,
+            """
+            package org.camunda.community.migration.example;
+
+            import org.camunda.bpm.engine.ProcessEngine;
+            import io.camunda.client.CamundaClient;
+            import org.springframework.beans.factory.annotation.Autowired;
+            import org.springframework.stereotype.Component;
+
+            import java.util.List;
+
+            @Component
+            public class MixedQueryTypesTestClass {
+
+                @Autowired
+                private ProcessEngine engine;
+
+                @Autowired
+                private CamundaClient camundaClient;
+
+                public void mixedQueries(String processDefinitionKey) {
+                    camundaClient
+                            .newProcessInstanceSearchRequest()
+                            .filter(filter -> filter
+                                    .processDefinitionId(processDefinitionKey))
+                            .send()
+                            .join()
+                            .items();
+
+                    engine.getTaskService().createTaskQuery()
+                            .processDefinitionKey(processDefinitionKey)
+                            .list();
+                }
+            }
+            """));
+  }
+
+  @Test
+  void warnsWhenBusinessKeyIsCombinedWithProcessDefinitionKey() {
+    rewriteRun(
+        spec -> spec.recipe(new MigrateProcessInstanceQueryMethodsRecipe()),
+        java(
+            """
+            package org.camunda.community.migration.example;
+
+            import io.camunda.client.CamundaClient;
+            import org.camunda.bpm.engine.ProcessEngine;
+            import org.springframework.beans.factory.annotation.Autowired;
+            import org.springframework.stereotype.Component;
+
+            import java.util.List;
+
+            @Component
+            public class CombinedQueryTestClass {
+
+                @Autowired
+                private ProcessEngine engine;
+
+                @Autowired
+                private CamundaClient camundaClient;
+
+                public void combinedQuery(String businessKey, String processDefinitionKey) {
+                    engine.getRuntimeService().createProcessInstanceQuery()
+                            .processInstanceBusinessKey(businessKey)
+                            .processDefinitionKey(processDefinitionKey)
+                            .list();
+                }
+            }
+            """,
+            """
+            package org.camunda.community.migration.example;
+
+            import io.camunda.client.CamundaClient;
+            import org.camunda.bpm.engine.ProcessEngine;
+            import org.springframework.beans.factory.annotation.Autowired;
+            import org.springframework.stereotype.Component;
+
+            import java.util.List;
+
+            @Component
+            public class CombinedQueryTestClass {
+
+                @Autowired
+                private ProcessEngine engine;
+
+                @Autowired
+                private CamundaClient camundaClient;
+
+                public void combinedQuery(String businessKey, String processDefinitionKey) {
+                    // TODO: processInstanceBusinessKey was removed - use businessId (Camunda 8.9+) instead
+                    camundaClient
+                            .newProcessInstanceSearchRequest()
+                            .filter(filter -> filter
+                                    .processDefinitionId(processDefinitionKey))
+                            .send()
+                            .join()
+                            .items();
+                }
+            }
+            """));
   }
 }

--- a/code-conversion/recipes/src/test/java/io/camunda/migration/code/recipes/delegate/JavaDelegateWithClientQueryRecipesTest.java
+++ b/code-conversion/recipes/src/test/java/io/camunda/migration/code/recipes/delegate/JavaDelegateWithClientQueryRecipesTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.migration.code.recipes.delegate;
+
+import static org.openrewrite.java.Assertions.java;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+public class JavaDelegateWithClientQueryRecipesTest implements RewriteTest {
+
+  @Override
+  public void defaults(RecipeSpec spec) {
+    spec.recipeFromResources(
+            "io.camunda.migration.code.recipes.AllClientRecipes",
+            "io.camunda.migration.code.recipes.AllDelegateRecipes")
+        .parser(JavaParser.fromJavaVersion().classpath(JavaParser.runtimeClasspath()));
+  }
+
+  @Test
+  void migrateDelegateWithRuntimeQuery() {
+    rewriteRun(
+        java(
+            """
+            package org.camunda.community.migration.example;
+
+            import org.camunda.bpm.engine.RuntimeService;
+            import org.camunda.bpm.engine.delegate.DelegateExecution;
+            import org.camunda.bpm.engine.delegate.JavaDelegate;
+            import org.springframework.beans.factory.annotation.Autowired;
+            import org.springframework.stereotype.Component;
+
+            @Component
+            public class ExampleWorkflowDelegate implements JavaDelegate {
+
+                @Autowired
+                private RuntimeService runtimeService;
+
+                @Override
+                public void execute(DelegateExecution execution) throws Exception {
+                    boolean proceed = runtimeService.createProcessInstanceQuery()
+                            .processDefinitionKey("example-workflow-process")
+                            .list()
+                            .size() % 2 == 0;
+
+                    Object inputValue = execution.getVariable("inputValue");
+                    System.out.println("ExampleWorkflowDelegate " + inputValue);
+
+                    execution.setVariable("readyToProceed", proceed);
+                }
+            }
+            """,
+            """
+            package org.camunda.community.migration.example;
+
+            import io.camunda.client.CamundaClient;
+            import io.camunda.client.annotation.JobWorker;
+            import io.camunda.client.api.response.ActivatedJob;
+            import org.springframework.beans.factory.annotation.Autowired;
+            import org.springframework.stereotype.Component;
+
+            import java.util.HashMap;
+            import java.util.Map;
+
+            @Component
+            public class ExampleWorkflowDelegate {
+
+                @Autowired
+                private CamundaClient camundaClient;
+
+                @JobWorker(type = "exampleWorkflowDelegate", autoComplete = true)
+                public Map<String, Object> executeJobMigrated(ActivatedJob job) throws Exception {
+                    Map<String, Object> resultMap = new HashMap<>();
+                    boolean proceed = camundaClient
+                            .newProcessInstanceSearchRequest()
+                            .filter(filter -> filter
+                                    .processDefinitionId("example-workflow-process"))
+                            .send()
+                            .join()
+                            .items()
+                            .size() % 2 == 0;
+
+                    Object inputValue = job.getVariable("inputValue");
+                    System.out.println("ExampleWorkflowDelegate " + inputValue);
+
+                    resultMap.put("readyToProceed", proceed);
+                    return resultMap;
+                }
+            }
+            """));
+  }
+}

--- a/code-conversion/recipes/src/test/java/io/camunda/migration/code/recipes/delegate/MigrateExecutionRecipeWarningTest.java
+++ b/code-conversion/recipes/src/test/java/io/camunda/migration/code/recipes/delegate/MigrateExecutionRecipeWarningTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.migration.code.recipes.delegate;
+
+import static org.openrewrite.java.Assertions.java;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+public class MigrateExecutionRecipeWarningTest implements RewriteTest {
+
+  @Override
+  public void defaults(RecipeSpec spec) {
+    spec.recipeFromResources("io.camunda.migration.code.recipes.AllDelegateMigrateRecipes")
+        .parser(JavaParser.fromJavaVersion().classpath(JavaParser.runtimeClasspath()));
+  }
+
+  @Test
+  void warnsWhenJobWorkerStubIsMissing() {
+    rewriteRun(
+        java(
+            """
+            package org.camunda.community.migration.example;
+
+            import org.camunda.bpm.engine.delegate.DelegateExecution;
+            import org.camunda.bpm.engine.delegate.JavaDelegate;
+            import org.springframework.stereotype.Component;
+
+            @Component
+            public class MissingStubDelegate implements JavaDelegate {
+
+                @Override
+                public void execute(DelegateExecution execution) throws Exception {
+                    execution.setVariable("done", true);
+                }
+            }
+            """,
+            """
+            package org.camunda.community.migration.example;
+
+            import org.camunda.bpm.engine.delegate.DelegateExecution;
+            import org.camunda.bpm.engine.delegate.JavaDelegate;
+            import org.springframework.stereotype.Component;
+
+            /* The delegate execute(DelegateExecution) method exists, but no generated executeJob(ActivatedJob) stub was found. The delegate body could not be copied automatically; migrate it manually.*/
+            @Component
+            public class MissingStubDelegate implements JavaDelegate {
+
+                @Override
+                public void execute(DelegateExecution execution) throws Exception {
+                    execution.setVariable("done", true);
+                }
+            }
+            """));
+  }
+
+  @Test
+  void preservesOriginalDelegateWhenAllRecipesWarn() {
+    rewriteRun(
+        spec -> spec.recipeFromResources("io.camunda.migration.code.recipes.AllDelegateRecipes"),
+        java(
+            """
+            package org.camunda.community.migration.example;
+
+            import io.camunda.client.annotation.JobWorker;
+            import io.camunda.client.api.response.ActivatedJob;
+            import org.camunda.bpm.engine.delegate.DelegateExecution;
+            import org.camunda.bpm.engine.delegate.JavaDelegate;
+            import org.springframework.stereotype.Component;
+
+            import java.util.Map;
+
+            @Component
+            public class UnmigratableDelegate implements JavaDelegate {
+
+                @JobWorker(type = "unmigratableDelegate")
+                public Map<String, Object> executeJob(ActivatedJob job) {
+                    return null;
+                }
+
+                @Override
+                public void execute(DelegateExecution execution) throws Exception {
+                    execution.setVariable("done", true);
+                }
+            }
+            """,
+            """
+            package org.camunda.community.migration.example;
+
+            import io.camunda.client.annotation.JobWorker;
+            import io.camunda.client.api.response.ActivatedJob;
+            import org.camunda.bpm.engine.delegate.DelegateExecution;
+            import org.camunda.bpm.engine.delegate.JavaDelegate;
+            import org.springframework.stereotype.Component;
+
+            import java.util.Map;
+
+            /* Could not copy delegate body: execute(DelegateExecution) or executeJob(ActivatedJob) is not in the expected shape. The delegate body could not be copied automatically; migrate the logic manually.*/
+            @Component
+            public class UnmigratableDelegate implements JavaDelegate {
+
+                @JobWorker(type = "unmigratableDelegate")
+                public Map<String, Object> executeJob(ActivatedJob job) {
+                    return null;
+                }
+
+                @Override
+                public void execute(DelegateExecution execution) throws Exception {
+                    execution.setVariable("done", true);
+                }
+            }
+            """));
+  }
+}

--- a/code-conversion/recipes/src/test/java/io/camunda/migration/code/recipes/delegate/SubinterfaceJavaDelegateMigrationTest.java
+++ b/code-conversion/recipes/src/test/java/io/camunda/migration/code/recipes/delegate/SubinterfaceJavaDelegateMigrationTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.migration.code.recipes.delegate;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+
+class SubinterfaceJavaDelegateMigrationTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipeFromResources("io.camunda.migration.code.recipes.AllDelegateRecipes")
+            .parser(JavaParser.fromJavaVersion().classpath(JavaParser.runtimeClasspath()));
+    }
+
+    @Test
+    void rewriteDelegateImplementingSubinterface() {
+        rewriteRun(
+            java(
+                """
+                package org.camunda.community.migration.example;
+
+                import org.camunda.bpm.engine.delegate.JavaDelegate;
+
+                public interface ExampleWorkflowDelegate extends JavaDelegate {
+                }
+                """),
+            java(
+                """
+                package org.camunda.community.migration.example;
+
+                import org.camunda.bpm.engine.delegate.DelegateExecution;
+                import org.springframework.stereotype.Component;
+
+                @Component
+                public class ExampleWorkflowStep implements ExampleWorkflowDelegate {
+
+                    @Override
+                    public void execute(DelegateExecution ctx) throws Exception {
+                        System.out.println(ctx.getVariable("x"));
+                    }
+
+                }
+                """,
+                """
+                package org.camunda.community.migration.example;
+
+                import io.camunda.client.annotation.JobWorker;
+                import io.camunda.client.api.response.ActivatedJob;
+                import org.springframework.stereotype.Component;
+
+                import java.util.HashMap;
+                import java.util.Map;
+
+                @Component
+                public class ExampleWorkflowStep {
+
+                    @JobWorker(type = "exampleWorkflowStep", autoComplete = true)
+                    public Map<String, Object> executeJobMigrated(ActivatedJob job) throws Exception {
+                        Map<String, Object> resultMap = new HashMap<>();
+                        System.out.println(job.getVariable("x"));
+                        return resultMap;
+                    }
+
+                }
+                """));
+    }
+}


### PR DESCRIPTION
Backport of #2092 to the `maintenance/0.3` branch.

Same changes: fixes silent loss of delegate body when `AllClientRecipes` and `AllDelegateRecipes` run together, corrects `processDefinitionKey(String)` → `processDefinitionId(String)` handling, and emits TODOs when `processInstanceBusinessKey` filters are dropped.

All recipe-module tests pass on this branch (78/78).

related to #2085