### PR TITLE
feat(skill): consume JSON analysis report in model migration flow

### DIFF
--- a/agentic-migration-skills/skills/migrate-c7-to-c8-code/references/model-migration-approaches.md
+++ b/agentic-migration-skills/skills/migrate-c7-to-c8-code/references/model-migration-approaches.md
@@ -56,13 +56,12 @@ The JAR is ~30 MB. If the project is a git repo, recommend adding `.camunda-migr
 The CLI local subcommand accepts a single file or a directory (recursive by default). Always pass `--platform-version` set to the target version from the interview.
 
 ```
-java -Dfile.encoding=UTF-8 -jar <jar> local <file-or-dir> --platform-version <target-version> --json
+java -Dfile.encoding=UTF-8 -jar <jar> local <file-or-dir> --platform-version <target-version> --json --xlsx
 ```
 
 Recommended flags:
-- `--json` - always pass this; the JSON report is the machine-readable input parsed in step 5
-- `--csv` - optional, tabular export of the same findings for human review
-- `--xlsx` - optional, for human spreadsheet review
+- `--json` - always pass this; the JSON report is the machine-readable input parsed in step 5. Requires a CLI release that includes the flag (0.3.6 or later) — if the run fails with `Unknown option: '--json'`, the downloaded JAR predates it; re-resolve the latest release (step 2).
+- `--xlsx` - always pass this; the spreadsheet is the human-readable report for reviewing and sharing findings with the customer
 - `-o` / `--override` - overwrite pre-existing outputs in place. Destructive — do not pass by default (see Pre-flight: Leftover Artifacts). Without it, a diagram whose converted target already exists is skipped with a `File already exists` error, and reports are written under ` (n)`-suffixed names.
 - `--check` - analyze-only (no converted diagrams exported)
 - `-nr` / `--not-recursive` - disable recursive search
@@ -81,7 +80,7 @@ After the run, report:
 - Converted files: list every `converted-c8-*.bpmn` / `*.dmn` produced (from the captured `Created ...` lines)
 - Skipped files: any `File already exists` errors, naming the stale targets — those diagrams were NOT converted; offer to re-run once the user removes the stale copies (see Pre-flight: Leftover Artifacts)
 - Analysis findings: summarize from CLI stdout and/or the JSON report, grouped by severity (WARNING / TASK / REVIEW / INFO)
-- Analysis artifacts: point user to the JSON file (always) and the CSV/XLSX files if generated
+- Analysis artifacts: point the user to the XLSX report — it is the human-readable artifact for reviewing and sharing findings with the customer. The JSON report is the machine-readable input for step 5.
 
 Severity counts are only a headline. Do not start per-finding work from them — parse and group the full report first (step 5).
 
@@ -95,12 +94,12 @@ On a real project the report can hold thousands of rows but only a handful of di
 
 Skip this check when the report comes from this skill's own CLI run — that run already passed the chosen `--platform-version`, and leftover reports from earlier local runs are never consumed at all (see Pre-flight: Leftover Artifacts).
 
-This check fires only for a report deliberately imported without a fresh run — generated earlier, by someone else, or by the hosted converter (M3). Confirm it was generated for the currently chosen target platform version before consuming it. Findings are version-dependent: e.g. conditional events are flagged as unsupported in a report targeting 8.6 but are native since 8.9, so a stale report can send the user chasing findings that don't apply to their target.
+This check fires only for a report deliberately imported without a fresh run — generated earlier, by someone else, or by the hosted converter (M3). Only a JSON report is consumable (see 5a — there is no CSV parsing path); if the import is CSV, markdown, or XLSX only, re-run the CLI locally with `--check --json` on the input models instead. For an imported JSON report, confirm it was generated for the currently chosen target platform version before consuming it. Findings are version-dependent: e.g. conditional events are flagged as unsupported in a report targeting 8.6 but are native since 8.9, so a stale report can send the user chasing findings that don't apply to their target.
 
 Determine the report's target version:
 
-1. Findings with `messageId` `element-available-in-future-version` name it: the message reads `Element '<name>' is not supported in Zeebe version '<report-target>'. It is available in version '<x.y>'.` — `<report-target>` is the version the report was generated against. The markdown report has no `messageId` column but carries the same message text.
-2. If no such rows exist, the version can't be determined from the content — ask the user which `--platform-version` the report was generated with.
+1. Findings with `messageId` `element-available-in-future-version` name it: the message reads `Element '<name>' is not supported in Zeebe version '<report-target>'. It is available in version '<x.y>'.` — `<report-target>` is the version the report was generated against.
+2. If no such findings exist, the version can't be determined from the content — ask the user which `--platform-version` the report was generated with.
 
 If the report's version doesn't match the chosen target, or it can't be determined, warn the user and offer via AskUserQuestion before grouping (5b) or any cross-checks:
 
@@ -119,9 +118,7 @@ filename, elementName, elementId, elementType, severity, messageId, message, lin
 
 Parse it with real JSON tooling (e.g. `jq` or the runtime's built-in JSON parser) — never with ad-hoc string splitting. JSON needs no quoting or escaping workarounds, so the parsed findings are identical on every run regardless of which agent or model executes the skill.
 
-If the JSON report is missing (e.g. only `analysis-results.md` was generated), re-run the converter with `--check --json` on the same input. Analyze-only mode writes no converted files and produces the JSON report quickly. The markdown report is grouped per element and carries no `messageId` column — it is for human reading, not for parsing.
-
-If the only available report is a CSV (e.g. imported from the hosted converter in M3, which has no JSON output), prefer re-running the CLI locally with `--check --json`. If that is not possible, parse the CSV with a real CSV parser (e.g. Python stdlib `csv`): the CLI writes it with opencsv (`;` separator, quoted fields), and `message` values routinely contain `;`, quotes, and JUEL/FEEL expressions — a naive split corrupts rows silently, producing wrong category counts and therefore wrong verdicts.
+If the JSON report is missing (e.g. only `analysis-results.md` or a CSV/XLSX was generated — the hosted converter in M3 has no JSON output), re-run the converter with `--check --json` on the same input. Analyze-only mode writes no converted files and produces the JSON report quickly. The markdown, CSV, and XLSX reports are for human reading, not for parsing — this skill has no CSV parsing path; the JSON report is the only machine-readable findings source.
 
 #### 5b. Group findings by category
 
@@ -194,7 +191,7 @@ Point user to the hosted converter:
 
 > Upload your BPMN/DMN files at https://diagram-converter.camunda.io/, set the target version there, and download the converted results.
 
-This path does not automate the hosted service. Once the user brings the converted files back into the project, offer the same agentic findings follow-up as in M1 step 5.
+This path does not automate the hosted service. The hosted converter produces CSV/markdown/XLSX reports, which this skill does not parse — once the user brings the converted files back into the project, produce the machine-readable findings by running the CLI locally in analyze-only mode (`--check --json --xlsx`, see M1) on the same models, then offer the same agentic findings follow-up as in M1 step 5.
 
 ---
 
@@ -215,7 +212,7 @@ Also ask whether to fetch all latest process/decision definitions or only named 
 For the all-latest case, download/reuse the CLI as in M1, create `.camunda-migration/c7-models`, and invoke:
 
 ```
