### PR TITLE
feat(diagram-converter): migrate Camunda Forms (.form files) in the webapp

### DIFF
--- a/diagram-converter/webapp/src/main/java/io/camunda/migration/diagram/converter/webapp/ConverterController.java
+++ b/diagram-converter/webapp/src/main/java/io/camunda/migration/diagram/converter/webapp/ConverterController.java
@@ -511,13 +511,13 @@ public class ConverterController {
   }
 
   /**
-   * Treats blank {@code platformVersion} values as absent so the configured default applies
-   * consistently across file types. Only {@code null} is treated as absent by {@link
+   * Trims the {@code platformVersion} and treats blank values as absent so the configured default
+   * applies consistently across file types. Only {@code null} is treated as absent by {@link
    * ConverterPropertiesFactory#merge}; a blank value would otherwise shadow the default and fail
    * version parsing for BPMN/DMN conversions (e.g. {@code SemanticVersion.parse}).
    */
   private String normalizePlatformVersion(String platformVersion) {
-    return StringUtils.hasText(platformVersion) ? platformVersion : null;
+    return StringUtils.hasText(platformVersion) ? platformVersion.trim() : null;
   }
 
   /**

--- a/diagram-converter/webapp/src/main/java/io/camunda/migration/diagram/converter/webapp/ConverterController.java
+++ b/diagram-converter/webapp/src/main/java/io/camunda/migration/diagram/converter/webapp/ConverterController.java
@@ -7,9 +7,13 @@
  */
 package io.camunda.migration.diagram.converter.webapp;
 
+import io.camunda.migration.diagram.converter.ConverterProperties;
+import io.camunda.migration.diagram.converter.ConverterPropertiesFactory;
+import io.camunda.migration.diagram.converter.DefaultConverterProperties;
 import io.camunda.migration.diagram.converter.DiagramCheckResult;
 import io.camunda.migration.diagram.converter.DiagramConverterResultDTO;
 import io.camunda.migration.diagram.converter.DiagramType;
+import io.camunda.migration.diagram.converter.FormConverter;
 import io.camunda.migration.diagram.converter.excel.ExcelWriter;
 import java.io.BufferedOutputStream;
 import java.io.ByteArrayOutputStream;
@@ -23,6 +27,7 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -35,9 +40,11 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.info.BuildProperties;
 import org.springframework.core.io.ByteArrayResource;
 import org.springframework.core.io.Resource;
