### PR TITLE
fix(deps): pin micrometer-core for CVE-2026-59296 [maintenance/0.2]

### DIFF
--- a/code-conversion/recipes/pom.xml
+++ b/code-conversion/recipes/pom.xml
@@ -52,6 +52,12 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
+      <!-- CVE-2026-59296: pin micrometer-core ahead of Spring Boot BOM. -->
+      <dependency>
+        <groupId>io.micrometer</groupId>
+        <artifactId>micrometer-core</artifactId>
+        <version>${version.micrometer}</version>
+      </dependency>
       <dependency>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-dependencies</artifactId>

--- a/data-migrator/core/pom.xml
+++ b/data-migrator/core/pom.xml
@@ -46,6 +46,12 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
+      <!-- CVE-2026-59296: pin micrometer-core ahead of Spring Boot BOM. -->
+      <dependency>
+        <groupId>io.micrometer</groupId>
+        <artifactId>micrometer-core</artifactId>
+        <version>${version.micrometer}</version>
+      </dependency>
       <dependency>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-dependencies</artifactId>

--- a/data-migrator/distro/pom.xml
+++ b/data-migrator/distro/pom.xml
@@ -46,6 +46,12 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
+      <!-- CVE-2026-59296: pin micrometer-core ahead of Spring Boot BOM. -->
+      <dependency>
+        <groupId>io.micrometer</groupId>
+        <artifactId>micrometer-core</artifactId>
+        <version>${version.micrometer}</version>
+      </dependency>
       <dependency>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-dependencies</artifactId>

--- a/diagram-converter/pom.xml
+++ b/diagram-converter/pom.xml
@@ -96,6 +96,12 @@
         <artifactId>tomcat-embed-websocket</artifactId>
         <version>${tomcat.version}</version>
       </dependency>
+      <!-- CVE-2026-59296: pin micrometer-core ahead of Spring Boot BOM. -->
+      <dependency>
+        <groupId>io.micrometer</groupId>
+        <artifactId>micrometer-core</artifactId>
+        <version>${version.micrometer}</version>
+      </dependency>
       <dependency>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-dependencies</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,7 @@
     <version.node>v22.22.2</version.node>
     <version.npm>10.8.2</version.npm>
     <version.netty>4.2.17.Final</version.netty>
+    <version.micrometer>1.17.1</version.micrometer>
     <version.httpcore5>5.4.3</version.httpcore5>
     <version.httpclient5>5.6.4</version.httpclient5>
     <version.commons-lang3>3.20.0</version.commons-lang3>
@@ -109,6 +110,12 @@
 
   <dependencyManagement>
     <dependencies>
+      <!-- CVE-2026-59296: pin micrometer-core to the fixed 1.17.1 version. -->
+      <dependency>
+        <groupId>io.micrometer</groupId>
+        <artifactId>micrometer-core</artifactId>
+        <version>${version.micrometer}</version>
+      </dependency>
       <!-- CVE-2026-59889: make the fixed Jackson BOM inherited by every module, including modules without a local BOM import. -->
       <dependency>
         <groupId>com.fasterxml.jackson</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -116,6 +116,21 @@
         <artifactId>micrometer-core</artifactId>
         <version>${version.micrometer}</version>
       </dependency>
+      <dependency>
+        <groupId>io.micrometer</groupId>
+        <artifactId>micrometer-commons</artifactId>
+        <version>${version.micrometer}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.micrometer</groupId>
+        <artifactId>micrometer-observation</artifactId>
+        <version>${version.micrometer}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.micrometer</groupId>
+        <artifactId>micrometer-jakarta9</artifactId>
+        <version>${version.micrometer}</version>
+      </dependency>
       <!-- CVE-2026-59889: make the fixed Jackson BOM inherited by every module, including modules without a local BOM import. -->
       <dependency>
         <groupId>com.fasterxml.jackson</groupId>


### PR DESCRIPTION
## Summary

- Fixes CVE-2026-59296 by adding direct `io.micrometer:micrometer-core` dependency-management pins.
- Pins the root and each BOM-importing child that can otherwise retain Spring Boot's 1.15.12 management: `code-conversion/recipes`, `data-migrator/core`, `data-migrator/distro`, and `diagram-converter`.
- Uses Micrometer 1.17.1. The requested 1.15.13 coordinate returned HTTP 404 from Maven Central and could not be resolved from the configured Camunda internal repository, while 1.17.1 is available and compatible with the Java 21-targeted modules.

## Packaging and reachability

- The 16-module maintenance/0.2 reactor resolves every `micrometer-core` occurrence at 1.17.1 across compile, runtime, provided, and test paths, including recipes, data-migrator core/distro/assembly, cockpit/examples, and diagram-converter webapp.
- The root dependency management also pins the required Micrometer family companions — `micrometer-commons`, `micrometer-observation`, and `micrometer-jakarta9` — to 1.17.1, keeping the runtime family binary-compatible.
- `micrometer-registry-statsd` is absent and remains undeclared.
- The packaged data-migrator distro contains `BOOT-INF/lib/micrometer-core-1.17.1.jar`; the assembly wraps that distro archive.

## CI follow-up and root cause

The initial `diagram-converter` CI job failed while starting the webapp because upgrading only `micrometer-core` to 1.17.1 left `micrometer-commons` and `micrometer-observation` at Spring Boot's 1.15.12 versions. Micrometer 1.17.1 core calls `WarnThenDebugLogger.isEnabled()`, which is not present in the 1.15.12 commons class, resulting in `NoSuchMethodError`. The companion pins correct that mismatch; the committed webapp runtime tree confirms all four Micrometer modules resolve to 1.17.1.

## Verification

- `mvn -DskipTests dependency:tree -Dincludes=io.micrometer:micrometer-core -Dverbose` — successful across all 16 reactor modules; all entries are 1.17.1.
- `mvn -pl diagram-converter/webapp -am -DskipTests dependency:tree -Dincludes=io.micrometer:* -Dverbose` — core, commons, observation, and jakarta9 all resolve to 1.17.1.
- With Java 21: `mvn -pl diagram-converter/webapp -am test` — 8 webapp tests passed (and 309 diagram-converter core tests passed).
- `mvn -pl data-migrator/core -am test` — 76 tests passed.
- `mvn -pl data-migrator/distro,data-migrator/assembly -am -DskipTests package` — successful.
- The broader targeted compile was initially limited by the local JDK 26.0.2: `code-conversion/recipes` enforces Java 21–25, and `diagram-converter/core` fails its existing `-Werror` source/target warning on JDK 26. The Java 21 toolchain is now used for the passing webapp validation.

Base verification commit: `6a0806a4`.