### PR TITLE
feat(skill): add fidelity, forms, and validation guidance from field feedback

### DIFF
--- a/agentic-migration-skills/skills/migrate-c7-to-c8-code/SKILL.md
+++ b/agentic-migration-skills/skills/migrate-c7-to-c8-code/SKILL.md
@@ -35,9 +35,9 @@ See `references/interview-questions.md` for the full question set and batching r
 Shared rules that apply throughout all subsequent steps:
 - Distinguish code from models. OpenRewrite/AI handles code; Diagram Converter handles models. Never hand-edit BPMN/DMN in the code flow.
 - Use project-local models first. Do not offer C7 engine access when local models are present.
-- Commits are opt-in. Check for uncommitted changes before starting; if dirty, ask user to commit or stash. Never auto-commit.
+- Commits are opt-in. Check for uncommitted changes before starting; if dirty, ask user to commit or stash. Never auto-commit; never commit without an explicit user request.
 - Prefer intent over shell dialect. Use platform-appropriate invocations for the current environment.
-- Never mutate user assets silently. Models convert to converted-c8-* copies; originals stay intact.
+- Never mutate user assets silently. Models convert to converted-c8-* copies; originals stay intact. If the user targets a separate output location (e.g. a sibling C8 project), treat the C7 project as read-only: copy assets into the target instead of editing in place.
 - Load the pattern catalog before editing. Never guess API/XML mappings. See `references/pattern-catalog-sources.md`.
 - Respect the target version. Do not offer features from a higher version than selected.
 - Prefer deterministic over agentic. Code: OpenRewrite + AI over AI-only. Models: CLI over agentic rewrite.
@@ -45,7 +45,10 @@ Shared rules that apply throughout all subsequent steps:
 - Do not redo what the tools changed. Check for existing transforms before rewriting.
 - Ask before high-complexity files and edge cases. Auto-apply only unambiguous 1:1 mappings.
 - Keep changes minimal. No refactors, renames, or improvements beyond the migration.
-- Keep `MIGRATION_REPORT.md` in the confirmed project root current with inventories, decisions, phase status, and validation results.
+- Preserve structural fidelity. Keep package names, class names, file/folder layout, and resource paths exactly as in the C7 project wherever a C8 equivalent exists. Rename or delete only what has no C8 equivalent at all, and record the reason in MIGRATION_REPORT.md.
+- Preserve behavior and dependency footprint. Startup behavior (what runs when, how many instances) and application constraints (e.g. a C7 app exposing no REST endpoints) carry over unchanged — including transitively: do not add dependencies the C7 app did not need (e.g. spring-boot-starter-web) for unrelated reasons.
+- Check the platform before porting a workaround. Many C7 patterns exist only because of C7 limitations (flat form binding, no computed display values, in-process engine API access). Verify whether Camunda 8 removed the limitation before replicating the pattern or adding a worker around it.
+- Keep `MIGRATION_REPORT.md` in the confirmed project root current with inventories, decisions, phase status, and validation results. It is the single source of truth for the migration — update it as work proceeds, every incompatibility and design decision lands there, not scattered across chat.
 
 ### Step 2: Assessment (always runs)
 
@@ -109,7 +112,8 @@ Convert BPMN/DMN from the camunda: namespace to zeebe: using the selected approa
 
 1. Confirm a converted-c8-* file exists for each in-scope diagram (unless analyze-only).
 2. Every WARNING/TASK/REVIEW finding is either fixed or classified in the per-category verdict table (category, count, cross-referenced code artifact, verdict: no action / needs review / needs fix) recorded in MIGRATION_REPORT.md — see `references/model-migration-approaches.md` step 5d. A flat "fixed or recorded" note is not sufficient.
-3. Originals are intact and were not overwritten.
+3. Converted BPMN files that were manually edited lint clean — see the linting section in `references/model-migration-approaches.md`.
+4. Originals are intact and were not overwritten.
 
 Present a validation summary showing status of: compilation, remaining C7 imports, remaining TODOs, businessKey usages, tests, models converted, and model findings needing follow-up. Record in MIGRATION_REPORT.md.
 

--- a/agentic-migration-skills/skills/migrate-c7-to-c8-code/SKILL.md
+++ b/agentic-migration-skills/skills/migrate-c7-to-c8-code/SKILL.md
@@ -47,7 +47,7 @@ Shared rules that apply throughout all subsequent steps:
 - Keep changes minimal. No refactors, renames, or improvements beyond the migration.
 - Preserve structural fidelity. Keep package names, class names, file/folder layout, and resource paths exactly as in the C7 project wherever a C8 equivalent exists. Rename or delete only what has no C8 equivalent at all, and record the reason in MIGRATION_REPORT.md.
 - Preserve behavior and dependency footprint. Startup behavior (what runs when, how many instances) and application constraints (e.g. a C7 app exposing no REST endpoints) carry over unchanged — including transitively: do not add dependencies the C7 app did not need (e.g. spring-boot-starter-web) for unrelated reasons.
-- Check the platform before porting a workaround. Many C7 patterns exist only because of C7 limitations (flat form binding, no computed display values, in-process engine API access). Verify whether Camunda 8 removed the limitation before replicating the pattern or adding a worker around it.
+- Check the platform before porting a workaround. Many C7 patterns exist only because of C7 limitations (flat form binding, no computed display values, in-process engine API access). Verify whether Camunda 8 removed the limitation before replicating the pattern or adding a worker around it. Converter findings that flag natively-supported capabilities drive the same check for deleting C7-side workaround code — see the cross-check in `references/composing-code-and-models.md`.
 - Keep `MIGRATION_REPORT.md` in the confirmed project root current with inventories, decisions, phase status, and validation results. It is the single source of truth for the migration — update it as work proceeds, every incompatibility and design decision lands there, not scattered across chat.
 
 ### Step 2: Assessment (always runs)
@@ -99,7 +99,7 @@ Convert BPMN/DMN from the camunda: namespace to zeebe: using the selected approa
 2. Check for remaining C7 references: search for `org.camunda.bpm` imports. Each is a missed migration.
 3. Check for remaining TODOs: search for `// TODO` migration comments. Each needs manual review.
 4. Check for legacy C8 client: search for `ZeebeClient` and `zeebe-client-java` (deprecated, removed in 8.10; migrate to CamundaClient).
-5. Check for leftover business keys: search for `businessKey`. Map to businessId (8.9+) or tags (8.8).
+5. Check for leftover business keys: search for `businessKey`. Map per the pattern catalog (businessId 8.9+ / tags 8.8); keys mutated during the process stay a `businessKey` process variable.
 6. Run tests: run `mvn test` or platform-appropriate Gradle test task. Fix failures.
 7. Check common pitfalls:
    - Critical naming swap: C7 processDefinitionKey (string key) becomes C8 bpmnProcessId; C7 processDefinitionId (UUID) becomes C8 processDefinitionKey. Same for decision definitions.
@@ -140,7 +140,7 @@ A second action type beyond fixing TODOs/findings is **delete now-redundant code
 4. All tests pass (or failures are documented with explanation)
 5. All // TODO migration comments are resolved or explicitly recorded
 6. No ZeebeClient/zeebe-client-java references remain (deprecated)
-7. businessKey usages are mapped to businessId (8.9+) or tags (8.8)
+7. businessKey usages are mapped per the pattern catalog (businessId 8.9+ / tags 8.8), or kept as a `businessKey` process variable when the key is mutated during the process
 8. Configuration uses camunda.client.* keys instead of camunda.* keys
 9. For model migration: converted-c8-* files exist for all in-scope diagrams
 10. For model migration: all WARNING/TASK/REVIEW findings are resolved or classified in the verdict table in MIGRATION_REPORT.md

