### PR TITLE
fix(deps): publish fixed Jackson version in Cockpit POM [maintenance/0.3]

### DIFF
--- a/data-migrator/plugins/cockpit/pom.xml
+++ b/data-migrator/plugins/cockpit/pom.xml
@@ -64,6 +64,13 @@
       <version>${version.camunda-7}</version>
       <scope>provided</scope>
     </dependency>
+    <!-- Keep Jackson host-provided while publishing a fixed version for dependency mediation. -->
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>${version.jackson-bom}</version>
+      <scope>provided</scope>
+    </dependency>
     <!-- test dependencies -->
     <dependency>
       <groupId>com.h2database</groupId>
@@ -203,6 +210,15 @@
             </configuration>
           </execution>
         </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <systemPropertyVariables>
+            <cockpit.flattenedPom>${project.basedir}/.flattened-pom.xml</cockpit.flattenedPom>
+          </systemPropertyVariables>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/data-migrator/plugins/cockpit/src/test/java/io/camunda/migration/data/plugin/cockpit/CockpitPomTest.java
+++ b/data-migrator/plugins/cockpit/src/test/java/io/camunda/migration/data/plugin/cockpit/CockpitPomTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.migration.data.plugin.cockpit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import javax.xml.parsers.DocumentBuilderFactory;
+import org.junit.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
+
+public class CockpitPomTest {
+
+  @Test
+  public void shouldPublishFixedJacksonDatabindAsProvided() throws Exception {
+    String flattenedPomPath = System.getProperty("cockpit.flattenedPom");
+    assertThat(flattenedPomPath)
+        .as("The flattened Cockpit POM path must be configured by Maven")
+        .isNotBlank();
+
+    Path flattenedPom = Path.of(flattenedPomPath);
+    assertThat(flattenedPom).as("The flattened Cockpit POM must exist").exists();
+
+    Document document = createDocumentBuilderFactory().newDocumentBuilder().parse(flattenedPom.toFile());
+    NodeList dependencies = document.getElementsByTagNameNS("*", "dependency");
+    List<Element> jacksonDependencies = new ArrayList<>();
+
+    for (int i = 0; i < dependencies.getLength(); i++) {
+      Element dependency = (Element) dependencies.item(i);
+      if ("com.fasterxml.jackson.core".equals(childText(dependency, "groupId"))
+          && "jackson-databind".equals(childText(dependency, "artifactId"))) {
+        jacksonDependencies.add(dependency);
+      }
+    }
+
+    assertThat(jacksonDependencies)
+        .as("The flattened Cockpit POM must publish one direct Jackson databind dependency")
+        .hasSize(1);
+    Element jacksonDependency = jacksonDependencies.get(0);
+    assertThat(childText(jacksonDependency, "scope")).isEqualTo("provided");
+
+    String[] versionParts = childText(jacksonDependency, "version").split("\\.");
+    assertThat(versionParts).hasSizeGreaterThanOrEqualTo(3);
+    int major = Integer.parseInt(versionParts[0]);
+    int minor = Integer.parseInt(versionParts[1]);
+    int patch = Integer.parseInt(versionParts[2]);
+    boolean fixed = major > 2 || major == 2 && (minor > 22 || minor == 22 && patch >= 2);
+    assertThat(fixed)
+        .as("Published Jackson databind must be at least 2.22.2 but was %s", childText(jacksonDependency, "version"))
+        .isTrue();
+  }
+
+  protected static DocumentBuilderFactory createDocumentBuilderFactory() throws Exception {
+    DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+    factory.setNamespaceAware(true);
+    factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+    factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+    factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+    factory.setXIncludeAware(false);
+    factory.setExpandEntityReferences(false);
+    return factory;
+  }
+
+  protected static String childText(Element element, String name) {
+    NodeList elements = element.getElementsByTagNameNS("*", name);
+    assertThat(elements.getLength()).as("Dependency must contain %s", name).isGreaterThan(0);
+    return elements.item(0).getTextContent().trim();
+  }
+}


### PR DESCRIPTION
## Summary

- Publish `com.fasterxml.jackson.core:jackson-databind` at the fixed `${version.jackson-bom}` version with `provided` scope in the Cockpit plugin POM.
- Add a regression test that inspects the generated flattened POM for the fixed version and provided scope.
- This keeps Jackson host-provided at runtime and addresses CVE-2026-54515 on the published POM surface.

## Validation

- Green baseline at `693db58d1443495016d90c96b95c42c475b2b175`: `mvn clean install` (Java 21).
- `mvn -pl data-migrator/plugins/cockpit -am verify -Dtest=CockpitPomTest -Dsurefire.failIfNoSpecifiedTests=false`.
- Standalone flattened-POM dependency tree selects `jackson-databind:2.22.2:provided`; Camunda 7 `2.21.4` paths are omitted for conflict.
- Built Cockpit plugin JAR contains no Jackson classes.