-java -Dfile.encoding=UTF-8 -jar <jar> engine <c7-rest-url> --target-directory .camunda-migration/c7-models --platform-version <target-version> --json [--username <username> --password <password>] [--csv] [--xlsx]
+java -Dfile.encoding=UTF-8 -jar <jar> engine <c7-rest-url> --target-directory .camunda-migration/c7-models --platform-version <target-version> --json --xlsx [--username <username> --password <password>]
 ```
 
 For named-key acquisition, query C7 REST list endpoints with key filters, fetch each definition's `/xml` resource, write XML files to `.camunda-migration/c7-models/`, then run M1 local mode on that directory.
@@ -228,4 +225,4 @@ Treat unreachable endpoint, TLS/DNS failure, 401/403, malformed XML, or empty re
 
 ## Analyze-Only Mode
 
-For "analyze but don't convert": run M1 with `--check --json` (optionally `--csv` or `--xlsx`) to produce findings and reports with no converted files, or do an M2 read-only pass. Parse and present findings grouped by category as in M1 step 5, and stop.
+For "analyze but don't convert": run M1 with `--check --json --xlsx` to produce findings and reports with no converted files, or do an M2 read-only pass. Parse and present findings grouped by category as in M1 step 5, and stop.

--- a/agentic-migration-skills/skills/migrate-c7-to-c8-code/references/model-migration-approaches.md
+++ b/agentic-migration-skills/skills/migrate-c7-to-c8-code/references/model-migration-approaches.md
@@ -94,7 +94,7 @@ On a real project the report can hold thousands of rows but only a handful of di
 
 Skip this check when the report comes from this skill's own CLI run — that run already passed the chosen `--platform-version`, and leftover reports from earlier local runs are never consumed at all (see Pre-flight: Leftover Artifacts).
 
-This check fires only for a report deliberately imported without a fresh run — generated earlier, by someone else, or by the hosted converter (M3). Only a JSON report is consumable (see 5a — there is no CSV parsing path); if the import is CSV, markdown, or XLSX only, re-run the CLI locally with `--check --json` on the input models instead. For an imported JSON report, confirm it was generated for the currently chosen target platform version before consuming it. Findings are version-dependent: e.g. conditional events are flagged as unsupported in a report targeting 8.6 but are native since 8.9, so a stale report can send the user chasing findings that don't apply to their target.
+This check fires only for a report deliberately imported without a fresh run — generated earlier, by someone else, or downloaded from the hosted converter (M3, which produces the same file via its 'Download JSON' button). Only a JSON report is consumable (see 5a — there is no CSV parsing path); if the import is CSV, markdown, or XLSX only, re-run the CLI locally with `--check --json --xlsx` on the input models instead. For an imported JSON report, confirm it was generated for the currently chosen target platform version before consuming it. Findings are version-dependent: e.g. conditional events are flagged as unsupported in a report targeting 8.6 but are native since 8.9, so a stale report can send the user chasing findings that don't apply to their target.
 
 Determine the report's target version:
 
@@ -103,7 +103,7 @@ Determine the report's target version:
 
 If the report's version doesn't match the chosen target, or it can't be determined, warn the user and offer via AskUserQuestion before grouping (5b) or any cross-checks:
 
-- **Re-run the converter at the chosen target** (recommended) - run the CLI from step 2 with `--check --json --platform-version <target-version>` on the same input. Analyze-only mode is fast, writes no converted files, and produces a fresh JSON report for 5a.
+- **Re-run the converter at the chosen target** (recommended) - run the CLI from step 2 with `--check --json --xlsx --platform-version <target-version>` on the same input. Analyze-only mode is fast, writes no converted files, and produces fresh JSON and XLSX reports for 5a.
 - **Keep the imported report** - proceed as-is and record in MIGRATION_REPORT.md that the findings were generated against a different or unknown target version.
 
 #### 5a. Parse the JSON report
@@ -118,7 +118,7 @@ filename, elementName, elementId, elementType, severity, messageId, message, lin
 
 Parse it with real JSON tooling (e.g. `jq` or the runtime's built-in JSON parser) — never with ad-hoc string splitting. JSON needs no quoting or escaping workarounds, so the parsed findings are identical on every run regardless of which agent or model executes the skill.
 
-If the JSON report is missing (e.g. only `analysis-results.md` or a CSV/XLSX was generated — the hosted converter in M3 has no JSON output), re-run the converter with `--check --json` on the same input. Analyze-only mode writes no converted files and produces the JSON report quickly. The markdown and XLSX reports are for human reading; CSV is not consumed at all — this skill has no CSV parsing path, and the JSON report is the only machine-readable findings source.
+If the JSON report is missing (e.g. only `analysis-results.md` or a CSV/XLSX was generated), re-run the converter with `--check --json --xlsx` on the same input. Analyze-only mode writes no converted files and produces both reports quickly. The markdown and XLSX reports are for human reading; CSV is not consumed at all — this skill has no CSV parsing path, and the JSON report is the only machine-readable findings source. (The hosted converter in M3 produces the same JSON file via its 'Download JSON' button.)
 
 #### 5b. Group findings by category
 
@@ -191,7 +191,7 @@ Point user to the hosted converter:
 
 > Upload your BPMN/DMN files at https://diagram-converter.camunda.io/, set the target version there, and download the converted results.
 
-This path does not automate the hosted service. The hosted converter produces CSV/markdown/XLSX reports, which this skill does not parse — once the user brings the converted files back into the project, produce the machine-readable findings by running the CLI locally in analyze-only mode (`--check --json --xlsx`, see M1) on the same models, then offer the same agentic findings follow-up as in M1 step 5.
+This path does not automate the hosted service. Once the user brings the converted files back into the project, offer the same agentic findings follow-up as in M1 step 5. For the machine-readable findings, use the hosted converter's 'Download JSON' button — it produces the same `analysis-results.json` the CLI writes; its CSV/markdown/XLSX downloads are not parsed (see 5a). The imported-report version check in step 5 applies.
 
 ---
 

--- a/agentic-migration-skills/skills/migrate-c7-to-c8-code/references/model-migration-approaches.md
+++ b/agentic-migration-skills/skills/migrate-c7-to-c8-code/references/model-migration-approaches.md
@@ -118,7 +118,7 @@ filename, elementName, elementId, elementType, severity, messageId, message, lin
 
 Parse it with real JSON tooling (e.g. `jq` or the runtime's built-in JSON parser) — never with ad-hoc string splitting. JSON needs no quoting or escaping workarounds, so the parsed findings are identical on every run regardless of which agent or model executes the skill.
 
-If the JSON report is missing (e.g. only `analysis-results.md` or a CSV/XLSX was generated — the hosted converter in M3 has no JSON output), re-run the converter with `--check --json` on the same input. Analyze-only mode writes no converted files and produces the JSON report quickly. The markdown, CSV, and XLSX reports are for human reading, not for parsing — this skill has no CSV parsing path; the JSON report is the only machine-readable findings source.
+If the JSON report is missing (e.g. only `analysis-results.md` or a CSV/XLSX was generated — the hosted converter in M3 has no JSON output), re-run the converter with `--check --json` on the same input. Analyze-only mode writes no converted files and produces the JSON report quickly. The markdown and XLSX reports are for human reading; CSV is not consumed at all — this skill has no CSV parsing path, and the JSON report is the only machine-readable findings source.
 
 #### 5b. Group findings by category
 

--- a/agentic-migration-skills/skills/migrate-c7-to-c8-code/references/model-migration-approaches.md
+++ b/agentic-migration-skills/skills/migrate-c7-to-c8-code/references/model-migration-approaches.md
@@ -13,7 +13,7 @@ Use the model scan from the assessment before choosing a conversion path:
 Before any local approach (M1, M2, E1), scan the project for outputs of previous migration attempts:
 
 - `converted-c8-*.bpmn` / `converted-c8-*.dmn` (or the `--prefix` equivalent)
-- `analysis-results.csv` / `.md` / `.xlsx`, including ` (n)`-suffixed siblings such as `analysis-results (1).csv` — a sure sign of a previous run
+- `analysis-results.csv` / `.json` / `.md` / `.xlsx`, including ` (n)`-suffixed siblings such as `analysis-results (1).json` — a sure sign of a previous run
 
 The `.camunda-migration/` CLI JAR is an intentional cache, not a leftover — never flag it.
 
@@ -60,7 +60,8 @@ java -Dfile.encoding=UTF-8 -jar <jar> local <file-or-dir> --platform-version <ta
 ```
 
 Recommended flags:
-- `--csv` - always pass this; the CSV report is the machine-readable input parsed in step 5
+- `--json` - always pass this; the JSON report is the machine-readable input parsed in step 5
+- `--csv` - optional, tabular export of the same findings for human review
 - `--xlsx` - optional, for human spreadsheet review
 - `-o` / `--override` - overwrite pre-existing outputs in place. Destructive — do not pass by default (see Pre-flight: Leftover Artifacts). Without it, a diagram whose converted target already exists is skipped with a `File already exists` error, and reports are written under ` (n)`-suffixed names.
 - `--check` - analyze-only (no converted diagrams exported)
@@ -72,15 +73,15 @@ Other options:
 
 The converter writes a new file next to the source (e.g., `converted-c8-order-process.bpmn`), so originals are never mutated in place.
 
-Capture the exact paths of everything the run produces from the `Created ...` lines in the CLI console output (e.g. `Created analysis-results (1).csv`). These paths are the authoritative inputs for steps 4 and 5 — never glob for `analysis-results.csv` or `converted-c8-*` on disk, which may match stale files from a previous attempt or a different `--platform-version`.
+Capture the exact paths of everything the run produces from the `Created ...` lines in the CLI console output (e.g. `Created analysis-results (1).json`). These paths are the authoritative inputs for steps 4 and 5 — never glob for `analysis-results.json` or `converted-c8-*` on disk, which may match stale files from a previous attempt or a different `--platform-version`.
 
 ### 4. Surface Outputs
 
 After the run, report:
 - Converted files: list every `converted-c8-*.bpmn` / `*.dmn` produced (from the captured `Created ...` lines)
 - Skipped files: any `File already exists` errors, naming the stale targets — those diagrams were NOT converted; offer to re-run once the user removes the stale copies (see Pre-flight: Leftover Artifacts)