--- a/agentic-migration-skills/skills/migrate-c7-to-c8-code/SKILL.md
+++ b/agentic-migration-skills/skills/migrate-c7-to-c8-code/SKILL.md
@@ -37,7 +37,7 @@ Shared rules that apply throughout all subsequent steps:
 - Use project-local models first. Do not offer C7 engine access when local models are present.
 - Commits are opt-in. Check for uncommitted changes before starting; if dirty, ask user to commit or stash. Never auto-commit; never commit without an explicit user request.
 - Prefer intent over shell dialect. Use platform-appropriate invocations for the current environment.
-- Never mutate user assets silently. Models convert to converted-c8-* copies; originals stay intact. If the user targets a separate output location (e.g. a sibling C8 project), treat the C7 project as read-only: copy assets into the target instead of editing in place.
+- Never mutate user assets silently. Models convert to converted-c8-* copies; originals stay intact. When migrating into a separate target location (e.g. a sibling C8 project), treat the C7 project as read-only: copy assets over, never edit in place.
 - Load the pattern catalog before editing. Never guess API/XML mappings. See `references/pattern-catalog-sources.md`.
 - Respect the target version. Do not offer features from a higher version than selected.
 - Prefer deterministic over agentic. Code: OpenRewrite + AI over AI-only. Models: CLI over agentic rewrite.
@@ -45,10 +45,9 @@ Shared rules that apply throughout all subsequent steps:
 - Do not redo what the tools changed. Check for existing transforms before rewriting.
 - Ask before high-complexity files and edge cases. Auto-apply only unambiguous 1:1 mappings.
 - Keep changes minimal. No refactors, renames, or improvements beyond the migration.
-- Preserve structural fidelity. Keep package names, class names, file/folder layout, and resource paths exactly as in the C7 project wherever a C8 equivalent exists. Rename or delete only what has no C8 equivalent at all, and record the reason in MIGRATION_REPORT.md.
-- Preserve behavior and dependency footprint. Startup behavior (what runs when, how many instances) and application constraints (e.g. a C7 app exposing no REST endpoints) carry over unchanged — including transitively: do not add dependencies the C7 app did not need (e.g. spring-boot-starter-web) for unrelated reasons.
-- Check the platform before porting a workaround. Many C7 patterns exist only because of C7 limitations (flat form binding, no computed display values, in-process engine API access). Verify whether Camunda 8 removed the limitation before replicating the pattern or adding a worker around it. Converter findings that flag natively-supported capabilities drive the same check for deleting C7-side workaround code — see the cross-check in `references/composing-code-and-models.md`.
-- Keep `MIGRATION_REPORT.md` in the confirmed project root current with inventories, decisions, phase status, and validation results. It is the single source of truth for the migration — update it as work proceeds, every incompatibility and design decision lands there, not scattered across chat.
+- Preserve fidelity: package names, class names, file/folder layout, resource paths, startup behavior, and dependency footprint (e.g. no REST endpoints → no spring-boot-starter-web) carry over unchanged wherever a C8 equivalent exists. Rename or delete only what has no C8 equivalent, and record why in MIGRATION_REPORT.md.
+- Check the platform before porting a workaround. Many C7 patterns exist only because of C7 limitations (flat form binding, no computed display values, in-process engine API). Verify whether C8 removed the limitation before replicating the pattern or adding a worker. Converter findings flagging natively-supported capabilities drive the same check for deleting C7-side workaround code — see `references/composing-code-and-models.md`.
+- Keep `MIGRATION_REPORT.md` in the confirmed project root current — it is the single source of truth for inventories, decisions, incompatibilities, and validation results; update as work proceeds, not in scattered notes.
 
 ### Step 2: Assessment (always runs)
 

--- a/agentic-migration-skills/skills/migrate-c7-to-c8-code/references/code-transform-checklist.md
+++ b/agentic-migration-skills/skills/migrate-c7-to-c8-code/references/code-transform-checklist.md
@@ -113,7 +113,7 @@ Use these to classify files during assessment:
 | `DecisionService` | Client code (maps to newEvaluateDecisionCommand) |
 | `IdentityService`, `FormService` | Client code (flag for manual design) |
 | `businessKey` usage | Flag: maps to Business ID / tags (see pattern catalog; mutable keys become a process variable) |
-| `FileValue` / `Values.fileValue(...)` | Flag: maps to Document API (see pattern catalog) |
+| `FileValue` / `Variables.fileValue(...)` | Flag: maps to Document API (see pattern catalog) |
 | Groovy/JavaScript in `conditionExpression`, script tasks, `camunda:script` | Script expression (maps to preceding job worker) |
 | `camunda:connector` / http-connector, HTTP client code in delegates | Flag: maps to out-of-the-box REST connector (see pattern catalog) |
 | Batch operations (`...Async`, ManagementService batches) | Client code |

--- a/agentic-migration-skills/skills/migrate-c7-to-c8-code/references/code-transform-checklist.md
+++ b/agentic-migration-skills/skills/migrate-c7-to-c8-code/references/code-transform-checklist.md
@@ -30,7 +30,7 @@ Confirm each item before the next (commit policy: ask user before committing).
 - Replace ProcessEngine/service autowiring (RuntimeService, TaskService, HistoryService, DecisionService, ManagementService) with CamundaClient.
 - Map: start instances (incl. businessId/tags), message correlation, signal broadcast, cancel, user tasks, variables, HistoryService to search requests, DecisionService to newEvaluateDecisionCommand, batch ...Async to batch operations (8.8+).
 - When a C7 API has a C8 counterpart, use the matching CamundaClient API (e.g. HistoryService to search requests) instead of introducing new process variables to carry what the API can already return.
-- Business key: map to businessId (8.9+) or tags (8.8). Both are set at instance start and are immutable. If the C7 process changes its business key during execution, neither fits — use a dedicated `businessKey` process variable instead, and flag the semantic difference (no longer an engine-level correlation identity) in MIGRATION_REPORT.md.
+- Business key: map per the pattern catalog (Business ID 8.9+ / tags 8.8, both immutable — mutable keys become a `businessKey` process variable). A mutable key loses its engine-level correlation identity in C8 — flag that semantic difference in MIGRATION_REPORT.md.
 - Preserve startup behavior exactly: what starts, when it starts, and how many instances. If migrated code starts instances from @PostConstruct while using @Deployment, move startup logic to `@EventListener(CamundaPostDeploymentEvent.class)`.
 
 ---
@@ -42,8 +42,7 @@ Confirm each item before the next (commit policy: ask user before committing).
 - BpmnError becomes `CamundaError.bpmnError(...)`.
 - Remove TypedValue usage.
 - Keep worker behavior unchanged. Inputs and outputs of a migrated worker stay the same; never add new features to an existing worker during migration. New logic belongs in a new, separate worker.
-- `FileValue` variables map to the Document API (`camundaClient.newCreateDocumentCommand()`), never to a bare filename string. Store the plain document reference in the process variable; wrap it in a one-element array only in the FEEL of the form that consumes it (see the Forms category in `model-migration-approaches.md`), not in the variable itself.
-- Outbound HTTP calls (C7 http-connector, hand-rolled HTTP clients in delegates): prefer a standard out-of-the-box connector — the REST connector for outbound HTTP — wherever one covers the need, instead of porting HTTP client code into a worker.
+- `FileValue` variables and outbound HTTP calls map per the pattern catalog (Document API; out-of-the-box REST connector).
 
 ---
 
