### PR TITLE
fix(e2e): stabilize Operate login navigation on main

### DIFF
--- a/data-migrator/qa/e2e-tests/tests/operate-decisions.spec.ts
+++ b/data-migrator/qa/e2e-tests/tests/operate-decisions.spec.ts
@@ -66,7 +66,7 @@ test.describe('Operate - Decision Instances', () => {
   test.setTimeout(180000);
 
   test.beforeEach(async ({ page, context }) => {
-    // Clear cookies and storage to ensure clean state between tests
+    // Clear cookies and permissions to ensure clean state between tests
     await context.clearCookies();
     await context.clearPermissions();
 

--- a/data-migrator/qa/e2e-tests/tests/operate-decisions.spec.ts
+++ b/data-migrator/qa/e2e-tests/tests/operate-decisions.spec.ts
@@ -61,45 +61,48 @@ async function navigateToDecisionByName(page: Page, decisionName: string) {
 test.describe('Operate - Decision Instances', () => {
   // Configure this test suite to run in isolation with its own browser context
   test.describe.configure({ mode: 'serial' });
+  // Firefox can take longer to finish navigation on CI runners. Leave enough
+  // time for the login page to load and for the test body to execute.
+  test.setTimeout(120000);
 
   test.beforeEach(async ({ page, context }) => {
     // Clear cookies and storage to ensure clean state between tests
     await context.clearCookies();
     await context.clearPermissions();
 
-    // Navigate directly to Camunda Operate login page
+    // Navigate directly to Camunda Operate login page. Waiting for the DOM is
+    // sufficient here; waiting for every resource and network-idle can exceed
+    // the default test timeout on slower Firefox CI runners.
     // Note: Operate is running on port 8088 as configured in docker-compose.yml
-    await page.goto('http://localhost:8088/operate/login');
+    await page.goto('http://localhost:8088/operate/login', {
+      waitUntil: 'domcontentloaded',
+      timeout: 60000,
+    });
 
-    // Wait for the page to load
-    await page.waitForLoadState('networkidle');
+    // Wait for the Angular-rendered login form instead of checking visibility
+    // immediately after navigation. A fresh Playwright context has no session,
+    // so Operate should always present the login form here.
+    const usernameInput = page.locator('input[name="username"]');
+    await usernameInput.waitFor({ state: 'visible', timeout: 60000 });
 
-    // Check if we need to log in (login form is visible)
-    const isLoginPage = await page.locator('input[name="username"]').isVisible().catch(() => false);
+    // Fill in login credentials - Camunda 8 default demo user
+    const passwordInput = page.locator('input[name="password"]');
+    const submitButton = page.locator('button[type="submit"]');
 
-    if (isLoginPage) {
-      // Fill in login credentials - Camunda 8 default demo user
-      const usernameInput = page.locator('input[name="username"]');
-      const passwordInput = page.locator('input[name="password"]');
-      const submitButton = page.locator('button[type="submit"]');
+    await usernameInput.fill('demo');
+    await passwordInput.fill('demo');
 
-      await usernameInput.waitFor({ state: 'visible', timeout: 10000 });
+    // Take screenshot before login
+    await page.screenshot({ path: 'test-results/operate-before-login.png', fullPage: true });
 
-      await usernameInput.fill('demo');
-      await passwordInput.fill('demo');
+    await submitButton.click();
 
-      // Take screenshot before login
-      await page.screenshot({ path: 'test-results/operate-before-login.png', fullPage: true });
+    await page.waitForURL((url) => !url.pathname.endsWith('/login'), {
+      timeout: 15000,
+    });
 
-      await submitButton.click();
-
-      await page.waitForURL((url) => !url.pathname.endsWith('/login'), {
-        timeout: 15000,
-      });
-
-      // Take screenshot after login
-      await page.screenshot({ path: 'test-results/operate-after-login.png', fullPage: true });
-    }
+    // Take screenshot after login
+    await page.screenshot({ path: 'test-results/operate-after-login.png', fullPage: true });
   });
 
   test.afterEach(async ({ page, context }) => {

--- a/data-migrator/qa/e2e-tests/tests/operate-decisions.spec.ts
+++ b/data-migrator/qa/e2e-tests/tests/operate-decisions.spec.ts
@@ -63,7 +63,7 @@ test.describe('Operate - Decision Instances', () => {
   test.describe.configure({ mode: 'serial' });
   // Firefox can take longer to finish navigation on CI runners. Leave enough
   // time for the login page to load and for the test body to execute.
-  test.setTimeout(120000);
+  test.setTimeout(180000);
 
   test.beforeEach(async ({ page, context }) => {
     // Clear cookies and storage to ensure clean state between tests

--- a/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/distribution/DistributionSmokeTest.java
+++ b/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/distribution/DistributionSmokeTest.java
@@ -644,8 +644,8 @@ public class DistributionSmokeTest {
       final TimeUnit unit)
       throws InterruptedException {
     final long deadlineNanos = System.nanoTime() + unit.toNanos(timeout);
-    waitForProcessHandlesToExit(List.of(proc.toHandle()), deadlineNanos);
     waitForProcessHandlesToExit(descendants, deadlineNanos);
+    waitForProcessHandlesToExit(List.of(proc.toHandle()), deadlineNanos);
   }
 
   private void waitForProcessHandlesToExit(

--- a/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/distribution/DistributionSmokeTest.java
+++ b/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/distribution/DistributionSmokeTest.java
@@ -644,7 +644,7 @@ public class DistributionSmokeTest {
     }
   }
 
-  protected void waitForDescendantsToExit(
+  private void waitForDescendantsToExit(
       final List<ProcessHandle> descendants, final long timeout, final TimeUnit unit)
       throws InterruptedException {
     final long deadlineNanos = System.nanoTime() + unit.toNanos(timeout);

--- a/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/distribution/DistributionSmokeTest.java
+++ b/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/distribution/DistributionSmokeTest.java
@@ -628,6 +628,11 @@ public class DistributionSmokeTest {
       // Best-effort wait for descendants before restoring the interrupt flag so that
       // file locks are released before @TempDir cleanup. The interrupt flag is clear
       // here, so onExit().get() can block normally.
+      try {
+        proc.onExit().get(1, TimeUnit.SECONDS);
+      } catch (ExecutionException | TimeoutException | InterruptedException ignored) {
+        // best effort
+      }
       for (final ProcessHandle child : descendants) {
         try {
           child.onExit().get(1, TimeUnit.SECONDS);

--- a/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/distribution/DistributionSmokeTest.java
+++ b/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/distribution/DistributionSmokeTest.java
@@ -18,7 +18,10 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 import org.junit.jupiter.api.AfterEach;
@@ -610,16 +613,51 @@ public class DistributionSmokeTest {
     if (proc == null) {
       return;
     }
-    proc.descendants().forEach(ProcessHandle::destroyForcibly);
+    final List<ProcessHandle> descendants = proc.descendants().toList();
+    descendants.forEach(ProcessHandle::destroyForcibly);
     proc.destroy();
     try {
       if (!proc.waitFor(5, TimeUnit.SECONDS)) {
         proc.destroyForcibly();
         proc.waitFor(5, TimeUnit.SECONDS);
       }
+      waitForDescendantsToExit(descendants, 5, TimeUnit.SECONDS);
     } catch (final InterruptedException e) {
-      Thread.currentThread().interrupt();
+      descendants.forEach(ProcessHandle::destroyForcibly);
       proc.destroyForcibly();
+      // Best-effort wait for descendants before restoring the interrupt flag so that
+      // file locks are released before @TempDir cleanup. The interrupt flag is clear
+      // here, so onExit().get() can block normally.
+      for (final ProcessHandle child : descendants) {
+        try {
+          child.onExit().get(1, TimeUnit.SECONDS);
+        } catch (ExecutionException | TimeoutException | InterruptedException ignored) {
+          // best effort
+        }
+      }
+      Thread.currentThread().interrupt();
+    }
+  }
+
+  protected void waitForDescendantsToExit(
+      final List<ProcessHandle> descendants, final long timeout, final TimeUnit unit)
+      throws InterruptedException {
+    final long deadlineNanos = System.nanoTime() + unit.toNanos(timeout);
+    for (final ProcessHandle child : descendants) {
+      while (child.isAlive() && System.nanoTime() < deadlineNanos) {
+        Thread.sleep(50);
+      }
+      if (child.isAlive()) {
+        child.destroyForcibly();
+        final long remainingNanos = deadlineNanos - System.nanoTime();
+        try {
+          if (remainingNanos > 0) {
+            child.onExit().get(remainingNanos, TimeUnit.NANOSECONDS);
+          }
+        } catch (ExecutionException | TimeoutException ignored) {
+          // best effort: process termination was already requested
+        }
+      }
     }
   }
 }

--- a/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/distribution/DistributionSmokeTest.java
+++ b/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/distribution/DistributionSmokeTest.java
@@ -620,9 +620,8 @@ public class DistributionSmokeTest {
     try {
       if (!proc.waitFor(5, TimeUnit.SECONDS)) {
         proc.destroyForcibly();
-        proc.waitFor(5, TimeUnit.SECONDS);
       }
-      waitForDescendantsToExit(descendants, 5, TimeUnit.SECONDS);
+      waitForProcessTreeToExit(proc, descendants, 5, TimeUnit.SECONDS);
     } catch (final InterruptedException e) {
       descendants.forEach(ProcessHandle::destroyForcibly);
       proc.destroyForcibly();
@@ -630,10 +629,7 @@ public class DistributionSmokeTest {
       // file locks are released before @TempDir cleanup. The interrupt flag is clear
       // here, so onExit().get() can block normally.
       try {
-        final long cleanupDeadlineNanos =
-            System.nanoTime() + TimeUnit.SECONDS.toNanos(5);
-        waitForProcessHandlesToExit(List.of(proc.toHandle()), cleanupDeadlineNanos);
-        waitForProcessHandlesToExit(descendants, cleanupDeadlineNanos);
+        waitForProcessTreeToExit(proc, descendants, 5, TimeUnit.SECONDS);
       } catch (InterruptedException ignored) {
         // best effort
       }
@@ -641,11 +637,15 @@ public class DistributionSmokeTest {
     }
   }
 
-  private void waitForDescendantsToExit(
-      final List<ProcessHandle> descendants, final long timeout, final TimeUnit unit)
+  private void waitForProcessTreeToExit(
+      final Process proc,
+      final List<ProcessHandle> descendants,
+      final long timeout,
+      final TimeUnit unit)
       throws InterruptedException {
-    waitForProcessHandlesToExit(
-        descendants, System.nanoTime() + unit.toNanos(timeout));
+    final long deadlineNanos = System.nanoTime() + unit.toNanos(timeout);
+    waitForProcessHandlesToExit(List.of(proc.toHandle()), deadlineNanos);
+    waitForProcessHandlesToExit(descendants, deadlineNanos);
   }
 
   private void waitForProcessHandlesToExit(

--- a/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/distribution/DistributionSmokeTest.java
+++ b/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/distribution/DistributionSmokeTest.java
@@ -626,20 +626,16 @@ public class DistributionSmokeTest {
     } catch (final InterruptedException e) {
       descendants.forEach(ProcessHandle::destroyForcibly);
       proc.destroyForcibly();
-      // Best-effort wait for descendants before restoring the interrupt flag so that
+      // Best-effort wait for the parent and descendants before restoring the interrupt flag so that
       // file locks are released before @TempDir cleanup. The interrupt flag is clear
       // here, so onExit().get() can block normally.
       try {
-        proc.onExit().get(1, TimeUnit.SECONDS);
-      } catch (ExecutionException | TimeoutException | InterruptedException ignored) {
+        final long cleanupDeadlineNanos =
+            System.nanoTime() + TimeUnit.SECONDS.toNanos(5);
+        waitForProcessHandlesToExit(List.of(proc.toHandle()), cleanupDeadlineNanos);
+        waitForProcessHandlesToExit(descendants, cleanupDeadlineNanos);
+      } catch (InterruptedException ignored) {
         // best effort
-      }
-      for (final ProcessHandle child : descendants) {
-        try {
-          child.onExit().get(1, TimeUnit.SECONDS);
-        } catch (ExecutionException | TimeoutException | InterruptedException ignored) {
-          // best effort
-        }
       }
       Thread.currentThread().interrupt();
     }
@@ -648,23 +644,29 @@ public class DistributionSmokeTest {
   private void waitForDescendantsToExit(
       final List<ProcessHandle> descendants, final long timeout, final TimeUnit unit)
       throws InterruptedException {
-    final long deadlineNanos = System.nanoTime() + unit.toNanos(timeout);
-    for (final ProcessHandle child : descendants) {
+    waitForProcessHandlesToExit(
+        descendants, System.nanoTime() + unit.toNanos(timeout));
+  }
+
+  private void waitForProcessHandlesToExit(
+      final List<ProcessHandle> processes, final long deadlineNanos)
+      throws InterruptedException {
+    for (final ProcessHandle process : processes) {
       final long remainingNanos = deadlineNanos - System.nanoTime();
       if (remainingNanos <= 0) {
-        child.destroyForcibly();
+        process.destroyForcibly();
         continue;
       }
       try {
-        child.onExit().get(remainingNanos, TimeUnit.NANOSECONDS);
+        process.onExit().get(remainingNanos, TimeUnit.NANOSECONDS);
       } catch (ExecutionException ignored) {
         // process state is already terminal
       } catch (TimeoutException ignored) {
-        child.destroyForcibly();
+        process.destroyForcibly();
         final long remainingAfterDestroyNanos = deadlineNanos - System.nanoTime();
         try {
           if (remainingAfterDestroyNanos > 0) {
-            child.onExit().get(remainingAfterDestroyNanos, TimeUnit.NANOSECONDS);
+            process.onExit().get(remainingAfterDestroyNanos, TimeUnit.NANOSECONDS);
           }
         } catch (ExecutionException | TimeoutException ignoredAfterDestroy) {
           // best effort: process termination was already requested

--- a/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/distribution/DistributionSmokeTest.java
+++ b/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/distribution/DistributionSmokeTest.java
@@ -607,7 +607,8 @@ public class DistributionSmokeTest {
    * spawns a child JVM that holds file locks on the extracted JARs; {@link Process#destroy()} only
    * kills the {@code cmd.exe} parent. Descendants are destroyed first, then the parent, with a
    * {@link Process#destroyForcibly()} fallback. {@link InterruptedException} from {@code waitFor}
-   * restores the interrupt flag and triggers an immediate forcible kill so cleanup always completes.
+   * triggers forcible termination followed by bounded best-effort waits for the parent and
+   * descendants before restoring the interrupt flag, allowing file locks to be released.
    */
   protected void destroyProcessTree(final Process proc) {
     if (proc == null) {

--- a/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/distribution/DistributionSmokeTest.java
+++ b/data-migrator/qa/integration-tests/src/test/java/io/camunda/migration/data/qa/distribution/DistributionSmokeTest.java
@@ -650,17 +650,23 @@ public class DistributionSmokeTest {
       throws InterruptedException {
     final long deadlineNanos = System.nanoTime() + unit.toNanos(timeout);
     for (final ProcessHandle child : descendants) {
-      while (child.isAlive() && System.nanoTime() < deadlineNanos) {
-        Thread.sleep(50);
-      }
-      if (child.isAlive()) {
+      final long remainingNanos = deadlineNanos - System.nanoTime();
+      if (remainingNanos <= 0) {
         child.destroyForcibly();
-        final long remainingNanos = deadlineNanos - System.nanoTime();
+        continue;
+      }
+      try {
+        child.onExit().get(remainingNanos, TimeUnit.NANOSECONDS);
+      } catch (ExecutionException ignored) {
+        // process state is already terminal
+      } catch (TimeoutException ignored) {
+        child.destroyForcibly();
+        final long remainingAfterDestroyNanos = deadlineNanos - System.nanoTime();
         try {
-          if (remainingNanos > 0) {
-            child.onExit().get(remainingNanos, TimeUnit.NANOSECONDS);
+          if (remainingAfterDestroyNanos > 0) {
+            child.onExit().get(remainingAfterDestroyNanos, TimeUnit.NANOSECONDS);
           }
-        } catch (ExecutionException | TimeoutException ignored) {
+        } catch (ExecutionException | TimeoutException ignoredAfterDestroy) {
           // best effort: process termination was already requested
         }
       }


### PR DESCRIPTION
## Summary
Backport the Operate login navigation stabilization included in the 0.3.6 release back-merge (#2152) to `main`.

The decisions E2E suite now avoids `networkidle` on login, waits explicitly for the Angular-rendered login form, allows longer Firefox CI navigation time, and waits for the post-login URL transition.

The PR also includes Windows distribution smoke-test process cleanup hardening. The first `main` CI run exposed child-JVM file locks during `@TempDir` cleanup; this is the CI stabilization needed alongside the backported login fix and keeps the same release-line stabilization green on Windows.

## Validation
- `mvn clean install` with Java 21 on baseline `a8ca6b298fffb21739933c399e04d456c446e080`
- `npm run typecheck`
- `npm run check:type-escapes`
- `mvn test -Pintegration -pl data-migrator/qa/integration-tests -Dtest=DistributionSmokeTest`

Source fix: `0befe749067d650b7de27687b0a6bf3da75e4e70`.