### PR TITLE
feat(diagram-converter): migrate Camunda Forms (.form files) in the CLI

### DIFF
--- a/diagram-converter/cli/README.md
+++ b/diagram-converter/cli/README.md
@@ -27,3 +27,5 @@ java -Dfile.encoding=UTF-8 -jar camunda-7-to-8-diagram-converter-cli-{version}.j
 ### Supported File Extensions
 
 Diagrams must have the `.bpmn`, `.bpmn20.xml`, `.dmn`, or `.dmn11.xml` file ending to be processed.
+
+Camunda 7 form files (`.form`) are converted as well: they are JSON documents, so the converter only updates the platform metadata (`executionPlatform` becomes `Camunda Cloud`, `executionPlatformVersion` becomes the target platform version) and leaves all other content untouched. Form files are skipped in `--check` mode.

--- a/diagram-converter/cli/README.md
+++ b/diagram-converter/cli/README.md
@@ -28,4 +28,4 @@ java -Dfile.encoding=UTF-8 -jar camunda-7-to-8-diagram-converter-cli-{version}.j
 
 Diagrams must have the `.bpmn`, `.bpmn20.xml`, `.dmn`, or `.dmn11.xml` file ending to be processed.
 
-Camunda 7 form files (`.form`) are converted as well: they are JSON documents, so the converter only updates the platform metadata (`executionPlatform` becomes `Camunda Cloud`, `executionPlatformVersion` becomes the target platform version) and leaves all other content untouched. Form files are skipped in `--check` mode.
+Camunda 7 form files (`.form`) are converted as well: they are JSON documents, so the converter only updates the platform metadata (`executionPlatform` becomes `Camunda Cloud`, `executionPlatformVersion` becomes the target platform version). All other fields and values are preserved semantically; the JSON may be re-formatted. Form files are skipped in `--check` mode.

--- a/diagram-converter/cli/src/main/java/io/camunda/migration/diagram/converter/cli/AbstractConvertCommand.java
+++ b/diagram-converter/cli/src/main/java/io/camunda/migration/diagram/converter/cli/AbstractConvertCommand.java
@@ -9,6 +9,7 @@ package io.camunda.migration.diagram.converter.cli;
 
 import static io.camunda.migration.diagram.converter.cli.ConvertCommand.*;
 
+import io.camunda.migration.diagram.converter.ConverterProperties;
 import io.camunda.migration.diagram.converter.ConverterPropertiesFactory;
 import io.camunda.migration.diagram.converter.DefaultConverterProperties;
 import io.camunda.migration.diagram.converter.DiagramCheckResult;
