### PR TITLE
feat(skill): emit per-category verdict table for model conversion findings

### DIFF
--- a/agentic-migration-skills/skills/migrate-c7-to-c8-code/SKILL.md
+++ b/agentic-migration-skills/skills/migrate-c7-to-c8-code/SKILL.md
@@ -108,14 +108,14 @@ Convert BPMN/DMN from the camunda: namespace to zeebe: using the selected approa
 #### Model Validation (if models were migrated)
 
 1. Confirm a converted-c8-* file exists for each in-scope diagram (unless analyze-only).
-2. Every WARNING/TASK/REVIEW finding is either fixed or recorded as remaining follow-up in MIGRATION_REPORT.md.
+2. Every WARNING/TASK/REVIEW finding is either fixed or classified in the per-category verdict table (category, count, cross-referenced code artifact, verdict: no action / needs review / needs fix) recorded in MIGRATION_REPORT.md — see `references/model-migration-approaches.md` step 5d. A flat "fixed or recorded" note is not sufficient.
 3. Originals are intact and were not overwritten.
 
 Present a validation summary showing status of: compilation, remaining C7 imports, remaining TODOs, businessKey usages, tests, models converted, and model findings needing follow-up. Record in MIGRATION_REPORT.md.
 
 ### Step 5: AI Follow-up (offer after validation)
 
-If there are remaining TODOs, findings, compilation issues, or unresolved items, proactively offer to resolve them:
+If there are remaining TODOs, findings, compilation issues, or unresolved items, proactively offer to resolve them. For model findings, work from the per-category verdict table (Step 4): categories with verdict **needs fix** are the follow-up work items; do not present findings as one undifferentiated list.
 
 > I found [N] remaining items that need follow-up. Would you like me to take care of them?
 
@@ -124,7 +124,7 @@ Use AskUserQuestion with options:
 - Show me the list first: Present full list grouped by type, then ask which to fix.
 - No, I will handle the rest manually: Stop here; record remaining items in MIGRATION_REPORT.md.
 
-When user opts in: apply unambiguous fixes directly using the pattern catalog, propose ambiguous ones via AskUserQuestion, skip anything declined. Ask whether to commit after each batch.
+When user opts in: apply unambiguous fixes directly using the pattern catalog, propose ambiguous ones via AskUserQuestion, skip anything declined. For model findings, resolve one **needs fix** category at a time using that category's cross-check guidance; categories with verdict **needs review** each need a user decision via AskUserQuestion before any fix; categories with verdict **no action** are not offered. Ask whether to commit after each batch, and update the verdict table in MIGRATION_REPORT.md as categories are resolved.
 
 ## Validation / Exit Criteria
 
@@ -137,6 +137,6 @@ When user opts in: apply unambiguous fixes directly using the pattern catalog, p
 7. businessKey usages are mapped to businessId (8.9+) or tags (8.8)
 8. Configuration uses camunda.client.* keys instead of camunda.* keys
 9. For model migration: converted-c8-* files exist for all in-scope diagrams
-10. For model migration: all WARNING/TASK/REVIEW findings are resolved or documented
+10. For model migration: all WARNING/TASK/REVIEW findings are resolved or classified in the verdict table in MIGRATION_REPORT.md
 11. MIGRATION_REPORT.md contains complete inventories, decisions, and validation results
 12. Original model files are intact (never overwritten)

--- a/agentic-migration-skills/skills/migrate-c7-to-c8-code/references/composing-code-and-models.md
+++ b/agentic-migration-skills/skills/migrate-c7-to-c8-code/references/composing-code-and-models.md
@@ -53,6 +53,14 @@ Handle these rows as ONE named category, not individually:
 
 Record the category, its total count, the decision taken, and any uncovered invoked methods in MIGRATION_REPORT.md.
 
+### 4. Assign verdicts to the verdict table
+
+Each cross-check result maps to a verdict in the per-category verdict table (see `model-migration-approaches.md` step 5d), with the matched code artifact named in the table's cross-reference column:
+
+- 1:1 job-type match confirmed, dispatcher covering every original expression, or every invoked method covered by a remediation: **no action** (the category is fully covered).
+- Mismatched job types, uncovered original expressions, or uncovered invoked methods: **needs fix** — these become AI follow-up work items.
+- Remediation decision still pending for a category (e.g. the FEEL method-invocation option not yet chosen): **needs review**.
+
 ## Deployment Wiring
 
 After both complete, ask whether to wire deployment of converted files in application code via AskUserQuestion:

--- a/agentic-migration-skills/skills/migrate-c7-to-c8-code/references/model-migration-approaches.md
+++ b/agentic-migration-skills/skills/migrate-c7-to-c8-code/references/model-migration-approaches.md
@@ -100,6 +100,29 @@ Present the grouped table before any per-finding follow-up work starts, and reco
 
 This grouped structure is the foundation for everything that follows: cross-checking categories against the code migration output, per-category verdicts, and category-specific handling all consume this table.
 
