### PR TITLE
fix(deps): pin httpclient5 to 5.6.3 [main]

### DIFF
--- a/code-conversion/patterns/10-general/dependencies.md
+++ b/code-conversion/patterns/10-general/dependencies.md
@@ -26,7 +26,7 @@ Also, configure your connection to the Camunda 8 cluster in the `application.pro
 
 **Java client artifact**: Use `io.camunda:camunda-client-java`. The legacy `io.camunda:zeebe-client-java` artifact is deprecated and will be discontinued in Camunda 8.10.
 
-**Spring Boot 3.5.x and Apache HttpClient**: Spring Boot 3.5.x may manage `org.apache.httpcomponents.client5:httpclient5` to `5.5.2`, while `io.camunda:camunda-client-java` 8.9.13 requires `5.6.1` or later. This mismatch can prevent the `CamundaClient` bean from starting with a `NoSuchMethodError`; versions before 5.6.3 also contain CVE-2026-64607. Until the upstream dependency alignment is fixed, override the managed version in the application:
+**Spring Boot 3.5.x and Apache HttpClient**: Spring Boot 3.5.x may manage `org.apache.httpcomponents.client5:httpclient5` to `5.5.2`, while `io.camunda:camunda-client-java` 8.9.13 requires `5.6.1` or later for API compatibility. This mismatch can prevent the `CamundaClient` bean from starting with a `NoSuchMethodError`; `5.6.3` is the minimum version that also addresses CVE-2026-64607. Until the upstream dependency alignment is fixed, override the managed version in the application:
 
 ```
 <dependencyManagement>

--- a/code-conversion/patterns/10-general/dependencies.md
+++ b/code-conversion/patterns/10-general/dependencies.md
@@ -26,7 +26,7 @@ Also, configure your connection to the Camunda 8 cluster in the `application.pro
 
 **Java client artifact**: Use `io.camunda:camunda-client-java`. The legacy `io.camunda:zeebe-client-java` artifact is deprecated and will be discontinued in Camunda 8.10.
 
-**Spring Boot 3.5.x and Apache HttpClient**: Spring Boot 3.5.x may manage `org.apache.httpcomponents.client5:httpclient5` to `5.5.2`, while `io.camunda:camunda-client-java` 8.9.13 requires `5.6.1` or later. This mismatch can prevent the `CamundaClient` bean from starting with a `NoSuchMethodError`. Until the upstream dependency alignment is fixed, override the managed version in the application:
+**Spring Boot 3.5.x and Apache HttpClient**: Spring Boot 3.5.x may manage `org.apache.httpcomponents.client5:httpclient5` to `5.5.2`, while `io.camunda:camunda-client-java` 8.9.13 requires `5.6.1` or later. This mismatch can prevent the `CamundaClient` bean from starting with a `NoSuchMethodError`; versions before 5.6.3 also contain CVE-2026-64607. Until the upstream dependency alignment is fixed, override the managed version in the application:
 
 ```
 <dependencyManagement>
@@ -34,7 +34,7 @@ Also, configure your connection to the Camunda 8 cluster in the `application.pro
 		<dependency>
 			<groupId>org.apache.httpcomponents.client5</groupId>
 			<artifactId>httpclient5</artifactId>
-			<version>5.6.1</version>
+			<version>5.6.3</version>
 		</dependency>
 	</dependencies>
 </dependencyManagement>

--- a/code-conversion/patterns/ALL_IN_ONE.md
+++ b/code-conversion/patterns/ALL_IN_ONE.md
@@ -83,7 +83,7 @@ Also, configure your connection to the Camunda 8 cluster in the `application.pro
 
 **Java client artifact**: Use `io.camunda:camunda-client-java`. The legacy `io.camunda:zeebe-client-java` artifact is deprecated and will be discontinued in Camunda 8.10.
 
-**Spring Boot 3.5.x and Apache HttpClient**: Spring Boot 3.5.x may manage `org.apache.httpcomponents.client5:httpclient5` to `5.5.2`, while `io.camunda:camunda-client-java` 8.9.13 requires `5.6.1` or later. This mismatch can prevent the `CamundaClient` bean from starting with a `NoSuchMethodError`; versions before 5.6.3 also contain CVE-2026-64607. Until the upstream dependency alignment is fixed, override the managed version in the application:
+**Spring Boot 3.5.x and Apache HttpClient**: Spring Boot 3.5.x may manage `org.apache.httpcomponents.client5:httpclient5` to `5.5.2`, while `io.camunda:camunda-client-java` 8.9.13 requires `5.6.1` or later for API compatibility. This mismatch can prevent the `CamundaClient` bean from starting with a `NoSuchMethodError`; `5.6.3` is the minimum version that also addresses CVE-2026-64607. Until the upstream dependency alignment is fixed, override the managed version in the application:
 
 ```
 <dependencyManagement>

--- a/code-conversion/patterns/ALL_IN_ONE.md
+++ b/code-conversion/patterns/ALL_IN_ONE.md
@@ -83,7 +83,7 @@ Also, configure your connection to the Camunda 8 cluster in the `application.pro
 
 **Java client artifact**: Use `io.camunda:camunda-client-java`. The legacy `io.camunda:zeebe-client-java` artifact is deprecated and will be discontinued in Camunda 8.10.
 