+import org.springframework.http.ContentDisposition;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -123,6 +130,17 @@ public class ConverterController {
     for (Iterator diagramFilesIterator = diagramFiles.iterator();
         diagramFilesIterator.hasNext(); ) {
       MultipartFile diagramFile = (MultipartFile) diagramFilesIterator.next();
+
+      // Form files are JSON and have no diagram elements to analyze - return an empty result
+      if (FormConverter.isFormFile(diagramFile.getOriginalFilename())) {
+        DiagramCheckResult formResult = new DiagramCheckResult();
+        formResult.setFilename(diagramFile.getOriginalFilename());
+        // keep the response schema consistent with BPMN/DMN results
+        formResult.setConverterVersion(buildProperties.getVersion());
+        resultList.add(formResult);
+        continue;
+      }
+
       DiagramType diagramType = determineDiagramType(diagramFile);
 
       try (InputStream in = diagramFile.getInputStream()) {
@@ -283,13 +301,13 @@ public class ConverterController {
   }
 
   /**
-   * POST method to actually convert a BPMN or DMN model.
+   * POST method to actually convert a BPMN, DMN or form model.
    *
    * @throws InterruptedException
    */
   @PostMapping(
       value = "/convert",
-      produces = {"application/bpmn+xml", "application/dmn+xml"},
+      produces = {"application/bpmn+xml", "application/dmn+xml", MediaType.APPLICATION_JSON_VALUE},
       consumes = {MediaType.MULTIPART_FORM_DATA_VALUE})
   public ResponseEntity<?> getFile(
       @RequestParam("file") MultipartFile diagramFile,
@@ -312,6 +330,26 @@ public class ConverterController {
               defaultValue = "migrator")
           String dataMigrationExecutionListenerJobType) {
 
+    // Form files are JSON - convert them by updating the platform metadata fields only
+    if (FormConverter.isFormFile(diagramFile.getOriginalFilename())) {
+      try (InputStream in = diagramFile.getInputStream()) {
+        String content = new String(in.readAllBytes(), StandardCharsets.UTF_8);
+        String converted = FormConverter.convert(content, converterProperties(platformVersion));
+        Resource file = new ByteArrayResource(converted.getBytes(StandardCharsets.UTF_8));
+        return ResponseEntity.ok()
+            .header(
+                HttpHeaders.CONTENT_DISPOSITION,
+                attachmentDisposition(convertedFileName(diagramFile.getOriginalFilename())))
+            .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+            .body(file);
+      } catch (IOException | IllegalArgumentException e) {
+        return ResponseEntity.badRequest().body(e.getMessage());
+      } catch (Exception e) {
+        LOG.error("Error while converting form file", e);
+        return ResponseEntity.internalServerError().body(e.getMessage());
+      }
+    }
+
     DiagramType diagramType = determineDiagramType(diagramFile);
     try (InputStream in = diagramFile.getInputStream()) {
       ModelInstance modelInstance = diagramType.readDiagram(in);
@@ -325,11 +363,11 @@ public class ConverterController {
           addDataMigrationExecutionListener,
           dataMigrationExecutionListenerJobType);
       String xml = bpmnConverter.printXml(modelInstance.getDocument(), true);
-      Resource file = new ByteArrayResource(xml.getBytes());
+      Resource file = new ByteArrayResource(xml.getBytes(StandardCharsets.UTF_8));
       return ResponseEntity.ok()
           .header(
               HttpHeaders.CONTENT_DISPOSITION,
-              "attachment; filename=\"converted-c8-" + diagramFile.getOriginalFilename() + "\"")
+              attachmentDisposition(convertedFileName(diagramFile.getOriginalFilename())))
           .header(HttpHeaders.CONTENT_TYPE, diagramType.getContentType())
           .body(file);
     } catch (IOException e) {
@@ -376,6 +414,26 @@ public class ConverterController {
         diagramFilesIterator.hasNext(); ) {
       MultipartFile diagramFile = (MultipartFile) diagramFilesIterator.next();
 
+      // Form files are JSON - convert them by updating the platform metadata fields only
+      if (FormConverter.isFormFile(diagramFile.getOriginalFilename())) {
+        try (InputStream in = diagramFile.getInputStream()) {
+          String content = new String(in.readAllBytes(), StandardCharsets.UTF_8);
+          String converted = FormConverter.convert(content, converterProperties(platformVersion));
+          Resource file = new ByteArrayResource(converted.getBytes(StandardCharsets.UTF_8));
+          putConverted(resultList, convertedFileName(diagramFile.getOriginalFilename()), file);
+        } catch (IllegalArgumentException e) {
+          // client error (invalid JSON or platform version) - no stack trace noise
+          return ResponseEntity.badRequest().body(e.getMessage());
+        } catch (IOException e) {
+          LOG.error("IO Error while converting form file in batch", e);
+          return ResponseEntity.badRequest().body(e.getMessage());
+        } catch (Exception e) {
+          LOG.error("Error while converting form file in batch", e);
+          return ResponseEntity.internalServerError().body(e.getMessage());
+        }
+        continue;
+      }
+
       DiagramType diagramType = determineDiagramType(diagramFile);
       try (InputStream in = diagramFile.getInputStream()) {
 
@@ -390,8 +448,8 @@ public class ConverterController {
             addDataMigrationExecutionListener,
             dataMigrationExecutionListenerJobType);
         String xml = bpmnConverter.printXml(modelInstance.getDocument(), true);
-        Resource file = new ByteArrayResource(xml.getBytes());
-        resultList.put("converted-c8-" + diagramFile.getOriginalFilename(), file);
+        Resource file = new ByteArrayResource(xml.getBytes(StandardCharsets.UTF_8));
+        putConverted(resultList, convertedFileName(diagramFile.getOriginalFilename()), file);
 
       } catch (IOException e) {
         LOG.error("IO Error while converting resources in batch", e);
@@ -440,5 +498,60 @@ public class ConverterController {
       throw new IllegalArgumentException("No file provided");
     }
     return DiagramType.fromFileName(originalFilename);
+  }
+
+  private ConverterProperties converterProperties(String platformVersion) {
+    DefaultConverterProperties properties = new DefaultConverterProperties();
+    // treat blank values as absent so the configured default applies
+    properties.setPlatformVersion(StringUtils.hasText(platformVersion) ? platformVersion : null);
+    return ConverterPropertiesFactory.getInstance().merge(properties);
+  }
+
+  /**
+   * Builds the name of a converted output file from the user-supplied filename. Only the filename
+   * portion is used, preventing path traversal via separators in the original filename from
+   * propagating into ZIP entry names or response headers.
+   */
+  private String convertedFileName(String originalFilename) {
+    if (originalFilename == null) {
+      return "converted-c8-file";
+    }
+    // normalize Windows-style separators so they are stripped on any platform
+    String baseName = StringUtils.getFilename(originalFilename.replace('\\', '/'));
+    if (!StringUtils.hasText(baseName)) {
+      // e.g. filename ended with a path separator
+      return "converted-c8-file";
+    }
+    return "converted-c8-" + baseName;
+  }
+
+  private String attachmentDisposition(String fileName) {
+    return ContentDisposition.attachment()
+        .filename(fileName, StandardCharsets.UTF_8)
+        .build()
+        .toString();
+  }
+
+  /**
+   * Adds a converted file to the batch results, disambiguating the ZIP entry name (appending {@code
+   * " (1)"}, {@code " (2)"}, ... before the extension, like the CLI does) when multiple uploaded
+   * files share the same name so no converted file silently disappears from the output ZIP.
+   */
+  private void putConverted(Map<String, Resource> results, String fileName, Resource content) {
+    String entryName = fileName;
+    int counter = 0;
+    while (results.containsKey(entryName)) {
+      counter++;
+      int extensionIndex = fileName.lastIndexOf('.');
+      entryName =
+          extensionIndex >= 0
+              ? fileName.substring(0, extensionIndex)
+                  + " ("
+                  + counter
+                  + ")"
+                  + fileName.substring(extensionIndex)
+              : fileName + " (" + counter + ")";
+    }
+    results.put(entryName, content);
   }
 }

--- a/diagram-converter/webapp/src/main/java/io/camunda/migration/diagram/converter/webapp/ConverterController.java
+++ b/diagram-converter/webapp/src/main/java/io/camunda/migration/diagram/converter/webapp/ConverterController.java
@@ -342,7 +342,11 @@ public class ConverterController {
                 attachmentDisposition(convertedFileName(diagramFile.getOriginalFilename())))
             .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
             .body(file);
-      } catch (IOException | IllegalArgumentException e) {
+      } catch (IllegalArgumentException e) {
+        // client error (invalid JSON or platform version) - no stack trace noise
+        return ResponseEntity.badRequest().body(e.getMessage());
+      } catch (IOException e) {
+        LOG.error("IO Error while reading form file", e);
         return ResponseEntity.badRequest().body(e.getMessage());
       } catch (Exception e) {
         LOG.error("Error while converting form file", e);

--- a/diagram-converter/webapp/src/main/java/io/camunda/migration/diagram/converter/webapp/ConverterController.java
+++ b/diagram-converter/webapp/src/main/java/io/camunda/migration/diagram/converter/webapp/ConverterController.java
@@ -151,7 +151,7 @@ public class ConverterController {
                 diagramFile.getOriginalFilename(),
                 modelInstance,
                 defaultJobType,
-                platformVersion,
+                normalizePlatformVersion(platformVersion),
                 keepJobTypeBlank,
                 alwaysUseDefaultJobType,
                 addDataMigrationExecutionListener,
@@ -361,7 +361,7 @@ public class ConverterController {
           modelInstance,
           appendDocumentation,
           defaultJobType,
-          platformVersion,
+          normalizePlatformVersion(platformVersion),
           keepJobTypeBlank,
           alwaysUseDefaultJobType,
           addDataMigrationExecutionListener,
@@ -446,7 +446,7 @@ public class ConverterController {
             modelInstance,
             appendDocumentation,
             defaultJobType,
-            platformVersion,
+            normalizePlatformVersion(platformVersion),
             keepJobTypeBlank,
             alwaysUseDefaultJobType,
             addDataMigrationExecutionListener,
@@ -506,9 +506,18 @@ public class ConverterController {
 
   private ConverterProperties converterProperties(String platformVersion) {
     DefaultConverterProperties properties = new DefaultConverterProperties();
-    // treat blank values as absent so the configured default applies
-    properties.setPlatformVersion(StringUtils.hasText(platformVersion) ? platformVersion : null);
+    properties.setPlatformVersion(normalizePlatformVersion(platformVersion));
     return ConverterPropertiesFactory.getInstance().merge(properties);
+  }
+
+  /**
+   * Treats blank {@code platformVersion} values as absent so the configured default applies
+   * consistently across file types. Only {@code null} is treated as absent by {@link
+   * ConverterPropertiesFactory#merge}; a blank value would otherwise shadow the default and fail
+   * version parsing for BPMN/DMN conversions (e.g. {@code SemanticVersion.parse}).
+   */
+  private String normalizePlatformVersion(String platformVersion) {
+    return StringUtils.hasText(platformVersion) ? platformVersion : null;
   }
 
   /**

--- a/diagram-converter/webapp/src/main/javascript/src/App.jsx
+++ b/diagram-converter/webapp/src/main/javascript/src/App.jsx
@@ -469,7 +469,7 @@ function App() {
                 <span className="flowStepNumber">1</span>
                 <h4>Add your files</h4>
               </div>
-              <p>Upload one or more BPMN and DMN models or Camunda Forms (.form files) to analyze and convert.</p>
+              <p>Upload one or more BPMN and DMN models to analyze and convert, or Camunda Forms (.form files) to convert.</p>
               <div className="fileUploadBox">
                 <DropZone
                   onFiles={(files) => {

--- a/diagram-converter/webapp/src/main/javascript/src/App.jsx
+++ b/diagram-converter/webapp/src/main/javascript/src/App.jsx
@@ -469,7 +469,7 @@ function App() {
                 <span className="flowStepNumber">1</span>
                 <h4>Add your files</h4>
               </div>
-              <p>Upload one or more BPMN and DMN models to analyze and convert.</p>
+              <p>Upload one or more BPMN and DMN models or Camunda Forms (.form files) to analyze and convert.</p>
               <div className="fileUploadBox">
                 <DropZone
                   onFiles={(files) => {
@@ -671,7 +671,7 @@ function App() {
                   status={r.status}
                   isChecked={r.checkResponseJson != null}
                   isConverted={r.convertedFileBlob != null}
-                  previewAction={() => preview(r)}
+                  previewAction={file.name.endsWith(".form") ? undefined : () => preview(r)}
                   downloadAction={() => download(r)}
                   findingCount={fileFindingCount}
                   error={

--- a/diagram-converter/webapp/src/main/javascript/src/DropZone.jsx
+++ b/diagram-converter/webapp/src/main/javascript/src/DropZone.jsx
@@ -11,7 +11,7 @@ export default function DropZone({ onFiles }) {
   function selectFileToUpload() {
     const input = document.createElement("input");
     input.setAttribute("type", "file");
-    input.setAttribute("accept", ".xml, .bpmn, .dmn");
+    input.setAttribute("accept", ".xml, .bpmn, .dmn, .form");
     input.setAttribute("multiple", "true");
 
     input.addEventListener("change", () => {
@@ -39,7 +39,7 @@ export default function DropZone({ onFiles }) {
     >
       <img src={InboxIcon} />
       <h2>Click or drag file to this area to upload</h2>
-      <p>Upload .xml .bpmn and .dmn files. </p>
+      <p>Upload .xml .bpmn .dmn and .form files. </p>
     </div>
   );
 }

--- a/diagram-converter/webapp/src/test/java/io/camunda/migration/diagram/converter/webapp/ConverterControllerTest.java
+++ b/diagram-converter/webapp/src/test/java/io/camunda/migration/diagram/converter/webapp/ConverterControllerTest.java
@@ -639,6 +639,27 @@ public class ConverterControllerTest {
   }
 
   @Test
+  void convertBpmnWithBlankPlatformVersionFallsBackToDefault() throws URISyntaxException {
+    // a blank platformVersion must behave like an absent one for all file types: the configured
+    // default applies instead of failing version parsing in core (e.g. SemanticVersion.parse)
+    byte[] bpmn =
+        RestAssured.given()
+            .contentType(ContentType.MULTIPART)
+            .multiPart(
+                "file", new File(getClass().getClassLoader().getResource("example.bpmn").toURI()))
+            .formParam("platformVersion", " ")
+            .accept("application/bpmn+xml")
+            .post("/convert")
+            .then()
+            .statusCode(200)
+            .extract()
+            .asByteArray();
+
+    assertThat(new String(bpmn, StandardCharsets.UTF_8))
+        .contains("executionPlatformVersion=\"8.9.0\"");
+  }
+
+  @Test
   void convertFormWithInvalidPlatformVersionReturnsBadRequest() throws URISyntaxException {
     RestAssured.given()
         .contentType(ContentType.MULTIPART)

--- a/diagram-converter/webapp/src/test/java/io/camunda/migration/diagram/converter/webapp/ConverterControllerTest.java
+++ b/diagram-converter/webapp/src/test/java/io/camunda/migration/diagram/converter/webapp/ConverterControllerTest.java
@@ -660,6 +660,25 @@ public class ConverterControllerTest {
   }
 
   @Test
+  void convertFormWithPaddedPlatformVersionTrimsWhitespace() throws URISyntaxException {
+    byte[] form =
+        RestAssured.given()
+            .contentType(ContentType.MULTIPART)
+            .multiPart(
+                "file", new File(getClass().getClassLoader().getResource("simple.form").toURI()))
+            .formParam("platformVersion", " 8.8 ")
+            .accept(ContentType.JSON)
+            .post("/convert")
+            .then()
+            .statusCode(200)
+            .extract()
+            .asByteArray();
+
+    String converted = new String(form, StandardCharsets.UTF_8);
+    assertThat(converted).contains("\"executionPlatformVersion\": \"8.8.0\"");
+  }
+
+  @Test
   void convertFormWithInvalidPlatformVersionReturnsBadRequest() throws URISyntaxException {
     RestAssured.given()
         .contentType(ContentType.MULTIPART)

--- a/diagram-converter/webapp/src/test/java/io/camunda/migration/diagram/converter/webapp/ConverterControllerTest.java
+++ b/diagram-converter/webapp/src/test/java/io/camunda/migration/diagram/converter/webapp/ConverterControllerTest.java
@@ -26,6 +26,10 @@ import java.io.File;
 import java.io.IOException;
 import java.io.StringReader;
 import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.zip.ZipEntry;
@@ -532,5 +536,224 @@ public class ConverterControllerTest {
       // Final assertions
       assertThat(entryCount).as("There should be exactly 2 entries in the zip").isEqualTo(2);
     }
+  }
+
+  @Test
+  void checkFormReturnsEmptyResult() throws URISyntaxException {
+    List<DiagramCheckResult> checkResult =
+        RestAssured.given()
+            .contentType(ContentType.MULTIPART)
+            .multiPart(
+                "file", new File(getClass().getClassLoader().getResource("simple.form").toURI()))
+            .accept(ContentType.JSON)
+            .post("/check")
+            .getBody()
+            .as(new TypeRef<List<DiagramCheckResult>>() {});
+
+    assertThat(checkResult)
+        .hasSize(1)
+        .first()
+        .matches(result -> result.getFilename().equals("simple.form"), "Filename is set correctly")
+        .matches(result -> result.getResults().isEmpty(), "Forms have no diagram elements");
+  }
+
+  @Test
+  void convertForm() throws URISyntaxException {
+    byte[] form =
+        RestAssured.given()
+            .contentType(ContentType.MULTIPART)
+            .multiPart(
+                "file", new File(getClass().getClassLoader().getResource("simple.form").toURI()))
+            .accept(ContentType.JSON)
+            .post("/convert")
+            .getBody()
+            .asByteArray();
+
+    String converted = new String(form, StandardCharsets.UTF_8);
+    assertThat(converted).contains("\"executionPlatform\": \"Camunda Cloud\"");
+    assertThat(converted).contains("\"executionPlatformVersion\": \"8.9.0\"");
+    assertThat(converted).contains("\"customerName\"");
+  }
+
+  @Test
+  void convertFormRespectsPlatformVersionParam() throws URISyntaxException {
+    byte[] form =
+        RestAssured.given()
+            .contentType(ContentType.MULTIPART)
+            .multiPart(
+                "file", new File(getClass().getClassLoader().getResource("simple.form").toURI()))
+            .formParam("platformVersion", "8.8")
+            .accept(ContentType.JSON)
+            .post("/convert")
+            .getBody()
+            .asByteArray();
+
+    String converted = new String(form, StandardCharsets.UTF_8);
+    assertThat(converted).contains("\"executionPlatformVersion\": \"8.8.0\"");
+  }
+
+  @Test
+  void convertBatchIncludesFormFiles() throws URISyntaxException, IOException {
+    byte[] zip =
+        RestAssured.given()
+            .contentType(ContentType.MULTIPART)
+            .multiPart(
+                "file", new File(getClass().getClassLoader().getResource("example.bpmn").toURI()))
+            .multiPart(
+                "file", new File(getClass().getClassLoader().getResource("simple.form").toURI()))
+            .accept("application/zip")
+            .post("/convertBatch")
+            .getBody()
+            .asByteArray();
+
+    Map<String, String> entries = new HashMap<>();
+    try (ZipInputStream zis = new ZipInputStream(new ByteArrayInputStream(zip))) {
+      ZipEntry zipEntry;
+      while ((zipEntry = zis.getNextEntry()) != null) {
+        entries.put(zipEntry.getName(), new String(zis.readAllBytes(), StandardCharsets.UTF_8));
+        zis.closeEntry();
+      }
+    }
+
+    assertThat(entries).containsOnlyKeys("converted-c8-example.bpmn", "converted-c8-simple.form");
+    assertThat(entries.get("converted-c8-simple.form"))
+        .contains("\"executionPlatform\": \"Camunda Cloud\"")
+        .contains("\"executionPlatformVersion\": \"8.9.0\"");
+  }
+
+  @Test
+  void convertFormWithBlankPlatformVersionFallsBackToDefault() throws URISyntaxException {
+    byte[] form =
+        RestAssured.given()
+            .contentType(ContentType.MULTIPART)
+            .multiPart(
+                "file", new File(getClass().getClassLoader().getResource("simple.form").toURI()))
+            .formParam("platformVersion", " ")
+            .accept(ContentType.JSON)
+            .post("/convert")
+            .getBody()
+            .asByteArray();
+
+    String converted = new String(form, StandardCharsets.UTF_8);
+    assertThat(converted).contains("\"executionPlatformVersion\": \"8.9.0\"");
+  }
+
+  @Test
+  void convertFormWithInvalidPlatformVersionReturnsBadRequest() throws URISyntaxException {
+    RestAssured.given()
+        .contentType(ContentType.MULTIPART)
+        .multiPart("file", new File(getClass().getClassLoader().getResource("simple.form").toURI()))
+        .formParam("platformVersion", "not-a-version")
+        .accept(ContentType.JSON)
+        .post("/convert")
+        .then()
+        .statusCode(400);
+  }
+
+  @Test
+  void convertFormWithInvalidJsonReturnsBadRequest() {
+    RestAssured.given()
+        .contentType(ContentType.MULTIPART)
+        .multiPart("file", "broken.form", "this is not json".getBytes(StandardCharsets.UTF_8))
+        .accept(ContentType.JSON)
+        .post("/convert")
+        .then()
+        .statusCode(400);
+  }
+
+  @Test
+  void convertBatchWithInvalidFormJsonReturnsBadRequest() {
+    RestAssured.given()
+        .contentType(ContentType.MULTIPART)
+        .multiPart("file", "broken.form", "this is not json".getBytes(StandardCharsets.UTF_8))
+        .accept("application/zip")
+        .post("/convertBatch")
+        .then()
+        .statusCode(400);
+  }
+
+  @Test
+  void convertSanitizesFilenameInContentDisposition() throws URISyntaxException, IOException {
+    byte[] formBytes =
+        Files.readAllBytes(
+            new File(getClass().getClassLoader().getResource("simple.form").toURI()).toPath());
+    String contentDisposition =
+        RestAssured.given()
+            .contentType(ContentType.MULTIPART)
+            .multiPart("file", "../../evil.form", formBytes, "application/json")
+            .accept(ContentType.JSON)
+            .post("/convert")
+            .getHeader("Content-Disposition");
+
+    assertThat(contentDisposition).contains("converted-c8-evil.form");
+    assertThat(contentDisposition).doesNotContain("..").doesNotContain("/");
+  }
+
+  @Test
+  void convertBatchSanitizesZipEntryNames() throws URISyntaxException, IOException {
+    byte[] formBytes =
+        Files.readAllBytes(
+            new File(getClass().getClassLoader().getResource("simple.form").toURI()).toPath());
+    byte[] bpmnBytes =
+        Files.readAllBytes(
+            new File(getClass().getClassLoader().getResource("example.bpmn").toURI()).toPath());
+    byte[] zip =
+        RestAssured.given()
+            .contentType(ContentType.MULTIPART)
+            .multiPart("file", "../../evil.form", formBytes, "application/json")
+            .multiPart("file", "..\\..\\evil.bpmn", bpmnBytes, "application/bpmn+xml")
+            .accept("application/zip")
+            .post("/convertBatch")
+            .getBody()
+            .asByteArray();
+
+    List<String> entryNames = new ArrayList<>();
+    try (ZipInputStream zis = new ZipInputStream(new ByteArrayInputStream(zip))) {
+      ZipEntry zipEntry;
+      while ((zipEntry = zis.getNextEntry()) != null) {
+        entryNames.add(zipEntry.getName());
+        zis.closeEntry();
+      }
+    }
+
+    assertThat(entryNames)
+        .containsExactlyInAnyOrder("converted-c8-evil.form", "converted-c8-evil.bpmn");
+  }
+
+  @Test
+  void convertBatchKeepsDuplicateFileNames() throws URISyntaxException, IOException {
+    byte[] formBytes =
+        Files.readAllBytes(
+            new File(getClass().getClassLoader().getResource("simple.form").toURI()).toPath());
+    byte[] bpmnBytes =
+        Files.readAllBytes(
+            new File(getClass().getClassLoader().getResource("example.bpmn").toURI()).toPath());
+    byte[] zip =
+        RestAssured.given()
+            .contentType(ContentType.MULTIPART)
+            .multiPart("file", "same.form", formBytes, "application/json")
+            .multiPart("file", "same.form", formBytes, "application/json")
+            .multiPart("file", "same.bpmn", bpmnBytes, "application/bpmn+xml")
+            .multiPart("file", "same.bpmn", bpmnBytes, "application/bpmn+xml")
+            .accept("application/zip")
+            .post("/convertBatch")
+            .getBody()
+            .asByteArray();
+
+    List<String> entryNames = new ArrayList<>();
+    try (ZipInputStream zis = new ZipInputStream(new ByteArrayInputStream(zip))) {
+      ZipEntry zipEntry;
+      while ((zipEntry = zis.getNextEntry()) != null) {
+        entryNames.add(zipEntry.getName());
+        zis.closeEntry();
+      }
+    }
+
+    assertThat(entryNames)
+        .containsExactlyInAnyOrder(
+            "converted-c8-same.form",
+            "converted-c8-same (1).form",
+            "converted-c8-same.bpmn",
+            "converted-c8-same (1).bpmn");
   }
 }

--- a/diagram-converter/webapp/src/test/resources/simple.form
+++ b/diagram-converter/webapp/src/test/resources/simple.form
@@ -1,0 +1,17 @@
+{
+  "executionPlatform": "Camunda Platform",
+  "executionPlatformVersion": "7.23.0",
+  "id": "formId",
+  "components": [
+    {
+      "label": "Customer name",
+      "type": "textfield",
+      "key": "customerName",
+      "validate": {
+        "required": true
+      }
+    }
+  ],
+  "type": "default",
+  "schemaVersion": 16
+}


### PR DESCRIPTION
## Description

This PR is **stacked on #2319** (core `FormConverter` + CLI support) and covers the **webapp** part of #1201: migrating Camunda 7 `*.form` files to Camunda 8 in the diagram-converter webapp.

Forms are JSON; conversion is metadata-only: `executionPlatform` becomes `Camunda Cloud`, `executionPlatformVersion` becomes the target version from `ConverterProperties` (default 8.9 becomes `8.9.0`). All other content is preserved.

### Backend — `ConverterController`

- **`POST /check`**: form files short-circuit to an empty `DiagramCheckResult` (only `filename` + `converterVersion` from `BuildProperties`) — forms have no diagram elements to analyze.
- **`POST /convert`**: form files are converted via `FormConverter` and returned as `application/json` with a UTF-8 `Content-Disposition` attachment header built via Spring's `ContentDisposition`. Error semantics: `400` for `IllegalArgumentException` (invalid JSON / invalid platform version — no stack-trace logging), `400` for `IOException`, `500` + error log for unexpected failures.
- **`POST /convertBatch`**: form files are converted and included in the result ZIP. Entry names go through `convertedFileName()` (strips path separators, normalizes backslashes to `/`, safe fallback `converted-c8-file`) and `putConverted()` (disambiguates duplicate names with ` (1)`, ` (2)`, … before the extension, like the CLI). Same error semantics as `/convert`.
- Category-level hardening applied to the BPMN/DMN branches too: the same `convertedFileName()` / `putConverted()` helpers (prevents path traversal into ZIP entry names and silent file loss on duplicate names) and UTF-8-pinned `xml.getBytes()`.

### Frontend

- `DropZone.jsx`: accepts `.form` files, updated hint text.
- `App.jsx`: upload instructions mention Camunda Forms; the preview action is hidden for `.form` files (no diagram preview possible).

### Tests

New tests in `ConverterControllerTest` (with new test resource `simple.form`):

- `checkFormReturnsEmptyResult`
- `convertForm`
- `convertFormRespectsPlatformVersionParam`
- `convertFormWithBlankPlatformVersionFallsBackToDefault`
- `convertFormWithInvalidPlatformVersionReturnsBadRequest`
- `convertFormWithInvalidJsonReturnsBadRequest`
- `convertBatchWithInvalidFormJsonReturnsBadRequest`
- `convertBatchIncludesFormFiles`
- `convertSanitizesFilenameInContentDisposition`
- `convertBatchSanitizesZipEntryNames`
- `convertBatchKeepsDuplicateFileNames`

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

## Testing Checklist

### Test Coverage
- [x] Added tests for new functionality
- [x] All tests pass locally (`mvn verify -Pdistro,checkFormat` in `diagram-converter` — all 5 modules green, 32/32 `ConverterControllerTest` tests pass)

## Documentation
- [x] Added Javadoc comments for public APIs
- [ ] Updated README if user-facing changes (CLI README updated in #2319; webapp has no README)

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed the code
- [x] Added comments for complex logic
- [x] No new compiler warnings
- [ ] Dependent changes have been merged (stacked on #2319 — merge that first)

## Related Issues
Related to #1201