@@ -115,10 +114,10 @@ Use these to classify files during assessment:
 | `HistoryService` | Client code (maps to search endpoints) |
 | `DecisionService` | Client code (maps to newEvaluateDecisionCommand) |
 | `IdentityService`, `FormService` | Client code (flag for manual design) |
-| `businessKey` usage | Flag: maps to Business ID (8.9+) or tags (8.8); if mutated during the process, use a `businessKey` process variable |
-| `FileValue` / `Values.fileValue(...)` | Flag: maps to Document API (`newCreateDocumentCommand`), never a filename string |
+| `businessKey` usage | Flag: maps to Business ID / tags (see pattern catalog; mutable keys become a process variable) |
+| `FileValue` / `Values.fileValue(...)` | Flag: maps to Document API (see pattern catalog) |
 | Groovy/JavaScript in `conditionExpression`, script tasks, `camunda:script` | Script expression (maps to preceding job worker) |
-| `camunda:connector` / http-connector, HTTP client code in delegates | Flag: prefer out-of-the-box REST connector |
+| `camunda:connector` / http-connector, HTTP client code in delegates | Flag: maps to out-of-the-box REST connector (see pattern catalog) |
 | Batch operations (`...Async`, ManagementService batches) | Client code |
 | `ZeebeClient` / Spring Zeebe SDK | Legacy C8 client (migrate to CamundaClient) |
 | `@Test` + Camunda 7 test rules | Test code |

--- a/agentic-migration-skills/skills/migrate-c7-to-c8-code/references/code-transform-checklist.md
+++ b/agentic-migration-skills/skills/migrate-c7-to-c8-code/references/code-transform-checklist.md
@@ -10,6 +10,8 @@ Confirm each item before the next (commit policy: ask user before committing).
 
 - Resolve the latest released GA Camunda version from Maven Central artifact metadata: query `https://repo.maven.apache.org/maven2/io/camunda/<artifact-id>/maven-metadata.xml`. From versions, choose the highest version matching the target Camunda minor (8.8.x, 8.9.x, etc.) and exclude SNAPSHOT, alpha, beta, and rc versions. If no GA version exists for the target, ask before using a pre-release.
 - Pick the starter by Spring Boot version: 3.x uses `io.camunda:camunda-spring-boot-3-starter`; 4.x uses `io.camunda:camunda-spring-boot-starter`.
+- Verify Spring Boot compatibility from the artifact, not from assumption: read the selected starter's (or BOM's) POM on Maven Central and confirm the Spring Boot version range it is built against actually covers the project's Spring Boot version. Do not assume a pairing works because both versions are "latest".
+- Preserve the dependency footprint. Do not add dependencies the C7 app did not need (e.g. never pull in `spring-boot-starter-web` for a C7 app that exposed no REST endpoints) — including transitively, via starter choices.
 - Add the Camunda public repository only if the selected artifact/version is not available on Maven Central:
   - Maven: `<repository><id>camunda-public</id><url>https://artifacts.camunda.com/artifactory/public/</url></repository>`
   - Gradle: `maven { url "https://artifacts.camunda.com/artifactory/public/" }`
@@ -27,7 +29,9 @@ Confirm each item before the next (commit policy: ask user before committing).
 
 - Replace ProcessEngine/service autowiring (RuntimeService, TaskService, HistoryService, DecisionService, ManagementService) with CamundaClient.
 - Map: start instances (incl. businessId/tags), message correlation, signal broadcast, cancel, user tasks, variables, HistoryService to search requests, DecisionService to newEvaluateDecisionCommand, batch ...Async to batch operations (8.8+).
-- If migrated code starts instances from @PostConstruct while using @Deployment, move startup logic to `@EventListener(CamundaPostDeploymentEvent.class)`.
+- When a C7 API has a C8 counterpart, use the matching CamundaClient API (e.g. HistoryService to search requests) instead of introducing new process variables to carry what the API can already return.
+- Business key: map to businessId (8.9+) or tags (8.8). Both are set at instance start and are immutable. If the C7 process changes its business key during execution, neither fits — use a dedicated `businessKey` process variable instead, and flag the semantic difference (no longer an engine-level correlation identity) in MIGRATION_REPORT.md.
+- Preserve startup behavior exactly: what starts, when it starts, and how many instances. If migrated code starts instances from @PostConstruct while using @Deployment, move startup logic to `@EventListener(CamundaPostDeploymentEvent.class)`.
 
 ---
 
@@ -37,6 +41,9 @@ Confirm each item before the next (commit policy: ask user before committing).
 - Variable access becomes method params / @Variable.
 - BpmnError becomes `CamundaError.bpmnError(...)`.
 - Remove TypedValue usage.
+- Keep worker behavior unchanged. Inputs and outputs of a migrated worker stay the same; never add new features to an existing worker during migration. New logic belongs in a new, separate worker.
+- `FileValue` variables map to the Document API (`camundaClient.newCreateDocumentCommand()`), never to a bare filename string. Store the plain document reference in the process variable; wrap it in a one-element array only in the FEEL of the form that consumes it (see the Forms category in `model-migration-approaches.md`), not in the variable itself.
+- Outbound HTTP calls (C7 http-connector, hand-rolled HTTP clients in delegates): prefer a standard out-of-the-box connector — the REST connector for outbound HTTP — wherever one covers the need, instead of porting HTTP client code into a worker.
 
 ---
 
@@ -72,6 +79,12 @@ Confirm each item before the next (commit policy: ask user before committing).
 - Conditional events are native since 8.9.
 - Method-invoking expressions (on beans or plain variables) are the named category **FEEL method-invocation**, handled below.
 
+### Named category: Script expressions (Groovy, JavaScript, ...)
+
+Script-language expressions — typical on sequence-flow condition expressions (`<conditionExpression xsi:type="tFormalExpression" language="groovy">`), script tasks, and `camunda:script` in listeners — cannot run in C8: FEEL is the only expression language and cannot execute scripts. Treat all occurrences as ONE category per script language.
+
+Default remediation: move the script logic into a preceding service task whose `@JobWorker` computes the outcome (e.g. a boolean for a gateway) into a plain process variable, and replace the sequence-flow expression with a FEEL reference to that variable. For a script task, convert the task itself into a service task with a worker holding the script logic. Decision weighting matches the FEEL method-invocation category (precompute via job worker is the default).
+
 ### Named category: FEEL method-invocation
 
 Every expression that invokes a Java method (e.g. `${order.getTotal()}`, `${pricingService.quote(customer)}`) fails for the same root cause: FEEL cannot call Java methods — whether the receiver is a Spring bean or a plain variable (e.g. `${objectVar.getAddress().getStreet()}`, `${execution.getVariable("a").size()}`). Treat all occurrences as ONE countable category — **FEEL method-invocation** — regardless of where they appear: sequence-flow/gateway condition expressions, multi-instance `collection` or completion conditions, callActivity `calledElement`, timer expressions, input/output parameters, or job/user-task attributes (assignee, dueDate, priority, ...).
@@ -102,7 +115,10 @@ Use these to classify files during assessment:
 | `HistoryService` | Client code (maps to search endpoints) |
 | `DecisionService` | Client code (maps to newEvaluateDecisionCommand) |
 | `IdentityService`, `FormService` | Client code (flag for manual design) |
