### PR TITLE
fix(ci): backport Maven Central release fixes to maintenance/0.2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,6 +90,14 @@ jobs:
           git config --global user.email "github-actions[release]"
           git config --global user.name "github-actions[release]@users.noreply.github.com"
 
+      - name: Validate release ref
+        if: ${{ !inputs.ONLY_PUSH_TO_MAVEN_CENTRAL }}
+        run: |
+          if [[ "${GITHUB_REF}" != refs/heads/release/* && "${GITHUB_REF}" != refs/heads/maintenance/* ]]; then
+            echo "::error::Full releases must run from a release/* or maintenance/* branch. Use ONLY_PUSH_TO_MAVEN_CENTRAL=true to publish an existing release tag to Maven Central without running release:prepare."
+            exit 1
+          fi
+
       - name: Install Maven Central GPG Key
         # setup-maven supports this as well but needs the key in the armor ascii format,
         # while we only have it plain bas64 encoded
@@ -170,8 +178,8 @@ jobs:
             -Darguments='-DskipTests=true -Dskip.central.release=true -Dskip.camunda.release=${SKIP_REPO_DEPLOY}'
 
       - name: Checkout Code
-        # Tag does not exist if dry run
-        if: ${{ !inputs.IS_DRY_RUN }}
+        # The release tag exists for backfills even when running a dry run.
+        if: ${{ inputs.ONLY_PUSH_TO_MAVEN_CENTRAL || !inputs.IS_DRY_RUN }}
         uses: actions/checkout@v7
         with:
           # Checkout the release tag to perform a second deployment 
@@ -187,13 +195,64 @@ jobs:
             -Dgpg.passphrase="${{ steps.secrets.outputs.MAVEN_CENTRAL_GPG_SIGNING_KEY_PASSPHRASE }}" \
             -DlocalCheckout=${{ inputs.IS_DRY_RUN }} \
             -Pcentral-sonatype-publish,central-release \
-            -DskipTests=true -Dskip.central.release=${SKIP_REPO_DEPLOY} -Dskip.camunda.release=true
+            -DskipTests=true \
+            -Dskip.central.release=${SKIP_REPO_DEPLOY} \
+            -Dskip.camunda.release=true \
+            -DautoPublish=true \
+            -DwaitUntil=published
+
+      - name: Verify Maven Central publication
+        if: ${{ !inputs.IS_DRY_RUN }}
+        run: |
+          set -euo pipefail
+
+          artifacts=(
+            "io/camunda/camunda-7-to-8-migration-tooling-root/${RELEASE_VERSION}/camunda-7-to-8-migration-tooling-root-${RELEASE_VERSION}.pom"
+            "io/camunda/camunda-7-to-8-code-conversion-parent/${RELEASE_VERSION}/camunda-7-to-8-code-conversion-parent-${RELEASE_VERSION}.pom"
+            "io/camunda/camunda-7-to-8-code-conversion-recipes/${RELEASE_VERSION}/camunda-7-to-8-code-conversion-recipes-${RELEASE_VERSION}.jar"
+            "io/camunda/camunda-7-to-8-code-conversion-recipes/${RELEASE_VERSION}/camunda-7-to-8-code-conversion-recipes-${RELEASE_VERSION}.pom"
+            "io/camunda/camunda-7-to-8-data-migrator-parent/${RELEASE_VERSION}/camunda-7-to-8-data-migrator-parent-${RELEASE_VERSION}.pom"
+            "io/camunda/camunda-7-to-8-data-migrator-core/${RELEASE_VERSION}/camunda-7-to-8-data-migrator-core-${RELEASE_VERSION}.jar"
+            "io/camunda/camunda-7-to-8-data-migrator-core/${RELEASE_VERSION}/camunda-7-to-8-data-migrator-core-${RELEASE_VERSION}.pom"
+            "io/camunda/camunda-7-to-8-data-migrator-cockpit-plugin/${RELEASE_VERSION}/camunda-7-to-8-data-migrator-cockpit-plugin-${RELEASE_VERSION}.jar"
+            "io/camunda/camunda-7-to-8-data-migrator-cockpit-plugin/${RELEASE_VERSION}/camunda-7-to-8-data-migrator-cockpit-plugin-${RELEASE_VERSION}.pom"
+            "io/camunda/camunda-7-to-8-diagram-converter-parent/${RELEASE_VERSION}/camunda-7-to-8-diagram-converter-parent-${RELEASE_VERSION}.pom"
+            "io/camunda/camunda-7-to-8-diagram-converter-core/${RELEASE_VERSION}/camunda-7-to-8-diagram-converter-core-${RELEASE_VERSION}.jar"
+            "io/camunda/camunda-7-to-8-diagram-converter-core/${RELEASE_VERSION}/camunda-7-to-8-diagram-converter-core-${RELEASE_VERSION}.pom"
+            "io/camunda/camunda-7-to-8-diagram-converter-webapp/${RELEASE_VERSION}/camunda-7-to-8-diagram-converter-webapp-${RELEASE_VERSION}.jar"
+            "io/camunda/camunda-7-to-8-diagram-converter-webapp/${RELEASE_VERSION}/camunda-7-to-8-diagram-converter-webapp-${RELEASE_VERSION}.pom"
+            "io/camunda/camunda-7-to-8-diagram-converter-cli/${RELEASE_VERSION}/camunda-7-to-8-diagram-converter-cli-${RELEASE_VERSION}.jar"
+            "io/camunda/camunda-7-to-8-diagram-converter-cli/${RELEASE_VERSION}/camunda-7-to-8-diagram-converter-cli-${RELEASE_VERSION}.pom"
+          )
+
+          for attempt in {1..30}; do
+            missing=()
+            for artifact in "${artifacts[@]}"; do
+              if ! curl --fail --head --location --silent --show-error \
+                --connect-timeout 10 --max-time 30 \
+                "https://repo.maven.apache.org/maven2/${artifact}" >/dev/null; then
+                missing+=("${artifact}")
+              fi
+            done
+
+            if ((${#missing[@]} == 0)); then
+              echo "All Maven Central artifacts for ${RELEASE_VERSION} are available."
+              exit 0
+            fi
+
+            echo "::notice::Maven Central propagation is incomplete for ${RELEASE_VERSION}; ${#missing[@]} artifact(s) are still unavailable (attempt ${attempt}/30)."
+            sleep 20
+          done
+
+          echo "::error::Maven Central publication verification failed for ${RELEASE_VERSION}."
+          printf 'Missing artifact: %s\n' "${missing[@]}"
+          exit 1
 
   docker-image:
     name: Build and Publish Docker Image
     runs-on: ubuntu-latest
     needs: release
-    if: ${{ !inputs.IS_DRY_RUN }}
+    if: ${{ !inputs.IS_DRY_RUN && !inputs.ONLY_PUSH_TO_MAVEN_CENTRAL }}
     timeout-minutes: 30
 
     steps:

--- a/README.md
+++ b/README.md
@@ -80,6 +80,33 @@ Every source file must contain the license header. See [license header template]
 5. Update documentation if needed
 6. Submit a pull request with a clear description
 
+## Releasing
+
+The `Release` GitHub Actions workflow is the supported way to publish release artifacts.
+
+### Standard release
+
+1. Create a `release/<version>` branch from the commit you want to release, or run from the relevant `maintenance/<line>` branch when releasing an existing maintenance line.
+2. Run the `Release` workflow from that `release/<version>` or `maintenance/<line>` branch with:
+   - `RELEASE_VERSION=<version>`
+   - `DEVELOPMENT_VERSION=<next-version>-SNAPSHOT`
+   - `IS_DRY_RUN=false`
+   - `ONLY_PUSH_TO_MAVEN_CENTRAL=false`
+3. The workflow now auto-publishes the validated Sonatype Central deployment, so no manual "Publish" step is required in the Central UI.
+4. The workflow waits until the deployment is published and verifies that all Maven Central artifacts are available before the release succeeds.
+
+### Backfill Maven Central for an existing tag
+
+If a GitHub release/tag already exists but Maven Central is missing the artifacts, rerun the `Release` workflow with:
+
+- `RELEASE_VERSION=<existing-tag>`
+- `DEVELOPMENT_VERSION=<next-version>-SNAPSHOT` (required workflow input; ignored in backfill mode)
+- `IS_DRY_RUN=false`
+- `ONLY_PUSH_TO_MAVEN_CENTRAL=true`
+
+Run the workflow from the current `maintenance/0.2` branch so it uses the fixed publication workflow, not the old workflow definition stored in the release tag. This mode skips `release:prepare`, checks out the release tag, rebuilds the artifacts from that source, and publishes them to Maven Central only.
+It performs the same publication verification and fails if any expected artifact is still unavailable after the Central propagation timeout.
+
 ## License
 
 The source files in this repository are made available under the [Camunda License Version 1.0](./CAMUNDA-LICENSE-1.0.txt).

--- a/code-conversion/pom.xml
+++ b/code-conversion/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>camunda-7-to-8-migration-tooling-root</artifactId>
-    <version>0.2.6-SNAPSHOT</version>
+    <version>0.2.7-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/code-conversion/recipes/pom.xml
+++ b/code-conversion/recipes/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>camunda-7-to-8-code-conversion-parent</artifactId>
-    <version>0.2.6-SNAPSHOT</version>
+    <version>0.2.7-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/data-migrator/assembly/pom.xml
+++ b/data-migrator/assembly/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>camunda-7-to-8-data-migrator-parent</artifactId>
-    <version>0.2.6-SNAPSHOT</version>
+    <version>0.2.7-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/data-migrator/core/pom.xml
+++ b/data-migrator/core/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>camunda-7-to-8-data-migrator-parent</artifactId>
-    <version>0.2.6-SNAPSHOT</version>
+    <version>0.2.7-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/data-migrator/distro/pom.xml
+++ b/data-migrator/distro/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>camunda-7-to-8-data-migrator-parent</artifactId>
-    <version>0.2.6-SNAPSHOT</version>
+    <version>0.2.7-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/data-migrator/examples/pom.xml
+++ b/data-migrator/examples/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>camunda-7-to-8-data-migrator-parent</artifactId>
-    <version>0.2.6-SNAPSHOT</version>
+    <version>0.2.7-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/data-migrator/examples/variable-interceptor/pom.xml
+++ b/data-migrator/examples/variable-interceptor/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.camunda</groupId>
         <artifactId>camunda-7-to-8-data-migrator-examples</artifactId>
-        <version>0.2.6-SNAPSHOT</version>
+        <version>0.2.7-SNAPSHOT</version>
         <relativePath>../</relativePath>
     </parent>
 
@@ -25,7 +25,7 @@
         <dependency>
             <groupId>io.camunda</groupId>
             <artifactId>camunda-7-to-8-data-migrator-core</artifactId>
-            <version>0.2.6-SNAPSHOT</version>
+            <version>0.2.7-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/data-migrator/plugins/cockpit/pom.xml
+++ b/data-migrator/plugins/cockpit/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>camunda-7-to-8-data-migrator-parent</artifactId>
-    <version>0.2.6-SNAPSHOT</version>
+    <version>0.2.7-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
 

--- a/data-migrator/pom.xml
+++ b/data-migrator/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>camunda-7-to-8-migration-tooling-root</artifactId>
-    <version>0.2.6-SNAPSHOT</version>
+    <version>0.2.7-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/data-migrator/qa/e2e-tests/pom.xml
+++ b/data-migrator/qa/e2e-tests/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>camunda-7-to-8-data-migrator-qa</artifactId>
-    <version>0.2.6-SNAPSHOT</version>
+    <version>0.2.7-SNAPSHOT</version>
   </parent>
 
   <artifactId>camunda-7-to-8-data-migrator-e2e-tests</artifactId>

--- a/data-migrator/qa/integration-tests/pom.xml
+++ b/data-migrator/qa/integration-tests/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>camunda-7-to-8-data-migrator-qa</artifactId>
-    <version>0.2.6-SNAPSHOT</version>
+    <version>0.2.7-SNAPSHOT</version>
   </parent>
 
   <artifactId>camunda-7-to-8-data-migrator-integration-tests</artifactId>

--- a/data-migrator/qa/pom.xml
+++ b/data-migrator/qa/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>camunda-7-to-8-data-migrator-parent</artifactId>
-    <version>0.2.6-SNAPSHOT</version>
+    <version>0.2.7-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/diagram-converter/cli/pom.xml
+++ b/diagram-converter/cli/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>camunda-7-to-8-diagram-converter-parent</artifactId>
-    <version>0.2.6-SNAPSHOT</version>
+    <version>0.2.7-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/diagram-converter/core/pom.xml
+++ b/diagram-converter/core/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>camunda-7-to-8-diagram-converter-parent</artifactId>
-    <version>0.2.6-SNAPSHOT</version>
+    <version>0.2.7-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/diagram-converter/extension-example/pom.xml
+++ b/diagram-converter/extension-example/pom.xml
@@ -4,12 +4,12 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>camunda-7-to-8-diagram-converter-parent</artifactId>
-    <version>0.2.6-SNAPSHOT</version>
+    <version>0.2.7-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 
   <artifactId>camunda-7-to-8-diagram-converter-extension-example</artifactId>
-  <version>0.2.6-SNAPSHOT</version>
+  <version>0.2.7-SNAPSHOT</version>
   <name>camunda-7-to-8-diagram-converter-extension-example</name>
 
   <properties>

--- a/diagram-converter/pom.xml
+++ b/diagram-converter/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>camunda-7-to-8-migration-tooling-root</artifactId>
-    <version>0.2.6-SNAPSHOT</version>
+    <version>0.2.7-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/diagram-converter/webapp/pom.xml
+++ b/diagram-converter/webapp/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>camunda-7-to-8-diagram-converter-parent</artifactId>
-    <version>0.2.6-SNAPSHOT</version>
+    <version>0.2.7-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
   <groupId>io.camunda</groupId>
   <artifactId>camunda-7-to-8-migration-tooling-root</artifactId>
-  <version>0.2.6-SNAPSHOT</version>
+  <version>0.2.7-SNAPSHOT</version>
 
   <packaging>pom</packaging>
 


### PR DESCRIPTION
Backports the Maven Central release workflow and runbook fixes from #2087.

Changes:
- enable Sonatype Central auto-publish and wait for PUBLISHED
- verify published JARs and POMs with bounded retries
- support maintenance release branches and dry-run backfills
- document standard releases and Maven Central backfills
- align the maintenance line to `0.2.7-SNAPSHOT` after the `0.2.6` release

Related to #2087
Related to #2086