### PR TITLE
fix(deps): remediate CVE-2026-59296 in Micrometer [main]

### DIFF
--- a/diagram-converter/pom.xml
+++ b/diagram-converter/pom.xml
@@ -20,7 +20,7 @@
     <version.slack-api-client>1.50.0</version.slack-api-client>
     <version.opencsv>5.12.0</version.opencsv>
     <version.grpc>1.83.1</version.grpc>
-    <version.protobuf>4.35.1</version.protobuf>
+    <version.protobuf>4.36.0</version.protobuf>
     <version.java-jwt>4.6.0</version.java-jwt>
     <version.archunit>1.5.0</version.archunit>
     <version.apache-poi>5.5.1</version.apache-poi>

--- a/pom.xml
+++ b/pom.xml
@@ -130,6 +130,12 @@
         <artifactId>tomcat-embed-core</artifactId>
         <version>${tomcat.version}</version>
       </dependency>
+      <!-- CVE-2026-59296: pin micrometer-core to the fixed 1.17.1 version -->
+      <dependency>
+        <groupId>io.micrometer</groupId>
+        <artifactId>micrometer-core</artifactId>
+        <version>1.17.1</version>
+      </dependency>
       <dependency>
         <groupId>org.apache.tomcat.embed</groupId>
         <artifactId>tomcat-embed-el</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
     <version.log4j-bom>2.26.1</version.log4j-bom>
     <logback.version>1.6.3</logback.version>
     <tomcat.version>11.0.25</tomcat.version>
-    <version.protobuf>4.35.1</version.protobuf>
+    <version.protobuf>4.36.0</version.protobuf>
     <version.assertj>3.27.7</version.assertj>
     <version.junit.jupiter>6.1.3</version.junit.jupiter>
     <version.h2>2.4.240</version.h2>


### PR DESCRIPTION
## Summary

Pins the exact `io.micrometer:micrometer-core` artifact to fixed OSS version `1.17.1` through the root `dependencyManagement`, remediating CVE-2026-59296 without changing application behavior.

The current Camunda 8.10.0-SNAPSHOT publishes generated protocol classes built with Protobuf `4.36.0`; the explicit repository Protobuf version was aligned from `4.35.1` to `4.36.0` in the root and `diagram-converter` POMs to prevent the deterministic gencode/runtime mismatch.

## Packaging and reachability

The Micrometer pin applies to every reactor module that resolves `micrometer-core`, including compile, provided, and runtime paths in code-conversion/recipes, data-migrator/core, distro, assembly, cockpit/examples, and diagram-converter/webapp. `micrometer-registry-statsd` is absent and needs no declaration.

The Protobuf alignment covers the C8 client/data-migrator/assembly paths and the diagram converter BOM. The C7-only Error Prone dependency path may retain its independent Protobuf version and does not load the C8 generated protocol classes.

## Verification

- Reactor `mvn dependency:tree -Dincludes=io.micrometer:micrometer-core` and the same check with `-Pintegration,e2e`: all resolved Micrometer Core entries are `1.17.1`.
- Reactor `mvn dependency:tree -Dincludes=com.google.protobuf:*`: C8 8.10.0-SNAPSHOT paths resolve `protobuf-java:4.36.0`.
- `mvn -pl data-migrator/core -am test`: passed with the normal POM version (`20` reports, no failures).
- `mvn -N validate`: passed.
- Protobuf `4.36.0` is available from the configured artifact repository.

The Aug 25 scheduled baseline run `32811848177` on parent commit `6d10b4a6` reproduced the same Protobuf mismatch and `camunda/camunda:SNAPSHOT` JVM `SIGILL`/exit-139 failures before these PR changes; the Aug 24 baseline passed. The SIGILL failures are moving snapshot-image/environment failures and are intentionally not changed here. The new-head CI run is being evaluated separately.