@@ -153,6 +154,8 @@ public abstract class AbstractConvertCommand implements Callable<Integer> {
     if (!createTargetDirectory()) {
       return;
     }
+    ConverterProperties properties =
+        ConverterPropertiesFactory.getInstance().merge(converterProperties());
     for (File formFile : formFileList) {
       File outFile = prefixFileName(formFile);
       if (!override && outFile.exists()) {
@@ -162,9 +165,7 @@ public abstract class AbstractConvertCommand implements Callable<Integer> {
       }
       try {
         String content = Files.readString(formFile.toPath(), StandardCharsets.UTF_8);
-        String converted =
-            FormConverter.convert(
-                content, ConverterPropertiesFactory.getInstance().merge(converterProperties()));
+        String converted = FormConverter.convert(content, properties);
         // JSON is specified as UTF-8 (RFC 8259); pin the charset so an explicit
         // -Dfile.encoding override can't corrupt the converted form
         Files.writeString(outFile.toPath(), converted, StandardCharsets.UTF_8);

--- a/diagram-converter/cli/src/main/java/io/camunda/migration/diagram/converter/cli/AbstractConvertCommand.java
+++ b/diagram-converter/cli/src/main/java/io/camunda/migration/diagram/converter/cli/AbstractConvertCommand.java
@@ -15,6 +15,7 @@ import io.camunda.migration.diagram.converter.DiagramCheckResult;
 import io.camunda.migration.diagram.converter.DiagramConverter;
 import io.camunda.migration.diagram.converter.DiagramConverterFactory;
 import io.camunda.migration.diagram.converter.DiagramType;
+import io.camunda.migration.diagram.converter.FormConverter;
 import io.camunda.migration.diagram.converter.excel.ExcelWriter;
 import java.io.File;
 import java.io.FileOutputStream;
@@ -137,7 +138,45 @@ public abstract class AbstractConvertCommand implements Callable<Integer> {
     Map<File, ModelInstance> modelInstances = modelInstances();
     List<DiagramCheckResult> results = checkModels(modelInstances);
     writeResults(modelInstances, results);
+    convertFormFiles(formFiles());
     return returnCode;
+  }
+
+  protected List<File> formFiles() {
+    return List.of();
+  }
+
+  private void convertFormFiles(List<File> formFileList) {
+    if (check || formFileList.isEmpty()) {
+      return;
+    }
+    if (!createTargetDirectory()) {
+      return;
+    }
+    for (File formFile : formFileList) {
+      File outFile = prefixFileName(formFile);
+      if (!override && outFile.exists()) {
+        LOG_CLI.error("File already exists: {}", outFile);
+        returnCode = 1;
+        continue;
+      }
+      try {
+        String content = Files.readString(formFile.toPath(), StandardCharsets.UTF_8);
+        String converted =
+            FormConverter.convert(
+                content, ConverterPropertiesFactory.getInstance().merge(converterProperties()));
+        // JSON is specified as UTF-8 (RFC 8259); pin the charset so an explicit
+        // -Dfile.encoding override can't corrupt the converted form
+        Files.writeString(outFile.toPath(), converted, StandardCharsets.UTF_8);
+        LOG_CLI.info("Created {}", outFile);
+      } catch (IOException | RuntimeException e) {
+        LOG_CLI.error(
+            "Error while converting form file {}: {}",
+            formFile.getAbsolutePath(),
+            createMessage(e));
+        returnCode = 1;
+      }
+    }
   }
 
   private void writeResults(

--- a/diagram-converter/cli/src/main/java/io/camunda/migration/diagram/converter/cli/ConvertLocalCommand.java
+++ b/diagram-converter/cli/src/main/java/io/camunda/migration/diagram/converter/cli/ConvertLocalCommand.java
@@ -10,6 +10,7 @@ package io.camunda.migration.diagram.converter.cli;
 import static io.camunda.migration.diagram.converter.cli.ConvertCommand.*;
 
 import io.camunda.migration.diagram.converter.DiagramType;
+import io.camunda.migration.diagram.converter.FormConverter;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -88,12 +89,40 @@ public class ConvertLocalCommand extends AbstractConvertCommand {
     } else {
       if (isValidFile(file)) {
         files.add(file);
-      } else {
-        LOG_CLI.error("The selected file is no bpmn or dmn file");
-        throw new IllegalArgumentException("The selected file is no bpmn or dmn file");
+      } else if (!FormConverter.isFormFile(file.getName())) {
+        LOG_CLI.error("The selected file is not a bpmn, dmn or form file");
+        throw new IllegalArgumentException("The selected file is not a bpmn, dmn or form file");
       }
     }
     return handleFiles(files);
+  }
+
+  @Override
+  protected List<File> formFiles() {
+    if (!file.exists()) {
+      return List.of();
+    }
+    if (!file.isDirectory()) {
+      return FormConverter.isFormFile(file.getName()) ? List.of(file) : List.of();
+    }
+    List<File> formFiles = new ArrayList<>();
+    try {
+      if (notRecursive) {
+        try (Stream<Path> stream = Files.list(file.toPath())) {
+          stream
+              .filter(Files::isRegularFile)
+              .map(Path::toFile)
+              .filter(f -> FormConverter.isFormFile(f.getName()))
+              .forEach(formFiles::add);
+        }
+      } else {
+        Files.walkFileTree(file.toPath(), new FindFormFilePathVisitor(formFiles));
+      }
+    } catch (Exception e) {
+      LOG_CLI.error("Error while finding form files: {}", createMessage(e));
+      returnCode = 1;
+    }
+    return formFiles;
   }
 
   private Map<File, ModelInstance> handleFiles(Collection<File> files) {
@@ -168,6 +197,43 @@ public class ConvertLocalCommand extends AbstractConvertCommand {
         LOG.debug("Visited file, added '{}'", file.toFile().getAbsolutePath());
       } else {
         LOG.debug("Visited file, not added '{}'", file.toFile().getAbsolutePath());
+      }
+      return FileVisitResult.CONTINUE;
+    }
+
+    @Override
+    public FileVisitResult visitFileFailed(Path file, IOException exc) throws IOException {
+      LOG.debug("Visiting file failed '{}'", file.toFile().getAbsolutePath());
+      return FileVisitResult.CONTINUE;
+    }
+
+    @Override
+    public FileVisitResult postVisitDirectory(Path dir, IOException exc) throws IOException {
+      LOG.debug("Done visiting directory '{}'", dir.toFile().getAbsolutePath());
+      return FileVisitResult.CONTINUE;
+    }
+  }
+
+  public static class FindFormFilePathVisitor implements PathVisitor {
+    private static final Logger LOG = LoggerFactory.getLogger(FindFormFilePathVisitor.class);
+    private final List<File> files;
+
+    public FindFormFilePathVisitor(List<File> files) {
+      this.files = files;
+    }
+
+    @Override
+    public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs)
+        throws IOException {
+      LOG.debug("Start visiting directory '{}'", dir.toFile().getAbsolutePath());
+      return FileVisitResult.CONTINUE;
+    }
+
+    @Override
+    public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+      if (FormConverter.isFormFile(file.toFile().getName())) {
+        files.add(file.toFile());
+        LOG.debug("Visited form file, added '{}'", file.toFile().getAbsolutePath());
       }
       return FileVisitResult.CONTINUE;
     }

--- a/diagram-converter/cli/src/test/java/io/camunda/migration/diagram/converter/cli/ConvertLocalCommandTest.java
+++ b/diagram-converter/cli/src/test/java/io/camunda/migration/diagram/converter/cli/ConvertLocalCommandTest.java
@@ -14,12 +14,15 @@ import static org.junit.jupiter.api.Assertions.*;
 import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.read.ListAppender;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
 import java.util.Objects;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -168,6 +171,170 @@ public class ConvertLocalCommandTest {
             command.createMessage(
                 new RuntimeException("outer", new IllegalArgumentException((String) null))))
         .isEqualTo("outer,\ncaused by: " + IllegalArgumentException.class.getName());
+  }
+
+  @Test
+  void shouldConvertFormFileInDirectory(@TempDir File tempDir) throws IOException {
+    setupDir("simple.form", tempDir);
+    ConvertLocalCommand command = new ConvertLocalCommand();
+    command.file = tempDir;
+    Integer call = command.call();
+    assertEquals(0, call);
+    assertThat(tempDir.listFiles())
+        .hasSize(2)
+        .anyMatch(file -> file.getName().equals("simple.form"))
+        .anyMatch(file -> file.getName().equals("converted-c8-simple.form"));
+
+    ObjectMapper objectMapper = new ObjectMapper();
+    JsonNode source = objectMapper.readTree(new File(tempDir, "simple.form"));
+    JsonNode converted = objectMapper.readTree(new File(tempDir, "converted-c8-simple.form"));
+    assertThat(converted.get("executionPlatform").asText()).isEqualTo("Camunda Cloud");
+    assertThat(converted.get("executionPlatformVersion").asText()).isEqualTo("8.9.0");
+    ((ObjectNode) source).remove(List.of("executionPlatform", "executionPlatformVersion"));
+    ((ObjectNode) converted).remove(List.of("executionPlatform", "executionPlatformVersion"));
+    assertThat(converted)
+        .as("Only the platform metadata may change during form conversion")
+        .isEqualTo(source);
+  }
+
+  @Test
+  void shouldConvertSingleFormFile(@TempDir File tempDir) throws IOException {
+    setupDir("simple.form", tempDir);
+    ConvertLocalCommand command = new ConvertLocalCommand();
+    command.file = new File(tempDir, "simple.form");
+    Integer call = command.call();
+    assertEquals(0, call);
+    assertThat(tempDir.listFiles())
+        .hasSize(2)
+        .anyMatch(file -> file.getName().equals("simple.form"))
+        .anyMatch(file -> file.getName().equals("converted-c8-simple.form"));
+    assertThat(Files.readString(new File(tempDir, "converted-c8-simple.form").toPath()))
+        .contains("\"Camunda Cloud\"")
+        .contains("\"8.9.0\"");
+  }
+
+  @Test
+  void shouldConvertMixedFilesIncludingForm(@TempDir File tempDir) {
+    setupDir("c7.bpmn", tempDir);
+    setupDir("simple.form", tempDir);
+    ConvertLocalCommand command = new ConvertLocalCommand();
+    command.file = tempDir;
+    Integer call = command.call();
+    assertEquals(0, call);
+    assertThat(tempDir.listFiles())
+        .hasSize(4)
+        .anyMatch(file -> file.getName().equals("c7.bpmn"))
+        .anyMatch(file -> file.getName().equals("converted-c8-c7.bpmn"))
+        .anyMatch(file -> file.getName().equals("simple.form"))
+        .anyMatch(file -> file.getName().equals("converted-c8-simple.form"));
+  }
+
+  @Test
+  void shouldConvertMultipleFormFiles(@TempDir File tempDir) throws IOException {
+    setupDir("simple.form", tempDir);
+    Files.copy(
+        new File(tempDir, "simple.form").toPath(),
+        new File(tempDir, "another.form").toPath(),
+        REPLACE_EXISTING);
+    ConvertLocalCommand command = new ConvertLocalCommand();
+    command.file = tempDir;
+    Integer call = command.call();
+    assertEquals(0, call);
+    assertThat(tempDir.listFiles())
+        .hasSize(4)
+        .anyMatch(file -> file.getName().equals("converted-c8-simple.form"))
+        .anyMatch(file -> file.getName().equals("converted-c8-another.form"));
+  }
+
+  @Test
+  void shouldSkipFormFileConversionInCheckMode(@TempDir File tempDir) {
+    setupDir("simple.form", tempDir);
+    ConvertLocalCommand command = new ConvertLocalCommand();
+    command.file = tempDir;
+    command.check = true;
+    Integer call = command.call();
+    assertEquals(0, call);
+    assertThat(tempDir.listFiles())
+        .hasSize(1)
+        .anyMatch(file -> file.getName().equals("simple.form"));
+  }
+
+  @Test
+  void shouldProcessNestedFormFilesByDefault(@TempDir File tempDir) throws IOException {
+    setupDir("simple.form", tempDir);
+    File nestedDir = new File(tempDir, "nested");
+    assertThat(nestedDir.mkdirs()).isTrue();
+    Files.copy(
+        new File(tempDir, "simple.form").toPath(),
+        new File(nestedDir, "nested.form").toPath(),
+        REPLACE_EXISTING);
+
+    ConvertLocalCommand command = new ConvertLocalCommand();
+    command.file = tempDir;
+
+    Integer call = command.call();
+
+    assertEquals(0, call);
+    assertThat(new File(tempDir, "converted-c8-simple.form")).exists();
+    assertThat(new File(nestedDir, "converted-c8-nested.form")).exists();
+  }
+
+  @Test
+  void shouldSkipNestedFormFilesWhenNotRecursive(@TempDir File tempDir) throws IOException {
+    setupDir("simple.form", tempDir);
+    File nestedDir = new File(tempDir, "nested");
+    assertThat(nestedDir.mkdirs()).isTrue();
+    Files.copy(
+        new File(tempDir, "simple.form").toPath(),
+        new File(nestedDir, "nested.form").toPath(),
+        REPLACE_EXISTING);
+
+    ConvertLocalCommand command = new ConvertLocalCommand();
+    command.file = tempDir;
+    command.notRecursive = true;
+
+    Integer call = command.call();
+
+    assertEquals(0, call);
+    assertThat(new File(tempDir, "converted-c8-simple.form")).exists();
+    assertThat(new File(nestedDir, "converted-c8-nested.form")).doesNotExist();
+  }
+
+  @Test
+  void shouldNotOverwriteExistingConvertedFormWithoutOverride(@TempDir File tempDir)
+      throws IOException {
+    setupDir("simple.form", tempDir);
+    File input = new File(tempDir, "simple.form");
+    File output = new File(tempDir, "converted-c8-simple.form");
+
+    ConvertLocalCommand firstCommand = new ConvertLocalCommand();
+    firstCommand.file = input;
+    assertThat(firstCommand.call()).isZero();
+
+    Files.writeString(output.toPath(), "existing output");
+
+    ConvertLocalCommand secondCommand = new ConvertLocalCommand();
+    secondCommand.file = input;
+    assertThat(secondCommand.call()).isEqualTo(1);
+    assertThat(Files.readString(output.toPath())).isEqualTo("existing output");
+
+    ConvertLocalCommand overrideCommand = new ConvertLocalCommand();
+    overrideCommand.file = input;
+    overrideCommand.override = true;
+    assertThat(overrideCommand.call()).isZero();
+    assertThat(Files.readString(output.toPath())).isNotEqualTo("existing output");
+  }
+
+  @Test
+  void shouldReturnErrorCodeForInvalidFormJson(@TempDir File tempDir) throws IOException {
+    File invalidForm = new File(tempDir, "invalid.form");
+    Files.writeString(invalidForm.toPath(), "this is not json");
+
+    ConvertLocalCommand command = new ConvertLocalCommand();
+    command.file = invalidForm;
+
+    assertThat(command.call()).isEqualTo(1);
+    assertThat(new File(tempDir, "converted-c8-invalid.form")).doesNotExist();
   }
 
   @Test

--- a/diagram-converter/cli/src/test/resources/simple.form
+++ b/diagram-converter/cli/src/test/resources/simple.form
@@ -1,0 +1,17 @@
+{
+  "executionPlatform": "Camunda Platform",
+  "executionPlatformVersion": "7.23.0",
+  "id": "formId",
+  "components": [
+    {
+      "label": "Customer name",
+      "type": "textfield",
+      "key": "customerName",
+      "validate": {
+        "required": true
+      }
+    }
+  ],
+  "type": "default",
+  "schemaVersion": 16
+}

--- a/diagram-converter/core/src/main/java/io/camunda/migration/diagram/converter/FormConverter.java
+++ b/diagram-converter/core/src/main/java/io/camunda/migration/diagram/converter/FormConverter.java
@@ -23,7 +23,7 @@ import java.io.IOException;
  * conversion is a metadata-only update of the two platform fields on the root object: {@code
  * executionPlatform} is set to {@value #TARGET_EXECUTION_PLATFORM} and {@code
  * executionPlatformVersion} to the target platform version. All other properties (components,
- * layout, validation, ids, ...) are left untouched.
+ * layout, validation, ids, ...) are semantically unchanged; the JSON may be re-formatted.
  */
 public class FormConverter {
 
@@ -48,7 +48,8 @@ public class FormConverter {
    * @param formContent the content of a Camunda 7 form file
    * @param properties the converter properties, providing the target platform version
    * @return the converted form JSON with updated platform metadata
-   * @throws IllegalArgumentException if the content is not a JSON object
+   * @throws IllegalArgumentException if the content is not valid JSON or not a JSON object, or the
+   *     platform version is missing or invalid
    */
   public static String convert(String formContent, ConverterProperties properties) {
     String targetVersion = resolveTargetVersion(properties);

--- a/diagram-converter/core/src/main/java/io/camunda/migration/diagram/converter/FormConverter.java
+++ b/diagram-converter/core/src/main/java/io/camunda/migration/diagram/converter/FormConverter.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.migration.diagram.converter;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.util.DefaultIndenter;
+import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.camunda.migration.diagram.converter.version.SemanticVersion;
+import java.io.IOException;
+
+/**
+ * Converts Camunda 7 form files ({@code *.form}) to Camunda 8. Forms are JSON documents, so the
+ * conversion is a metadata-only update of the two platform fields on the root object: {@code
+ * executionPlatform} is set to {@value #TARGET_EXECUTION_PLATFORM} and {@code
+ * executionPlatformVersion} to the target platform version. All other properties (components,
+ * layout, validation, ids, ...) are left untouched.
+ */
+public class FormConverter {
+
+  public static final String FILE_EXTENSION = ".form";
+  public static final String TARGET_EXECUTION_PLATFORM = "Camunda Cloud";
+
+  private static final String EXECUTION_PLATFORM_FIELD = "executionPlatform";
+  private static final String EXECUTION_PLATFORM_VERSION_FIELD = "executionPlatformVersion";
+
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+  private static final ObjectWriter WRITER = createWriter();
+
+  private FormConverter() {}
+
+  public static boolean isFormFile(String fileName) {
+    return fileName != null && fileName.endsWith(FILE_EXTENSION);
+  }
+
+  /**
+   * Converts the given form JSON to the target platform described by the converter properties.
+   *
+   * @param formContent the content of a Camunda 7 form file
+   * @param properties the converter properties, providing the target platform version
+   * @return the converted form JSON with updated platform metadata
+   * @throws IllegalArgumentException if the content is not a JSON object
+   */
+  public static String convert(String formContent, ConverterProperties properties) {
+    String targetVersion = resolveTargetVersion(properties);
+    JsonNode root = readTree(formContent);
+    if (!(root instanceof ObjectNode form)) {
+      throw new IllegalArgumentException(
+          "Form content must be a JSON object, but was: " + root.getNodeType());
+    }
+    form.put(EXECUTION_PLATFORM_FIELD, TARGET_EXECUTION_PLATFORM);
+    form.put(EXECUTION_PLATFORM_VERSION_FIELD, targetVersion);
+    try {
+      return WRITER.writeValueAsString(form);
+    } catch (JsonProcessingException e) {
+      throw new IllegalStateException("Error while writing converted form", e);
+    }
+  }
+
+  private static JsonNode readTree(String formContent) {
+    try {
+      return OBJECT_MAPPER.readTree(formContent);
+    } catch (JsonProcessingException e) {
+      throw new IllegalArgumentException("Form content is not valid JSON: " + e.getMessage(), e);
+    }
+  }
+
+  private static String resolveTargetVersion(ConverterProperties properties) {
+    String platformVersion = properties.getPlatformVersion();
+    if (platformVersion == null || platformVersion.isBlank()) {
+      throw new IllegalArgumentException("No platform version configured");
+    }
+    try {
+      return SemanticVersion.parse(platformVersion).getPatchZeroVersion();
+    } catch (IllegalStateException e) {
+      // user-provided platform versions are client input, so surface parse failures as such
+      throw new IllegalArgumentException("Not a valid platform version: " + platformVersion, e);
+    }
+  }
+
+  private static ObjectWriter createWriter() {
+    DefaultPrettyPrinter prettyPrinter = new FormPrettyPrinter();
+    DefaultIndenter indenter = new DefaultIndenter("  ", "\n");
+    prettyPrinter.indentObjectsWith(indenter);
+    prettyPrinter.indentArraysWith(indenter);
+    return OBJECT_MAPPER.writer(prettyPrinter);
+  }
+
+  private static class FormPrettyPrinter extends DefaultPrettyPrinter {
+
+    FormPrettyPrinter() {
+      super();
+    }
+
+    FormPrettyPrinter(FormPrettyPrinter base) {
+      super(base);
+    }
+
+    @Override
+    public FormPrettyPrinter createInstance() {
+      return new FormPrettyPrinter(this);
+    }
+
+    @Override
+    public void writeObjectFieldValueSeparator(JsonGenerator g) throws IOException {
+      // use the JSON-conventional ": " separator instead of the " : " default
+      g.writeRaw(": ");
+    }
+  }
+}

--- a/diagram-converter/core/src/test/java/io/camunda/migration/diagram/converter/FormConverterTest.java
+++ b/diagram-converter/core/src/test/java/io/camunda/migration/diagram/converter/FormConverterTest.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.migration.diagram.converter;
+
+import static org.assertj.core.api.Assertions.*;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.junit.jupiter.api.Test;
+
+class FormConverterTest {
+
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+  private static final String C7_FORM =
+      """
+      {
+        "executionPlatform": "Camunda Platform",
+        "executionPlatformVersion": "7.23.0",
+        "id": "myForm",
+        "components": [
+          {
+            "label": "Customer name",
+            "type": "textfield",
+            "key": "customerName",
+            "validate": { "required": true }
+          }
+        ],
+        "type": "default",
+        "schemaVersion": 16
+      }
+      """;
+
+  @Test
+  void shouldIdentifyFormFile() {
+    assertThat(FormConverter.isFormFile("myForm.form")).isTrue();
+    assertThat(FormConverter.isFormFile("myForm.bpmn")).isFalse();
+    assertThat(FormConverter.isFormFile("myForm.dmn")).isFalse();
+    assertThat(FormConverter.isFormFile(null)).isFalse();
+  }
+
+  @Test
+  void shouldSetTargetPlatformMetadata() throws Exception {
+    String converted = FormConverter.convert(C7_FORM, defaultProperties());
+
+    JsonNode root = OBJECT_MAPPER.readTree(converted);
+    assertThat(root.get("executionPlatform").asText()).isEqualTo("Camunda Cloud");
+    assertThat(root.get("executionPlatformVersion").asText()).isEqualTo("8.9.0");
+  }
+
+  @Test
+  void shouldNotChangeAnythingButPlatformMetadata() throws Exception {
+    JsonNode source = OBJECT_MAPPER.readTree(C7_FORM);
+    JsonNode converted =
+        OBJECT_MAPPER.readTree(FormConverter.convert(C7_FORM, defaultProperties()));
+
+    assertThat(converted.get("executionPlatform").asText()).isEqualTo("Camunda Cloud");
+    assertThat(converted.get("executionPlatformVersion").asText()).isEqualTo("8.9.0");
+
+    ((ObjectNode) source).remove("executionPlatform");
+    ((ObjectNode) source).remove("executionPlatformVersion");
+    ((ObjectNode) converted).remove("executionPlatform");
+    ((ObjectNode) converted).remove("executionPlatformVersion");
+
+    assertThat(converted).isEqualTo(source);
+  }
+
+  @Test
+  void shouldUseConfiguredPlatformVersion() throws Exception {
+    DefaultConverterProperties properties = new DefaultConverterProperties();
+    properties.setPlatformVersion("8.8");
+    ConverterProperties merged = ConverterPropertiesFactory.getInstance().merge(properties);
+
+    String converted = FormConverter.convert(C7_FORM, merged);
+
+    JsonNode root = OBJECT_MAPPER.readTree(converted);
+    assertThat(root.get("executionPlatformVersion").asText()).isEqualTo("8.8.0");
+  }
+
+  @Test
+  void shouldNormalizePatchVersionToZero() throws Exception {
+    DefaultConverterProperties properties = new DefaultConverterProperties();
+    properties.setPlatformVersion("8.9.3");
+    ConverterProperties merged = ConverterPropertiesFactory.getInstance().merge(properties);
+
+    String converted = FormConverter.convert(C7_FORM, merged);
+
+    JsonNode root = OBJECT_MAPPER.readTree(converted);
+    assertThat(root.get("executionPlatformVersion").asText()).isEqualTo("8.9.0");
+  }
+
+  @Test
+  void shouldAddPlatformMetadataIfAbsent() throws Exception {
+    String input =
+        """
+        {
+          "id": "myForm",
+          "components": []
+        }
+        """;
+
+    String converted = FormConverter.convert(input, defaultProperties());
+
+    JsonNode root = OBJECT_MAPPER.readTree(converted);
+    assertThat(root.get("executionPlatform").asText()).isEqualTo("Camunda Cloud");
+    assertThat(root.get("executionPlatformVersion").asText()).isEqualTo("8.9.0");
+    assertThat(root.get("id").asText()).isEqualTo("myForm");
+  }
+
+  @Test
+  void shouldRejectNonObjectJson() {
+    assertThatThrownBy(() -> FormConverter.convert("[1, 2, 3]", defaultProperties()))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("must be a JSON object");
+  }
+
+  @Test
+  void shouldRejectInvalidJson() {
+    assertThatThrownBy(() -> FormConverter.convert("this is not json", defaultProperties()))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("not valid JSON");
+  }
+
+  @Test
+  void shouldRejectInvalidPlatformVersion() {
+    DefaultConverterProperties properties = new DefaultConverterProperties();
+    properties.setPlatformVersion("not-a-version");
+
+    assertThatThrownBy(() -> FormConverter.convert(C7_FORM, properties))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Not a valid platform version");
+  }
+
+  @Test
+  void shouldRejectMissingPlatformVersion() {
+    assertThatThrownBy(() -> FormConverter.convert(C7_FORM, new DefaultConverterProperties()))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("No platform version configured");
+  }
+
+  private ConverterProperties defaultProperties() {
+    return ConverterPropertiesFactory.getInstance().get();
+  }
+}


### PR DESCRIPTION
> [!NOTE]
> This PR was split in two to keep reviews focused: this one covers **core + CLI**; the webapp (server endpoints + React frontend) follows in a stacked PR on top of this branch.

## Description

Adds support for migrating Camunda 7 `*.form` files in the diagram converter **core engine and CLI**, so process application forms can be migrated alongside BPMN and DMN models. Form files are JSON documents, so they are **not** routed through the BPMN/XML pipeline — conversion is a metadata-only update of the two platform fields on the root object: `executionPlatform` → `"Camunda Cloud"` and `executionPlatformVersion` → the target platform version (e.g. `8.9.0`). All other content (components, layout, validation, ids) is preserved semantically unchanged.

Fresh implementation inspired by the abandoned draft #1202, with these differences:
- **Reuses the existing target-platform metadata conventions**: the version is resolved from `ConverterProperties` (`--platform-version` CLI option, defaulting to `zeebe-platform.version=8.9` → `8.9.0` via `SemanticVersion.getPatchZeroVersion()`), not hardcoded
- **Jackson-based** conversion (already a core dependency) instead of regex, so only root-level fields are touched and invalid JSON is rejected with a clear error

### Core (`FormConverter.java`)
- `isFormFile(fileName)` — detects `.form` files
- `convert(content, properties)` — parses the JSON, sets the two platform metadata fields on the root object, and writes it back with 2-space indentation; throws `IllegalArgumentException` for invalid JSON, non-object roots, or missing/invalid platform versions

### CLI
- **`AbstractConvertCommand`**: new `formFiles()` hook (default empty) and `convertFormFiles()` invoked at the end of `call()`; skipped in `--check` mode; honors `--override` and `--prefix` like diagram conversion; UTF-8 pinned output
- **`ConvertLocalCommand`**: discovers `.form` files in directory mode (recursively, or top-level only with `-nr`) and accepts a single `.form` file argument

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Test-only changes (no production code changes)

## Testing Checklist

### Test Coverage
- [x] Added tests for new functionality
- [ ] Updated tests for modified functionality
- [x] All tests pass locally

**New tests:**
- `FormConverterTest` (core) — file detection, metadata update, semantic no-other-changes comparison, configured/patch-version normalization, metadata added when absent, invalid JSON / non-object JSON / missing / invalid platform version rejected
- `ConvertLocalCommandTest` (cli) — form in directory, single form file, mixed BPMN+form directory, multiple forms, check-mode skip, nested discovery default vs `--not-recursive`, no-overwrite semantics, invalid JSON error code

Verified locally (JDK 21): `mvn clean install -pl diagram-converter/core,diagram-converter/cli` is green.

## Documentation
- [ ] Updated TESTING_GUIDELINES.md if adding new test patterns
- [x] Added Javadoc comments for public APIs
- [x] Updated README if user-facing changes (`diagram-converter/cli/README.md` — supported file extensions)

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed the code
- [x] Added comments for complex logic
- [x] No new compiler warnings
- [ ] Dependent changes have been merged

## Related Issues
related to #1201