### PR TITLE
fix(e2e): avoid browser dependency timeout (maintenance/0.2)

### DIFF
--- a/data-migrator/qa/e2e-tests/pom.xml
+++ b/data-migrator/qa/e2e-tests/pom.xml
@@ -14,6 +14,9 @@
   <name>Camunda 7 to 8 Data Migrator - E2E Tests</name>
   <description>End-to-end tests for the Cockpit plugin using Playwright</description>
 
+  <properties>
+    <playwright.install.arguments>playwright install --with-deps chromium firefox msedge</playwright.install.arguments>
+  </properties>
 
   <dependencies>
     <dependency>
@@ -120,7 +123,7 @@
               <goal>npx</goal>
             </goals>
             <configuration>
-              <arguments>playwright install --with-deps chromium firefox msedge</arguments>
+              <arguments>${playwright.install.arguments}</arguments>
             </configuration>
           </execution>
 
@@ -142,5 +145,19 @@
       </plugin>
     </plugins>
   </build>
+
+  <profiles>
+    <profile>
+      <id>ci-playwright</id>
+      <activation>
+        <property>
+          <name>env.CI</name>
+        </property>
+      </activation>
+      <properties>
+        <playwright.install.arguments>playwright install chromium firefox msedge</playwright.install.arguments>
+      </properties>
+    </profile>
+  </profiles>
 </project>
 


### PR DESCRIPTION
## Summary

Backports the CI portion of #2174 to maintenance/0.2.

The E2E job previously installed Playwright browsers with `--with-deps`, which can spend most of the 30-minute job timeout downloading apt packages before tests start. This keeps system dependency installation for local runs but uses browser-only installation when `CI` is set.

The maintenance/0.2 E2E suite does not contain the Operate decisions/processes tests, so only the shared CI setup fix is applicable here.

## Validation

- Verified the CI-effective Maven POM resolves to `playwright install chromium firefox msedge`.

related to #2174