### PR TITLE
fix(deps): pin kotlin-stdlib for CVE-2020-29582

### DIFF
--- a/code-conversion/recipes/pom.xml
+++ b/code-conversion/recipes/pom.xml
@@ -58,6 +58,13 @@
         <artifactId>micrometer-core</artifactId>
         <version>${version.micrometer}</version>
       </dependency>
+      <!-- CVE-2020-29582: pin kotlin-stdlib ahead of the rewrite-recipe-bom
+           and Spring Boot BOM imports. -->
+      <dependency>
+        <groupId>org.jetbrains.kotlin</groupId>
+        <artifactId>kotlin-stdlib</artifactId>
+        <version>${version.kotlin-stdlib}</version>
+      </dependency>
       <dependency>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-dependencies</artifactId>

--- a/diagram-converter/pom.xml
+++ b/diagram-converter/pom.xml
@@ -102,6 +102,22 @@
         <artifactId>micrometer-core</artifactId>
         <version>${version.micrometer}</version>
       </dependency>
+      <!-- CVE-2020-29582: pin kotlin-stdlib ahead of Spring Boot BOM. -->
+      <dependency>
+        <groupId>org.jetbrains.kotlin</groupId>
+        <artifactId>kotlin-stdlib</artifactId>
+        <version>${version.kotlin-stdlib}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jetbrains.kotlin</groupId>
+        <artifactId>kotlin-stdlib-jdk8</artifactId>
+        <version>${version.kotlin-stdlib}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jetbrains.kotlin</groupId>
+        <artifactId>kotlin-stdlib-jdk7</artifactId>
+        <version>${version.kotlin-stdlib}</version>
+      </dependency>
       <dependency>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-dependencies</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,7 @@
     <version.npm>10.8.2</version.npm>
     <version.netty>4.2.17.Final</version.netty>
     <version.micrometer>1.17.1</version.micrometer>
+    <version.kotlin-stdlib>2.3.21</version.kotlin-stdlib>
     <version.httpcore5>5.4.3</version.httpcore5>
     <version.httpclient5>5.6.4</version.httpclient5>
     <version.commons-lang3>3.20.0</version.commons-lang3>
@@ -130,6 +131,23 @@
         <groupId>io.micrometer</groupId>
         <artifactId>micrometer-jakarta9</artifactId>
         <version>${version.micrometer}</version>
+      </dependency>
+      <!-- CVE-2020-29582: pin kotlin-stdlib to 2.3.21 (aligned with main and
+           maintenance/0.3) so scanners stop flagging the 1.9.25 resolution. -->
+      <dependency>
+        <groupId>org.jetbrains.kotlin</groupId>
+        <artifactId>kotlin-stdlib</artifactId>
+        <version>${version.kotlin-stdlib}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jetbrains.kotlin</groupId>
+        <artifactId>kotlin-stdlib-jdk8</artifactId>
+        <version>${version.kotlin-stdlib}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jetbrains.kotlin</groupId>
+        <artifactId>kotlin-stdlib-jdk7</artifactId>
+        <version>${version.kotlin-stdlib}</version>
       </dependency>
       <!-- CVE-2026-59889: make the fixed Jackson BOM inherited by every module, including modules without a local BOM import. -->
       <dependency>


### PR DESCRIPTION
## Summary

Security scanners flag `org.jetbrains.kotlin:kotlin-stdlib:1.9.25` on the 0.2.x line for [CVE-2020-29582](https://github.com/advisories/GHSA-cqj8-47ch-rvvq). The flag is a false positive — the CVE was fixed in kotlin-stdlib **1.4.21**, and 0.2.8 already resolves 1.9.25 — but the cleanest way to make it disappear from scanner reports is to move the resolution forward.

This PR pins `kotlin-stdlib` (plus `kotlin-stdlib-jdk7`/`-jdk8`) to **2.3.21** via direct `dependencyManagement` entries, the same pattern as #2214, aligning maintenance/0.2 with `main` and `maintenance/0.3` which already resolve 2.3.21:

- root `pom.xml`: new `version.kotlin-stdlib` property + catch-all entries
- `code-conversion/recipes/pom.xml`: pin ahead of `rewrite-recipe-bom`/Spring Boot BOM imports (kotlin-stdlib arrives via `rewrite-kotlin`, runtime scope)
- `diagram-converter/pom.xml`: pin ahead of Spring Boot BOM import (arrives via okhttp → okio → kotlin-stdlib-jdk8, compile scope in webapp)

`kotlin-stdlib-common` is intentionally left unmanaged — no `2.3.21` jar exists for it — and remains at 1.9.25, already past the 1.4.21 fix (same approach as `main`, where it resolves unmanaged at 1.9.10).

## Verification

- `mvn dependency:tree -Dincludes='org.jetbrains.kotlin:kotlin-stdlib*'` → 2.3.21 for kotlin-stdlib (recipes, runtime), kotlin-stdlib/-jdk7/-jdk8 (webapp, compile); common remains 1.9.25
- `mvn test -pl code-conversion/recipes,diagram-converter/webapp -am` → BUILD SUCCESS (all tests pass, incl. 313 diagram-converter core and 21 webapp tests)

Note: if the scanner matches on artifact presence alone rather than version ranges, this bump may not silence it — in that case the finding has to be dismissed as a false positive in the scanner itself (assessment: resolved version has always been past the 1.4.21 fix; the repo has no Kotlin sources and never calls the vulnerable `createTempDir`/`createTempFile` APIs).