### PR TITLE
[Backport maintenance/0.3] fix(ci): skip jobs for non-CI pull request labels

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,15 @@ on:
 
 jobs:
   # Read Camunda 8 versions from pom.xml to avoid hard-coding in CI
+  # Ignore non-CI PR label events while preserving explicit ci:* escalation.
   read-versions:
+    if: |
+      github.event_name != 'pull_request' ||
+      (
+        github.event.action != 'labeled' &&
+        github.event.action != 'unlabeled'
+      ) ||
+      startsWith(github.event.label.name, 'ci:')
     runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:
@@ -80,6 +88,13 @@ jobs:
   # Detect changed module surfaces and derive default test scopes for PRs.
   # For non-PR events we execute the full CI surface.
   detect-changes:
+    if: |
+      github.event_name != 'pull_request' ||
+      (
+        github.event.action != 'labeled' &&
+        github.event.action != 'unlabeled'
+      ) ||
+      startsWith(github.event.label.name, 'ci:')
     runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:
@@ -1203,7 +1218,16 @@ jobs:
       - it-history-h2-windows
       - it-identity-h2
       - e2e
-    if: always()
+    if: |
+      always() &&
+      (
+        github.event_name != 'pull_request' ||
+        (
+          github.event.action != 'labeled' &&
+          github.event.action != 'unlabeled'
+        ) ||
+        startsWith(github.event.label.name, 'ci:')
+      )
     runs-on: ubuntu-latest
     permissions:
       actions: read


### PR DESCRIPTION
## Summary

Backport of #2337 to maintenance/0.3.

This applies the CI event filter so non-CI pull request label changes do not run the CI jobs, while ci:* label escalation remains supported.

## Backport

Original PR: #2337
Cherry-picked commit: 8aa563bf15d077e00990f03651da667fc8e47a4b