### PR TITLE
fix(core): compile with newer JDKs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -214,7 +214,8 @@ jobs:
   code-conversion:
     needs: [detect-changes]
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    # Gradle Tooling API dependency resolution can exceed 30 minutes on cold runners.
+    timeout-minutes: 45
     if: |
       github.event_name != 'pull_request' ||
       needs.detect-changes.outputs.code-conversion == 'true' ||

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -301,7 +301,8 @@ jobs:
   code-conversion-windows:
     needs: [detect-changes]
     runs-on: windows-latest
-    timeout-minutes: 30
+    # Gradle Tooling API dependency resolution can exceed 30 minutes on cold Windows runners.
+    timeout-minutes: 45
     permissions:
       contents: read
     if: |

--- a/code-conversion/examples/process-solution-camunda-7/pom.xml
+++ b/code-conversion/examples/process-solution-camunda-7/pom.xml
@@ -16,7 +16,7 @@
   <description>Example Camunda 7 process solution used as input for OpenRewrite code conversion recipes.</description>
 
   <properties>
-    <maven.compiler.release>21</maven.compiler.release>
+    <maven.compiler.release>${version.java}</maven.compiler.release>
   </properties>
 
   <dependencies>

--- a/code-conversion/examples/process-solution-camunda-7/pom.xml
+++ b/code-conversion/examples/process-solution-camunda-7/pom.xml
@@ -16,8 +16,6 @@
   <description>Example Camunda 7 process solution used as input for OpenRewrite code conversion recipes.</description>
 
   <properties>
-    <maven.compiler.source>21</maven.compiler.source>
-    <maven.compiler.target>21</maven.compiler.target>
     <maven.compiler.release>21</maven.compiler.release>
   </properties>
 

--- a/code-conversion/patterns/code-examples/camunda-7/pom.xml
+++ b/code-conversion/patterns/code-examples/camunda-7/pom.xml
@@ -15,8 +15,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.source>17</maven.compiler.source>
-    <maven.compiler.target>17</maven.compiler.target>
+    <maven.compiler.release>17</maven.compiler.release>
   </properties>
 
   <dependencyManagement>

--- a/data-migrator/examples/entity-interceptor/pom.xml
+++ b/data-migrator/examples/entity-interceptor/pom.xml
@@ -16,8 +16,7 @@
     <description>Example entity interceptor for Camunda 7 to 8 Migration Tooling - Data</description>
 
     <properties>
-        <maven.compiler.source>21</maven.compiler.source>
-        <maven.compiler.target>21</maven.compiler.target>
+        <maven.compiler.release>21</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
@@ -40,4 +39,3 @@
         </plugins>
     </build>
 </project>
-

--- a/data-migrator/examples/entity-interceptor/pom.xml
+++ b/data-migrator/examples/entity-interceptor/pom.xml
@@ -16,7 +16,7 @@
     <description>Example entity interceptor for Camunda 7 to 8 Migration Tooling - Data</description>
 
     <properties>
-        <maven.compiler.release>21</maven.compiler.release>
+        <maven.compiler.release>${version.java}</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 

--- a/data-migrator/examples/variable-interceptor/pom.xml
+++ b/data-migrator/examples/variable-interceptor/pom.xml
@@ -16,8 +16,7 @@
     <description>Example variable interceptor for Camunda 7 to 8 Migration Tooling - Data</description>
 
     <properties>
-        <maven.compiler.source>21</maven.compiler.source>
-        <maven.compiler.target>21</maven.compiler.target>
+        <maven.compiler.release>21</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 

--- a/data-migrator/examples/variable-interceptor/pom.xml
+++ b/data-migrator/examples/variable-interceptor/pom.xml
@@ -16,7 +16,7 @@
     <description>Example variable interceptor for Camunda 7 to 8 Migration Tooling - Data</description>
 
     <properties>
-        <maven.compiler.release>21</maven.compiler.release>
+        <maven.compiler.release>${version.java}</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -25,8 +25,7 @@
   </licenses>
 
   <properties>
-    <maven.compiler.source>21</maven.compiler.source>
-    <maven.compiler.target>21</maven.compiler.target>
+    <maven.compiler.release>21</maven.compiler.release>
     <version.java>21</version.java>
 
     <version.camunda-7>7.24.11-ee</version.camunda-7>

--- a/pom.xml
+++ b/pom.xml
@@ -25,8 +25,8 @@
   </licenses>
 
   <properties>
-    <maven.compiler.release>21</maven.compiler.release>
     <version.java>21</version.java>
+    <maven.compiler.release>${version.java}</maven.compiler.release>
 
     <version.camunda-7>7.24.11-ee</version.camunda-7>
     <version.camunda-8>8.10.0-SNAPSHOT</version.camunda-8>


### PR DESCRIPTION
## Summary

- compile Java 21 sources with `--release 21` instead of separate source and target flags
- allow the diagram converter to build on JDK 26 and newer without the `-Xlint:options` warning becoming an error

The OpenRewrite recipes module remains limited to Java 21–25 because its parser currently relies on javac internals that changed in Java 26.