### PR TITLE
fix(deps): pin micrometer-core to 1.17.1 [maintenance/0.3]

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,7 @@
     <camunda8.docker.image>camunda/camunda:${version.camunda-8}</camunda8.docker.image>
     <version.elasticsearch>8.19.6</version.elasticsearch>
     <version.spring-boot>4.1.0</version.spring-boot>
+    <version.micrometer-core>1.17.1</version.micrometer-core>
     <version.jackson-bom>2.22.2</version.jackson-bom>
     <version.jackson-3-bom>3.2.2</version.jackson-3-bom>
     <version.log4j-bom>2.26.1</version.log4j-bom>
@@ -114,6 +115,12 @@
         <version>${version.junit.jupiter}</version>
         <type>pom</type>
         <scope>import</scope>
+      </dependency>
+      <!-- CVE-2026-59296: pin micrometer-core to the fixed version -->
+      <dependency>
+        <groupId>io.micrometer</groupId>
+        <artifactId>micrometer-core</artifactId>
+        <version>${version.micrometer-core}</version>
       </dependency>
       <!-- CVE-2026-55955: pin tomcat-embed to 11.0.23 -->
       <dependency>


### PR DESCRIPTION
## Summary

Pin `io.micrometer:micrometer-core` to `1.17.1`, the fixed OSS version for CVE-2026-59296, through the root `dependencyManagement` entry. This is a dependency-hygiene change only; no source behavior changes.

## Packaging and reachability

Before this pin, the `maintenance/0.3` reactor resolved `1.17.0` on compile paths in `code-conversion/recipes`, `data-migrator/core`, `data-migrator/distro`, and `diagram-converter/webapp`; `data-migrator/plugins/cockpit` and both interceptor examples resolved `1.16.6` with `provided` scope, and `data-migrator/assembly` resolved `1.16.6` at runtime. After the pin, every reactor occurrence resolves `1.17.1`:

- Compile: `code-conversion/recipes`, `data-migrator/core`, `data-migrator/distro`, `diagram-converter/webapp`
- Runtime: `data-migrator/assembly`
- Provided: `data-migrator/plugins/cockpit`, `data-migrator/examples/variable-interceptor`, `data-migrator/examples/entity-interceptor`

`data-migrator/core` directly uses `MeterRegistry` and `SimpleMeterRegistry` in `C8Configuration`; the data migrator distro and assembly therefore carry the reachable application path, while the cockpit/examples remain `provided` and are not bundled by their own JARs. `micrometer-registry-statsd` is absent and no declaration is added.

## Verification

- `mvn -Denforcer.skip=true -DskipTests dependency:tree -Dincludes=io.micrometer:micrometer-core -Dverbose`: reactor build succeeded; all resolved occurrences are `1.17.1`.
- `mvn -Denforcer.skip=true -DskipTests -pl data-migrator/core validate`: succeeded.
- Baseline commit: `cf0dd8fcc635aa7154c67291178a82c3dac0a46b`.
- `mvn clean install` is blocked locally by the installed Java 26 JDK; `code-conversion/recipes` requires Java 21-25.