### PR TITLE
chore(release): merge release 0.2.8 back to maintenance/0.2

### DIFF
--- a/code-conversion/patterns/code-examples/camunda-8/pom.xml
+++ b/code-conversion/patterns/code-examples/camunda-8/pom.xml
@@ -38,7 +38,7 @@
 		<dependency>
 			<groupId>io.camunda</groupId>
 			<artifactId>camunda-spring-boot-starter</artifactId>
-			<version>8.8.35</version>
+			<version>8.8.36</version>
 		</dependency>
 
 		<dependency>
@@ -50,7 +50,7 @@
 		<dependency>
 			<groupId>io.camunda</groupId>
 			<artifactId>camunda-process-test-spring</artifactId>
-			<version>8.8.35</version>
+			<version>8.8.36</version>
 		</dependency>
 	</dependencies>
 

--- a/code-conversion/pom.xml
+++ b/code-conversion/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>camunda-7-to-8-migration-tooling-root</artifactId>
-    <version>0.2.8-SNAPSHOT</version>
+    <version>0.2.8</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/code-conversion/pom.xml
+++ b/code-conversion/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>camunda-7-to-8-migration-tooling-root</artifactId>
-    <version>0.2.7</version>
+    <version>0.2.8-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/code-conversion/pom.xml
+++ b/code-conversion/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>camunda-7-to-8-migration-tooling-root</artifactId>
-    <version>0.2.8</version>
+    <version>0.2.9-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/code-conversion/recipes/pom.xml
+++ b/code-conversion/recipes/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>camunda-7-to-8-code-conversion-parent</artifactId>
-    <version>0.2.8-SNAPSHOT</version>
+    <version>0.2.8</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/code-conversion/recipes/pom.xml
+++ b/code-conversion/recipes/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>camunda-7-to-8-code-conversion-parent</artifactId>
-    <version>0.2.7</version>
+    <version>0.2.8-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/code-conversion/recipes/pom.xml
+++ b/code-conversion/recipes/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>camunda-7-to-8-code-conversion-parent</artifactId>
-    <version>0.2.8</version>
+    <version>0.2.9-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/data-migrator/assembly/pom.xml
+++ b/data-migrator/assembly/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>camunda-7-to-8-data-migrator-parent</artifactId>
-    <version>0.2.8-SNAPSHOT</version>
+    <version>0.2.8</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/data-migrator/assembly/pom.xml
+++ b/data-migrator/assembly/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>camunda-7-to-8-data-migrator-parent</artifactId>
-    <version>0.2.8</version>
+    <version>0.2.9-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/data-migrator/assembly/pom.xml
+++ b/data-migrator/assembly/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>camunda-7-to-8-data-migrator-parent</artifactId>
-    <version>0.2.7</version>
+    <version>0.2.8-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/data-migrator/core/pom.xml
+++ b/data-migrator/core/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>camunda-7-to-8-data-migrator-parent</artifactId>
-    <version>0.2.8-SNAPSHOT</version>
+    <version>0.2.8</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/data-migrator/core/pom.xml
+++ b/data-migrator/core/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>camunda-7-to-8-data-migrator-parent</artifactId>
-    <version>0.2.8</version>
+    <version>0.2.9-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/data-migrator/core/pom.xml
+++ b/data-migrator/core/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>camunda-7-to-8-data-migrator-parent</artifactId>
-    <version>0.2.7</version>
+    <version>0.2.8-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/data-migrator/distro/pom.xml
+++ b/data-migrator/distro/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>camunda-7-to-8-data-migrator-parent</artifactId>
-    <version>0.2.8-SNAPSHOT</version>
+    <version>0.2.8</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/data-migrator/distro/pom.xml
+++ b/data-migrator/distro/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>camunda-7-to-8-data-migrator-parent</artifactId>
-    <version>0.2.8</version>
+    <version>0.2.9-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/data-migrator/distro/pom.xml
+++ b/data-migrator/distro/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>camunda-7-to-8-data-migrator-parent</artifactId>
-    <version>0.2.7</version>
+    <version>0.2.8-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/data-migrator/examples/pom.xml
+++ b/data-migrator/examples/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>camunda-7-to-8-data-migrator-parent</artifactId>
-    <version>0.2.8-SNAPSHOT</version>
+    <version>0.2.8</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/data-migrator/examples/pom.xml
+++ b/data-migrator/examples/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>camunda-7-to-8-data-migrator-parent</artifactId>
-    <version>0.2.8</version>
+    <version>0.2.9-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/data-migrator/examples/pom.xml
+++ b/data-migrator/examples/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>camunda-7-to-8-data-migrator-parent</artifactId>
-    <version>0.2.7</version>
+    <version>0.2.8-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/data-migrator/examples/variable-interceptor/pom.xml
+++ b/data-migrator/examples/variable-interceptor/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.camunda</groupId>
         <artifactId>camunda-7-to-8-data-migrator-examples</artifactId>
