### PR TITLE
fix(deps): publish fixed Jackson version in Cockpit POM [main]

### DIFF
--- a/data-migrator/plugins/cockpit/pom.xml
+++ b/data-migrator/plugins/cockpit/pom.xml
@@ -40,6 +40,13 @@
       <version>${version.camunda-7}</version>
       <scope>provided</scope>
     </dependency>
+    <!-- Keep Jackson host-provided while pinning the version in the published plugin POM. -->
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>${version.jackson-bom}</version>
+      <scope>provided</scope>
+    </dependency>
     <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>camunda-7-to-8-data-migrator-core</artifactId>

--- a/data-migrator/plugins/cockpit/src/test/java/io/camunda/migration/data/plugin/cockpit/PublishedPomTest.java
+++ b/data-migrator/plugins/cockpit/src/test/java/io/camunda/migration/data/plugin/cockpit/PublishedPomTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.migration.data.plugin.cockpit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.file.Path;
+import java.util.Arrays;
+import javax.xml.parsers.DocumentBuilderFactory;
+import org.junit.Test;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
+
+public class PublishedPomTest {
+
+  @Test
+  public void shouldPublishFixedJacksonDatabindAsProvidedDependency() throws Exception {
+    var flattenedPom =
+        DocumentBuilderFactory.newInstance()
+            .newDocumentBuilder()
+            .parse(Path.of(System.getProperty("basedir"), ".flattened-pom.xml").toFile());
+    var dependencies = flattenedPom.getElementsByTagName("dependency");
+    Element jacksonDatabind = null;
+
+    for (int i = 0; i < dependencies.getLength(); i++) {
+      var dependency = (Element) dependencies.item(i);
+      if ("com.fasterxml.jackson.core".equals(childText(dependency, "groupId"))
+          && "jackson-databind".equals(childText(dependency, "artifactId"))) {
+        jacksonDatabind = dependency;
+        break;
+      }
+    }
+
+    assertThat(jacksonDatabind)
+        .as("the flattened Cockpit POM must declare Jackson databind directly")
+        .isNotNull();
+    assertThat(childText(jacksonDatabind, "scope")).isEqualTo("provided");
+
+    var version =
+        Arrays.stream(childText(jacksonDatabind, "version").split("\\."))
+            .mapToInt(Integer::parseInt)
+            .toArray();
+    assertThat(version).hasSizeGreaterThanOrEqualTo(3);
+    assertThat(Arrays.compare(version, new int[] {2, 21, 5}))
+        .as("the flattened Cockpit POM must select a fixed Jackson databind version")
+        .isGreaterThanOrEqualTo(0);
+  }
+
+  protected static String childText(Element parent, String name) {
+    NodeList elements = parent.getElementsByTagName(name);
+    return elements.item(0).getTextContent().trim();
+  }
+}


### PR DESCRIPTION
## Description
Declare Jackson databind directly in the Cockpit plugin POM with `provided` scope. The flattened published POM therefore selects Jackson 2.22.2 over Camunda 7 REST's transitive 2.21.4 without bundling or overriding host-provided runtime libraries.

Add a regression test that inspects the generated flattened POM for a fixed provided Jackson dependency.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Testing Checklist
- [x] Tests follow a black-box approach for the published POM surface
- [x] Added tests for the publishing regression
- [x] All targeted tests pass locally

## Validation
- Baseline commit: `c54ec46b`
- `mvn clean install` (Java 21)
- `mvn -pl data-migrator/plugins/cockpit -am clean install`
- Standalone flattened-POM dependency tree resolves `com.fasterxml.jackson.core:jackson-databind:2.22.2:provided`; the Cockpit JAR contains no Jackson classes

## Related Issues
related to #1785