### PR TITLE
fix(ci): backport Maven Central auto-publication to maintenance/0.2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -198,7 +198,7 @@ jobs:
             -DskipTests=true \
             -Dskip.central.release=${SKIP_REPO_DEPLOY} \
             -Dskip.camunda.release=true \
-            -DautoPublish=true \
+            -Dcentral.autoPublish=true \
             -DwaitUntil=published
 
       - name: Verify Maven Central publication

--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,7 @@
     <nexus.release.repository.id>camunda-artifactory</nexus.release.repository.id>
     <nexus.staging.deploy.id>camunda-artifactory</nexus.staging.deploy.id>
     <central.sonatype.deployment.name>${project.groupId}:${project.artifactId}:${project.version}</central.sonatype.deployment.name>
+    <central.autoPublish>false</central.autoPublish>
   </properties>
 
   <modules>
@@ -253,6 +254,13 @@
     </pluginManagement>
 
     <plugins>
+      <plugin>
+        <groupId>org.sonatype.central</groupId>
+        <artifactId>central-publishing-maven-plugin</artifactId>
+        <configuration>
+          <autoPublish>${central.autoPublish}</autoPublish>
+        </configuration>
+      </plugin>
       <plugin>
         <groupId>com.mycila</groupId>
         <artifactId>license-maven-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,7 @@
     <version.commons-lang3>3.20.0</version.commons-lang3>
     <plugin.version.compiler>3.15.0</plugin.version.compiler>
     <plugin.version.nexus-staging>1.7.0</plugin.version.nexus-staging>
+    <plugin.version.central-publishing>0.8.0</plugin.version.central-publishing>
     <plugin.version.frontend-maven>2.0.2</plugin.version.frontend-maven>
     <plugin.version.surefire>3.5.6</plugin.version.surefire>
     <plugin.version.failsafe>3.5.6</plugin.version.failsafe>
@@ -203,6 +204,11 @@
           <configuration>
             <stagingProgressTimeoutMinutes>40</stagingProgressTimeoutMinutes>
           </configuration>
+        </plugin>
+        <plugin>
+          <groupId>org.sonatype.central</groupId>
+          <artifactId>central-publishing-maven-plugin</artifactId>
+          <version>${plugin.version.central-publishing}</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Backports #2140 to maintenance/0.2.

This applies both Maven Central publication fixes:
- use `central.autoPublish` for release publication
- pin `central-publishing-maven-plugin` to 0.8.0

Baseline: `e780d7ab`
Validation: `mvn clean install` on Java 21

related to #2140