-        <version>0.2.8</version>
+        <version>0.2.9-SNAPSHOT</version>
         <relativePath>../</relativePath>
     </parent>
 
@@ -25,7 +25,7 @@
         <dependency>
             <groupId>io.camunda</groupId>
             <artifactId>camunda-7-to-8-data-migrator-core</artifactId>
-            <version>0.2.8</version>
+            <version>0.2.9-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/data-migrator/examples/variable-interceptor/pom.xml
+++ b/data-migrator/examples/variable-interceptor/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.camunda</groupId>
         <artifactId>camunda-7-to-8-data-migrator-examples</artifactId>
-        <version>0.2.8-SNAPSHOT</version>
+        <version>0.2.8</version>
         <relativePath>../</relativePath>
     </parent>
 
@@ -25,7 +25,7 @@
         <dependency>
             <groupId>io.camunda</groupId>
             <artifactId>camunda-7-to-8-data-migrator-core</artifactId>
-            <version>0.2.8-SNAPSHOT</version>
+            <version>0.2.8</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/data-migrator/examples/variable-interceptor/pom.xml
+++ b/data-migrator/examples/variable-interceptor/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.camunda</groupId>
         <artifactId>camunda-7-to-8-data-migrator-examples</artifactId>
-        <version>0.2.7</version>
+        <version>0.2.8-SNAPSHOT</version>
         <relativePath>../</relativePath>
     </parent>
 
@@ -25,7 +25,7 @@
         <dependency>
             <groupId>io.camunda</groupId>
             <artifactId>camunda-7-to-8-data-migrator-core</artifactId>
-            <version>0.2.7</version>
+            <version>0.2.8-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/data-migrator/plugins/cockpit/pom.xml
+++ b/data-migrator/plugins/cockpit/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>camunda-7-to-8-data-migrator-parent</artifactId>
-    <version>0.2.8-SNAPSHOT</version>
+    <version>0.2.8</version>
     <relativePath>../../</relativePath>
   </parent>
 

--- a/data-migrator/plugins/cockpit/pom.xml
+++ b/data-migrator/plugins/cockpit/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>camunda-7-to-8-data-migrator-parent</artifactId>
-    <version>0.2.8</version>
+    <version>0.2.9-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
 

--- a/data-migrator/plugins/cockpit/pom.xml
+++ b/data-migrator/plugins/cockpit/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>camunda-7-to-8-data-migrator-parent</artifactId>
-    <version>0.2.7</version>
+    <version>0.2.8-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
 

--- a/data-migrator/pom.xml
+++ b/data-migrator/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>camunda-7-to-8-migration-tooling-root</artifactId>
-    <version>0.2.8-SNAPSHOT</version>
+    <version>0.2.8</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/data-migrator/pom.xml
+++ b/data-migrator/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>camunda-7-to-8-migration-tooling-root</artifactId>
-    <version>0.2.7</version>
+    <version>0.2.8-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/data-migrator/pom.xml
+++ b/data-migrator/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>camunda-7-to-8-migration-tooling-root</artifactId>
-    <version>0.2.8</version>
+    <version>0.2.9-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/data-migrator/qa/e2e-tests/pom.xml
+++ b/data-migrator/qa/e2e-tests/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>camunda-7-to-8-data-migrator-qa</artifactId>
-    <version>0.2.7</version>
+    <version>0.2.8-SNAPSHOT</version>
   </parent>
 
   <artifactId>camunda-7-to-8-data-migrator-e2e-tests</artifactId>
@@ -160,4 +160,3 @@
     </profile>
   </profiles>
 </project>
-

--- a/data-migrator/qa/e2e-tests/pom.xml
+++ b/data-migrator/qa/e2e-tests/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>camunda-7-to-8-data-migrator-qa</artifactId>
-    <version>0.2.8-SNAPSHOT</version>
+    <version>0.2.9-SNAPSHOT</version>
   </parent>
 
   <artifactId>camunda-7-to-8-data-migrator-e2e-tests</artifactId>

--- a/data-migrator/qa/integration-tests/pom.xml
+++ b/data-migrator/qa/integration-tests/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>camunda-7-to-8-data-migrator-qa</artifactId>
-    <version>0.2.7</version>
+    <version>0.2.8-SNAPSHOT</version>
   </parent>
 
   <artifactId>camunda-7-to-8-data-migrator-integration-tests</artifactId>

