### PR TITLE
fix(ci): wire Maven Central auto-publication

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -208,7 +208,7 @@ jobs:
             -DskipTests=true \
             -Dskip.central.release=${SKIP_REPO_DEPLOY} \
             -Dskip.camunda.release=true \
-            -DautoPublish=true \
+            -Dcentral.autoPublish=true \
             -DwaitUntil=published
 
       - name: Verify Maven Central publication

--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,7 @@
     <nexus.release.repository.id>camunda-artifactory</nexus.release.repository.id>
     <nexus.staging.deploy.id>camunda-artifactory</nexus.staging.deploy.id>
     <central.sonatype.deployment.name>${project.groupId}:${project.artifactId}:${project.version}</central.sonatype.deployment.name>
+    <central.autoPublish>false</central.autoPublish>
   </properties>
 
   <modules>
@@ -258,6 +259,13 @@
     </pluginManagement>
 
     <plugins>
+      <plugin>
+        <groupId>org.sonatype.central</groupId>
+        <artifactId>central-publishing-maven-plugin</artifactId>
+        <configuration>
+          <autoPublish>${central.autoPublish}</autoPublish>
+        </configuration>
+      </plugin>
       <plugin>
         <groupId>com.mycila</groupId>
         <artifactId>license-maven-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,7 @@
     <version.httpcore5>5.4.3</version.httpcore5>
     <plugin.version.compiler>3.15.0</plugin.version.compiler>
     <plugin.version.nexus-staging>1.7.0</plugin.version.nexus-staging>
+    <plugin.version.central-publishing>0.8.0</plugin.version.central-publishing>
     <plugin.version.frontend-maven>2.0.2</plugin.version.frontend-maven>
     <plugin.version.surefire>3.5.6</plugin.version.surefire>
     <plugin.version.failsafe>3.5.6</plugin.version.failsafe>
@@ -208,6 +209,11 @@
           <configuration>
             <stagingProgressTimeoutMinutes>40</stagingProgressTimeoutMinutes>
           </configuration>
+        </plugin>
+        <plugin>
+          <groupId>org.sonatype.central</groupId>
+          <artifactId>central-publishing-maven-plugin</artifactId>
+          <version>${plugin.version.central-publishing}</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
## Summary

- Make the release workflow publish validated Sonatype Central deployments automatically.
- Override the inherited camunda-release-parent default that hard-codes auto-publishing off.

## Changes

- Add a default-off `central.autoPublish` property and wire it into the active root Central publishing plugin configuration.
- Pass `-Dcentral.autoPublish=true` from the Maven Central release step.
- Preserve the existing `waitUntil=published` and Maven Central artifact verification behavior.

## Test plan

- [x] `mvn clean install -DskipTests` with Java 21
- [x] Effective POM confirms `autoPublish=true` for the root and `data-migrator/core` when enabled.
- [x] Effective POM confirms the default remains `autoPublish=false` without the release property.

## Baseline

Built from commit: `b9e0cadcaf40e214b07bd00631385af1b53a377f`