-- Analysis findings: summarize from CLI stdout and/or CSV/XLSX report, grouped by severity (WARNING / TASK / REVIEW / INFO)
-- Analysis artifacts: point user to the CSV file (always) and the XLSX file if generated
+- Analysis findings: summarize from CLI stdout and/or the JSON report, grouped by severity (WARNING / TASK / REVIEW / INFO)
+- Analysis artifacts: point user to the JSON file (always) and the CSV/XLSX files if generated
 
 Severity counts are only a headline. Do not start per-finding work from them — parse and group the full report first (step 5).
 
@@ -98,29 +99,33 @@ This check fires only for a report deliberately imported without a fresh run —
 
 Determine the report's target version:
 
-1. Rows with `messageId` `element-available-in-future-version` name it: the message reads `Element '<name>' is not supported in Zeebe version '<report-target>'. It is available in version '<x.y>'.` — `<report-target>` is the version the report was generated against. The markdown report has no `messageId` column but carries the same message text.
+1. Findings with `messageId` `element-available-in-future-version` name it: the message reads `Element '<name>' is not supported in Zeebe version '<report-target>'. It is available in version '<x.y>'.` — `<report-target>` is the version the report was generated against. The markdown report has no `messageId` column but carries the same message text.
 2. If no such rows exist, the version can't be determined from the content — ask the user which `--platform-version` the report was generated with.
 
 If the report's version doesn't match the chosen target, or it can't be determined, warn the user and offer via AskUserQuestion before grouping (5b) or any cross-checks:
 