--- a/data-migrator/qa/integration-tests/pom.xml
+++ b/data-migrator/qa/integration-tests/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>camunda-7-to-8-data-migrator-qa</artifactId>
-    <version>0.2.8-SNAPSHOT</version>
+    <version>0.2.9-SNAPSHOT</version>
   </parent>
 
   <artifactId>camunda-7-to-8-data-migrator-integration-tests</artifactId>

--- a/data-migrator/qa/pom.xml
+++ b/data-migrator/qa/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>camunda-7-to-8-data-migrator-parent</artifactId>
-    <version>0.2.8-SNAPSHOT</version>
+    <version>0.2.8</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/data-migrator/qa/pom.xml
+++ b/data-migrator/qa/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>camunda-7-to-8-data-migrator-parent</artifactId>
-    <version>0.2.8</version>
+    <version>0.2.9-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/data-migrator/qa/pom.xml
+++ b/data-migrator/qa/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>camunda-7-to-8-data-migrator-parent</artifactId>
-    <version>0.2.7</version>
+    <version>0.2.8-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/diagram-converter/cli/pom.xml
+++ b/diagram-converter/cli/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>camunda-7-to-8-diagram-converter-parent</artifactId>
-    <version>0.2.8-SNAPSHOT</version>
+    <version>0.2.8</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/diagram-converter/cli/pom.xml
+++ b/diagram-converter/cli/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>camunda-7-to-8-diagram-converter-parent</artifactId>
-    <version>0.2.7</version>
+    <version>0.2.8-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/diagram-converter/cli/pom.xml
+++ b/diagram-converter/cli/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>camunda-7-to-8-diagram-converter-parent</artifactId>
-    <version>0.2.8</version>
+    <version>0.2.9-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/diagram-converter/core/pom.xml
+++ b/diagram-converter/core/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>camunda-7-to-8-diagram-converter-parent</artifactId>
-    <version>0.2.8-SNAPSHOT</version>
+    <version>0.2.8</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/diagram-converter/core/pom.xml
+++ b/diagram-converter/core/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>camunda-7-to-8-diagram-converter-parent</artifactId>
-    <version>0.2.7</version>
+    <version>0.2.8-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/diagram-converter/core/pom.xml
+++ b/diagram-converter/core/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>camunda-7-to-8-diagram-converter-parent</artifactId>
-    <version>0.2.8</version>
+    <version>0.2.9-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/diagram-converter/extension-example/pom.xml
+++ b/diagram-converter/extension-example/pom.xml
@@ -4,12 +4,12 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>camunda-7-to-8-diagram-converter-parent</artifactId>
-    <version>0.2.8-SNAPSHOT</version>
+    <version>0.2.8</version>
     <relativePath>../</relativePath>
   </parent>
 
   <artifactId>camunda-7-to-8-diagram-converter-extension-example</artifactId>
-  <version>0.2.8-SNAPSHOT</version>
+  <version>0.2.8</version>
   <name>camunda-7-to-8-diagram-converter-extension-example</name>
 
   <properties>

--- a/diagram-converter/extension-example/pom.xml
+++ b/diagram-converter/extension-example/pom.xml
@@ -4,12 +4,12 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>camunda-7-to-8-diagram-converter-parent</artifactId>
-    <version>0.2.8</version>
+    <version>0.2.9-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 
   <artifactId>camunda-7-to-8-diagram-converter-extension-example</artifactId>
-  <version>0.2.8</version>
+  <version>0.2.9-SNAPSHOT</version>
   <name>camunda-7-to-8-diagram-converter-extension-example</name>
 
   <properties>

--- a/diagram-converter/extension-example/pom.xml
+++ b/diagram-converter/extension-example/pom.xml
@@ -4,12 +4,12 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>camunda-7-to-8-diagram-converter-parent</artifactId>
-    <version>0.2.7</version>
+    <version>0.2.8-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 
   <artifactId>camunda-7-to-8-diagram-converter-extension-example</artifactId>
-  <version>0.2.7</version>
+  <version>0.2.8-SNAPSHOT</version>
   <name>camunda-7-to-8-diagram-converter-extension-example</name>
 
   <properties>