+#### 5d. Emit a per-category verdict table
+
+After grouping (and after the code cross-checks in `composing-code-and-models.md` when code is also in scope), assign each category exactly one verdict and record the table in MIGRATION_REPORT.md. Do not leave findings as severity counts or a generic "findings need follow-up" note — on a real project with thousands of rows, the verdict table is what makes review tractable.
+
+Verdicts:
+
+- **no action** — nothing to do: the converter handled the category deterministically, the finding is purely informational (typical for INFO), or a cross-check confirmed full coverage.
+- **needs review** — a human decision is required before any fix can start: e.g. choosing the remediation approach for a category (one decision per category, not per row), or confirming a cross-check result.
+- **needs fix** — concrete, known work remains: an uncovered cross-check item (job-type mismatch, uncovered original expressions, uncovered invoked methods) or a WARNING/TASK category with a clear remediation.
+
+| Category (messageId) | Count | Cross-referenced code artifact | Verdict |
+|---|---|---|---|
+| `expression-method-not-possible` | 2,137 | none yet — remediation decision pending | needs review |
+| `delegate-expression-as-job-type` | 2,491 | `DelegateDispatcher` @JobWorker (routes 38/42 expressions) | needs fix |
+| `form-reference` | 96 | n/a | no action |
+
+Rules:
+
+- One row per category, sorted as in 5b (highest severity, then count descending).
+- The cross-referenced code artifact column names the `@JobWorker`, DMN definition, or other code element the cross-check matched the category to — or `none yet` when no remediation exists. For models-only scope there is no code output to cross-reference: use `n/a` and derive the verdict from severity alone (INFO → no action, REVIEW → needs review, WARNING/TASK → needs fix).
+- Every WARNING/TASK/REVIEW category must end up classified — none may be left without a verdict.
+- Categories with verdict **needs fix** are the input to the AI follow-up step.
+
 ---
 
 ## Approach M2 - Agentic AI (direct XML rewrite)

--- a/agentic-migration-skills/skills/migrate-c7-to-c8-code/references/model-migration-approaches.md
+++ b/agentic-migration-skills/skills/migrate-c7-to-c8-code/references/model-migration-approaches.md
@@ -121,7 +121,7 @@ Rules:
 - One row per category, sorted as in 5b (highest severity, then count descending).
 - The cross-referenced code artifact column names the `@JobWorker`, DMN definition, or other code element the cross-check matched the category to — or `none yet` when no remediation exists. For models-only scope there is no code output to cross-reference: use `n/a` and derive the verdict from severity alone (INFO → no action, REVIEW → needs review, WARNING/TASK → needs fix).
 - Every WARNING/TASK/REVIEW category must end up classified — none may be left without a verdict.
-- Categories with verdict **needs fix** are the input to the AI follow-up step.
+- Categories with verdict **needs fix** are the direct work items for the AI follow-up step. Categories with verdict **needs review** are also surfaced there, but only to collect the pending user decision (via AskUserQuestion) before any fix is attempted.
 
 ---
 

--- a/agentic-migration-skills/skills/migrate-c7-to-c8-code/references/model-migration-approaches.md
+++ b/agentic-migration-skills/skills/migrate-c7-to-c8-code/references/model-migration-approaches.md
@@ -102,7 +102,7 @@ This grouped structure is the foundation for everything that follows: cross-chec
 
 #### 5d. Emit a per-category verdict table
 
-After grouping (and after the code cross-checks in `composing-code-and-models.md` when code is also in scope), assign each category exactly one verdict and record the table in MIGRATION_REPORT.md. Do not leave findings as severity counts or a generic "findings need follow-up" note — on a real project with thousands of rows, the verdict table is what makes review tractable.
+After grouping (and after the code cross-checks in `composing-code-and-models.md` when code is also in scope), assign each WARNING/TASK/REVIEW category exactly one verdict and record the table in MIGRATION_REPORT.md. INFO categories may be included as well, typically with verdict no action, but are not required. Do not leave findings as severity counts or a generic "findings need follow-up" note — on a real project with thousands of rows, the verdict table is what makes review tractable.
 
 Verdicts:
 


### PR DESCRIPTION
## Summary

- Adds a required per-category **verdict table** to `MIGRATION_REPORT.md` for model conversion findings: category (messageId) → count → cross-referenced code artifact → verdict (**no action** / **needs review** / **needs fix**), replacing the flat "fixed or recorded" note.
- Feeds **needs fix** verdicts into the existing Step 5 AI Follow-up flow as differentiated work items, instead of one undifferentiated "findings need follow-up" note.
- Builds on the already-merged sub-issues: grouped findings (#2241), job-type collapse cross-check (#2242), and the FEEL method-invocation category (#2243) — it consumes their categories/verdicts and defines no new cross-check rules (per scope limitation).

## Changes

- `references/model-migration-approaches.md` — new step **5d. Emit a per-category verdict table**: verdict definitions, table format with example rows, and rules (one row per category, sorting, models-only fallback, every WARNING/TASK/REVIEW category must be classified, needs-fix feeds follow-up).
- `references/composing-code-and-models.md` — new section **4. Assign verdicts to the verdict table**: maps each cross-check outcome (1:1 match, dispatcher coverage, uncovered expressions/methods, pending remediation decision) to a verdict.
- `SKILL.md` — Step 4 Model Validation item 2 now requires the verdict table; Step 5 AI Follow-up works from the verdict table (needs fix = work items, needs review = AskUserQuestion decision first, no action = not offered); exit criterion 10 aligned.

## Test plan

- Documentation-only change under `agentic-migration-skills/` (not part of the Maven build) — no code tests apply.
- [ ] Manual check: verdict definitions and table format are consistent across all three files
- [ ] Manual check: no new cross-check rules introduced (scope limitation of #2244)

related to #2244