-- **Re-run the converter at the chosen target** (recommended) - run the CLI from step 2 with `--check --csv --platform-version <target-version>` on the same input. Analyze-only mode is fast, writes no converted files, and produces a fresh CSV for 5a.
+- **Re-run the converter at the chosen target** (recommended) - run the CLI from step 2 with `--check --json --platform-version <target-version>` on the same input. Analyze-only mode is fast, writes no converted files, and produces a fresh JSON report for 5a.
 - **Keep the imported report** - proceed as-is and record in MIGRATION_REPORT.md that the findings were generated against a different or unknown target version.
 
-#### 5a. Parse the CSV report
+#### 5a. Parse the JSON report
 
-Read the CSV report programmatically, using the exact path captured from this run's `Created ...` output line (it is written next to the converted files when `--csv` is passed, which M1 always does — under a ` (n)`-suffixed name when a stale report exists). Never parse a pre-existing `analysis-results.csv` found on disk. Do not rely on stdout severity counts as a substitute.
+Read the JSON report programmatically, using the exact path captured from this run's `Created ...` output line (it is written next to the converted files when `--json` is passed, which M1 always does — under a ` (n)`-suffixed name when a stale report exists). Never parse a pre-existing `analysis-results.json` found on disk. Do not rely on stdout severity counts as a substitute.
 
-Format: `;`-separated, one header row, columns:
+Format: a JSON array with one object per finding, fields:
 
 ```
-filename;elementName;elementId;elementType;severity;messageId;message;link
+filename, elementName, elementId, elementType, severity, messageId, message, link
 ```
 
