### PR TITLE
feat(skill): detect many-to-one job-type collapse in cross-check

### DIFF
--- a/agentic-migration-skills/skills/migrate-c7-to-c8-code/references/composing-code-and-models.md
+++ b/agentic-migration-skills/skills/migrate-c7-to-c8-code/references/composing-code-and-models.md
@@ -8,7 +8,38 @@ The two paths are independent. A reasonable default is models first (diagrams de
 
 ## Cross-Check After Both Complete
 
+Cross-reference the grouped Diagram Converter findings (see `model-migration-approaches.md` step 5) against the code migration output. First detect the mapping shape, then apply the matching check.
+
+### 1. Detect many-to-one job-type collapse
+
+Take all rows in the `delegate-expression-as-job-type` category. Each message has the shape:
+
+> Delegate class or expression '\<original\>' has been transformed to job type '\<jobType\>'.
+
+Extract the original expression and the job type from each row's `message` and group by job type:
+
+- **1:1**: every job type maps to exactly one original expression — apply the simple check in 2a.
+- **Many-to-one**: one job type maps to multiple distinct original expressions — the converter collapsed several delegates onto a shared job type. Apply the dispatcher check in 2b. This shape is common at scale: in real projects a single generic job type can cover thousands of expression-based service tasks.
+
+Also treat the `delegate-implementation` category (emitted when the converter ran with a configured default job type) as inherently many-to-one: every row shares the same job type.
+
+### 2a. 1:1 mapping - simple job-type match
+
 Job types emitted by the Diagram Converter should match the `@JobWorker(type = ...)` values produced by the code migration. Flag mismatches for the user.
+
+### 2b. Many-to-one mapping - dispatcher/adapter worker needed
+
+Do NOT generate one `@JobWorker` per BPMN element for a collapsed job type - they would all subscribe to the same type and race for the same jobs.
+
+Instead, flag for the user that the shared job type needs a single dispatcher/adapter job worker:
+
+- One `@JobWorker(type = "<shared job type>")` for the whole group.
+- The worker reads the retained original expression from the job's task headers. The converter always preserves it as a `zeebe:taskHeader` whose key is the original C7 attribute name (`expression`, `delegateExpression`, or `class`) and whose value is the original expression string (e.g. `${myBean.myMethod(execution)}`).
+- The worker routes on that header value to the correct legacy bean/method (e.g. via a Spring bean lookup by name, or an explicit mapping table).
+
+The cross-check for this shape: verify exactly one worker subscribes to the shared job type, and that its routing covers every distinct original expression found in the findings rows for that job type. List uncovered expressions for the user.
+
+Record the detected shape (1:1 vs many-to-one, per job type) in MIGRATION_REPORT.md.
 
 ## Deployment Wiring
 

--- a/agentic-migration-skills/skills/migrate-c7-to-c8-code/references/composing-code-and-models.md
+++ b/agentic-migration-skills/skills/migrate-c7-to-c8-code/references/composing-code-and-models.md
@@ -34,7 +34,7 @@ Do NOT generate one `@JobWorker` per BPMN element for a collapsed job type - the
 Instead, flag for the user that the shared job type needs a single dispatcher/adapter job worker:
 
 - One `@JobWorker(type = "<shared job type>")` for the whole group.
-- The worker reads the retained original expression from the job's task headers. The converter always preserves it as a `zeebe:taskHeader` whose key is the original C7 attribute name (`expression`, `delegateExpression`, or `class`) and whose value is the original expression string (e.g. `${myBean.myMethod(execution)}`).
+- The worker reads the retained original expression from the job's task headers. The converter always preserves it as a `zeebe:header` entry (inside `zeebe:taskHeaders`) whose key is the original C7 attribute name (`expression`, `delegateExpression`, or `class`) and whose value is the original expression string (e.g. `${myBean.myMethod(execution)}`).
 - The worker routes on that header value to the correct legacy bean/method (e.g. via a Spring bean lookup by name, or an explicit mapping table).
 
 The cross-check for this shape: verify exactly one worker subscribes to the shared job type, and that its routing covers every distinct original expression found in the findings rows for that job type. List uncovered expressions for the user.


### PR DESCRIPTION
## Description

Extends the migration skill's "Cross-Check After Both Complete" section in `composing-code-and-models.md` beyond its single job-type-matching bullet, so the skill detects when the Diagram Converter collapses many BPMN delegate expressions onto one shared job type.

The cross-check now works in two steps:

1. **Detect the mapping shape**: extract the original expression and job type from each `delegate-expression-as-job-type` finding and group by job type. The `delegate-implementation` category (converter ran with a default job type) is treated as inherently many-to-one.
2. **Apply the matching check**:
   - **1:1**: keep the existing "job types should match `@JobWorker(type = ...)`" check.
   - **Many-to-one**: flag that a single dispatcher/adapter `@JobWorker` is needed - one that reads the retained original expression from the `zeebe:taskHeader` (key `expression`/`delegateExpression`/`class`) and routes to the correct legacy bean/method - instead of one worker per element, which would race on the same job type. The check then verifies exactly one worker subscribes to the shared type and that its routing covers every distinct original expression.

This mirrors the converter's actual behavior: `AbstractDelegateImplementationVisitor` always preserves the original attribute as a task header, so the routing information survives conversion. Scope is docs/skill guidance only - no changes to OpenRewrite recipes or the converter CLI.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Test-only changes (no production code changes)

## Testing Checklist

### Black-Box Testing Requirements
- [ ] Tests follow **black-box testing approach**: verify behavior through observable outputs (logs, C8 API queries, real-world skip scenarios)
- [ ] Tests **DO NOT** access implementation details (`DbClient`, `IdKeyMapper`, `..impl..` packages except logging constants)
- [ ] Architecture tests pass (`ArchitectureTest` validates these rules)

### Test Coverage
- [ ] Added tests for new functionality
- [ ] Updated tests for modified functionality
- [ ] All tests pass locally

N/A - skill documentation (markdown) only; the `agentic-migration-skills` content is not covered by automated tests. The described message IDs, message shapes, and task-header behavior were verified against `diagram-converter/core` sources (`MessageFactory`, `message-templates.properties`, `AbstractDelegateImplementationVisitor`).

## Architecture Compliance

N/A - no code changes.

## Documentation
- [ ] Updated TESTING_GUIDELINES.md if adding new test patterns
- [ ] Added Javadoc comments for public APIs
- [x] Updated README if user-facing changes

This IS the documentation update (skill reference doc).

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed the code
- [ ] Added comments for complex logic
- [x] No new compiler warnings
- [x] Dependent changes have been merged

## Related Issues

Related to #2242
Part of epic #2240