### PR TITLE
chore(ci): enable Renovate vulnerability alerts for npm packages

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -68,6 +68,7 @@
     }
   ],
   "vulnerabilityAlerts": {
-    "enabled": false
+    "enabled": true,
+    "addLabels": ["security"]
   }
 }


### PR DESCRIPTION
## Summary

- `renovate.json` had `vulnerabilityAlerts.enabled: false`, so Renovate never auto-opened PRs for known CVEs in npm deps.
- Java vulnerability alerts already worked via Renovate; npm was inconsistent and required manual tracking.

## Changes

- `.github/renovate.json`: set `vulnerabilityAlerts.enabled: true` and add `addLabels: ["security"]`, scoped to the affected version range only (not general updates).

## Test plan

- [ ] Config is valid JSON5 (verified locally by parsing with trailing-comma stripping)
- [ ] Renovate dashboard picks up the change on next scheduled run and opens vuln PRs for npm CVEs going forward

## Baseline

Built from commit: f7f37572a6b7de5a6a7ac0ba8a6a2c5ebd801b0e

closes #1566

🤖 Generated with [Claude Code](https://claude.com/claude-code)