-If the CSV is missing (e.g. only `analysis-results.md` was generated), re-run the converter with `--check --csv` on the same input. Analyze-only mode writes no converted files and produces the CSV quickly. The markdown report is grouped per element and carries no `messageId` column — it is for human reading, not for parsing.
+Parse it with real JSON tooling (e.g. `jq` or the runtime's built-in JSON parser) — never with ad-hoc string splitting. JSON needs no quoting or escaping workarounds, so the parsed findings are identical on every run regardless of which agent or model executes the skill.
+
+If the JSON report is missing (e.g. only `analysis-results.md` was generated), re-run the converter with `--check --json` on the same input. Analyze-only mode writes no converted files and produces the JSON report quickly. The markdown report is grouped per element and carries no `messageId` column — it is for human reading, not for parsing.
+
+If the only available report is a CSV (e.g. imported from the hosted converter in M3, which has no JSON output), prefer re-running the CLI locally with `--check --json`. If that is not possible, parse the CSV with a real CSV parser (e.g. Python stdlib `csv`): the CLI writes it with opencsv (`;` separator, quoted fields), and `message` values routinely contain `;`, quotes, and JUEL/FEEL expressions — a naive split corrupts rows silently, producing wrong category counts and therefore wrong verdicts.
 
 #### 5b. Group findings by category
 
-Group rows by `messageId` (the category). For each category compute:
+Group findings by `messageId` (the category). For each category compute:
 
 - Total count, and count per severity
 - Distinct `elementType` values affected (e.g. serviceTask, sequenceFlow, multiInstanceLoopCharacteristics)
@@ -210,7 +215,7 @@ Also ask whether to fetch all latest process/decision definitions or only named 
 For the all-latest case, download/reuse the CLI as in M1, create `.camunda-migration/c7-models`, and invoke:
 
 ```
-java -Dfile.encoding=UTF-8 -jar <jar> engine <c7-rest-url> --target-directory .camunda-migration/c7-models --platform-version <target-version> [--username <username> --password <password>] [--csv] [--xlsx]
+java -Dfile.encoding=UTF-8 -jar <jar> engine <c7-rest-url> --target-directory .camunda-migration/c7-models --platform-version <target-version> --json [--username <username> --password <password>] [--csv] [--xlsx]
 ```
 
 For named-key acquisition, query C7 REST list endpoints with key filters, fetch each definition's `/xml` resource, write XML files to `.camunda-migration/c7-models/`, then run M1 local mode on that directory.
@@ -223,4 +228,4 @@ Treat unreachable endpoint, TLS/DNS failure, 401/403, malformed XML, or empty re
 
 ## Analyze-Only Mode
 
-For "analyze but don't convert": run M1 with `--check --csv` (optionally `--xlsx`) to produce findings and reports with no converted files, or do an M2 read-only pass. Parse and present findings grouped by category as in M1 step 5, and stop.
+For "analyze but don't convert": run M1 with `--check --json` (optionally `--csv` or `--xlsx`) to produce findings and reports with no converted files, or do an M2 read-only pass. Parse and present findings grouped by category as in M1 step 5, and stop.

--- a/agentic-migration-skills/skills/migrate-c7-to-c8-code/references/model-migration-approaches.md
+++ b/agentic-migration-skills/skills/migrate-c7-to-c8-code/references/model-migration-approaches.md
@@ -56,7 +56,7 @@ The JAR is ~30 MB. If the project is a git repo, recommend adding `.camunda-migr
 The CLI local subcommand accepts a single file or a directory (recursive by default). Always pass `--platform-version` set to the target version from the interview.
 
 ```
-java -Dfile.encoding=UTF-8 -jar <jar> local <file-or-dir> --platform-version <target-version>
+java -Dfile.encoding=UTF-8 -jar <jar> local <file-or-dir> --platform-version <target-version> --json
 ```
 
 Recommended flags:


### PR DESCRIPTION
## Summary

- Makes the model migration skill's findings flow deterministic and single-format: the JSON report (`--json`, added in sibling PR #2294) is the only machine-readable findings source. Step 5a parses the captured `Created ...` JSON path with real JSON tooling — no CSV parsing anywhere in the skill, so the grouped category table (5b/5c) is identical on every run, regardless of which agent/model executes it.
- M1/E1/analyze-only now always produce the XLSX alongside the JSON; step 4 points the user to the XLSX as the human-readable artifact for reviewing and sharing findings with the customer.
- Imported reports: only JSON is consumable. Reports without JSON output (hosted converter M3, pre-`--json` CLI releases) are regenerated locally with `--check --json` instead of being parsed.

## Changes

- `agentic-migration-skills/.../model-migration-approaches.md` only: M1 step 3 flags and example command (`--json --xlsx` always), step 4 artifacts (XLSX customer-facing, JSON machine-facing), imported-report version gate (JSON-only), steps 5a/5b, E1 command line, M3 follow-up note, pre-flight leftover-artifact list, and analyze-only mode.
- The previous CSV-parsing guidance (including the real-CSV-parser fallback) is removed entirely.

## Notes

- This PR is the middle of stack #2300: stacked on #2294 (which adds `--json` to the Diagram Converter CLI), with #2301 (webapp JSON download) on top. The base retargets automatically as lower layers merge. The skill documents that `--json` requires a CLI release containing the flag (0.3.6+). Together the two PRs close #2286.
- The changes here were already reviewed by Copilot as part of #2294 before the split; the release-boundary and format-scope feedback from the first review round on this PR is incorporated.

## Test plan

- [x] Docs-only change; no code paths affected
- [ ] CI green

## Baseline

Branched from commit: e519813d (main)

related to #2286

🤖 Generated with [Claude Code](https://claude.com/claude-code)


