### PR TITLE
fix(deps): inherit fixed Jackson BOM for all modules

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -108,6 +108,14 @@
 
   <dependencyManagement>
     <dependencies>
+      <!-- CVE-2026-59889: make the fixed Jackson BOM inherited by every module, including modules without a local BOM import. -->
+      <dependency>
+        <groupId>com.fasterxml.jackson</groupId>
+        <artifactId>jackson-bom</artifactId>
+        <version>${version.jackson-bom}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
       <dependency>
         <groupId>org.junit</groupId>
         <artifactId>junit-bom</artifactId>


### PR DESCRIPTION
## Summary

- Inherit the fixed `com.fasterxml.jackson:jackson-bom` from the root dependency management.
- Cover modules that do not declare a local Jackson BOM import, making the fixed version visible to Maven dependency scanners.

## Changes

- Added a root-level Jackson BOM import using the existing `version.jackson-bom` property.
- Preserved the existing direct `jackson-databind` pins and vulnerable-version enforcer guard.

## Test plan

- [x] `mvn clean install -DskipTests`
- [x] `mvn test -pl code-conversion/recipes,data-migrator/core,diagram-converter/core,diagram-converter/webapp -am`
- [x] `mvn -DskipTests -DskipITs validate`
- [x] Dependency trees resolve Jackson 2.22.2 and Jackson 3.2.2 in representative shipped modules.

## Baseline

Built from commit: adda64d38020fa200e405f960571fa2761982a52