-| `businessKey` usage | Flag: maps to Business ID (8.9+) or tags (8.8) |
+| `businessKey` usage | Flag: maps to Business ID (8.9+) or tags (8.8); if mutated during the process, use a `businessKey` process variable |
+| `FileValue` / `Values.fileValue(...)` | Flag: maps to Document API (`newCreateDocumentCommand`), never a filename string |
+| Groovy/JavaScript in `conditionExpression`, script tasks, `camunda:script` | Script expression (maps to preceding job worker) |
+| `camunda:connector` / http-connector, HTTP client code in delegates | Flag: prefer out-of-the-box REST connector |
 | Batch operations (`...Async`, ManagementService batches) | Client code |
 | `ZeebeClient` / Spring Zeebe SDK | Legacy C8 client (migrate to CamundaClient) |
 | `@Test` + Camunda 7 test rules | Test code |

--- a/agentic-migration-skills/skills/migrate-c7-to-c8-code/references/code-transform-checklist.md
+++ b/agentic-migration-skills/skills/migrate-c7-to-c8-code/references/code-transform-checklist.md
@@ -10,8 +10,8 @@ Confirm each item before the next (commit policy: ask user before committing).
 
 - Resolve the latest released GA Camunda version from Maven Central artifact metadata: query `https://repo.maven.apache.org/maven2/io/camunda/<artifact-id>/maven-metadata.xml`. From versions, choose the highest version matching the target Camunda minor (8.8.x, 8.9.x, etc.) and exclude SNAPSHOT, alpha, beta, and rc versions. If no GA version exists for the target, ask before using a pre-release.
 - Pick the starter by Spring Boot version: 3.x uses `io.camunda:camunda-spring-boot-3-starter`; 4.x uses `io.camunda:camunda-spring-boot-starter`.
-- Verify Spring Boot compatibility from the artifact, not from assumption: read the selected starter's (or BOM's) POM on Maven Central and confirm the Spring Boot version range it is built against actually covers the project's Spring Boot version. Do not assume a pairing works because both versions are "latest".
-- Preserve the dependency footprint. Do not add dependencies the C7 app did not need (e.g. never pull in `spring-boot-starter-web` for a C7 app that exposed no REST endpoints) — including transitively, via starter choices.
+- Verify Spring Boot compatibility from the selected starter's/BOM's POM on Maven Central — do not assume a pairing works because both versions are "latest".
+- Preserve the dependency footprint: never add dependencies the C7 app did not need (e.g. `spring-boot-starter-web` when it exposed no REST endpoints), including transitively via starter choices.
 - Add the Camunda public repository only if the selected artifact/version is not available on Maven Central:
   - Maven: `<repository><id>camunda-public</id><url>https://artifacts.camunda.com/artifactory/public/</url></repository>`
   - Gradle: `maven { url "https://artifacts.camunda.com/artifactory/public/" }`
@@ -80,9 +80,7 @@ Confirm each item before the next (commit policy: ask user before committing).
 
 ### Named category: Script expressions (Groovy, JavaScript, ...)
 
-Script-language expressions — typical on sequence-flow condition expressions (`<conditionExpression xsi:type="tFormalExpression" language="groovy">`), script tasks, and `camunda:script` in listeners — cannot run in C8: FEEL is the only expression language and cannot execute scripts. Treat all occurrences as ONE category per script language.
-
-Default remediation: move the script logic into a preceding service task whose `@JobWorker` computes the outcome (e.g. a boolean for a gateway) into a plain process variable, and replace the sequence-flow expression with a FEEL reference to that variable. For a script task, convert the task itself into a service task with a worker holding the script logic. Decision weighting matches the FEEL method-invocation category (precompute via job worker is the default).
+Script-language expressions (sequence-flow conditions with `language="groovy"`, script tasks, `camunda:script` in listeners) cannot run in C8 — FEEL cannot execute scripts. Treat as ONE category per script language. Default remediation (same decision weighting as FEEL method-invocation): move the script logic into a preceding service task whose `@JobWorker` computes the outcome into a plain variable; replace the expression with a FEEL reference. A script task itself becomes a service task with a worker holding the script logic.
 
 ### Named category: FEEL method-invocation
 

--- a/agentic-migration-skills/skills/migrate-c7-to-c8-code/references/model-migration-approaches.md
+++ b/agentic-migration-skills/skills/migrate-c7-to-c8-code/references/model-migration-approaches.md
@@ -197,28 +197,14 @@ Treat unreachable endpoint, TLS/DNS failure, 401/403, malformed XML, or empty re
 
 ## Linting Converted BPMN (M1 and M2)
 
-After any manual edit to a converted BPMN file (findings follow-up, form wiring, expression fixes), lint immediately — missing DI, overlapping flows, and disconnected nodes are cheapest to catch at edit time, not at the end.
+After any manual BPMN edit (findings follow-up, form wiring, expression fixes), lint immediately with bpmnlint and the Camunda compatibility ruleset for the target version — missing DI, overlaps, and disconnected flows are cheapest to catch at edit time:
 
