### PR TITLE
chore(ci): extend Windows test coverage (maintenance/0.3)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -302,6 +302,56 @@ jobs:
           if-no-files-found: error
           retention-days: 7
 
+  code-conversion-windows:
+    needs: [detect-changes]
+    runs-on: windows-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    if: |
+      github.event_name != 'pull_request' ||
+      needs.detect-changes.outputs.code-conversion == 'true' ||
+      needs.detect-changes.outputs.shared == 'true'
+    outputs:
+      maven-cache-hit: ${{ steps.setup-maven.outputs.maven-cache-hit }}
+    steps:
+      - name: Enable long paths for Git on Windows
+        if: runner.os == 'Windows'
+        run: git config --global core.longpaths true
+
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 0
+
+      - name: Import secrets
+        id: secrets
+        uses: hashicorp/vault-action@892a26828f195e65540a40b4768ae4571f51ebfc # v4.0.0
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secrets: |
+            secret/data/products/cambpm/ci/nexus USER | NEXUS_APP_CAMUNDA_COM_USR;
+            secret/data/products/cambpm/ci/nexus PASSWORD | NEXUS_APP_CAMUNDA_COM_PSW;
+
+      - name: Setup Maven
+        id: setup-maven
+        uses: ./.github/actions/setup-maven
+        with:
+          vault-address: ${{ secrets.VAULT_ADDR }}
+          vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
+          vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+
+      - name: Build and test code-conversion module on Windows
+        working-directory: code-conversion
+        # CPT uses Testcontainers and is not supported on Windows runners.
+        run: >-
+          mvn verify --batch-mode
+          "-Dtest=!ProcessPaymentsApplicationTests,!MyExecutionListenerTest"
+          "-Dsurefire.failIfNoSpecifiedTests=false"
+
   diagram-converter:
     needs: [detect-changes]
     runs-on: ubuntu-latest
@@ -353,6 +403,53 @@ jobs:
             diagram-converter/cli/target/camunda-7-to-8-diagram-converter-cli-*.jar
           if-no-files-found: error
           retention-days: 7
+
+  diagram-converter-windows:
+    needs: [detect-changes]
+    runs-on: windows-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    if: |
+      github.event_name != 'pull_request' ||
+      needs.detect-changes.outputs.diagram-converter == 'true' ||
+      needs.detect-changes.outputs.shared == 'true'
+    outputs:
+      maven-cache-hit: ${{ steps.setup-maven.outputs.maven-cache-hit }}
+    steps:
+      - name: Enable long paths for Git on Windows
+        if: runner.os == 'Windows'
+        run: git config --global core.longpaths true
+
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 0
+
+      - name: Import secrets
+        id: secrets
+        uses: hashicorp/vault-action@892a26828f195e65540a40b4768ae4571f51ebfc # v4.0.0
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secrets: |
+            secret/data/products/cambpm/ci/nexus USER | NEXUS_APP_CAMUNDA_COM_USR;
+            secret/data/products/cambpm/ci/nexus PASSWORD | NEXUS_APP_CAMUNDA_COM_PSW;
+
+      - name: Setup Maven
+        id: setup-maven
+        uses: ./.github/actions/setup-maven
+        with:
+          vault-address: ${{ secrets.VAULT_ADDR }}
+          vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
+          vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+
+      - name: Build and test diagram-converter module on Windows
+        working-directory: diagram-converter
+        # The distro profile is active by default; only checkFormat is omitted on Windows.
+        run: mvn verify --batch-mode
 
   # Compile-check all modules against the previous Camunda 8 version
   # to catch API-level incompatibilities before merge.
@@ -1097,7 +1194,9 @@ jobs:
       - detect-changes
       - distro
       - code-conversion
+      - code-conversion-windows
       - diagram-converter
+      - diagram-converter-windows
       - compile-previous-version
       - it-runtime-h2
       - it-history-h2
@@ -1112,7 +1211,9 @@ jobs:
     env:
       EXPECT_DISTRO: ${{ github.event_name != 'pull_request' || needs.detect-changes.outputs.data-migrator == 'true' || needs.detect-changes.outputs.shared == 'true' }}
       EXPECT_CODE_CONVERSION: ${{ github.event_name != 'pull_request' || needs.detect-changes.outputs.code-conversion == 'true' || needs.detect-changes.outputs.shared == 'true' }}
+      EXPECT_CODE_CONVERSION_WINDOWS: ${{ github.event_name != 'pull_request' || needs.detect-changes.outputs.code-conversion == 'true' || needs.detect-changes.outputs.shared == 'true' }}
       EXPECT_DIAGRAM_CONVERTER: ${{ github.event_name != 'pull_request' || needs.detect-changes.outputs.diagram-converter == 'true' || needs.detect-changes.outputs.shared == 'true' }}
