### PR TITLE
feat(diagram-converter): analyze Camunda 7 .form files and report findings

### DIFF
--- a/diagram-converter/cli/src/main/java/io/camunda/migration/diagram/converter/cli/AbstractConvertCommand.java
+++ b/diagram-converter/cli/src/main/java/io/camunda/migration/diagram/converter/cli/AbstractConvertCommand.java
@@ -16,6 +16,7 @@ import io.camunda.migration.diagram.converter.DiagramCheckResult;
 import io.camunda.migration.diagram.converter.DiagramConverter;
 import io.camunda.migration.diagram.converter.DiagramConverterFactory;
 import io.camunda.migration.diagram.converter.DiagramType;
+import io.camunda.migration.diagram.converter.FormChecker;
 import io.camunda.migration.diagram.converter.FormConverter;
 import io.camunda.migration.diagram.converter.excel.ExcelWriter;
 import java.io.File;
@@ -26,6 +27,7 @@ import java.io.Writer;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
@@ -137,14 +139,36 @@ public abstract class AbstractConvertCommand implements Callable<Integer> {
   public final Integer call() {
     returnCode = 0;
     Map<File, ModelInstance> modelInstances = modelInstances();
+    List<File> formFileList = formFiles();
     List<DiagramCheckResult> results = checkModels(modelInstances);
+    results.addAll(checkFormFiles(formFileList));
     writeResults(modelInstances, results);
-    convertFormFiles(formFiles());
+    convertFormFiles(formFileList);
     return returnCode;
   }
 
   protected List<File> formFiles() {
     return List.of();
+  }
+
+  private List<DiagramCheckResult> checkFormFiles(List<File> formFileList) {
+    if (formFileList.isEmpty()) {
+      return List.of();
+    }
+    ConverterProperties properties =
+        ConverterPropertiesFactory.getInstance().merge(converterProperties());
+    List<DiagramCheckResult> results = new ArrayList<>();
+    for (File formFile : formFileList) {
+      try {
+        String content = Files.readString(formFile.toPath(), StandardCharsets.UTF_8);
+        results.add(FormChecker.check(modelIdentifier(formFile), content, properties));
+      } catch (IOException | RuntimeException e) {
+        LOG_CLI.error(
+            "Error while checking form file {}: {}", formFile.getAbsolutePath(), createMessage(e));
+        returnCode = 1;
+      }
+    }
+    return results;
   }
 
   private void convertFormFiles(List<File> formFileList) {

--- a/diagram-converter/cli/src/test/java/io/camunda/migration/diagram/converter/cli/ConvertLocalCommandTest.java
+++ b/diagram-converter/cli/src/test/java/io/camunda/migration/diagram/converter/cli/ConvertLocalCommandTest.java
@@ -260,6 +260,47 @@ public class ConvertLocalCommandTest {
   }
 
   @Test
+  void shouldIncludeFormFindingsInCsvReport(@TempDir File tempDir) throws IOException {
+    setupDir("simple.form", tempDir);
+    ConvertLocalCommand command = new ConvertLocalCommand();
+    command.file = tempDir;
+    command.check = true;
+    command.csv = true;
+    Integer call = command.call();
+    assertEquals(0, call);
+    File csvFile = new File(tempDir, "analysis-results.csv");
+    assertThat(csvFile).exists();
+    String csv = Files.readString(csvFile.toPath());
+    assertThat(csv).contains("simple.form").contains("form-schema-version-outdated");
+  }
+
+  @Test
+  void shouldIncludeFormFindingsInJsonReportForMultipleForms(@TempDir File tempDir)
+      throws IOException {
+    setupDir("simple.form", tempDir);
+    File nestedDir = new File(tempDir, "nested");
+    assertThat(nestedDir.mkdirs()).isTrue();
+    Files.copy(
+        new File(tempDir, "simple.form").toPath(),
+        new File(nestedDir, "nested.form").toPath(),
+        REPLACE_EXISTING);
+
+    ConvertLocalCommand command = new ConvertLocalCommand();
+    command.file = tempDir;
+    command.check = true;
+    command.json = true;
+    Integer call = command.call();
+    assertEquals(0, call);
+    File jsonFile = new File(tempDir, "analysis-results.json");
+    assertThat(jsonFile).exists();
+    String json = Files.readString(jsonFile.toPath());
+    assertThat(json)
+        .contains("simple.form")
+        .contains("nested.form")
+        .contains("form-schema-version-outdated");
+  }
+
+  @Test
   void shouldProcessNestedFormFilesByDefault(@TempDir File tempDir) throws IOException {
     setupDir("simple.form", tempDir);
     File nestedDir = new File(tempDir, "nested");

--- a/diagram-converter/core/src/main/java/io/camunda/migration/diagram/converter/FormChecker.java
+++ b/diagram-converter/core/src/main/java/io/camunda/migration/diagram/converter/FormChecker.java
@@ -8,7 +8,6 @@
 package io.camunda.migration.diagram.converter;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.camunda.migration.diagram.converter.DiagramCheckResult.ElementCheckMessage;
 import io.camunda.migration.diagram.converter.DiagramCheckResult.ElementCheckResult;
@@ -84,8 +83,6 @@ public class FormChecker {
   private static final String KEY_FIELD = "key";
   private static final String TYPE_FIELD = "type";
   private static final String LABEL_FIELD = "label";
-
-  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
   private FormChecker() {}
 

--- a/diagram-converter/core/src/main/java/io/camunda/migration/diagram/converter/FormChecker.java
+++ b/diagram-converter/core/src/main/java/io/camunda/migration/diagram/converter/FormChecker.java
@@ -93,10 +93,14 @@ public class FormChecker {
    * @param formContent the content of a form file
    * @param properties the converter properties, providing the target platform version
    * @return the check result containing one entry per finding
-   * @throws IllegalArgumentException if the content is not valid JSON or not a JSON object
+   * @throws IllegalArgumentException if the content is not valid JSON or not a JSON object, or the
+   *     platform version is missing or invalid
    */
   public static DiagramCheckResult check(
       String filename, String formContent, ConverterProperties properties) {
+    // validates the target platform version up front, consistent with FormConverter.convert; it
+    // is also the basis for future version-dependent findings
+    FormConverter.targetVersion(properties);
     JsonNode root = FormConverter.parse(formContent);
     if (!(root instanceof ObjectNode form)) {
       throw new IllegalArgumentException(

--- a/diagram-converter/core/src/main/java/io/camunda/migration/diagram/converter/FormChecker.java
+++ b/diagram-converter/core/src/main/java/io/camunda/migration/diagram/converter/FormChecker.java
@@ -110,7 +110,7 @@ public class FormChecker {
     result.setConverterVersion(FormChecker.class.getPackage().getImplementationVersion());
     Map<String, ElementCheckResult> elementResults = new LinkedHashMap<>();
     checkFileLevel(filename, form, elementResults);
-    checkComponents(form.path(COMPONENTS_FIELD), elementResults);
+    checkComponents(form.path(COMPONENTS_FIELD), COMPONENTS_FIELD, elementResults);
     result.setResults(new ArrayList<>(elementResults.values()));
     return result;
   }
@@ -143,26 +143,29 @@ public class FormChecker {
   }
 
   private static void checkComponents(
-      JsonNode components, Map<String, ElementCheckResult> elementResults) {
+      JsonNode components, String path, Map<String, ElementCheckResult> elementResults) {
     if (!components.isArray()) {
       return;
     }
+    int index = 0;
     for (JsonNode component : components) {
+      String componentPath = path + "/" + index++;
       if (!component.isObject()) {
         continue;
       }
-      checkComponent((ObjectNode) component, elementResults);
+      checkComponent((ObjectNode) component, componentPath, elementResults);
       // containers (e.g. group, dynamiclist) nest their own components
-      checkComponents(component.path(COMPONENTS_FIELD), elementResults);
+      checkComponents(
+          component.path(COMPONENTS_FIELD), componentPath + "/" + COMPONENTS_FIELD, elementResults);
     }
   }
 
   private static void checkComponent(
-      ObjectNode component, Map<String, ElementCheckResult> elementResults) {
+      ObjectNode component, String path, Map<String, ElementCheckResult> elementResults) {
     String type = component.path(TYPE_FIELD).asText(null);
     ElementCheckResult elementResult = null;
     if (type == null || !KNOWN_COMPONENT_TYPES.contains(type)) {
-      elementResult = componentResult(component, type, elementResults);
+      elementResult = componentResult(component, type, path, elementResults);
       addMessage(elementResult, MessageFactory.formComponentUnknown(String.valueOf(type)));
     }
     for (Map.Entry<String, JsonNode> property : component.properties()) {
@@ -174,7 +177,7 @@ public class FormChecker {
       collectJuelExpressions(property.getValue(), expressions);
       for (String expression : expressions) {
         if (elementResult == null) {
-          elementResult = componentResult(component, type, elementResults);
+          elementResult = componentResult(component, type, path, elementResults);
         }
         addMessage(elementResult, MessageFactory.formJuelExpression(expression, property.getKey()));
       }
@@ -182,10 +185,15 @@ public class FormChecker {
   }
 
   private static ElementCheckResult componentResult(
-      ObjectNode component, String type, Map<String, ElementCheckResult> elementResults) {
+      ObjectNode component,
+      String type,
+      String path,
+      Map<String, ElementCheckResult> elementResults) {
     String id = componentId(component);
+    // key the map by the component's position in the JSON tree: the key/id/type fallback used as
+    // display id is not necessarily unique (e.g. several keyless textfields)
     return elementResults.computeIfAbsent(
-        FORM_ELEMENT_TYPE + ":" + id,
+        FORM_ELEMENT_TYPE + ":" + path,
         key ->
             createElementResult(
                 id, type != null ? type : "unknown", component.path(LABEL_FIELD).asText(null)));

--- a/diagram-converter/core/src/main/java/io/camunda/migration/diagram/converter/FormChecker.java
+++ b/diagram-converter/core/src/main/java/io/camunda/migration/diagram/converter/FormChecker.java
@@ -1,0 +1,236 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.migration.diagram.converter;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.camunda.migration.diagram.converter.DiagramCheckResult.ElementCheckMessage;
+import io.camunda.migration.diagram.converter.DiagramCheckResult.ElementCheckResult;
+import io.camunda.migration.diagram.converter.message.Message;
+import io.camunda.migration.diagram.converter.message.MessageFactory;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Analyzes Camunda 7 form files ({@code *.form}) and reports findings for content that needs manual
+ * review when migrating to Camunda 8. Unlike BPMN/DMN analysis, forms are JSON documents, so this
+ * checker operates on the parsed JSON tree instead of the DOM visitor pipeline. It takes a
+ * conservative approach: everything that is not trivially migratable is reported for review, no
+ * content is transformed.
+ *
+ * <p>Findings are reported as {@link ElementCheckResult}s so they appear in the same analysis
+ * outputs (JSON, CSV, XLSX, markdown, webapp) as BPMN/DMN findings. File-level findings (schema
+ * version, target platform) are attached to a synthetic element of type {@value
+ * #FORM_ELEMENT_TYPE}; component-level findings (JUEL expressions, unknown component types) are
+ * attached to the component they belong to.
+ */
+public class FormChecker {
+
+  /** Synthetic element type used for findings that apply to the form file as a whole. */
+  public static final String FORM_ELEMENT_TYPE = "form";
+
+  /**
+   * Highest form-js schema version known to this converter. Forms with an older (or missing) schema
+   * version are flagged for review.
+   */
+  public static final int LATEST_KNOWN_SCHEMA_VERSION = 18;
+
+  /**
+   * Component types provided by form-js on recent Camunda 8 versions. Anything else is flagged for
+   * review.
+   */
+  private static final Set<String> KNOWN_COMPONENT_TYPES =
+      Set.of(
+          "button",
+          "checkbox",
+          "checklist",
+          "datetime",
+          "documentPreview",
+          "dynamiclist",
+          "expression",
+          "filepicker",
+          "group",
+          "html",
+          "iframe",
+          "image",
+          "number",
+          "radio",
+          "select",
+          "separator",
+          "spacer",
+          "table",
+          "taglist",
+          "text",
+          "textarea",
+          "textfield");
+
+  private static final Pattern JUEL_EXPRESSION = Pattern.compile("[$#]\\{[^}]*}");
+
+  private static final String EXECUTION_PLATFORM_FIELD = "executionPlatform";
+  private static final String SCHEMA_VERSION_FIELD = "schemaVersion";
+  private static final String COMPONENTS_FIELD = "components";
+  private static final String ID_FIELD = "id";
+  private static final String KEY_FIELD = "key";
+  private static final String TYPE_FIELD = "type";
+  private static final String LABEL_FIELD = "label";
+
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+  private FormChecker() {}
+
+  /**
+   * Checks the given form JSON and returns the findings.
+   *
+   * @param filename the name of the form file, used in the result
+   * @param formContent the content of a form file
+   * @param properties the converter properties, providing the target platform version
+   * @return the check result containing one entry per finding
+   * @throws IllegalArgumentException if the content is not valid JSON or not a JSON object
+   */
+  public static DiagramCheckResult check(
+      String filename, String formContent, ConverterProperties properties) {
+    JsonNode root = FormConverter.parse(formContent);
+    if (!(root instanceof ObjectNode form)) {
+      throw new IllegalArgumentException(
+          "Form content must be a JSON object, but was: " + root.getNodeType());
+    }
+    DiagramCheckResult result = new DiagramCheckResult();
+    result.setFilename(filename);
+    result.setConverterVersion(FormChecker.class.getPackage().getImplementationVersion());
+    Map<String, ElementCheckResult> elementResults = new LinkedHashMap<>();
+    checkFileLevel(filename, form, elementResults);
+    checkComponents(form.path(COMPONENTS_FIELD), elementResults);
+    result.setResults(new ArrayList<>(elementResults.values()));
+    return result;
+  }
+
+  private static void checkFileLevel(
+      String filename, ObjectNode form, Map<String, ElementCheckResult> elementResults) {
+    ElementCheckResult fileLevel =
+        elementResults.computeIfAbsent(
+            FORM_ELEMENT_TYPE,
+            key -> createElementResult(formId(form, filename), FORM_ELEMENT_TYPE, null));
+    String executionPlatform = form.path(EXECUTION_PLATFORM_FIELD).asText(null);
+    if (FormConverter.TARGET_EXECUTION_PLATFORM.equals(executionPlatform)) {
+      addMessage(fileLevel, MessageFactory.formAlreadyCamunda8(executionPlatform));
+    }
+    JsonNode schemaVersion = form.get(SCHEMA_VERSION_FIELD);
+    if (schemaVersion == null || !schemaVersion.isInt()) {
+      addMessage(
+          fileLevel,
+          MessageFactory.formSchemaVersionMissing(String.valueOf(LATEST_KNOWN_SCHEMA_VERSION)));
+    } else if (schemaVersion.intValue() < LATEST_KNOWN_SCHEMA_VERSION) {
+      addMessage(
+          fileLevel,
+          MessageFactory.formSchemaVersionOutdated(
+              String.valueOf(schemaVersion.intValue()),
+              String.valueOf(LATEST_KNOWN_SCHEMA_VERSION)));
+    }
+    if (fileLevel.getMessages().isEmpty()) {
+      elementResults.remove(FORM_ELEMENT_TYPE);
+    }
+  }
+
+  private static void checkComponents(
+      JsonNode components, Map<String, ElementCheckResult> elementResults) {
+    if (!components.isArray()) {
+      return;
+    }
+    for (JsonNode component : components) {
+      if (!component.isObject()) {
+        continue;
+      }
+      checkComponent((ObjectNode) component, elementResults);
+      // containers (e.g. group, dynamiclist) nest their own components
+      checkComponents(component.path(COMPONENTS_FIELD), elementResults);
+    }
+  }
+
+  private static void checkComponent(
+      ObjectNode component, Map<String, ElementCheckResult> elementResults) {
+    String type = component.path(TYPE_FIELD).asText(null);
+    ElementCheckResult elementResult = null;
+    if (type == null || !KNOWN_COMPONENT_TYPES.contains(type)) {
+      elementResult = componentResult(component, type, elementResults);
+      addMessage(elementResult, MessageFactory.formComponentUnknown(String.valueOf(type)));
+    }
+    for (Map.Entry<String, JsonNode> property : component.properties()) {
+      if (COMPONENTS_FIELD.equals(property.getKey())) {
+        // nested components are checked as components of their own, not as properties here
+        continue;
+      }
+      List<String> expressions = new ArrayList<>();
+      collectJuelExpressions(property.getValue(), expressions);
+      for (String expression : expressions) {
+        if (elementResult == null) {
+          elementResult = componentResult(component, type, elementResults);
+        }
+        addMessage(elementResult, MessageFactory.formJuelExpression(expression, property.getKey()));
+      }
+    }
+  }
+
+  private static ElementCheckResult componentResult(
+      ObjectNode component, String type, Map<String, ElementCheckResult> elementResults) {
+    String id = componentId(component);
+    return elementResults.computeIfAbsent(
+        FORM_ELEMENT_TYPE + ":" + id,
+        key ->
+            createElementResult(
+                id, type != null ? type : "unknown", component.path(LABEL_FIELD).asText(null)));
+  }
+
+  private static void collectJuelExpressions(JsonNode node, List<String> expressions) {
+    if (node.isTextual()) {
+      Matcher matcher = JUEL_EXPRESSION.matcher(node.textValue());
+      while (matcher.find()) {
+        expressions.add(matcher.group());
+      }
+    } else if (node.isContainerNode()) {
+      node.forEach(child -> collectJuelExpressions(child, expressions));
+    }
+  }
+
+  private static ElementCheckResult createElementResult(
+      String elementId, String elementType, String elementName) {
+    ElementCheckResult elementResult = new ElementCheckResult();
+    elementResult.setElementId(elementId);
+    elementResult.setElementType(elementType);
+    elementResult.setElementName(elementName);
+    return elementResult;
+  }
+
+  private static void addMessage(ElementCheckResult elementResult, Message message) {
+    ElementCheckMessage checkMessage = new ElementCheckMessage();
+    checkMessage.setSeverity(message.getSeverity());
+    checkMessage.setMessage(message.getMessage());
+    checkMessage.setLink(message.getLink());
+    checkMessage.setId(message.getId());
+    elementResult.getMessages().add(checkMessage);
+  }
+
+  private static String formId(ObjectNode form, String filename) {
+    String id = form.path(ID_FIELD).asText(null);
+    return id != null ? id : filename;
+  }
+
+  private static String componentId(ObjectNode component) {
+    String key = component.path(KEY_FIELD).asText(null);
+    if (key != null) {
+      return key;
+    }
+    String id = component.path(ID_FIELD).asText(null);
+    return id != null ? id : component.path(TYPE_FIELD).asText("unknown");
+  }
+}

--- a/diagram-converter/core/src/main/java/io/camunda/migration/diagram/converter/FormChecker.java
+++ b/diagram-converter/core/src/main/java/io/camunda/migration/diagram/converter/FormChecker.java
@@ -163,7 +163,8 @@ public class FormChecker {
     ElementCheckResult elementResult = null;
     if (type == null || !KNOWN_COMPONENT_TYPES.contains(type)) {
       elementResult = componentResult(component, type, path, elementResults);
-      addMessage(elementResult, MessageFactory.formComponentUnknown(String.valueOf(type)));
+      addMessage(
+          elementResult, MessageFactory.formComponentUnknown(type != null ? type : "missing"));
     }
     for (Map.Entry<String, JsonNode> property : component.properties()) {
       if (COMPONENTS_FIELD.equals(property.getKey())) {

--- a/diagram-converter/core/src/main/java/io/camunda/migration/diagram/converter/FormConverter.java
+++ b/diagram-converter/core/src/main/java/io/camunda/migration/diagram/converter/FormConverter.java
@@ -67,6 +67,17 @@ public class FormConverter {
     }
   }
 
+  /**
+   * Parses the given form JSON.
+   *
+   * @param formContent the content of a form file
+   * @return the parsed JSON tree
+   * @throws IllegalArgumentException if the content is not valid JSON
+   */
+  static JsonNode parse(String formContent) {
+    return readTree(formContent);
+  }
+
   private static JsonNode readTree(String formContent) {
     try {
       return OBJECT_MAPPER.readTree(formContent);

--- a/diagram-converter/core/src/main/java/io/camunda/migration/diagram/converter/FormConverter.java
+++ b/diagram-converter/core/src/main/java/io/camunda/migration/diagram/converter/FormConverter.java
@@ -86,6 +86,17 @@ public class FormConverter {
     }
   }
 
+  /**
+   * Resolves and validates the target platform version from the converter properties.
+   *
+   * @param properties the converter properties, providing the target platform version
+   * @return the target platform version in patch-zero form (e.g. {@code 8.9.0})
+   * @throws IllegalArgumentException if the platform version is missing or invalid
+   */
+  static String targetVersion(ConverterProperties properties) {
+    return resolveTargetVersion(properties);
+  }
+
   private static String resolveTargetVersion(ConverterProperties properties) {
     String platformVersion = properties.getPlatformVersion();
     if (platformVersion == null || platformVersion.isBlank()) {

--- a/diagram-converter/core/src/main/java/io/camunda/migration/diagram/converter/message/MessageFactory.java
+++ b/diagram-converter/core/src/main/java/io/camunda/migration/diagram/converter/message/MessageFactory.java
@@ -691,6 +691,43 @@ public class MessageFactory {
     return INSTANCE.staticMessage("modeler-template-version");
   }
 
+  public static Message formAlreadyCamunda8(String executionPlatform) {
+    return INSTANCE.composeMessage(
+        "form-already-camunda-8",
+        ContextBuilder.builder().entry("executionPlatform", executionPlatform).build());
+  }
+
+  public static Message formSchemaVersionOutdated(
+      String schemaVersion, String latestSchemaVersion) {
+    return INSTANCE.composeMessage(
+        "form-schema-version-outdated",
+        ContextBuilder.builder()
+            .entry("schemaVersion", schemaVersion)
+            .entry("latestSchemaVersion", latestSchemaVersion)
+            .build());
+  }
+
+  public static Message formSchemaVersionMissing(String latestSchemaVersion) {
+    return INSTANCE.composeMessage(
+        "form-schema-version-missing",
+        ContextBuilder.builder().entry("latestSchemaVersion", latestSchemaVersion).build());
+  }
+
+  public static Message formJuelExpression(String expression, String propertyName) {
+    return INSTANCE.composeMessage(
+        "form-juel-expression",
+        ContextBuilder.builder()
+            .entry("expression", expression)
+            .entry("propertyName", propertyName)
+            .build());
+  }
+
+  public static Message formComponentUnknown(String componentType) {
+    return INSTANCE.composeMessage(
+        "form-component-unknown",
+        ContextBuilder.builder().entry("componentType", componentType).build());
+  }
+
   private ComposedMessage composeMessage(String templateName, Map<String, String> context) {
     ComposedMessage message = new ComposedMessage();
     MessageTemplate template = messageTemplateProvider.getMessageTemplate(templateName);

--- a/diagram-converter/core/src/main/resources/message-templates.properties
+++ b/diagram-converter/core/src/main/resources/message-templates.properties
@@ -273,3 +273,25 @@ input-variable-not-supported.severity=TASK
 #
 number-type.message=Only type 'number' is supported on number types. Please review the rules.
 number-type.severity=REVIEW
+#
+# Form files (.form)
+#
+form-already-camunda-8.message=This form is already a Camunda 8 form (executionPlatform '{{ executionPlatform }}'). No conversion is needed.
+form-already-camunda-8.severity=INFO
+form-already-camunda-8.link=https://docs.camunda.io/docs/components/modeler/forms/camunda-forms-reference/
+#
+form-schema-version-outdated.message=The form schema version '{{ schemaVersion }}' is older than the schema version '{{ latestSchemaVersion }}' used by recent Camunda 8 versions. The form can usually still be read, but please review.
+form-schema-version-outdated.severity=REVIEW
+form-schema-version-outdated.link=https://docs.camunda.io/docs/components/modeler/forms/camunda-forms-reference/
+#
+form-schema-version-missing.message=The form has no schema version. Recent Camunda 8 versions expect schema version '{{ latestSchemaVersion }}'. Please review.
+form-schema-version-missing.severity=REVIEW
+form-schema-version-missing.link=https://docs.camunda.io/docs/components/modeler/forms/camunda-forms-reference/
+#
+form-juel-expression.message=JUEL expression '{{ expression }}' in property '{{ propertyName }}' cannot be transformed automatically. Camunda 8 forms use FEEL expressions. Please review.
+form-juel-expression.severity=REVIEW
+form-juel-expression.link=https://docs.camunda.io/docs/components/modeler/feel/what-is-feel/
+#
+form-component-unknown.message=Component type '{{ componentType }}' is not a known Camunda 8 form-js component type. Please review.
+form-component-unknown.severity=REVIEW
+form-component-unknown.link=https://docs.camunda.io/docs/components/modeler/forms/form-element-library/forms-element-library/

--- a/diagram-converter/core/src/test/java/io/camunda/migration/diagram/converter/FormCheckerTest.java
+++ b/diagram-converter/core/src/test/java/io/camunda/migration/diagram/converter/FormCheckerTest.java
@@ -9,6 +9,7 @@ package io.camunda.migration.diagram.converter;
 
 import static org.assertj.core.api.Assertions.*;
 
+import io.camunda.migration.diagram.converter.DiagramCheckResult.ElementCheckMessage;
 import io.camunda.migration.diagram.converter.DiagramCheckResult.ElementCheckResult;
 import io.camunda.migration.diagram.converter.DiagramCheckResult.Severity;
 import org.junit.jupiter.api.Test;
@@ -315,6 +316,36 @@ class FormCheckerTest {
     assertThat(result.getResults())
         .extracting(ElementCheckResult::getElementId)
         .containsExactly("myForm", "first", "second");
+  }
+
+  @Test
+  void shouldKeepFindingsSeparateForComponentsWithoutKeyOrId() {
+    DiagramCheckResult result =
+        check(
+            """
+            {
+              "executionPlatform": "Camunda Platform",
+              "executionPlatformVersion": "7.23.0",
+              "id": "myForm",
+              "components": [
+                { "type": "textfield", "defaultValue": "${a}" },
+                { "type": "textfield", "defaultValue": "${b}" }
+              ],
+              "type": "default",
+              "schemaVersion": 18
+            }
+            """);
+
+    // both keyless textfields fall back to the type as display id, but must not be merged
+    assertThat(result.getResults()).hasSize(2);
+    assertThat(result.getResults())
+        .extracting(ElementCheckResult::getElementId)
+        .containsExactly("textfield", "textfield");
+    assertThat(result.getResults())
+        .flatExtracting(ElementCheckResult::getMessages)
+        .extracting(ElementCheckMessage::getMessage)
+        .anySatisfy(message -> assertThat(message).contains("${a}"))
+        .anySatisfy(message -> assertThat(message).contains("${b}"));
   }
 
   @Test

--- a/diagram-converter/core/src/test/java/io/camunda/migration/diagram/converter/FormCheckerTest.java
+++ b/diagram-converter/core/src/test/java/io/camunda/migration/diagram/converter/FormCheckerTest.java
@@ -1,0 +1,338 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.migration.diagram.converter;
+
+import static org.assertj.core.api.Assertions.*;
+
+import io.camunda.migration.diagram.converter.DiagramCheckResult.ElementCheckResult;
+import io.camunda.migration.diagram.converter.DiagramCheckResult.Severity;
+import org.junit.jupiter.api.Test;
+
+class FormCheckerTest {
+
+  private static final String CLEAN_C7_FORM =
+      """
+      {
+        "executionPlatform": "Camunda Platform",
+        "executionPlatformVersion": "7.23.0",
+        "id": "myForm",
+        "components": [
+          {
+            "label": "Customer name",
+            "type": "textfield",
+            "key": "customerName",
+            "validate": { "required": true }
+          }
+        ],
+        "type": "default",
+        "schemaVersion": %s
+      }
+      """;
+
+  @Test
+  void shouldReportNothingForCleanRecentForm() {
+    DiagramCheckResult result = check(String.format(CLEAN_C7_FORM, 18));
+
+    assertThat(result.getResults()).isEmpty();
+  }
+
+  @Test
+  void shouldSetFilename() {
+    DiagramCheckResult result = check(String.format(CLEAN_C7_FORM, 18));
+
+    assertThat(result.getFilename()).isEqualTo("myForm.form");
+  }
+
+  @Test
+  void shouldReportOutdatedSchemaVersionAsFileLevelFinding() {
+    DiagramCheckResult result = check(String.format(CLEAN_C7_FORM, 16));
+
+    assertThat(result.getResults()).hasSize(1);
+    ElementCheckResult element = result.getResults().get(0);
+    assertThat(element.getElementType()).isEqualTo(FormChecker.FORM_ELEMENT_TYPE);
+    assertThat(element.getElementId()).isEqualTo("myForm");
+    assertThat(element.getMessages())
+        .singleElement()
+        .satisfies(
+            message -> {
+              assertThat(message.getId()).isEqualTo("form-schema-version-outdated");
+              assertThat(message.getSeverity()).isEqualTo(Severity.REVIEW);
+              assertThat(message.getMessage()).contains("16").contains("18");
+              assertThat(message.getLink()).isNotBlank();
+            });
+  }
+
+  @Test
+  void shouldReportMissingSchemaVersion() {
+    DiagramCheckResult result =
+        check(
+            """
+            {
+              "executionPlatform": "Camunda Platform",
+              "executionPlatformVersion": "7.23.0",
+              "id": "myForm",
+              "components": [],
+              "type": "default"
+            }
+            """);
+
+    assertThat(result.getResults()).hasSize(1);
+    assertThat(result.getResults().get(0).getMessages())
+        .singleElement()
+        .satisfies(
+            message -> {
+              assertThat(message.getId()).isEqualTo("form-schema-version-missing");
+              assertThat(message.getSeverity()).isEqualTo(Severity.REVIEW);
+            });
+  }
+
+  @Test
+  void shouldReportAlreadyCamunda8Form() {
+    DiagramCheckResult result =
+        check(
+            """
+            {
+              "executionPlatform": "Camunda Cloud",
+              "executionPlatformVersion": "8.9.0",
+              "id": "myForm",
+              "components": [],
+              "type": "default",
+              "schemaVersion": 18
+            }
+            """);
+
+    assertThat(result.getResults()).hasSize(1);
+    assertThat(result.getResults().get(0).getElementType())
+        .isEqualTo(FormChecker.FORM_ELEMENT_TYPE);
+    assertThat(result.getResults().get(0).getMessages())
+        .singleElement()
+        .satisfies(
+            message -> {
+              assertThat(message.getId()).isEqualTo("form-already-camunda-8");
+              assertThat(message.getSeverity()).isEqualTo(Severity.INFO);
+            });
+  }
+
+  @Test
+  void shouldReportJuelExpressionsOnComponent() {
+    DiagramCheckResult result =
+        check(
+            """
+            {
+              "executionPlatform": "Camunda Platform",
+              "executionPlatformVersion": "7.23.0",
+              "id": "myForm",
+              "components": [
+                {
+                  "label": "Hello ${customerName}",
+                  "type": "textfield",
+                  "key": "greeting",
+                  "defaultValue": "#{defaultGreeting}"
+                }
+              ],
+              "type": "default",
+              "schemaVersion": 18
+            }
+            """);
+
+    assertThat(result.getResults()).hasSize(1);
+    ElementCheckResult element = result.getResults().get(0);
+    assertThat(element.getElementId()).isEqualTo("greeting");
+    assertThat(element.getElementType()).isEqualTo("textfield");
+    assertThat(element.getElementName()).isEqualTo("Hello ${customerName}");
+    assertThat(element.getMessages())
+        .hasSize(2)
+        .allSatisfy(
+            message -> {
+              assertThat(message.getId()).isEqualTo("form-juel-expression");
+              assertThat(message.getSeverity()).isEqualTo(Severity.REVIEW);
+            })
+        .anySatisfy(
+            message ->
+                assertThat(message.getMessage()).contains("${customerName}").contains("label"))
+        .anySatisfy(
+            message ->
+                assertThat(message.getMessage())
+                    .contains("#{defaultGreeting}")
+                    .contains("defaultValue"));
+  }
+
+  @Test
+  void shouldNotReportFeelExpressions() {
+    DiagramCheckResult result =
+        check(
+            """
+            {
+              "executionPlatform": "Camunda Platform",
+              "executionPlatformVersion": "7.23.0",
+              "id": "myForm",
+              "components": [
+                {
+                  "label": "= customerName",
+                  "type": "textfield",
+                  "key": "greeting"
+                }
+              ],
+              "type": "default",
+              "schemaVersion": 18
+            }
+            """);
+
+    assertThat(result.getResults()).isEmpty();
+  }
+
+  @Test
+  void shouldReportJuelExpressionsInNestedProperties() {
+    DiagramCheckResult result =
+        check(
+            """
+            {
+              "executionPlatform": "Camunda Platform",
+              "executionPlatformVersion": "7.23.0",
+              "id": "myForm",
+              "components": [
+                {
+                  "label": "Options",
+                  "type": "select",
+                  "key": "choice",
+                  "values": [
+                    { "label": "${optionA}", "value": "a" },
+                    { "label": "Static", "value": "b" }
+                  ]
+                }
+              ],
+              "type": "default",
+              "schemaVersion": 18
+            }
+            """);
+
+    assertThat(result.getResults()).hasSize(1);
+    ElementCheckResult element = result.getResults().get(0);
+    assertThat(element.getElementId()).isEqualTo("choice");
+    assertThat(element.getMessages())
+        .singleElement()
+        .satisfies(
+            message -> assertThat(message.getMessage()).contains("${optionA}").contains("values"));
+  }
+
+  @Test
+  void shouldReportUnknownComponentType() {
+    DiagramCheckResult result =
+        check(
+            """
+            {
+              "executionPlatform": "Camunda Platform",
+              "executionPlatformVersion": "7.23.0",
+              "id": "myForm",
+              "components": [
+                {
+                  "label": "Legacy widget",
+                  "type": "camunda7-legacy-widget",
+                  "key": "legacy"
+                }
+              ],
+              "type": "default",
+              "schemaVersion": 18
+            }
+            """);
+
+    assertThat(result.getResults()).hasSize(1);
+    ElementCheckResult element = result.getResults().get(0);
+    assertThat(element.getElementId()).isEqualTo("legacy");
+    assertThat(element.getElementType()).isEqualTo("camunda7-legacy-widget");
+    assertThat(element.getMessages())
+        .singleElement()
+        .satisfies(
+            message -> {
+              assertThat(message.getId()).isEqualTo("form-component-unknown");
+              assertThat(message.getSeverity()).isEqualTo(Severity.REVIEW);
+              assertThat(message.getMessage()).contains("camunda7-legacy-widget");
+            });
+  }
+
+  @Test
+  void shouldCheckComponentsNestedInGroups() {
+    DiagramCheckResult result =
+        check(
+            """
+            {
+              "executionPlatform": "Camunda Platform",
+              "executionPlatformVersion": "7.23.0",
+              "id": "myForm",
+              "components": [
+                {
+                  "type": "group",
+                  "id": "group1",
+                  "components": [
+                    {
+                      "label": "Nested ${value}",
+                      "type": "textfield",
+                      "key": "nested"
+                    }
+                  ]
+                }
+              ],
+              "type": "default",
+              "schemaVersion": 18
+            }
+            """);
+
+    assertThat(result.getResults()).hasSize(1);
+    ElementCheckResult element = result.getResults().get(0);
+    assertThat(element.getElementId()).isEqualTo("nested");
+    assertThat(element.getMessages())
+        .singleElement()
+        .satisfies(message -> assertThat(message.getId()).isEqualTo("form-juel-expression"));
+  }
+
+  @Test
+  void shouldGroupFindingsPerComponentAndReportEachComponent() {
+    DiagramCheckResult result =
+        check(
+            """
+            {
+              "executionPlatform": "Camunda Platform",
+              "executionPlatformVersion": "7.23.0",
+              "id": "myForm",
+              "components": [
+                { "label": "A ${x}", "type": "textfield", "key": "first" },
+                { "label": "B ${y}", "type": "textarea", "key": "second" }
+              ],
+              "type": "default",
+              "schemaVersion": 16
+            }
+            """);
+
+    assertThat(result.getResults()).hasSize(3);
+    assertThat(result.getResults())
+        .extracting(ElementCheckResult::getElementType)
+        .containsExactly(FormChecker.FORM_ELEMENT_TYPE, "textfield", "textarea");
+    assertThat(result.getResults())
+        .extracting(ElementCheckResult::getElementId)
+        .containsExactly("myForm", "first", "second");
+  }
+
+  @Test
+  void shouldRejectInvalidJson() {
+    assertThatThrownBy(() -> check("{ not json"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("not valid JSON");
+  }
+
+  @Test
+  void shouldRejectNonObjectJson() {
+    assertThatThrownBy(() -> check("[1, 2]"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("must be a JSON object");
+  }
+
+  private DiagramCheckResult check(String formContent) {
+    return FormChecker.check(
+        "myForm.form", formContent, ConverterPropertiesFactory.getInstance().get());
+  }
+}

--- a/diagram-converter/core/src/test/java/io/camunda/migration/diagram/converter/FormCheckerTest.java
+++ b/diagram-converter/core/src/test/java/io/camunda/migration/diagram/converter/FormCheckerTest.java
@@ -319,6 +319,36 @@ class FormCheckerTest {
   }
 
   @Test
+  void shouldReportComponentWithMissingType() {
+    DiagramCheckResult result =
+        check(
+            """
+            {
+              "executionPlatform": "Camunda Platform",
+              "executionPlatformVersion": "7.23.0",
+              "id": "myForm",
+              "components": [
+                { "label": "No type", "key": "typeless" }
+              ],
+              "type": "default",
+              "schemaVersion": 18
+            }
+            """);
+
+    assertThat(result.getResults()).hasSize(1);
+    ElementCheckResult element = result.getResults().get(0);
+    assertThat(element.getElementId()).isEqualTo("typeless");
+    assertThat(element.getElementType()).isEqualTo("unknown");
+    assertThat(element.getMessages())
+        .singleElement()
+        .satisfies(
+            message -> {
+              assertThat(message.getId()).isEqualTo("form-component-unknown");
+              assertThat(message.getMessage()).contains("missing");
+            });
+  }
+
+  @Test
   void shouldKeepFindingsSeparateForComponentsWithoutKeyOrId() {
     DiagramCheckResult result =
         check(

--- a/diagram-converter/core/src/test/java/io/camunda/migration/diagram/converter/FormCheckerTest.java
+++ b/diagram-converter/core/src/test/java/io/camunda/migration/diagram/converter/FormCheckerTest.java
@@ -392,6 +392,17 @@ class FormCheckerTest {
         .hasMessageContaining("must be a JSON object");
   }
 
+  @Test
+  void shouldRejectInvalidPlatformVersion() {
+    DefaultConverterProperties properties = new DefaultConverterProperties();
+    properties.setPlatformVersion("not-a-version");
+
+    assertThatThrownBy(
+            () -> FormChecker.check("myForm.form", String.format(CLEAN_C7_FORM, 18), properties))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Not a valid platform version");
+  }
+
   private DiagramCheckResult check(String formContent) {
     return FormChecker.check(
         "myForm.form", formContent, ConverterPropertiesFactory.getInstance().get());

--- a/diagram-converter/webapp/src/main/java/io/camunda/migration/diagram/converter/webapp/ConverterController.java
+++ b/diagram-converter/webapp/src/main/java/io/camunda/migration/diagram/converter/webapp/ConverterController.java
@@ -126,6 +126,8 @@ public class ConverterController {
       @RequestHeader(HttpHeaders.ACCEPT) String[] contentType) {
 
     ArrayList<DiagramCheckResult> resultList = new ArrayList<DiagramCheckResult>();
+    // computed once per request instead of per uploaded form file
+    ConverterProperties formCheckProperties = converterProperties(platformVersion);
 
     // Check all files
     for (Iterator diagramFilesIterator = diagramFiles.iterator();
@@ -137,10 +139,7 @@ public class ConverterController {
         try (InputStream in = diagramFile.getInputStream()) {
           String content = new String(in.readAllBytes(), StandardCharsets.UTF_8);
           resultList.add(
-              FormChecker.check(
-                  diagramFile.getOriginalFilename(),
-                  content,
-                  converterProperties(platformVersion)));
+              FormChecker.check(diagramFile.getOriginalFilename(), content, formCheckProperties));
         } catch (IOException e) {
           LOG.error("Error while reading input stream of form file", e);
           return ResponseEntity.badRequest().body(e.getMessage());

--- a/diagram-converter/webapp/src/main/java/io/camunda/migration/diagram/converter/webapp/ConverterController.java
+++ b/diagram-converter/webapp/src/main/java/io/camunda/migration/diagram/converter/webapp/ConverterController.java
@@ -13,6 +13,7 @@ import io.camunda.migration.diagram.converter.DefaultConverterProperties;
 import io.camunda.migration.diagram.converter.DiagramCheckResult;
 import io.camunda.migration.diagram.converter.DiagramConverterResultDTO;
 import io.camunda.migration.diagram.converter.DiagramType;
+import io.camunda.migration.diagram.converter.FormChecker;
 import io.camunda.migration.diagram.converter.FormConverter;
 import io.camunda.migration.diagram.converter.excel.ExcelWriter;
 import java.io.BufferedOutputStream;
@@ -131,13 +132,21 @@ public class ConverterController {
         diagramFilesIterator.hasNext(); ) {
       MultipartFile diagramFile = (MultipartFile) diagramFilesIterator.next();
 
-      // Form files are JSON and have no diagram elements to analyze - return an empty result
+      // Form files are JSON and use a dedicated checker instead of the DOM visitor pipeline
       if (FormConverter.isFormFile(diagramFile.getOriginalFilename())) {
-        DiagramCheckResult formResult = new DiagramCheckResult();
-        formResult.setFilename(diagramFile.getOriginalFilename());
-        // keep the response schema consistent with BPMN/DMN results
-        formResult.setConverterVersion(buildProperties.getVersion());
-        resultList.add(formResult);
+        try (InputStream in = diagramFile.getInputStream()) {
+          String content = new String(in.readAllBytes(), StandardCharsets.UTF_8);
+          resultList.add(
+              FormChecker.check(
+                  diagramFile.getOriginalFilename(),
+                  content,
+                  converterProperties(platformVersion)));
+        } catch (IOException e) {
+          LOG.error("Error while reading input stream of form file", e);
+          return ResponseEntity.badRequest().body(e.getMessage());
+        } catch (IllegalArgumentException e) {
+          return ResponseEntity.badRequest().body(e.getMessage());
+        }
         continue;
       }
 

--- a/diagram-converter/webapp/src/main/javascript/package-lock.json
+++ b/diagram-converter/webapp/src/main/javascript/package-lock.json
@@ -7389,9 +7389,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7409,9 +7406,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7429,9 +7423,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7449,9 +7440,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7469,9 +7457,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7489,9 +7474,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9370,9 +9352,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -9394,9 +9373,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -9418,9 +9394,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -9442,9 +9415,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [

--- a/diagram-converter/webapp/src/test/java/io/camunda/migration/diagram/converter/webapp/ConverterControllerTest.java
+++ b/diagram-converter/webapp/src/test/java/io/camunda/migration/diagram/converter/webapp/ConverterControllerTest.java
@@ -16,6 +16,8 @@ import com.opencsv.CSVReader;
 import com.opencsv.CSVReaderBuilder;
 import com.opencsv.exceptions.CsvException;
 import io.camunda.migration.diagram.converter.DiagramCheckResult;
+import io.camunda.migration.diagram.converter.DiagramCheckResult.ElementCheckMessage;
+import io.camunda.migration.diagram.converter.DiagramCheckResult.ElementCheckResult;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.restassured.RestAssured;
@@ -539,7 +541,7 @@ public class ConverterControllerTest {
   }
 
   @Test
-  void checkFormReturnsEmptyResult() throws URISyntaxException {
+  void checkFormReturnsFindings() throws URISyntaxException {
     List<DiagramCheckResult> checkResult =
         RestAssured.given()
             .contentType(ContentType.MULTIPART)
@@ -554,7 +556,61 @@ public class ConverterControllerTest {
         .hasSize(1)
         .first()
         .matches(result -> result.getFilename().equals("simple.form"), "Filename is set correctly")
-        .matches(result -> result.getResults().isEmpty(), "Forms have no diagram elements");
+        .matches(
+            result ->
+                result.getResults().stream()
+                    .flatMap(element -> element.getMessages().stream())
+                    .anyMatch(message -> message.getId().equals("form-schema-version-outdated")),
+            "Outdated schema version is reported");
+  }
+
+  @Test
+  void checkMultipleFormsReturnsFindingsPerFile() throws URISyntaxException {
+    String juelForm =
+        """
+        {
+          "executionPlatform": "Camunda Platform",
+          "executionPlatformVersion": "7.23.0",
+          "id": "juelForm",
+          "components": [
+            { "label": "Hello ${name}", "type": "textfield", "key": "greeting" }
+          ],
+          "type": "default",
+          "schemaVersion": 18
+        }
+        """;
+
+    List<DiagramCheckResult> checkResult =
+        RestAssured.given()
+            .contentType(ContentType.MULTIPART)
+            .multiPart(
+                "file", new File(getClass().getClassLoader().getResource("simple.form").toURI()))
+            .multiPart(
+                "file", "juel.form", juelForm.getBytes(StandardCharsets.UTF_8), "application/json")
+            .accept(ContentType.JSON)
+            .post("/check")
+            .getBody()
+            .as(new TypeRef<List<DiagramCheckResult>>() {});
+
+    assertThat(checkResult)
+        .hasSize(2)
+        .extracting(DiagramCheckResult::getFilename)
+        .containsExactly("simple.form", "juel.form");
+    assertThat(checkResult.get(0).getResults())
+        .flatExtracting(ElementCheckResult::getMessages)
+        .extracting(ElementCheckMessage::getId)
+        .containsExactly("form-schema-version-outdated");
+    assertThat(checkResult.get(1).getResults())
+        .flatExtracting(ElementCheckResult::getMessages)
+        .extracting(ElementCheckMessage::getId)
+        .containsExactly("form-juel-expression");
+    assertThat(checkResult.get(1).getResults())
+        .first()
+        .satisfies(
+            element -> {
+              assertThat(element.getElementId()).isEqualTo("greeting");
+              assertThat(element.getElementType()).isEqualTo("textfield");
+            });
   }
 
   @Test


### PR DESCRIPTION
## Summary

- Adds analysis findings for Camunda 7 `.form` files, produced by a new JSON-based `FormChecker` in core (forms are JSON, so they bypass the DOM visitor pipeline)
- Findings appear on the same surfaces as BPMN/DMN findings: `DiagramCheckResult` JSON (webapp `/check` now returns real findings instead of a hardcoded empty result), CLI reports (CSV, XLSX, JSON, markdown)
- Conservative approach: everything non-trivial is flagged for human review, no form content is transformed

## Finding categories

| Finding | Severity | Scope |
|---|---|---|
| `form-schema-version-outdated` / `form-schema-version-missing` | REVIEW | file-level (element type `form`) |
| `form-juel-expression` (`${...}` / `#{...}` in component properties; C8 forms use FEEL) | REVIEW | component-level (element id = component key/id, element type = component type) |
| `form-component-unknown` (not a known form-js component type) | REVIEW | component-level |
| `form-already-camunda-8` | INFO | file-level |

File-level findings show up as individual findings per file in the webapp; component-level findings are attached to the affected component.

## Changes

- `core`: new `FormChecker`, 5 new message templates + `MessageFactory` methods, `FormConverter.parse` exposed for shared JSON parsing
- `cli`: `AbstractConvertCommand` checks `.form` files and merges results into the analysis reports; conversion behavior unchanged (still skipped in `--check`)
- `webapp`: `/check` returns actual findings for forms (400 on invalid JSON)

## Test plan

- [x] `mvn test -pl diagram-converter/core,diagram-converter/cli,diagram-converter/webapp` passes (439 + 36 + 36 tests)
- [x] `FormCheckerTest`: each finding category, nested groups, FEEL vs JUEL, batch grouping, invalid JSON
- [x] `ConvertLocalCommandTest`: form findings in CSV/JSON reports in `--check` mode, multi-form batches
- [x] `ConverterControllerTest`: `/check` returns findings for single and multiple forms
- [x] `mvn verify -PcheckFormat` passes

## Baseline

Built from commit: 025b0911dae734528b8affd26052cf63bbe81059

related to #2340