### PR TITLE
fix(ci): skip jobs for non-CI pull request labels

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,15 @@ on:
 
 jobs:
   # Read Camunda 8 versions from pom.xml to avoid hard-coding in CI
+  # Ignore non-CI PR label events while preserving explicit ci:* escalation.
   read-versions:
+    if: |
+      github.event_name != 'pull_request' ||
+      (
+        github.event.action != 'labeled' &&
+        github.event.action != 'unlabeled'
+      ) ||
+      startsWith(github.event.label.name, 'ci:')
     runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:
@@ -61,6 +69,13 @@ jobs:
   # Detect changed module surfaces and derive default test scopes for PRs.
   # For non-PR events we execute the full CI surface.
   detect-changes:
+    if: |
+      github.event_name != 'pull_request' ||
+      (
+        github.event.action != 'labeled' &&
+        github.event.action != 'unlabeled'
+      ) ||
+      startsWith(github.event.label.name, 'ci:')
     runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:
@@ -1184,7 +1199,16 @@ jobs:
       - it-history-h2-windows
       - it-identity-h2
       - e2e
-    if: always()
+    if: |
+      always() &&
+      (
+        github.event_name != 'pull_request' ||
+        (
+          github.event.action != 'labeled' &&
+          github.event.action != 'unlabeled'
+        ) ||
+        startsWith(github.event.label.name, 'ci:')
+      )
     runs-on: ubuntu-latest
     permissions:
       actions: read


### PR DESCRIPTION
## Summary

- Keep intentional `ci:*` label escalation for CI runs.
- Skip CI workflow jobs when a pull request only receives or loses a non-CI label, such as a backport label.
- Keep the CI Summary Gate from running for filtered label events.

## Validation

- `docker run --rm -v "$PWD:/repo" -w /repo rhysd/actionlint:latest -ignore 'shellcheck reported issue in this script' .github/workflows/ci.yml`
- `mvn clean install` with Java 21

## Baseline

Built from commit: bd9d8ebda1761a079ac0366f1c9d7189697556a