### PR TITLE
Backport #2294 to maintenance/0.2: add --json analysis report output to CLI

### DIFF
--- a/diagram-converter/cli/src/main/java/io/camunda/migration/diagram/converter/cli/AbstractConvertCommand.java
+++ b/diagram-converter/cli/src/main/java/io/camunda/migration/diagram/converter/cli/AbstractConvertCommand.java
@@ -231,19 +231,24 @@ public abstract class AbstractConvertCommand implements Callable<Integer> {
   }
 
   private DiagramCheckResult checkModel(Entry<File, ModelInstance> modelInstance) {
+    String modelIdentifier = modelIdentifier(modelInstance.getKey());
     try {
       return converter.check(
-          modelInstance.getKey().getPath(),
+          modelIdentifier,
           modelInstance.getValue(),
           ConverterPropertiesFactory.getInstance().merge(converterProperties()));
     } catch (Exception e) {
-      LOG_CLI.error("Problem while converting: {}", createMessage(e));
+      LOG_CLI.error("Problem while converting {}: {}", modelIdentifier, createMessage(e));
       returnCode = 1;
       return null;
     }
   }
 
   protected abstract Map<File, ModelInstance> modelInstances();
+
+  protected String modelIdentifier(File modelFile) {
+    return modelFile.getAbsolutePath();
+  }
 
   protected DefaultConverterProperties converterProperties() {
     DefaultConverterProperties properties = new DefaultConverterProperties();

--- a/diagram-converter/cli/src/main/java/io/camunda/migration/diagram/converter/cli/AbstractConvertCommand.java
+++ b/diagram-converter/cli/src/main/java/io/camunda/migration/diagram/converter/cli/AbstractConvertCommand.java
@@ -20,6 +20,8 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
@@ -72,6 +74,12 @@ public abstract class AbstractConvertCommand implements Callable<Integer> {
       description =
           "If enabled, a CSV file will be created containing the results for the analysis")
   boolean csv;
+
+  @Option(
+      names = {"--json"},
+      description =
+          "If enabled, a JSON file will be created containing the results for the analysis")
+  boolean json;
 
   @Option(
       names = {"--xlsx"},
@@ -134,7 +142,7 @@ public abstract class AbstractConvertCommand implements Callable<Integer> {
 
   private void writeResults(
       Map<File, ModelInstance> modelInstances, List<DiagramCheckResult> results) {
-    if ((!check || csv || xlsx || markdown) && !createTargetDirectory()) {
+    if ((!check || csv || xlsx || markdown || json) && !createTargetDirectory()) {
       return;
     }
     if (!check) {
@@ -150,7 +158,7 @@ public abstract class AbstractConvertCommand implements Callable<Integer> {
           converter.printXml(modelInstance.getValue().getDocument(), true, fw);
           fw.flush();
           LOG_CLI.info("Created {}", file);
-        } catch (IOException e) {
+        } catch (IOException | RuntimeException e) {
           LOG_CLI.error("Error while creating diagram file: {}", createMessage(e));
           returnCode = 1;
         }
@@ -161,7 +169,7 @@ public abstract class AbstractConvertCommand implements Callable<Integer> {
       try (FileWriter fw = new FileWriter(csvFile)) {
         converter.writeCsvFile(results, fw);
         LOG_CLI.info("Created {}", csvFile);
-      } catch (IOException e) {
+      } catch (IOException | RuntimeException e) {
         LOG_CLI.error("Error while creating csv results: {}", createMessage(e));
         returnCode = 1;
       }
@@ -171,8 +179,20 @@ public abstract class AbstractConvertCommand implements Callable<Integer> {
       try (FileOutputStream fos = new FileOutputStream(xlsxFile)) {
         new ExcelWriter().writeResultsToExcel(converter.createLineItemDTOList(results), fos);
         LOG_CLI.info("Created {}", xlsxFile);
-      } catch (IOException e) {
+      } catch (IOException | RuntimeException e) {
         LOG_CLI.error("Error while creating xlsx results: {}", createMessage(e));
+        returnCode = 1;
+      }
+    }
+    if (json) {
+      File jsonFile = determineFileName(new File(targetDirectory(), "analysis-results.json"));
+      // JSON is specified as UTF-8 (RFC 8259); pin the charset so an explicit
+      // -Dfile.encoding override can't corrupt the machine-readable report
+      try (Writer fw = Files.newBufferedWriter(jsonFile.toPath(), StandardCharsets.UTF_8)) {
+        converter.writeJsonFile(results, fw);
+        LOG_CLI.info("Created {}", jsonFile);
+      } catch (IOException | RuntimeException e) {
+        LOG_CLI.error("Error while creating json results: {}", createMessage(e));
         returnCode = 1;
       }
     }
@@ -181,7 +201,7 @@ public abstract class AbstractConvertCommand implements Callable<Integer> {
       try (FileWriter fw = new FileWriter(markdownFile)) {
         converter.writeMarkdownFile(results, fw);
         LOG_CLI.info("Created {}", markdownFile);
-      } catch (IOException e) {
+      } catch (IOException | RuntimeException e) {
         LOG_CLI.error("Error while creating markdown results: {}", createMessage(e));
         returnCode = 1;
       }
@@ -275,12 +295,16 @@ public abstract class AbstractConvertCommand implements Callable<Integer> {
   }
 
   protected String createMessage(Exception e) {
-    StringBuilder message = new StringBuilder(e.getMessage());
+    StringBuilder message = new StringBuilder(exceptionMessage(e));
     Throwable ex = e.getCause();
     while (ex != null) {
-      message.append(",").append("\n").append("caused by: ").append(ex.getMessage());
+      message.append(",").append("\n").append("caused by: ").append(exceptionMessage(ex));
       ex = ex.getCause();
     }
     return message.toString();
+  }
+
+  private String exceptionMessage(Throwable t) {
+    return t.getMessage() != null ? t.getMessage() : t.getClass().getName();
   }
 }

--- a/diagram-converter/cli/src/main/java/io/camunda/migration/diagram/converter/cli/ConvertLocalCommand.java
+++ b/diagram-converter/cli/src/main/java/io/camunda/migration/diagram/converter/cli/ConvertLocalCommand.java
@@ -48,6 +48,20 @@ public class ConvertLocalCommand extends AbstractConvertCommand {
   @Parameters(index = "0", description = "The file to convert or directory to search in")
   File file;
 
+  @Override
+  protected String modelIdentifier(File modelFile) {
+    Path absoluteModelPath = modelFile.toPath().toAbsolutePath().normalize();
+    Path absoluteInputRoot =
+        (file.isDirectory() ? file.toPath() : file.getAbsoluteFile().getParentFile().toPath())
+            .toAbsolutePath()
+            .normalize();
+
+    if (absoluteModelPath.startsWith(absoluteInputRoot)) {
+      return absoluteInputRoot.relativize(absoluteModelPath).toString();
+    }
+    return absoluteModelPath.toString();
+  }
+
   @Option(
       names = {"-nr", "--not-recursive"},
       description = "If enabled, recursive search in subfolders will be omitted")

--- a/diagram-converter/cli/src/test/java/io/camunda/migration/diagram/converter/cli/ConvertLocalCommandTest.java
+++ b/diagram-converter/cli/src/test/java/io/camunda/migration/diagram/converter/cli/ConvertLocalCommandTest.java
@@ -11,6 +11,10 @@ import static java.nio.file.StandardCopyOption.*;
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
 
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -19,6 +23,7 @@ import java.nio.file.Path;
 import java.util.Objects;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.slf4j.LoggerFactory;
 
 public class ConvertLocalCommandTest {
   private void setupDir(String filename, File tempDir) {
@@ -125,6 +130,47 @@ public class ConvertLocalCommandTest {
   }
 
   @Test
+  void shouldCreateJson(@TempDir File tempDir) throws IOException {
+    setupDir("c7.bpmn", tempDir);
+    ConvertLocalCommand command = new ConvertLocalCommand();
+    command.json = true;
+    command.file = tempDir;
+    Integer call = command.call();
+    assertEquals(0, call);
+    assertThat(tempDir.listFiles())
+        .hasSize(3)
+        .anyMatch(file -> file.getName().equals("c7.bpmn"))
+        .anyMatch(file -> file.getName().equals("converted-c8-c7.bpmn"))
+        .anyMatch(file -> file.getName().equals("analysis-results.json"));
+    File jsonFile = new File(tempDir, "analysis-results.json");
+    assertThat(new ObjectMapper().readTree(jsonFile).isArray()).isTrue();
+  }
+
+  @Test
+  void shouldNotCreateJson(@TempDir File tempDir) {
+    setupDir("c7.bpmn", tempDir);
+    ConvertLocalCommand command = new ConvertLocalCommand();
+    command.file = tempDir;
+    Integer call = command.call();
+    assertEquals(0, call);
+    assertThat(tempDir.listFiles())
+        .noneMatch(file -> file.getName().equals("analysis-results.json"));
+  }
+
+  @Test
+  void shouldHandleNullExceptionMessagesInCreateMessage() {
+    ConvertLocalCommand command = new ConvertLocalCommand();
+
+    // unchecked exceptions like NPE carry a null message; error handling must not crash on them
+    assertThat(command.createMessage(new NullPointerException()))
+        .isEqualTo(NullPointerException.class.getName());
+    assertThat(
+            command.createMessage(
+                new RuntimeException("outer", new IllegalArgumentException((String) null))))
+        .isEqualTo("outer,\ncaused by: " + IllegalArgumentException.class.getName());
+  }
+
+  @Test
   void shouldNotCreateConvertedDiagrams(@TempDir File tempDir) {
     setupDir("c7.bpmn", tempDir);
     ConvertLocalCommand command = new ConvertLocalCommand();
@@ -133,6 +179,63 @@ public class ConvertLocalCommandTest {
     Integer call = command.call();
     assertEquals(0, call);
     assertThat(tempDir.listFiles()).hasSize(1).anyMatch(file -> file.getName().equals("c7.bpmn"));
+  }
+
+  @Test
+  void shouldReturnErrorCodeForAlreadyCamunda8Dmn(@TempDir File tempDir) {
+    setupDir("c8.dmn", tempDir);
+    ConvertLocalCommand command = new ConvertLocalCommand();
+    command.file = tempDir;
+    Integer call = command.call();
+    assertEquals(1, call);
+  }
+
+  @Test
+  void shouldIncludeFilenameInErrorForAlreadyCamunda8Dmn(@TempDir File tempDir) {
+    setupDir("c8.dmn", tempDir);
+    String expectedPath = "c8.dmn";
+    Logger cliLogger = (Logger) LoggerFactory.getLogger("cli");
+    ListAppender<ILoggingEvent> listAppender = new ListAppender<>();
+    listAppender.start();
+    cliLogger.addAppender(listAppender);
+    try {
+      ConvertLocalCommand command = new ConvertLocalCommand();
+      command.file = tempDir;
+      Integer call = command.call();
+      assertEquals(1, call);
+      assertThat(listAppender.list)
+          .anyMatch(
+              event ->
+                  event.getFormattedMessage().contains(expectedPath)
+                      && event.getFormattedMessage().contains("Problem while converting"));
+    } finally {
+      cliLogger.detachAppender(listAppender);
+      listAppender.stop();
+    }
+  }
+
+  @Test
+  void shouldIncludeFilenameInErrorForAlreadyCamunda8Bpmn(@TempDir File tempDir) {
+    setupDir("c8.bpmn", tempDir);
+    String expectedPath = "c8.bpmn";
+    Logger cliLogger = (Logger) LoggerFactory.getLogger("cli");
+    ListAppender<ILoggingEvent> listAppender = new ListAppender<>();
+    listAppender.start();
+    cliLogger.addAppender(listAppender);
+    try {
+      ConvertLocalCommand command = new ConvertLocalCommand();
+      command.file = tempDir;
+      Integer call = command.call();
+      assertEquals(1, call);
+      assertThat(listAppender.list)
+          .anyMatch(
+              event ->
+                  event.getFormattedMessage().contains(expectedPath)
+                      && event.getFormattedMessage().contains("Problem while converting"));
+    } finally {
+      cliLogger.detachAppender(listAppender);
+      listAppender.stop();
+    }
   }
 
   @Test

--- a/diagram-converter/cli/src/test/resources/c8.dmn
+++ b/diagram-converter/cli/src/test/resources/c8.dmn
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_c8dmn" name="DRD" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="5.15.2" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.3.0">
+  <decision id="Decision_1" name="Decision 1">
+    <decisionTable id="DecisionTable_1">
+      <input id="Input_1">
+        <inputExpression id="InputExpression_1" typeRef="string">
+          <text>input</text>
+        </inputExpression>
+      </input>
+      <output id="Output_1" typeRef="string" />
+    </decisionTable>
+  </decision>
+  <dmndi:DMNDI>
+    <dmndi:DMNDiagram>
+      <dmndi:DMNShape dmnElementRef="Decision_1">
+        <dc:Bounds height="80" width="180" x="160" y="100" />
+      </dmndi:DMNShape>
+    </dmndi:DMNDiagram>
+  </dmndi:DMNDI>
+</definitions>

--- a/diagram-converter/core/pom.xml
+++ b/diagram-converter/core/pom.xml
@@ -51,7 +51,6 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>

--- a/diagram-converter/core/src/main/java/io/camunda/migration/diagram/converter/DiagramConverter.java
+++ b/diagram-converter/core/src/main/java/io/camunda/migration/diagram/converter/DiagramConverter.java
@@ -9,6 +9,7 @@ package io.camunda.migration.diagram.converter;
 
 import static io.camunda.migration.diagram.converter.NamespaceUri.*;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.opencsv.CSVWriterBuilder;
 import com.opencsv.ICSVWriter;
 import com.samskivert.mustache.Mustache;
@@ -53,6 +54,7 @@ import org.slf4j.LoggerFactory;
 public class DiagramConverter {
   private static final Logger LOG = LoggerFactory.getLogger(DiagramConverter.class);
   private static final Template MARKDOWN_TEMPLATE;
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
   static {
     try (InputStream in =
@@ -268,6 +270,14 @@ public class DiagramConverter {
       csvWriter.writeAll(createLines(results));
     } catch (IOException e) {
       throw new RuntimeException("Error while writing csv file", e);
+    }
+  }
+
+  public void writeJsonFile(List<DiagramCheckResult> results, Writer writer) {
+    try {
+      OBJECT_MAPPER.writeValue(writer, createLineItemDTOList(results));
+    } catch (IOException e) {
+      throw new RuntimeException("Error while writing json file", e);
     }
   }
 

--- a/diagram-converter/core/src/test/java/io/camunda/migration/diagram/converter/JsonWriterTest.java
+++ b/diagram-converter/core/src/test/java/io/camunda/migration/diagram/converter/JsonWriterTest.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.migration.diagram.converter;
+
+import static org.assertj.core.api.Assertions.*;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.opencsv.CSVParserBuilder;
+import com.opencsv.CSVReader;
+import com.opencsv.CSVReaderBuilder;
+import com.opencsv.exceptions.CsvException;
+import io.camunda.migration.diagram.converter.DiagramCheckResult.ElementCheckMessage;
+import io.camunda.migration.diagram.converter.DiagramCheckResult.ElementCheckResult;
+import io.camunda.migration.diagram.converter.DiagramCheckResult.Severity;
+import java.io.IOException;
+import java.io.StringReader;
+import java.io.StringWriter;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+public class JsonWriterTest {
+  private static final String FILENAME = "mock-process.bpmn";
+  private static final String LINK = "https://www.example.com";
+  private static final String MESSAGE_ID = "test-message";
+  private static final String MESSAGE = "Test message";
+  private static final String ELEMENT_ID = "abc.123";
+  private static final String ELEMENT_NAME = "Example;Name";
+  private static final String ELEMENT_TYPE = "userTask";
+  private static final Severity SEVERITY = Severity.TASK;
+  private static final DiagramConverter SERVICE = DiagramConverterFactory.getInstance().get();
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+  @Test
+  public void shouldCreateValidJson() throws IOException {
+    StringWriter writer = new StringWriter();
+    SERVICE.writeJsonFile(mockResults(), writer);
+
+    JsonNode root = OBJECT_MAPPER.readTree(writer.toString());
+    assertThat(root.isArray()).isTrue();
+    assertThat(root).hasSize(1);
+    JsonNode entry = root.get(0);
+    assertThat(entry.get("filename").asText()).isEqualTo(FILENAME);
+    assertThat(entry.get("elementName").asText()).isEqualTo(ELEMENT_NAME);
+    assertThat(entry.get("elementId").asText()).isEqualTo(ELEMENT_ID);
+    assertThat(entry.get("elementType").asText()).isEqualTo(ELEMENT_TYPE);
+    assertThat(entry.get("severity").asText()).isEqualTo(SEVERITY.name());
+    assertThat(entry.get("messageId").asText()).isEqualTo(MESSAGE_ID);
+    assertThat(entry.get("message").asText()).isEqualTo(MESSAGE);
+    assertThat(entry.get("link").asText()).isEqualTo(LINK);
+  }
+
+  @Test
+  public void shouldSerializeAllFindings() throws IOException {
+    DiagramCheckResult result = mockDiagramResult();
+    result.getResults().getFirst().getMessages().add(mockMessage());
+
+    StringWriter writer = new StringWriter();
+    SERVICE.writeJsonFile(List.of(result), writer);
+
+    JsonNode root = OBJECT_MAPPER.readTree(writer.toString());
+    assertThat(root).hasSize(2);
+  }
+
+  @Test
+  public void shouldPreserveSpecialCharactersVerbatim() throws IOException {
+    // report messages routinely contain ';', quotes and JUEL/FEEL expressions - content that
+    // corrupts rows when a report format is parsed with naive string splitting
+    String trickyMessage =
+        "Method invocation is not possible in FEEL: ${execution.getVariable(\"a\").size()}; use a different expression";
+    DiagramCheckResult result = mockDiagramResult();
+    result.getResults().getFirst().getMessages().getFirst().setMessage(trickyMessage);
+
+    StringWriter writer = new StringWriter();
+    SERVICE.writeJsonFile(List.of(result), writer);
+
+    JsonNode root = OBJECT_MAPPER.readTree(writer.toString());
+    assertThat(root.get(0).get("message").asText()).isEqualTo(trickyMessage);
+  }
+
+  @Test
+  public void shouldMatchCsvRowContent() throws IOException {
+    List<DiagramCheckResult> results = mockResults();
+
+    StringWriter jsonWriter = new StringWriter();
+    SERVICE.writeJsonFile(results, jsonWriter);
+    JsonNode entry = OBJECT_MAPPER.readTree(jsonWriter.toString()).get(0);
+
+    StringWriter csvWriter = new StringWriter();
+    SERVICE.writeCsvFile(results, csvWriter);
+    List<String[]> csvLines = readCsv(csvWriter);
+
+    assertThat(csvLines).hasSize(2);
+    assertThat(csvLines.get(1))
+        .containsExactly(
+            entry.get("filename").asText(),
+            entry.get("elementName").asText(),
+            entry.get("elementId").asText(),
+            entry.get("elementType").asText(),
+            entry.get("severity").asText(),
+            entry.get("messageId").asText(),
+            entry.get("message").asText(),
+            entry.get("link").asText());
+  }
+
+  private List<String[]> readCsv(StringWriter writer) {
+    StringReader reader = new StringReader(writer.toString());
+    try (CSVReader csvReader =
+        new CSVReaderBuilder(reader)
+            .withCSVParser(new CSVParserBuilder().withSeparator(';').build())
+            .build()) {
+      return csvReader.readAll();
+    } catch (IOException | CsvException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private List<DiagramCheckResult> mockResults() {
+    List<DiagramCheckResult> results = new ArrayList<>();
+    results.add(mockDiagramResult());
+    return results;
+  }
+
+  private DiagramCheckResult mockDiagramResult() {
+    DiagramCheckResult result = new DiagramCheckResult();
+    result.setFilename(FILENAME);
+    result.getResults().add(mockElementResult());
+    return result;
+  }
+
+  private ElementCheckResult mockElementResult() {
+    ElementCheckResult result = new ElementCheckResult();
+    result.setElementId(ELEMENT_ID);
+    result.setElementName(ELEMENT_NAME);
+    result.setElementType(ELEMENT_TYPE);
+    result.getMessages().add(mockMessage());
+    return result;
+  }
+
+  private ElementCheckMessage mockMessage() {
+    ElementCheckMessage message = new ElementCheckMessage();
+    message.setSeverity(SEVERITY);
+    message.setMessage(MESSAGE);
+    message.setLink(LINK);
+    message.setId(MESSAGE_ID);
+    return message;
+  }
+}


### PR DESCRIPTION
## Summary

Manual backport of #2294 to `maintenance/0.2`. The automated backport failed on a cherry-pick conflict in `ConvertLocalCommandTest.java` (import block), and the backported tests additionally need the filename-in-error-message behavior (#1433, commit 59d9efc0) that was only backported to 0.3, never to 0.2.

## Changes

- Cherry-picked 266b44e7 (#2294): `--json` CLI analysis report, `writeJsonFile`, JsonWriterTest, CLI tests.
- Conflict resolution: import block in `ConvertLocalCommandTest.java` (took the main-side imports).
- Included the prerequisite bits of 59d9efc0: `modelIdentifier` (input-root-relative paths) in `ConvertLocalCommand`/`AbstractConvertCommand`, filename in the conversion error log, and the `c8.dmn` test resource.

## Test plan

- [x] `cd diagram-converter && mvn verify -Pdistro,checkFormat -pl core,cli` green (25/25 cli tests)

Backports #2294
related to #2286
