### PR TITLE
fix(deps): pin httpclient5 to 5.6.3 [maintenance/0.3]

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,7 @@
     <version.node>v22.22.2</version.node>
     <version.npm>10.8.2</version.npm>
     <version.httpcore5>5.4.3</version.httpcore5>
+    <version.httpclient5>5.6.3</version.httpclient5>
     <plugin.version.compiler>3.15.0</plugin.version.compiler>
     <plugin.version.nexus-staging>1.7.0</plugin.version.nexus-staging>
     <plugin.version.central-publishing>0.11.0</plugin.version.central-publishing>
@@ -141,6 +142,12 @@
         <groupId>org.apache.httpcomponents.core5</groupId>
         <artifactId>httpcore5-h2</artifactId>
         <version>${version.httpcore5}</version>
+      </dependency>
+      <!-- CVE-2026-64607: pin httpclient5 to the version containing the classic I/O connection release fix -->
+      <dependency>
+        <groupId>org.apache.httpcomponents.client5</groupId>
+        <artifactId>httpclient5</artifactId>
+        <version>${version.httpclient5}</version>
       </dependency>
       <!-- CVE-2026-13006: pin logback to 1.5.37 (a property override alone is a no-op against modules that pull logback in via an imported spring-boot-dependencies BOM) -->
       <dependency>


### PR DESCRIPTION
## Summary

- Pin `org.apache.httpcomponents.client5:httpclient5` to 5.6.3 to address CVE-2026-64607.

## Changes

- Add an explicit root dependency-management entry so the Spring Boot BOM cannot select a vulnerable version.

## Test plan

- [x] `JAVA_HOME=/opt/homebrew/opt/openjdk@21 mvn clean install -DskipTests`
- [x] `JAVA_HOME=/opt/homebrew/opt/openjdk@21 mvn test -pl data-migrator/core -am`
- [x] Dependency tree resolves `httpclient5:5.6.3`.

## Baseline

- Session baseline: `be37c0c5`
- PR base: `72e57fd5` (`maintenance/0.3`)