+      EXPECT_DIAGRAM_CONVERTER_WINDOWS: ${{ github.event_name != 'pull_request' || needs.detect-changes.outputs.diagram-converter == 'true' || needs.detect-changes.outputs.shared == 'true' }}
       EXPECT_COMPILE_PREVIOUS: ${{ github.event_name != 'pull_request' || github.event_name == 'workflow_dispatch' || needs.detect-changes.outputs.run-compile-previous-version == 'true' }}
       EXPECT_RUNTIME_H2: ${{ github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'ci:runtime') || (needs.detect-changes.outputs.run-runtime == 'true' && !contains(github.event.pull_request.labels.*.name, 'ci:history') && !contains(github.event.pull_request.labels.*.name, 'ci:identity')) }}
       EXPECT_HISTORY_H2: ${{ github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'ci:history') || (needs.detect-changes.outputs.run-history == 'true' && !contains(github.event.pull_request.labels.*.name, 'ci:runtime') && !contains(github.event.pull_request.labels.*.name, 'ci:identity')) }}
@@ -1121,7 +1222,9 @@ jobs:
       EXPECT_E2E: ${{ github.event_name != 'pull_request' || needs.detect-changes.outputs.run-e2e == 'true' || contains(github.event.pull_request.labels.*.name, 'ci:e2e') }}
       CACHE_DISTRO: ${{ needs.distro.outputs.maven-cache-hit }}
       CACHE_CODE_CONVERSION: ${{ needs.code-conversion.outputs.maven-cache-hit }}
+      CACHE_CODE_CONVERSION_WINDOWS: ${{ needs.code-conversion-windows.outputs.maven-cache-hit }}
       CACHE_DIAGRAM_CONVERTER: ${{ needs.diagram-converter.outputs.maven-cache-hit }}
+      CACHE_DIAGRAM_CONVERTER_WINDOWS: ${{ needs.diagram-converter-windows.outputs.maven-cache-hit }}
       CACHE_COMPILE_PREVIOUS: ${{ needs.compile-previous-version.outputs.maven-cache-hit }}
       CACHE_HISTORY_H2: ${{ needs.it-history-h2.outputs.maven-cache-hit }}
       CACHE_HISTORY_H2_WINDOWS: ${{ needs.it-history-h2-windows.outputs.maven-cache-hit }}
@@ -1146,7 +1249,9 @@ jobs:
             const requiredChecks = [
               { key: "distro", label: "distro", expected: parseBool(process.env.EXPECT_DISTRO) },
               { key: "code-conversion", label: "code-conversion", expected: parseBool(process.env.EXPECT_CODE_CONVERSION) },
+              { key: "code-conversion-windows", label: "code-conversion-windows", expected: parseBool(process.env.EXPECT_CODE_CONVERSION_WINDOWS) },
               { key: "diagram-converter", label: "diagram-converter", expected: parseBool(process.env.EXPECT_DIAGRAM_CONVERTER) },
+              { key: "diagram-converter-windows", label: "diagram-converter-windows", expected: parseBool(process.env.EXPECT_DIAGRAM_CONVERTER_WINDOWS) },
               { key: "compile-previous-version", label: "compile-previous-version", expected: parseBool(process.env.EXPECT_COMPILE_PREVIOUS) },
               { key: "it-runtime-h2", label: "it-runtime-h2", expected: parseBool(process.env.EXPECT_RUNTIME_H2) },
               { key: "it-history-h2", label: "it-history-h2", expected: parseBool(process.env.EXPECT_HISTORY_H2) },
@@ -1223,7 +1328,9 @@ jobs:
             const cacheValues = [
               process.env.CACHE_DISTRO,
               process.env.CACHE_CODE_CONVERSION,
+              process.env.CACHE_CODE_CONVERSION_WINDOWS,
               process.env.CACHE_DIAGRAM_CONVERTER,
+              process.env.CACHE_DIAGRAM_CONVERTER_WINDOWS,
               process.env.CACHE_COMPILE_PREVIOUS,
               process.env.CACHE_HISTORY_H2,
               process.env.CACHE_HISTORY_H2_WINDOWS,
@@ -1267,8 +1374,10 @@ jobs:
     needs:
       - distro
       - code-conversion
+      - code-conversion-windows
       - diagram-converter
       - compile-previous-version
+      - diagram-converter-windows
       - it-runtime-h2
       - it-history-h2
       - it-history-h2-windows


### PR DESCRIPTION
Backport of #2293 to maintenance/0.3.

Extends change-scoped CI coverage to run the code-conversion and diagram-converter verification jobs on Windows. The code-conversion job excludes the two unsupported CPT/Testcontainers tests; the diagram-converter job retains its default distro profile and omits only checkFormat.

Validation:
- Workflow YAML parsed successfully.
- code-conversion Maven verification passed with Java 21 and the Windows CPT exclusions.
- diagram-converter Maven verification passed with Java 21.

Related to #375