--- a/diagram-converter/pom.xml
+++ b/diagram-converter/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>camunda-7-to-8-migration-tooling-root</artifactId>
-    <version>0.2.8-SNAPSHOT</version>
+    <version>0.2.8</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/diagram-converter/pom.xml
+++ b/diagram-converter/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>camunda-7-to-8-migration-tooling-root</artifactId>
-    <version>0.2.7</version>
+    <version>0.2.8-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/diagram-converter/pom.xml
+++ b/diagram-converter/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>camunda-7-to-8-migration-tooling-root</artifactId>
-    <version>0.2.8</version>
+    <version>0.2.9-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/diagram-converter/webapp/pom.xml
+++ b/diagram-converter/webapp/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>camunda-7-to-8-diagram-converter-parent</artifactId>
-    <version>0.2.8-SNAPSHOT</version>
+    <version>0.2.8</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/diagram-converter/webapp/pom.xml
+++ b/diagram-converter/webapp/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>camunda-7-to-8-diagram-converter-parent</artifactId>
-    <version>0.2.7</version>
+    <version>0.2.8-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/diagram-converter/webapp/pom.xml
+++ b/diagram-converter/webapp/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>camunda-7-to-8-diagram-converter-parent</artifactId>
-    <version>0.2.8</version>
+    <version>0.2.9-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
   <groupId>io.camunda</groupId>
   <artifactId>camunda-7-to-8-migration-tooling-root</artifactId>
-  <version>0.2.8-SNAPSHOT</version>
+  <version>0.2.8</version>
 
   <packaging>pom</packaging>
 
@@ -86,7 +86,7 @@
     <connection>scm:git:https://${env.GITHUB_TOKEN_USR}:${env.GITHUB_TOKEN_PSW}@github.com/camunda/camunda-7-to-8-migration-tooling
       .git</connection>
     <developerConnection>scm:git:https://${env.GITHUB_TOKEN_USR}:${env.GITHUB_TOKEN_PSW}@github.com/camunda/camunda-7-to-8-migration-tooling.git</developerConnection>
-    <tag>HEAD</tag>
+    <tag>0.2.8</tag>
     <url>https://github.com/camunda/camunda-7-to-8-migration-tooling</url>
   </scm>
 

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
     <version.java>21</version.java>
 
     <version.camunda-7>7.24.5-ee</version.camunda-7>
-    <version.camunda-8>8.8.35</version.camunda-8>
+    <version.camunda-8>8.8.36</version.camunda-8>
     <camunda8.docker.image>camunda/camunda:${version.camunda-8}</camunda8.docker.image>
     <version.elasticsearch>8.19.6</version.elasticsearch>
     <version.spring-boot>3.5.16</version.spring-boot>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
   <groupId>io.camunda</groupId>
   <artifactId>camunda-7-to-8-migration-tooling-root</artifactId>
-  <version>0.2.7</version>
+  <version>0.2.8-SNAPSHOT</version>
 
   <packaging>pom</packaging>
 
@@ -86,7 +86,7 @@
     <connection>scm:git:https://${env.GITHUB_TOKEN_USR}:${env.GITHUB_TOKEN_PSW}@github.com/camunda/camunda-7-to-8-migration-tooling
       .git</connection>
     <developerConnection>scm:git:https://${env.GITHUB_TOKEN_USR}:${env.GITHUB_TOKEN_PSW}@github.com/camunda/camunda-7-to-8-migration-tooling.git</developerConnection>
-    <tag>0.2.7</tag>
+    <tag>HEAD</tag>
     <url>https://github.com/camunda/camunda-7-to-8-migration-tooling</url>
   </scm>
 

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
   <groupId>io.camunda</groupId>
   <artifactId>camunda-7-to-8-migration-tooling-root</artifactId>
-  <version>0.2.8</version>
+  <version>0.2.9-SNAPSHOT</version>
 
   <packaging>pom</packaging>
 
@@ -86,7 +86,7 @@
     <connection>scm:git:https://${env.GITHUB_TOKEN_USR}:${env.GITHUB_TOKEN_PSW}@github.com/camunda/camunda-7-to-8-migration-tooling
       .git</connection>
     <developerConnection>scm:git:https://${env.GITHUB_TOKEN_USR}:${env.GITHUB_TOKEN_PSW}@github.com/camunda/camunda-7-to-8-migration-tooling.git</developerConnection>
-    <tag>0.2.8</tag>
+    <tag>HEAD</tag>
     <url>https://github.com/camunda/camunda-7-to-8-migration-tooling</url>
   </scm>
 


### PR DESCRIPTION
## Summary

- Merge the 0.2.8 release changes back into maintenance/0.2.
- Align Camunda 8 dependencies and examples with 8.8.36.
- Continue maintenance development at 0.2.9-SNAPSHOT.

The 0.2.8 release workflow completed successfully: https://github.com/camunda/camunda-7-to-8-migration-tooling/actions/runs/32835524094