-**Spring Boot 3.5.x and Apache HttpClient**: Spring Boot 3.5.x may manage `org.apache.httpcomponents.client5:httpclient5` to `5.5.2`, while `io.camunda:camunda-client-java` 8.9.13 requires `5.6.1` or later. This mismatch can prevent the `CamundaClient` bean from starting with a `NoSuchMethodError`. Until the upstream dependency alignment is fixed, override the managed version in the application:
+**Spring Boot 3.5.x and Apache HttpClient**: Spring Boot 3.5.x may manage `org.apache.httpcomponents.client5:httpclient5` to `5.5.2`, while `io.camunda:camunda-client-java` 8.9.13 requires `5.6.1` or later. This mismatch can prevent the `CamundaClient` bean from starting with a `NoSuchMethodError`; versions before 5.6.3 also contain CVE-2026-64607. Until the upstream dependency alignment is fixed, override the managed version in the application:
 
 ```
 <dependencyManagement>
@@ -91,7 +91,7 @@ Also, configure your connection to the Camunda 8 cluster in the `application.pro
 		<dependency>
 			<groupId>org.apache.httpcomponents.client5</groupId>
 			<artifactId>httpclient5</artifactId>
-			<version>5.6.1</version>
+			<version>5.6.3</version>
 		</dependency>
 	</dependencies>
 </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -150,7 +150,7 @@
         <artifactId>httpclient5</artifactId>
         <version>${version.httpclient5}</version>
       </dependency>
-      <!-- CVE-2026-13006: pin logback to 1.5.37 (a property override alone is a no-op against modules that pull logback in via an imported spring-boot-dependencies BOM) -->
+      <!-- CVE-2026-13006: pin logback to ${logback.version} (a property override alone is a no-op against modules that pull logback in via an imported spring-boot-dependencies BOM) -->
       <dependency>
         <groupId>ch.qos.logback</groupId>
         <artifactId>logback-classic</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,7 @@
     <version.node>v22.18.0</version.node>
     <version.npm>10.8.2</version.npm>
     <version.httpcore5>5.4.3</version.httpcore5>
+    <version.httpclient5>5.6.3</version.httpclient5>
     <plugin.version.compiler>3.15.0</plugin.version.compiler>
     <plugin.version.nexus-staging>1.7.0</plugin.version.nexus-staging>
     <plugin.version.central-publishing>0.11.0</plugin.version.central-publishing>
@@ -142,6 +143,12 @@
         <groupId>org.apache.httpcomponents.core5</groupId>
         <artifactId>httpcore5-h2</artifactId>
         <version>${version.httpcore5}</version>
+      </dependency>
+      <!-- CVE-2026-64607: pin httpclient5 to the version containing the classic I/O connection release fix -->
+      <dependency>
+        <groupId>org.apache.httpcomponents.client5</groupId>
+        <artifactId>httpclient5</artifactId>
+        <version>${version.httpclient5}</version>
       </dependency>
       <!-- CVE-2026-13006: pin logback to 1.5.37 (a property override alone is a no-op against modules that pull logback in via an imported spring-boot-dependencies BOM) -->
       <dependency>


### PR DESCRIPTION
## Summary

- Pin `org.apache.httpcomponents.client5:httpclient5` to 5.6.3 to address CVE-2026-64607.
- Update the migration guidance to recommend the CVE-fixed minimum version.

## Changes

- Add an explicit root dependency-management entry so imported Spring Boot BOMs cannot select a vulnerable version.
- Update both generated dependency-pattern documentation copies from 5.6.1 to 5.6.3 and document the CVE boundary.

## Test plan

- [x] `JAVA_HOME=/opt/homebrew/opt/openjdk@21 mvn clean install -DskipTests`
- [x] `JAVA_HOME=/opt/homebrew/opt/openjdk@21 mvn test -pl data-migrator/core,code-conversion/recipes -am`
- [x] Dependency trees resolve `httpclient5:5.6.3`.

## Baseline

- Session baseline: `be37c0c5`
- PR base: `698c4cb1` (`main`)