### PR TITLE
feat: make .gitignore update opt-in instead of silent

### DIFF
--- a/agentic-migration-skills/skills/migrate-c7-to-c8-code/references/model-migration-approaches.md
+++ b/agentic-migration-skills/skills/migrate-c7-to-c8-code/references/model-migration-approaches.md
@@ -29,7 +29,7 @@ Steps:
 4. If that JAR already exists, reuse it
 5. Otherwise download from: `https://github.com/camunda/camunda-7-to-8-migration-tooling/releases/download/<tag>/camunda-7-to-8-diagram-converter-cli-<tag>.jar`
 
-The JAR is ~30 MB. If the project is a git repo, add `.camunda-migration/` to `.gitignore`.
+The JAR is ~30 MB. If the project is a git repo, recommend adding `.camunda-migration/` to `.gitignore`; only modify `.gitignore` after the user confirms via AskUserQuestion.
 
 ### 3. Run the Converter
 


### PR DESCRIPTION
## Description

Addresses the suppressed Copilot review comment from #2194 (`pullrequestreview-5021196683`): the model-migration guidance told the agent to add `.camunda-migration/` to the project's `.gitignore` unconditionally, which conflicts with the skill's shared principles — "Never mutate user assets silently" and "Commits are opt-in" (`SKILL.md`).

The instruction is now phrased as a recommendation: the agent suggests adding `.camunda-migration/` to `.gitignore` and only edits the file after the user confirms via AskUserQuestion.

## Type of Change
- [x] Documentation update

## Testing Checklist

Markdown-only change to an agent skill reference document — no code, no tests affected.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed the code
- [x] No new compiler warnings

## Related Issues

Related to #2194