-Use bpmnlint with the Camunda compatibility ruleset matching the target version:
-
-1. Install once in the project (or a scratch directory): `npm install -D bpmnlint zeebe-bpmn-moddle bpmnlint-plugin-camunda-compat`
-2. `.bpmnlintrc`:
-
-```json
-{
-  "extends": [
-    "bpmnlint:recommended",
-    "plugin:camunda-compat/camunda-cloud-<target-version>"
-  ],
-  "moddleExtensions": {
-    "zeebe": "zeebe-bpmn-moddle/resources/zeebe.json"
-  }
-}
+```sh
+npm install -D bpmnlint zeebe-bpmn-moddle bpmnlint-plugin-camunda-compat   # once
+npx bpmnlint <converted-file>.bpmn
 ```
 
-3. Run: `npx bpmnlint <converted-file>.bpmn`
-
-Fix or record every lint error before continuing.
+`.bpmnlintrc`: extend `bpmnlint:recommended` and `plugin:camunda-compat/camunda-cloud-<target-version>`, and set `moddleExtensions.zeebe` to `zeebe-bpmn-moddle/resources/zeebe.json`. Fix or record every lint error before continuing.
 
 ---
 

--- a/agentic-migration-skills/skills/migrate-c7-to-c8-code/references/model-migration-approaches.md
+++ b/agentic-migration-skills/skills/migrate-c7-to-c8-code/references/model-migration-approaches.md
@@ -65,6 +65,8 @@ Severity counts are only a headline. Do not start per-finding work from them —
 
 REVIEW/WARNING/TASK findings remain and JUEL conversion is partial. Resolve them in the AI follow-up step, working on the `converted-c8-*` copies (never the originals).
 
+Trust the converter's output for what it did NOT flag: job types and listener wiring it emitted are authoritative — apply manual fixes only for what the report flags. Do not second-guess or re-derive converted structures.
+
 On a real project the report can hold thousands of rows but only a handful of distinct categories. Parse the report and group by category first — the category, not the individual row, is the unit of work for follow-up.
 
 #### 5a. Parse the CSV report
@@ -114,7 +116,7 @@ Verdicts:
 |---|---|---|---|
 | `expression-method-not-possible` | 2,137 | none yet — remediation decision pending | needs review |
 | `delegate-expression-as-job-type` | 2,491 | `DelegateDispatcher` @JobWorker (routes 38/42 expressions) | needs fix |
-| `form-reference` | 96 | n/a | no action |
+| `form-reference` | 96 | one `.form` per C7 form (see 5e) | needs fix |
 
 Rules:
 
@@ -122,6 +124,17 @@ Rules:
 - The cross-referenced code artifact column names the `@JobWorker`, DMN definition, or other code element the cross-check matched the category to — or `none yet` when no remediation exists. For models-only scope there is no code output to cross-reference: use `n/a` and derive the verdict from severity alone (INFO → no action, REVIEW → needs review, WARNING/TASK → needs fix).
 - Every WARNING/TASK/REVIEW category must end up classified — none may be left without a verdict.
 - Categories with verdict **needs fix** are the direct work items for the AI follow-up step. Categories with verdict **needs review** are also surfaced there, but only to collect the pending user decision (via AskUserQuestion) before any fix is attempted.
+
+#### 5e. Named category: Forms
+
+C7 form references (`camunda:formKey`, `camunda:formData` / generated forms, embedded forms) surface as findings (typically `form-reference`). Handle them as one category:
+
+- **One C8 form per C7 form.** For every C7 form (generated or otherwise), create a Camunda 8 `.form` and reference it from the user task. Do not drop forms or merge several C7 forms into one.
+- **Check what C8 forms do natively before adding a worker.** Many C7 projects carry flattening/computing service tasks that exist only because C7 forms could not bind or compute. Camunda 8 forms removed those limitations:
+  - Field `key` supports path-as-key binding into nested variables (e.g. `customerInfo.firstName`) — no flattening worker needed for passthrough fields.
+  - `text` components support feelers templating: `{{ }}` interpolation with full FEEL, including `{{#loop}}` — counts, joined lists, and other computed display values belong in the form itself, not in a preceding service task. The JSON property is `text`, not `content` (`content` is for `html`-type components only).
+  - A dedicated `documentPreview` component (property `dataSource`, a FEEL expression over an array of document references) renders an inline preview and download link for a Document API reference — prefer it over a plain-text filename display or a hand-built HTML anchor. Wrap the reference in a one-element array here in the form's FEEL only; the process variable itself holds the plain reference.
+- **Add a worker only when the form genuinely cannot do it**: real business logic, external calls, side effects. A service task that only reshapes variables for form consumption is a C7 workaround — do not port it.
 
 ---
 
@@ -140,7 +153,7 @@ For each in-scope diagram, produce a new `converted-c8-<name>.bpmn`/`.dmn` (neve
 - Conditional events natively only on 8.9+; otherwise flag
 - DMN: update decision/definition namespaces and expression language as needed
 
-Emit a findings summary mirroring CLI severities (WARNING/TASK/REVIEW/INFO) and ask for human review.
+Emit a findings summary mirroring CLI severities (WARNING/TASK/REVIEW/INFO) and ask for human review. Lint every rewritten BPMN file per the linting section below.
 
 ---
 
@@ -179,6 +192,33 @@ For named-key acquisition, query C7 REST list endpoints with key filters, fetch 
 ### 3. Handle Failures
 
 Treat unreachable endpoint, TLS/DNS failure, 401/403, malformed XML, or empty response as a blocking error. Report URL, operation, status/error, and concrete next action. Do not silently continue or report success when any requested definition failed.
+
+---
+
+## Linting Converted BPMN (M1 and M2)
+
+After any manual edit to a converted BPMN file (findings follow-up, form wiring, expression fixes), lint immediately — missing DI, overlapping flows, and disconnected nodes are cheapest to catch at edit time, not at the end.
+
+Use bpmnlint with the Camunda compatibility ruleset matching the target version:
+
+1. Install once in the project (or a scratch directory): `npm install -D bpmnlint zeebe-bpmn-moddle bpmnlint-plugin-camunda-compat`
+2. `.bpmnlintrc`:
+
+```json
+{
+  "extends": [
+    "bpmnlint:recommended",
+    "plugin:camunda-compat/camunda-cloud-<target-version>"
+  ],
+  "moddleExtensions": {
+    "zeebe": "zeebe-bpmn-moddle/resources/zeebe.json"
+  }
+}
+```
+
+3. Run: `npx bpmnlint <converted-file>.bpmn`
+
+Fix or record every lint error before continuing.
 
 ---
 

--- a/code-conversion/patterns/20-client-code/10-process-engine/business-key-and-tags.md
+++ b/code-conversion/patterns/20-client-code/10-process-engine/business-key-and-tags.md
@@ -35,7 +35,7 @@ If your target version is **8.8**, use tags (for example, `order:1234`) or store
     }
 ```
 
--   the Business ID is immutable — it cannot be changed or removed after creation (Camunda 7 allowed updating the business key, Camunda 8 does not)
+-   the Business ID is immutable — it cannot be changed or removed after creation (Camunda 7 allowed updating the business key, Camunda 8 does not). If the migrated process updates its business key during execution, neither Business ID nor tags fit — keep it as a plain `businessKey` process variable and filter by variable in searches; note that it loses engine-level correlation identity
 -   the Business ID is automatically propagated to child instances created via call activities
 -   uniqueness can be enforced at the cluster level: only one *running* root instance per process definition may carry the same Business ID, which enables idempotent process starts
 -   maximum length is 256 characters

--- a/code-conversion/patterns/20-client-code/10-process-engine/handle-files-and-documents.md
+++ b/code-conversion/patterns/20-client-code/10-process-engine/handle-files-and-documents.md
@@ -1,0 +1,40 @@
+# File Variables &#8594; Document API
+
+In Camunda 7, files are stored as process variables of type `FileValue` (via the Typed Value API), carrying the file content plus filename and MIME type metadata.
+
+Camunda 8 has no typed file variable. Files become **documents** managed by the [Document API](https://docs.camunda.io/docs/components/document-handling/getting-started/) (`newCreateDocumentCommand`); the process variable holds only the resulting **document reference**, never a bare filename string.
+
+| Camunda 7                          | Camunda 8                                                        |
+| ---------------------------------- | ---------------------------------------------------------------- |
+| `FileValue` variable (`Values.fileValue(...)`) | Document uploaded via `camundaClient.newCreateDocumentCommand()`; the `DocumentReference` is stored as the process variable |
+
+## Creating a File Variable
+
+### ProcessEngine (Camunda 7)
+
+```java
+    public void storeFile(DelegateExecution execution) {
+        FileValue contract = Variables.fileValue("contract.pdf")
+                .file(fileBytes)
+                .mimeType("application/pdf")
+                .create();
+        execution.setVariable("contract", contract);
+    }
+```
+
+### CamundaClient (Camunda 8)
+
+```java
+    public DocumentReference storeDocument(byte[] fileBytes) {
+        return camundaClient.newCreateDocumentCommand()
+                .content(fileBytes)
+                .fileName("contract.pdf")
+                .contentType("application/pdf")
+                .send()
+                .join(); // add reactive response and error handling instead of join()
+    }
+```
+
+-   store the plain `DocumentReference` in the process variable — do not wrap it in an array in the variable itself
+-   forms consuming the reference (for example a `documentPreview` component) expect a FEEL expression over an *array* of references; do the one-element wrap (`[contract]`) in the form's FEEL expression, not in the variable
+-   documents have a store-specific time-to-live and size limits — check the [document handling docs](https://docs.camunda.io/docs/components/document-handling/getting-started/) for your storage backend

--- a/code-conversion/patterns/20-client-code/10-process-engine/handle-files-and-documents.md
+++ b/code-conversion/patterns/20-client-code/10-process-engine/handle-files-and-documents.md
@@ -1,12 +1,6 @@
 # File Variables &#8594; Document API
 
-In Camunda 7, files are stored as process variables of type `FileValue` (via the Typed Value API), carrying the file content plus filename and MIME type metadata.
-
-Camunda 8 has no typed file variable. Files become **documents** managed by the [Document API](https://docs.camunda.io/docs/components/document-handling/getting-started/) (`newCreateDocumentCommand`); the process variable holds only the resulting **document reference**, never a bare filename string.
-
-| Camunda 7                          | Camunda 8                                                        |
-| ---------------------------------- | ---------------------------------------------------------------- |
-| `FileValue` variable (`Values.fileValue(...)`) | Document uploaded via `camundaClient.newCreateDocumentCommand()`; the `DocumentReference` is stored as the process variable |
+In Camunda 7, files are stored as `FileValue` process variables (Typed Value API) carrying content plus filename and MIME type. Camunda 8 has no typed file variable: files become **documents** managed by the [Document API](https://docs.camunda.io/docs/components/document-handling/getting-started/) (`newCreateDocumentCommand`); the process variable holds only the resulting **document reference**, never a bare filename string.
 
 ## Creating a File Variable
 
@@ -35,6 +29,5 @@ Camunda 8 has no typed file variable. Files become **documents** managed by the 
     }
 ```
 
--   store the plain `DocumentReference` in the process variable — do not wrap it in an array in the variable itself
--   forms consuming the reference (for example a `documentPreview` component) expect a FEEL expression over an *array* of references; do the one-element wrap (`[contract]`) in the form's FEEL expression, not in the variable
--   documents have a store-specific time-to-live and size limits — check the [document handling docs](https://docs.camunda.io/docs/components/document-handling/getting-started/) for your storage backend
+-   store the plain `DocumentReference` in the process variable; forms consuming it (e.g. a `documentPreview` component) expect a FEEL expression over an *array* — do the one-element wrap (`[contract]`) in the form's FEEL, not in the variable
+-   documents have store-specific time-to-live and size limits — check the document handling docs for your storage backend

--- a/code-conversion/patterns/30-glue-code/outbound-http-rest-connector.md
+++ b/code-conversion/patterns/30-glue-code/outbound-http-rest-connector.md
@@ -1,14 +1,10 @@
 # Outbound HTTP &#8594; REST Connector
 
-In Camunda 7, outbound HTTP calls are made with the `camunda:connector` / **http-connector** extension on service tasks, or with hand-rolled HTTP client code inside a JavaDelegate or external task worker.
-
-Camunda 8 provides a standard out-of-the-box [REST connector](https://docs.camunda.io/docs/components/connectors/protocol/rest/) for outbound HTTP. Prefer it wherever it covers the need instead of porting HTTP client code into a job worker.
+C7 outbound HTTP uses the `camunda:connector` / **http-connector** extension or hand-rolled HTTP client code inside a delegate/worker. Camunda 8 provides a standard out-of-the-box [REST connector](https://docs.camunda.io/docs/components/connectors/protocol/rest/) — prefer it wherever it covers the need instead of porting HTTP client code into a job worker.
 
 | Camunda 7                                          | Camunda 8                                  |
 | -------------------------------------------------- | ------------------------------------------ |
-| `camunda:connector` with http-connector on a task  | Service task templated with the out-of-the-box REST connector (URL, method, headers, authentication, and result expression configured on the element) |
-| HTTP client code inside a delegate/worker          | Same — keep a custom `@JobWorker` only for what the connector cannot express (complex multi-step logic, non-HTTP protocols) |
+| `camunda:connector` with http-connector, HTTP client code in a delegate/worker | Service task with the out-of-the-box REST connector (URL, method, headers, authentication, result expression configured on the element; no Java code) |
 
--   connector templates are applied in the Modeler or as element templates in the BPMN XML; no Java code is needed for the HTTP call itself
--   the connector's result expression maps the HTTP response into process variables — this replaces the delegate's `setVariable` calls
--   for more information, see [the REST connector docs](https://docs.camunda.io/docs/components/connectors/protocol/rest/)
+-   the connector's result expression maps the HTTP response into process variables — replacing the delegate's `setVariable` calls
+-   keep a custom `@JobWorker` only for what the connector cannot express (complex multi-step logic, non-HTTP protocols)

--- a/code-conversion/patterns/30-glue-code/outbound-http-rest-connector.md
+++ b/code-conversion/patterns/30-glue-code/outbound-http-rest-connector.md
@@ -1,0 +1,14 @@
+# Outbound HTTP &#8594; REST Connector
+
+In Camunda 7, outbound HTTP calls are made with the `camunda:connector` / **http-connector** extension on service tasks, or with hand-rolled HTTP client code inside a JavaDelegate or external task worker.
+
+Camunda 8 provides a standard out-of-the-box [REST connector](https://docs.camunda.io/docs/components/connectors/protocol/rest/) for outbound HTTP. Prefer it wherever it covers the need instead of porting HTTP client code into a job worker.
+
+| Camunda 7                                          | Camunda 8                                  |
+| -------------------------------------------------- | ------------------------------------------ |
+| `camunda:connector` with http-connector on a task  | Service task templated with the out-of-the-box REST connector (URL, method, headers, authentication, and result expression configured on the element) |
+| HTTP client code inside a delegate/worker          | Same — keep a custom `@JobWorker` only for what the connector cannot express (complex multi-step logic, non-HTTP protocols) |
+
+-   connector templates are applied in the Modeler or as element templates in the BPMN XML; no Java code is needed for the HTTP call itself
+-   the connector's result expression maps the HTTP response into process variables — this replaces the delegate's `setVariable` calls
+-   for more information, see [the REST connector docs](https://docs.camunda.io/docs/components/connectors/protocol/rest/)

--- a/code-conversion/patterns/ALL_IN_ONE.md
+++ b/code-conversion/patterns/ALL_IN_ONE.md
@@ -18,6 +18,7 @@ Patterns:
     - [Cancel Process Instance](#cancel-process-instance)
     - [Correlate Messages](#correlate-messages)
     - [Evaluate Decisions (DMN)](#evaluate-decisions-dmn)
+    - [File Variables &#8594; Document API](#file-variables-8594-document-api)
     - [Handle Variables](#handle-variables)
     - [Handle Resources](#handle-resources)
     - [Handle User Tasks](#handle-user-tasks)
@@ -26,6 +27,7 @@ Patterns:
     - [Search Process Definitions](#search-process-definitions)
     - [Starting Process Instances](#starting-process-instances)
 - [Glue code](#glue-code)
+  - [Outbound HTTP &#8594; REST Connector](#outbound-http-8594-rest-connector)
   - [JavaDelegate &#8594; Job Worker (Spring)](#javadelegate-8594-job-worker-spring)
     - [Class-level Changes](#class-level-changes)
     - [Handling a BPMN error](#handling-a-bpmn-error)
@@ -341,7 +343,7 @@ If your target version is **8.8**, use tags (for example, `order:1234`) or store
     }
 ```
 
--   the Business ID is immutable — it cannot be changed or removed after creation (Camunda 7 allowed updating the business key, Camunda 8 does not)
+-   the Business ID is immutable — it cannot be changed or removed after creation (Camunda 7 allowed updating the business key, Camunda 8 does not). If the migrated process updates its business key during execution, neither Business ID nor tags fit — keep it as a plain `businessKey` process variable and filter by variable in searches; note that it loses engine-level correlation identity
 -   the Business ID is automatically propagated to child instances created via call activities
 -   uniqueness can be enforced at the cluster level: only one *running* root instance per process definition may carry the same Business ID, which enables idempotent process starts
 -   maximum length is 256 characters
@@ -561,6 +563,49 @@ In Camunda 7, DMN decisions are evaluated via the `DecisionService`. In Camunda 
 -   the result is returned as JSON: `response.getDecisionOutput()` contains the output, `response.getEvaluatedDecisions()` the details of all evaluated (required) decisions
 -   `DmnDecisionTableResult` convenience methods like `getSingleEntry()` have no direct equivalent — parse the JSON output instead
 -   decisions evaluated *inside* a process should be modeled as a BPMN business rule task instead of being evaluated from glue code; the task's binding (`latest`, `deployment`, `versionTag`) controls version selection
+
+---
+
+#### File Variables &#8594; Document API
+
+In Camunda 7, files are stored as process variables of type `FileValue` (via the Typed Value API), carrying the file content plus filename and MIME type metadata.
+
+Camunda 8 has no typed file variable. Files become **documents** managed by the [Document API](https://docs.camunda.io/docs/components/document-handling/getting-started/) (`newCreateDocumentCommand`); the process variable holds only the resulting **document reference**, never a bare filename string.
+
+| Camunda 7                          | Camunda 8                                                        |
+| ---------------------------------- | ---------------------------------------------------------------- |
+| `FileValue` variable (`Values.fileValue(...)`) | Document uploaded via `camundaClient.newCreateDocumentCommand()`; the `DocumentReference` is stored as the process variable |
+
+###### Creating a File Variable
+
+###### ProcessEngine (Camunda 7)
+
+```java
+    public void storeFile(DelegateExecution execution) {
+        FileValue contract = Variables.fileValue("contract.pdf")
+                .file(fileBytes)
+                .mimeType("application/pdf")
+                .create();
+        execution.setVariable("contract", contract);
+    }
+```
+
+###### CamundaClient (Camunda 8)
+
+```java
+    public DocumentReference storeDocument(byte[] fileBytes) {
+        return camundaClient.newCreateDocumentCommand()
+                .content(fileBytes)
+                .fileName("contract.pdf")
+                .contentType("application/pdf")
+                .send()
+                .join(); // add reactive response and error handling instead of join()
+    }
+```
+
+-   store the plain `DocumentReference` in the process variable — do not wrap it in an array in the variable itself
+-   forms consuming the reference (for example a `documentPreview` component) expect a FEEL expression over an *array* of references; do the one-element wrap (`[contract]`) in the form's FEEL expression, not in the variable
+-   documents have a store-specific time-to-live and size limits — check the [document handling docs](https://docs.camunda.io/docs/components/document-handling/getting-started/) for your storage backend
 
 ---
 
@@ -1303,6 +1348,23 @@ The glue code patterns look into the different scenarios and proposes code conve
 | `camunda:expression`             | `camunda:expression="${someBean.doStuff()}"`    | `someBeanDoStuff`                  | Method name used as job type; original expression saved as header so you can have your own worker evaluating the original expression     | [Java Expression](15-java-expression/README.md) |
 | No implementation / fallback     | *(none or unsupported type)*                    | `defaultJobType`           | Uses configured fallback (`"camunda-7-job"` by default)               | — |
 
+
+### Outbound HTTP &#8594; REST Connector
+
+In Camunda 7, outbound HTTP calls are made with the `camunda:connector` / **http-connector** extension on service tasks, or with hand-rolled HTTP client code inside a JavaDelegate or external task worker.
+
+Camunda 8 provides a standard out-of-the-box [REST connector](https://docs.camunda.io/docs/components/connectors/protocol/rest/) for outbound HTTP. Prefer it wherever it covers the need instead of porting HTTP client code into a job worker.
+
+| Camunda 7                                          | Camunda 8                                  |
+| -------------------------------------------------- | ------------------------------------------ |
+| `camunda:connector` with http-connector on a task  | Service task templated with the out-of-the-box REST connector (URL, method, headers, authentication, and result expression configured on the element) |
+| HTTP client code inside a delegate/worker          | Same — keep a custom `@JobWorker` only for what the connector cannot express (complex multi-step logic, non-HTTP protocols) |
+
+-   connector templates are applied in the Modeler or as element templates in the BPMN XML; no Java code is needed for the HTTP call itself
+-   the connector's result expression maps the HTTP response into process variables — this replaces the delegate's `setVariable` calls
+-   for more information, see [the REST connector docs](https://docs.camunda.io/docs/components/connectors/protocol/rest/)
+
+---
 
 ### JavaDelegate &#8594; Job Worker (Spring)
 

--- a/code-conversion/patterns/ALL_IN_ONE.md
+++ b/code-conversion/patterns/ALL_IN_ONE.md
@@ -568,13 +568,7 @@ In Camunda 7, DMN decisions are evaluated via the `DecisionService`. In Camunda 
 
 #### File Variables &#8594; Document API
 
-In Camunda 7, files are stored as process variables of type `FileValue` (via the Typed Value API), carrying the file content plus filename and MIME type metadata.
-
-Camunda 8 has no typed file variable. Files become **documents** managed by the [Document API](https://docs.camunda.io/docs/components/document-handling/getting-started/) (`newCreateDocumentCommand`); the process variable holds only the resulting **document reference**, never a bare filename string.
-
-| Camunda 7                          | Camunda 8                                                        |
-| ---------------------------------- | ---------------------------------------------------------------- |
-| `FileValue` variable (`Values.fileValue(...)`) | Document uploaded via `camundaClient.newCreateDocumentCommand()`; the `DocumentReference` is stored as the process variable |
+In Camunda 7, files are stored as `FileValue` process variables (Typed Value API) carrying content plus filename and MIME type. Camunda 8 has no typed file variable: files become **documents** managed by the [Document API](https://docs.camunda.io/docs/components/document-handling/getting-started/) (`newCreateDocumentCommand`); the process variable holds only the resulting **document reference**, never a bare filename string.
 
 ###### Creating a File Variable
 
@@ -603,9 +597,8 @@ Camunda 8 has no typed file variable. Files become **documents** managed by the 
     }
 ```
 
--   store the plain `DocumentReference` in the process variable — do not wrap it in an array in the variable itself
--   forms consuming the reference (for example a `documentPreview` component) expect a FEEL expression over an *array* of references; do the one-element wrap (`[contract]`) in the form's FEEL expression, not in the variable
--   documents have a store-specific time-to-live and size limits — check the [document handling docs](https://docs.camunda.io/docs/components/document-handling/getting-started/) for your storage backend
+-   store the plain `DocumentReference` in the process variable; forms consuming it (e.g. a `documentPreview` component) expect a FEEL expression over an *array* — do the one-element wrap (`[contract]`) in the form's FEEL, not in the variable
+-   documents have store-specific time-to-live and size limits — check the document handling docs for your storage backend
 
 ---
 
@@ -1351,18 +1344,14 @@ The glue code patterns look into the different scenarios and proposes code conve
 
 ### Outbound HTTP &#8594; REST Connector
 
-In Camunda 7, outbound HTTP calls are made with the `camunda:connector` / **http-connector** extension on service tasks, or with hand-rolled HTTP client code inside a JavaDelegate or external task worker.
-
-Camunda 8 provides a standard out-of-the-box [REST connector](https://docs.camunda.io/docs/components/connectors/protocol/rest/) for outbound HTTP. Prefer it wherever it covers the need instead of porting HTTP client code into a job worker.
+C7 outbound HTTP uses the `camunda:connector` / **http-connector** extension or hand-rolled HTTP client code inside a delegate/worker. Camunda 8 provides a standard out-of-the-box [REST connector](https://docs.camunda.io/docs/components/connectors/protocol/rest/) — prefer it wherever it covers the need instead of porting HTTP client code into a job worker.
 
 | Camunda 7                                          | Camunda 8                                  |
 | -------------------------------------------------- | ------------------------------------------ |
-| `camunda:connector` with http-connector on a task  | Service task templated with the out-of-the-box REST connector (URL, method, headers, authentication, and result expression configured on the element) |
-| HTTP client code inside a delegate/worker          | Same — keep a custom `@JobWorker` only for what the connector cannot express (complex multi-step logic, non-HTTP protocols) |
+| `camunda:connector` with http-connector, HTTP client code in a delegate/worker | Service task with the out-of-the-box REST connector (URL, method, headers, authentication, result expression configured on the element; no Java code) |
 
--   connector templates are applied in the Modeler or as element templates in the BPMN XML; no Java code is needed for the HTTP call itself
--   the connector's result expression maps the HTTP response into process variables — this replaces the delegate's `setVariable` calls
--   for more information, see [the REST connector docs](https://docs.camunda.io/docs/components/connectors/protocol/rest/)
+-   the connector's result expression maps the HTTP response into process variables — replacing the delegate's `setVariable` calls
+-   keep a custom `@JobWorker` only for what the connector cannot express (complex multi-step logic, non-HTTP protocols)
 
 ---
 

--- a/code-conversion/patterns/README.md
+++ b/code-conversion/patterns/README.md
@@ -41,6 +41,7 @@ Patterns:
 - [Cancel Process Instance](20-client-code/10-process-engine/cancel-process-instance.md)
 - [Correlate Messages](20-client-code/10-process-engine/correlate-messages.md)
 - [Evaluate Decisions (DMN)](20-client-code/10-process-engine/evaluate-decisions.md)
+- [File Variables &#8594; Document API](20-client-code/10-process-engine/handle-files-and-documents.md)
 - [Handle Variables](20-client-code/10-process-engine/handle-process-variables.md)
 - [Handle Resources](20-client-code/10-process-engine/handle-resources.md)
 - [Handle User Tasks](20-client-code/10-process-engine/handle-user-tasks.md)
@@ -53,6 +54,9 @@ Patterns:
 
 Whenever you define code that is executed when a process arrives at a specific state in the process, specifically JavaDelegates and external task workers.
 
+Patterns:
+
+- [Outbound HTTP &#8594; REST Connector](30-glue-code/outbound-http-rest-connector.md)
 
 ### JavaDelegate &#8594; Job Worker (Spring)
 

--- a/code-conversion/patterns/code-examples/camunda-8/src/test/resources/camunda-container-runtime.properties
+++ b/code-conversion/patterns/code-examples/camunda-8/src/test/resources/camunda-container-runtime.properties
@@ -4,3 +4,7 @@
 # Docker Hub camunda/* images, so this resolves to Docker Hub camunda/camunda but authenticated
 # and cached via Harbor.
 camundaDockerImageName=registry.camunda.cloud/camunda/camunda
+
+# The amd64 image contains a JDK 25 AOT cache created on the image builder. Its CPU-specific
+# generated code can crash on CI runners with SIGILL, so disable AOT for process-test containers.
+camundaEnvVars.JAVA_TOOL_OPTIONS=-XX:AOTMode=off


### PR DESCRIPTION
## What

A colleague ran the `migrate-c7-to-c8-code` skill on a real project and had to supply 16 extra instructions via prompt because the skill lacked them. This PR folds the missing guidance in — split by responsibility:

- **Skill** (`agentic-migration-skills/`): workflow rules, decision points, validation gates
- **Pattern catalog** (`code-conversion/patterns/`, the skill's runtime API reference loaded via `ALL_IN_ONE.md`): feature-level "how to migrate X" mappings with code examples

## Gap analysis (prompt point → status → where added)

| # | Prompt point | Skill status before | Change |
|---|---|---|---|
| 1 | Sibling-folder target, never modify C7, no unrequested commits | Commits covered; "never mutate" covered models only; separate target layout not covered | `SKILL.md` shared rules: C7 project read-only when targeting a separate output location; never commit without explicit request |
| 2 | Preserve package/class names, file/folder layout; justify renames | Only generic "keep changes minimal" | `SKILL.md`: new structural-fidelity rule, reasons recorded in MIGRATION_REPORT.md |
| 3 | Preserve startup behavior and "no REST endpoints" constraint, incl. transitively | Startup partially covered (`@PostConstruct` → `CamundaPostDeploymentEvent`); footprint missing | `SKILL.md` rule + checklist items 1–2: dependency footprint, no `spring-boot-starter-web` pulled in for unrelated reasons |
| 4 | Verify exact versions/compatibility via Maven Central — don't assume | GA resolution covered; Spring Boot pairing verification missing | Checklist item 1: verify SB compatibility from the starter/BOM POM |
| 5 | Trust Diagram Converter output for job types/listener wiring | Mostly covered | M1 step 5: explicit "trust unflagged output" line |
| 6 | MIGRATION_REPORT.md as single living source of truth | Covered | `SKILL.md`: strengthened wording |
| 7 | Business key → tags; mutable key → `businessKey` process variable | Mutable case missing (businessId/tags are immutable) | **Catalog**: mutable-key remediation added to `business-key-and-tags.md`; **skill**: checklist points at catalog, keeps the MIGRATION_REPORT.md decision hook |
| 8 | `FileValue` → Document API; one-element array wrap only in consuming form's FEEL | Missing | **Catalog**: new `handle-files-and-documents.md` pattern (API verified against `camunda/camunda` `CreateDocumentIT`); **skill**: pointer + Forms category for the FEEL wrap |
| 9 | Report every warning for human review | Covered (verdict tables) | — |
| 10 | One C8 form per C7 form; no service task if values are FEEL-reachable | Missing | New named category "Forms" (5e) in model-migration-approaches.md |
| 11 | Check platform before porting C7-limitation workarounds (path-as-key, feelers `{{ }}`/`{{#loop}}`, `text` vs `content`, `documentPreview`) | Missing | `SKILL.md` rule + concrete form facts in category 5e |
| 12 | Use matching CamundaClient API instead of inventing process variables | Partially covered | Checklist item 2 |
| 13 | Complex Groovy on sequence flows → upstream service task | Script expressions not covered (only JUEL method calls) | New named category "Script expressions" in checklist item 7 + detection hints |
| 14 | Keep worker inputs/outputs unchanged; new logic → new worker | Missing | Checklist item 3 |
| 15 | Prefer out-of-the-box connectors (REST connector) for outbound HTTP | Missing | **Catalog**: new `outbound-http-rest-connector.md` pattern; **skill**: pointer + detection hint |
| 16 | Lint after every structural BPMN edit | Missing | New "Linting Converted BPMN (M1 and M2)" section + model validation step |

## Notes

- **Point 16 tool correction:** the prompt referenced `c8ctl bpmn lint`, but c8ctl's command registry has no lint verb (verified against the [c8ctl command reference](https://github.com/camunda/c8ctl/blob/main/docs/command-reference.md) — likely a plugin in the colleague's setup). The skill instead prescribes the standard stack: `bpmnlint` + `bpmnlint-plugin-camunda-compat` (official Camunda ruleset) with the `zeebe-bpmn-moddle` extension.
- Facts verified against Camunda docs/npm: `documentPreview` (`dataSource` FEEL over document-reference arrays), path-as-key binding, feelers templating, businessId/tags immutability, Document API (`newCreateDocumentCommand` — signature taken from `camunda/camunda` `CreateDocumentIT`).
- `code-conversion/patterns/README.md` and `ALL_IN_ONE.md` are generated — regenerated with `generate-catalog.js` / `generate-all-in-one.js` and verified idempotent (CI runs the same check).
- Also fixed a now-contradictory example row: `form-reference` in the 5d verdict-table example was `no action`; with the new Forms category it is `needs fix`.

## Testing

- Pattern catalog: ran `node generate-catalog.js && node generate-all-in-one.js` — output matches committed files (CI's "Validate pattern catalog is up-to-date" check replicates this).
- Skill: markdown-only change under `agentic-migration-skills/`; no CI job covers these files (verified), so no further validation applies.