### PR TITLE
feat(diagram-converter): add --json analysis report output to CLI

### DIFF
--- a/diagram-converter/cli/src/main/java/io/camunda/migration/diagram/converter/cli/AbstractConvertCommand.java
+++ b/diagram-converter/cli/src/main/java/io/camunda/migration/diagram/converter/cli/AbstractConvertCommand.java
@@ -156,7 +156,7 @@ public abstract class AbstractConvertCommand implements Callable<Integer> {
           converter.printXml(modelInstance.getValue().getDocument(), true, fw);
           fw.flush();
           LOG_CLI.info("Created {}", file);
-        } catch (IOException e) {
+        } catch (IOException | RuntimeException e) {
           LOG_CLI.error("Error while creating diagram file: {}", createMessage(e));
           returnCode = 1;
         }
@@ -167,7 +167,7 @@ public abstract class AbstractConvertCommand implements Callable<Integer> {
       try (FileWriter fw = new FileWriter(csvFile)) {
         converter.writeCsvFile(results, fw);
         LOG_CLI.info("Created {}", csvFile);
-      } catch (IOException e) {
+      } catch (IOException | RuntimeException e) {
         LOG_CLI.error("Error while creating csv results: {}", createMessage(e));
         returnCode = 1;
       }
@@ -177,7 +177,7 @@ public abstract class AbstractConvertCommand implements Callable<Integer> {
       try (FileOutputStream fos = new FileOutputStream(xlsxFile)) {
         new ExcelWriter().writeResultsToExcel(converter.createLineItemDTOList(results), fos);
         LOG_CLI.info("Created {}", xlsxFile);
-      } catch (IOException e) {
+      } catch (IOException | RuntimeException e) {
         LOG_CLI.error("Error while creating xlsx results: {}", createMessage(e));
         returnCode = 1;
       }
@@ -187,7 +187,7 @@ public abstract class AbstractConvertCommand implements Callable<Integer> {
       try (FileWriter fw = new FileWriter(jsonFile)) {
         converter.writeJsonFile(results, fw);
         LOG_CLI.info("Created {}", jsonFile);
-      } catch (IOException e) {
+      } catch (IOException | RuntimeException e) {
         LOG_CLI.error("Error while creating json results: {}", createMessage(e));
         returnCode = 1;
       }
@@ -197,7 +197,7 @@ public abstract class AbstractConvertCommand implements Callable<Integer> {
       try (FileWriter fw = new FileWriter(markdownFile)) {
         converter.writeMarkdownFile(results, fw);
         LOG_CLI.info("Created {}", markdownFile);
-      } catch (IOException e) {
+      } catch (IOException | RuntimeException e) {
         LOG_CLI.error("Error while creating markdown results: {}", createMessage(e));
         returnCode = 1;
       }

--- a/diagram-converter/cli/src/main/java/io/camunda/migration/diagram/converter/cli/AbstractConvertCommand.java
+++ b/diagram-converter/cli/src/main/java/io/camunda/migration/diagram/converter/cli/AbstractConvertCommand.java
@@ -20,6 +20,8 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
@@ -184,7 +186,9 @@ public abstract class AbstractConvertCommand implements Callable<Integer> {
     }
     if (json) {
       File jsonFile = determineFileName(new File(targetDirectory(), "analysis-results.json"));
-      try (FileWriter fw = new FileWriter(jsonFile)) {
+      // JSON is specified as UTF-8 (RFC 8259); pin the charset so an explicit
+      // -Dfile.encoding override can't corrupt the machine-readable report
+      try (Writer fw = Files.newBufferedWriter(jsonFile.toPath(), StandardCharsets.UTF_8)) {
         converter.writeJsonFile(results, fw);
         LOG_CLI.info("Created {}", jsonFile);
       } catch (IOException | RuntimeException e) {

--- a/diagram-converter/cli/src/main/java/io/camunda/migration/diagram/converter/cli/AbstractConvertCommand.java
+++ b/diagram-converter/cli/src/main/java/io/camunda/migration/diagram/converter/cli/AbstractConvertCommand.java
@@ -296,12 +296,16 @@ public abstract class AbstractConvertCommand implements Callable<Integer> {
   }
 
   protected String createMessage(Exception e) {
-    StringBuilder message = new StringBuilder(e.getMessage());
+    StringBuilder message = new StringBuilder(exceptionMessage(e));
     Throwable ex = e.getCause();
     while (ex != null) {
-      message.append(",").append("\n").append("caused by: ").append(ex.getMessage());
+      message.append(",").append("\n").append("caused by: ").append(exceptionMessage(ex));
       ex = ex.getCause();
     }
     return message.toString();
+  }
+
+  private String exceptionMessage(Throwable t) {
+    return t.getMessage() != null ? t.getMessage() : t.getClass().getName();
   }
 }

--- a/diagram-converter/cli/src/main/java/io/camunda/migration/diagram/converter/cli/AbstractConvertCommand.java
+++ b/diagram-converter/cli/src/main/java/io/camunda/migration/diagram/converter/cli/AbstractConvertCommand.java
@@ -74,6 +74,12 @@ public abstract class AbstractConvertCommand implements Callable<Integer> {
   boolean csv;
 
   @Option(
+      names = {"--json"},
+      description =
+          "If enabled, a JSON file will be created containing the results for the analysis")
+  boolean json;
+
+  @Option(
       names = {"--xlsx"},
       description =
           "If enabled, a XLSX file will be created containing the results for the analysis")
@@ -134,7 +140,7 @@ public abstract class AbstractConvertCommand implements Callable<Integer> {
 
   private void writeResults(
       Map<File, ModelInstance> modelInstances, List<DiagramCheckResult> results) {
-    if ((!check || csv || xlsx || markdown) && !createTargetDirectory()) {
+    if ((!check || csv || xlsx || markdown || json) && !createTargetDirectory()) {
       return;
     }
     if (!check) {
@@ -173,6 +179,16 @@ public abstract class AbstractConvertCommand implements Callable<Integer> {
         LOG_CLI.info("Created {}", xlsxFile);
       } catch (IOException e) {
         LOG_CLI.error("Error while creating xlsx results: {}", createMessage(e));
+        returnCode = 1;
+      }
+    }
+    if (json) {
+      File jsonFile = determineFileName(new File(targetDirectory(), "analysis-results.json"));
+      try (FileWriter fw = new FileWriter(jsonFile)) {
+        converter.writeJsonFile(results, fw);
+        LOG_CLI.info("Created {}", jsonFile);
+      } catch (IOException e) {
+        LOG_CLI.error("Error while creating json results: {}", createMessage(e));
         returnCode = 1;
       }
     }

--- a/diagram-converter/cli/src/test/java/io/camunda/migration/diagram/converter/cli/ConvertLocalCommandTest.java
+++ b/diagram-converter/cli/src/test/java/io/camunda/migration/diagram/converter/cli/ConvertLocalCommandTest.java
@@ -158,6 +158,19 @@ public class ConvertLocalCommandTest {
   }
 
   @Test
+  void shouldHandleNullExceptionMessagesInCreateMessage() {
+    ConvertLocalCommand command = new ConvertLocalCommand();
+
+    // unchecked exceptions like NPE carry a null message; error handling must not crash on them
+    assertThat(command.createMessage(new NullPointerException()))
+        .isEqualTo(NullPointerException.class.getName());
+    assertThat(
+            command.createMessage(
+                new RuntimeException("outer", new IllegalArgumentException((String) null))))
+        .isEqualTo("outer,\ncaused by: " + IllegalArgumentException.class.getName());
+  }
+
+  @Test
   void shouldNotCreateConvertedDiagrams(@TempDir File tempDir) {
     setupDir("c7.bpmn", tempDir);
     ConvertLocalCommand command = new ConvertLocalCommand();

--- a/diagram-converter/cli/src/test/java/io/camunda/migration/diagram/converter/cli/ConvertLocalCommandTest.java
+++ b/diagram-converter/cli/src/test/java/io/camunda/migration/diagram/converter/cli/ConvertLocalCommandTest.java
@@ -14,6 +14,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.read.ListAppender;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -126,6 +127,34 @@ public class ConvertLocalCommandTest {
         .hasSize(2)
         .anyMatch(file -> file.getName().equals("c7.bpmn"))
         .anyMatch(file -> file.getName().equals("converted-c8-c7.bpmn"));
+  }
+
+  @Test
+  void shouldCreateJson(@TempDir File tempDir) throws IOException {
+    setupDir("c7.bpmn", tempDir);
+    ConvertLocalCommand command = new ConvertLocalCommand();
+    command.json = true;
+    command.file = tempDir;
+    Integer call = command.call();
+    assertEquals(0, call);
+    assertThat(tempDir.listFiles())
+        .hasSize(3)
+        .anyMatch(file -> file.getName().equals("c7.bpmn"))
+        .anyMatch(file -> file.getName().equals("converted-c8-c7.bpmn"))
+        .anyMatch(file -> file.getName().equals("analysis-results.json"));
+    File jsonFile = new File(tempDir, "analysis-results.json");
+    assertThat(new ObjectMapper().readTree(jsonFile).isArray()).isTrue();
+  }
+
+  @Test
+  void shouldNotCreateJson(@TempDir File tempDir) {
+    setupDir("c7.bpmn", tempDir);
+    ConvertLocalCommand command = new ConvertLocalCommand();
+    command.file = tempDir;
+    Integer call = command.call();
+    assertEquals(0, call);
+    assertThat(tempDir.listFiles())
+        .noneMatch(file -> file.getName().equals("analysis-results.json"));
   }
 
   @Test

--- a/diagram-converter/core/pom.xml
+++ b/diagram-converter/core/pom.xml
@@ -51,7 +51,6 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>

--- a/diagram-converter/core/src/main/java/io/camunda/migration/diagram/converter/DiagramConverter.java
+++ b/diagram-converter/core/src/main/java/io/camunda/migration/diagram/converter/DiagramConverter.java
@@ -275,9 +275,7 @@ public class DiagramConverter {
 
   public void writeJsonFile(List<DiagramCheckResult> results, Writer writer) {
     try {
-      OBJECT_MAPPER
-          .writerWithDefaultPrettyPrinter()
-          .writeValue(writer, createLineItemDTOList(results));
+      OBJECT_MAPPER.writeValue(writer, createLineItemDTOList(results));
     } catch (IOException e) {
       throw new RuntimeException("Error while writing json file", e);
     }

--- a/diagram-converter/core/src/main/java/io/camunda/migration/diagram/converter/DiagramConverter.java
+++ b/diagram-converter/core/src/main/java/io/camunda/migration/diagram/converter/DiagramConverter.java
@@ -9,6 +9,7 @@ package io.camunda.migration.diagram.converter;
 
 import static io.camunda.migration.diagram.converter.NamespaceUri.*;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.opencsv.CSVWriterBuilder;
 import com.opencsv.ICSVWriter;
 import com.samskivert.mustache.Mustache;
@@ -53,6 +54,7 @@ import org.slf4j.LoggerFactory;
 public class DiagramConverter {
   private static final Logger LOG = LoggerFactory.getLogger(DiagramConverter.class);
   private static final Template MARKDOWN_TEMPLATE;
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
   static {
     try (InputStream in =
@@ -268,6 +270,16 @@ public class DiagramConverter {
       csvWriter.writeAll(createLines(results));
     } catch (IOException e) {
       throw new RuntimeException("Error while writing csv file", e);
+    }
+  }
+
+  public void writeJsonFile(List<DiagramCheckResult> results, Writer writer) {
+    try {
+      OBJECT_MAPPER
+          .writerWithDefaultPrettyPrinter()
+          .writeValue(writer, createLineItemDTOList(results));
+    } catch (IOException e) {
+      throw new RuntimeException("Error while writing json file", e);
     }
   }
 

--- a/diagram-converter/core/src/test/java/io/camunda/migration/diagram/converter/JsonWriterTest.java
+++ b/diagram-converter/core/src/test/java/io/camunda/migration/diagram/converter/JsonWriterTest.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.migration.diagram.converter;
+
+import static org.assertj.core.api.Assertions.*;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.migration.diagram.converter.DiagramCheckResult.ElementCheckMessage;
+import io.camunda.migration.diagram.converter.DiagramCheckResult.ElementCheckResult;
+import io.camunda.migration.diagram.converter.DiagramCheckResult.Severity;
+import java.io.IOException;
+import java.io.StringWriter;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+public class JsonWriterTest {
+  private static final String FILENAME = "mock-process.bpmn";
+  private static final String LINK = "https://www.example.com";
+  private static final String MESSAGE_ID = "test-message";
+  private static final String MESSAGE = "Test message";
+  private static final String ELEMENT_ID = "abc.123";
+  private static final String ELEMENT_NAME = "Example;Name";
+  private static final String ELEMENT_TYPE = "userTask";
+  private static final Severity SEVERITY = Severity.TASK;
+  private static final DiagramConverter SERVICE = DiagramConverterFactory.getInstance().get();
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+  @Test
+  public void shouldCreateValidJson() throws IOException {
+    StringWriter writer = new StringWriter();
+    SERVICE.writeJsonFile(mockResults(), writer);
+
+    JsonNode root = OBJECT_MAPPER.readTree(writer.toString());
+    assertThat(root.isArray()).isTrue();
+    assertThat(root).hasSize(1);
+    JsonNode entry = root.get(0);
+    assertThat(entry.get("filename").asText()).isEqualTo(FILENAME);
+    assertThat(entry.get("elementName").asText()).isEqualTo(ELEMENT_NAME);
+    assertThat(entry.get("elementId").asText()).isEqualTo(ELEMENT_ID);
+    assertThat(entry.get("elementType").asText()).isEqualTo(ELEMENT_TYPE);
+    assertThat(entry.get("severity").asText()).isEqualTo(SEVERITY.name());
+    assertThat(entry.get("messageId").asText()).isEqualTo(MESSAGE_ID);
+    assertThat(entry.get("message").asText()).isEqualTo(MESSAGE);
+    assertThat(entry.get("link").asText()).isEqualTo(LINK);
+  }
+
+  @Test
+  public void shouldSerializeAllFindings() throws IOException {
+    DiagramCheckResult result = mockDiagramResult();
+    result.getResults().getFirst().getMessages().add(mockMessage());
+
+    StringWriter writer = new StringWriter();
+    SERVICE.writeJsonFile(List.of(result), writer);
+
+    JsonNode root = OBJECT_MAPPER.readTree(writer.toString());
+    assertThat(root).hasSize(2);
+  }
+
+  @Test
+  public void shouldPreserveSpecialCharactersVerbatim() throws IOException {
+    // report messages routinely contain ';', quotes and JUEL/FEEL expressions - content that
+    // corrupts rows when a report format is parsed with naive string splitting
+    String trickyMessage =
+        "Method invocation is not possible in FEEL: ${execution.getVariable(\"a\").size()}; use a different expression";
+    DiagramCheckResult result = mockDiagramResult();
+    result.getResults().getFirst().getMessages().getFirst().setMessage(trickyMessage);
+
+    StringWriter writer = new StringWriter();
+    SERVICE.writeJsonFile(List.of(result), writer);
+
+    JsonNode root = OBJECT_MAPPER.readTree(writer.toString());
+    assertThat(root.get(0).get("message").asText()).isEqualTo(trickyMessage);
+  }
+
+  @Test
+  public void shouldMatchCsvRowContent() throws IOException {
+    List<DiagramCheckResult> results = mockResults();
+
+    StringWriter jsonWriter = new StringWriter();
+    SERVICE.writeJsonFile(results, jsonWriter);
+    JsonNode entry = OBJECT_MAPPER.readTree(jsonWriter.toString()).get(0);
+
+    StringWriter csvWriter = new StringWriter();
+    SERVICE.writeCsvFile(results, csvWriter);
+    String csv = csvWriter.toString();
+
+    assertThat(csv).contains(entry.get("filename").asText());
+    assertThat(csv).contains(entry.get("elementName").asText());
+    assertThat(csv).contains(entry.get("elementId").asText());
+    assertThat(csv).contains(entry.get("elementType").asText());
+    assertThat(csv).contains(entry.get("severity").asText());
+    assertThat(csv).contains(entry.get("messageId").asText());
+    assertThat(csv).contains(entry.get("message").asText());
+    assertThat(csv).contains(entry.get("link").asText());
+  }
+
+  private List<DiagramCheckResult> mockResults() {
+    List<DiagramCheckResult> results = new ArrayList<>();
+    results.add(mockDiagramResult());
+    return results;
+  }
+
+  private DiagramCheckResult mockDiagramResult() {
+    DiagramCheckResult result = new DiagramCheckResult();
+    result.setFilename(FILENAME);
+    result.getResults().add(mockElementResult());
+    return result;
+  }
+
+  private ElementCheckResult mockElementResult() {
+    ElementCheckResult result = new ElementCheckResult();
+    result.setElementId(ELEMENT_ID);
+    result.setElementName(ELEMENT_NAME);
+    result.setElementType(ELEMENT_TYPE);
+    result.getMessages().add(mockMessage());
+    return result;
+  }
+
+  private ElementCheckMessage mockMessage() {
+    ElementCheckMessage message = new ElementCheckMessage();
+    message.setSeverity(SEVERITY);
+    message.setMessage(MESSAGE);
+    message.setLink(LINK);
+    message.setId(MESSAGE_ID);
+    return message;
+  }
+}

--- a/diagram-converter/core/src/test/java/io/camunda/migration/diagram/converter/JsonWriterTest.java
+++ b/diagram-converter/core/src/test/java/io/camunda/migration/diagram/converter/JsonWriterTest.java
@@ -11,10 +11,15 @@ import static org.assertj.core.api.Assertions.*;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.opencsv.CSVParserBuilder;
+import com.opencsv.CSVReader;
+import com.opencsv.CSVReaderBuilder;
+import com.opencsv.exceptions.CsvException;
 import io.camunda.migration.diagram.converter.DiagramCheckResult.ElementCheckMessage;
 import io.camunda.migration.diagram.converter.DiagramCheckResult.ElementCheckResult;
 import io.camunda.migration.diagram.converter.DiagramCheckResult.Severity;
 import java.io.IOException;
+import java.io.StringReader;
 import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.List;
@@ -89,16 +94,31 @@ public class JsonWriterTest {
 
     StringWriter csvWriter = new StringWriter();
     SERVICE.writeCsvFile(results, csvWriter);
-    String csv = csvWriter.toString();
+    List<String[]> csvLines = readCsv(csvWriter);
 
-    assertThat(csv).contains(entry.get("filename").asText());
-    assertThat(csv).contains(entry.get("elementName").asText());
-    assertThat(csv).contains(entry.get("elementId").asText());
-    assertThat(csv).contains(entry.get("elementType").asText());
-    assertThat(csv).contains(entry.get("severity").asText());
-    assertThat(csv).contains(entry.get("messageId").asText());
-    assertThat(csv).contains(entry.get("message").asText());
-    assertThat(csv).contains(entry.get("link").asText());
+    assertThat(csvLines).hasSize(2);
+    assertThat(csvLines.get(1))
+        .containsExactly(
+            entry.get("filename").asText(),
+            entry.get("elementName").asText(),
+            entry.get("elementId").asText(),
+            entry.get("elementType").asText(),
+            entry.get("severity").asText(),
+            entry.get("messageId").asText(),
+            entry.get("message").asText(),
+            entry.get("link").asText());
+  }
+
+  private List<String[]> readCsv(StringWriter writer) {
+    StringReader reader = new StringReader(writer.toString());
+    try (CSVReader csvReader =
+        new CSVReaderBuilder(reader)
+            .withCSVParser(new CSVParserBuilder().withSeparator(';').build())
+            .build()) {
+      return csvReader.readAll();
+    } catch (IOException | CsvException e) {
+      throw new RuntimeException(e);
+    }
   }
 
   private List<DiagramCheckResult> mockResults() {


### PR DESCRIPTION
## Summary

- Adds a `--json` flag to the Diagram Converter CLI (sibling to `--csv`/`--xlsx`/`--md`) writing `analysis-results.json` — a faithful Jackson serialization of the existing line-item DTO model (`filename`, `elementName`, `elementId`, `elementType`, `severity`, `messageId`, `message`, `link`), riding the existing `determineFileName` uniquification so ` (n)`-suffixed reports and `Created ...` console capture work unchanged.
- Machine-readable JSON removes the need for consumers to reimplement opencsv `;`-separated quoted-field parsing, which corrupts rows containing `;`, quotes, or JUEL/FEEL expressions when split naively.

## Changes

- `diagram-converter/core`: `DiagramConverter.writeJsonFile` next to `writeCsvFile` (Jackson `ObjectMapper` on `createLineItemDTOList`, compact output); `jackson-databind` promoted from test to compile scope (already a compile dependency of `cli`).
- `diagram-converter/cli`: `--json` option in `AbstractConvertCommand`, wired next to the csv/xlsx blocks and included in the target-directory guard. All output-writing blocks now also catch unchecked writer failures (every core writer wraps I/O errors in unchecked exceptions), and `createMessage` is null-safe for exceptions without a message.
- Tests: new `JsonWriterTest` in core (valid JSON, all findings serialized, verbatim round-trip of messages containing `;`/quotes/JUEL expressions, parsed CSV/JSON cell parity); `shouldCreateJson`/`shouldNotCreateJson` + null-message test in `ConvertLocalCommandTest`.

## Notes

- This PR is the bottom of stack #2300: #2299 (skill consumes this JSON output) is stacked on top and merges after it; GitHub retargets #2299 to `main` automatically on merge. Together they close #2286.
- The JSON report is compact (not pretty-printed): it is machine-consumed, and human-readable output already exists via `--md`.

## Test plan

- [x] `cd diagram-converter && mvn verify -Pdistro,checkFormat -pl core,cli` passes (Spotless format check included)
- [x] Full baseline `mvn clean install -DskipTests` green (JDK 21)
- [x] CI green on previous head (CI Summary Gate, diagram-converter, diagram-converter-windows, compile-previous-version)

## Baseline

Rebased onto commit: e519813d (main)

related to #2286