### PR TITLE
fix(e2e): avoid unstable Cockpit navbar click

### DIFF
--- a/data-migrator/qa/e2e-tests/tests/cockpit-plugin.spec.ts
+++ b/data-migrator/qa/e2e-tests/tests/cockpit-plugin.spec.ts
@@ -25,9 +25,13 @@ import { test, expect, Page } from '@playwright/test';
 // regardless of DOM order (the hidden responsive copy may come first).
 const processesLink = (page: Page) => page.locator('a[href="#/processes"]:visible').first();
 
-// Navigate from the dashboard to the plugin's processes page.
+// Navigate directly to the plugin's processes page. The AngularJS navbar can
+// replace the link while it is settling, so clicking it can remain in
+// Playwright's actionability retry loop indefinitely.
 async function openProcessesPage(page: Page) {
-  await processesLink(page).click();
+  await page.goto('/camunda/app/cockpit/default/#/processes', {
+    waitUntil: 'domcontentloaded',
+  });
   await page.waitForURL(/#\/processes/, { timeout: 15000 });
 }
 

--- a/data-migrator/qa/e2e-tests/tests/cockpit-plugin.spec.ts
+++ b/data-migrator/qa/e2e-tests/tests/cockpit-plugin.spec.ts
@@ -31,6 +31,7 @@ const processesLink = (page: Page) => page.locator('a[href="#/processes"]:visibl
 async function openProcessesPage(page: Page) {
   await page.goto('/camunda/app/cockpit/default/#/processes', {
     waitUntil: 'domcontentloaded',
+    timeout: 15000,
   });
   await page.waitForURL(/#\/processes/, { timeout: 15000 });
 }


### PR DESCRIPTION
## Summary

- Avoid the Firefox flake caused by the AngularJS Cockpit navbar replacing the Processes link during actionability checks.
- Navigate directly to the Cockpit processes route for plugin assertions while retaining the navbar-rendering assertion.

## Changes

- Updated `data-migrator/qa/e2e-tests/tests/cockpit-plugin.spec.ts` so the shared `openProcessesPage` helper uses a bounded page navigation instead of clicking the unstable third-party navbar link.

## Test plan

- [x] `npm run typecheck` (from `data-migrator/qa/e2e-tests`)
- [x] `npm run check:type-escapes` (from `data-migrator/qa/e2e-tests`)
- [x] `CI=true npx playwright test tests/cockpit-plugin.spec.ts --project=firefox` (6 passed)
- [x] `mvn -U clean install` with Java 21

## Baseline

Built from commit: bd9d8ebda1761a079ac0366f1c9d7189697556a0

closes #2334