### PR TITLE
feat(diagram-converter): show analysis findings for all file types in webapp

### DIFF
--- a/diagram-converter/webapp/src/main/javascript/src/App.jsx
+++ b/diagram-converter/webapp/src/main/javascript/src/App.jsx
@@ -52,6 +52,7 @@ function App() {
   const [isPreviewOpen, setIsPreviewOpen] = useState(false);
   const [previewbpmnXml, setPreviewbpmnXml] = useState("");
   const [previewIsBpmn, setPreviewIsBpmn] = useState(false);
+  const [previewDiagramError, setPreviewDiagramError] = useState(false);
   const [previewCheckJson, setPreviewCheckJson] = useState([]);
 
   const [previewTableHeader, setPreviewTableHeader] = useState([]);
@@ -156,6 +157,7 @@ function App() {
 
       }).catch((err) => {
         console.error('Failed to render BPMN preview', err);
+        setPreviewDiagramError(true);
       });
 
       return () => viewer.destroy();
@@ -380,7 +382,7 @@ function App() {
     );
   }
 
-  async function preview(response, file) {
+  async function preview(response) {
     if (!response?.checkResponseJson) return;
 
     setPreviewTableHeader([
@@ -411,7 +413,13 @@ function App() {
 
     setPreviewCheckJson(response.checkResponseJson);
     setPreviewbpmnXml(response.originalModelXml);
-    setPreviewIsBpmn(!!file?.name?.endsWith(".bpmn"));
+    // BPMN is detected by content, not extension: the dropzone also accepts
+    // .xml files, which can be BPMN (or DMN) models.
+    setPreviewIsBpmn(
+      typeof response.originalModelXml === "string" &&
+      response.originalModelXml.includes("omg.org/spec/BPMN")
+    );
+    setPreviewDiagramError(false);
 
     setIsPreviewOpen(true);
   }
@@ -681,7 +689,7 @@ function App() {
                   status={r.status}
                   isChecked={r.checkResponseJson != null}
                   isConverted={r.convertedFileBlob != null}
-                  previewAction={() => preview(r, file)}
+                  previewAction={() => preview(r)}
                   downloadAction={() => download(r)}
                   findingCount={fileFindingCount}
                   error={
@@ -815,10 +823,12 @@ function App() {
         </div>
       </div>
 
-      {previewIsBpmn && <div id="bpmnDiagram" className="diagram-container"></div>}
-      {!previewIsBpmn && (
+      {previewIsBpmn && !previewDiagramError && <div id="bpmnDiagram" className="diagram-container"></div>}
+      {(!previewIsBpmn || previewDiagramError) && (
         <p style={{ color: 'var(--neutral-foreground-subtle)', marginTop: '1rem' }}>
-          Diagram preview is only available for BPMN models. The findings for this file are listed below.
+          {previewDiagramError
+            ? 'The diagram could not be rendered. The findings for this file are listed below.'
+            : 'Diagram preview is only available for BPMN models. The findings for this file are listed below.'}
         </p>
       )}
       {previewTableRows.length === 0 && (

--- a/diagram-converter/webapp/src/main/javascript/src/App.jsx
+++ b/diagram-converter/webapp/src/main/javascript/src/App.jsx
@@ -132,7 +132,7 @@ function App() {
   }, []);
 
   useEffect(() => {
-      if (!isPreviewOpen || !previewIsBpmn || !previewbpmnXml) return;
+      if (!isPreviewOpen || !previewIsBpmn || previewDiagramError || !previewbpmnXml) return;
 
       const viewer = new BpmnJS({ container: '#bpmnDiagram' });
       viewer.importXML(previewbpmnXml).then(() => {
@@ -161,7 +161,7 @@ function App() {
       });
 
       return () => viewer.destroy();
-    }, [isPreviewOpen, previewIsBpmn, previewbpmnXml, previewCheckJson]);
+    }, [isPreviewOpen, previewIsBpmn, previewDiagramError, previewbpmnXml, previewCheckJson]);
 
   useEffect(() => {
     if (!allDone || totalFindings === 0) return;

--- a/diagram-converter/webapp/src/main/javascript/src/App.jsx
+++ b/diagram-converter/webapp/src/main/javascript/src/App.jsx
@@ -27,6 +27,7 @@ import {
 import { Download, ExternalLink, X, Settings, ChevronDown, ChevronUp } from "lucide-react";
 import DropZone from "./DropZone";
 import FileItem from "./FileItem";
+import { FINDINGS_TABLE_HEADER, buildFindingsRows } from "./findings";
 import BpmnJS from 'bpmn-js';
 import FormPreview from "./FormPreview";
 import { parseFormSchema } from "./formSchema";
@@ -43,6 +44,51 @@ const SUPPORTED_PLATFORM_VERSIONS = [
   { value: "8.10", label: "8.10", hint: "Next version" },
 ];
 const DEFAULT_PLATFORM_VERSION = "8.9";
+
+function FindingsSection({ header, rows }) {
+  if (rows.length === 0) {
+    return (
+      <p style={{ color: 'var(--neutral-foreground-subtle)', marginTop: '1rem' }}>No findings for this file.</p>
+    );
+  }
+  return (
+    <>
+      <h3>Findings</h3>
+      <p style={{ color: 'var(--neutral-foreground-subtle)', marginBottom: '0.75rem' }}>
+        Elements in this file that need attention during migration. Each row describes one finding — its location, severity, and a message explaining what to address.
+      </p>
+      <Table className="analysis-table">
+        <TableHeader>
+          <TableRow>
+            {header.map((h) => (
+              <TableHead key={h.key}>
+                {h.header}
+              </TableHead>
+            ))}
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {rows.map((row) => (
+            <TableRow key={row.id}>
+              {header.map((h) => {
+                const value = row[h.key];
+                return (
+                  <TableCell key={`${row.id}-${h.key}`}>
+                    {h.key === 'link'
+                      ? value
+                        ? <a href={value} target="_blank" rel="noopener noreferrer">Link</a>
+                        : '-'
+                      : value}
+                  </TableCell>
+                );
+              })}
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </>
+  );
+}
 
 function App() {
   const baseUrl = ""; // Change this to "http://localhost:8080" if you want to play with it locally by using npm run dev
@@ -398,31 +444,8 @@ function App() {
   async function preview(response) {
     if (!response?.checkResponseJson) return;
 
-    setPreviewTableHeader([
-      { key: 'elementType', header: 'Element Type' },
-      { key: 'elementId', header: 'Element ID' },
-      { key: 'elementName', header: 'Element Name' },
-      { key: 'severity', header: 'Severity' },
-      { key: 'message', header: 'Message' },
-      { key: 'link', header: 'Link' },
-    ]);
-
-    setPreviewTableRows(
-      response.checkResponseJson.flatMap((item, itemIdx) =>
-        (item.results || []).flatMap((element, elementIdx) =>
-          (element.messages || []).map((message, msgIdx) => ({
-            id: `${itemIdx}-${elementIdx}-${msgIdx}`,
-            elementType: element.elementType || '-',
-            elementId: element.elementId || '-',
-            elementName: element.elementName || '(unnamed)',
-            severity: message.severity,
-            message: message.message,
-            link: message.link || null,
-          }))
-        )
-      )
-    );
-
+    setPreviewTableHeader(FINDINGS_TABLE_HEADER);
+    setPreviewTableRows(buildFindingsRows(response.checkResponseJson));
 
     setPreviewCheckJson(response.checkResponseJson);
     setPreviewbpmnXml(response.originalModelXml);
@@ -456,6 +479,9 @@ function App() {
   function previewForm(response) {
     const { schema, error } = parseFormSchema(response?.originalModelXml);
     openFormPreview(schema, error);
+    setPreviewCheckJson(response?.checkResponseJson || []);
+    setPreviewTableHeader(FINDINGS_TABLE_HEADER);
+    setPreviewTableRows(buildFindingsRows(response?.checkResponseJson));
   }
 
   async function download(response) {
@@ -690,7 +716,7 @@ function App() {
         {step === 2 && (
           <>
             <section>
-              <h3>Your Models</h3>
+              <h3>Your Files</h3>
               <p>
                 Download models converted to Camunda 8 individually or as one Zip
                 file. Use the eye icon to preview analysis findings on BPMN models
@@ -701,7 +727,7 @@ function App() {
                   <Alert
                     variant="warning"
                     title={`${totalFindings} finding${totalFindings !== 1 ? 's' : ''} detected for Camunda ${platformVersion}`}
-                    description="Some elements may not be fully supported in this version. Use the preview per model or download the XLSX report for a complete overview."
+                    description="Some elements may not be fully supported in this version. Use the preview per file or download the XLSX report for a complete overview."
                     className="incompatibility-notification"
                   >
                     <Button variant="secondary" size="sm" onClick={downloadXLS}>
@@ -872,50 +898,16 @@ function App() {
                 : 'Diagram preview is only available for BPMN models. The findings for this file are listed below.'}
             </p>
           )}
-          {previewTableRows.length === 0 && (
-            <p style={{ color: 'var(--neutral-foreground-subtle)', marginTop: '1rem' }}>No findings for this file.</p>
-          )}
-          {previewTableRows.length > 0 && <>
-            <h3>Findings</h3>
-            <p style={{ color: 'var(--neutral-foreground-subtle)', marginBottom: '0.75rem' }}>
-              Elements in this model that need attention during migration. Each row describes one finding — its location, severity, and a message explaining what to address.
-            </p>
-            <Table className="analysis-table">
-              <TableHeader>
-                <TableRow>
-                  {previewTableHeader.map((header) => (
-                    <TableHead key={header.key}>
-                      {header.header}
-                    </TableHead>
-                  ))}
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                {previewTableRows.map((row) => (
-                  <TableRow key={row.id}>
-                    {previewTableHeader.map((header) => {
-                      const value = row[header.key];
-                      return (
-                        <TableCell key={`${row.id}-${header.key}`}>
-                          {header.key === 'link'
-                            ? value
-                              ? <a href={value} target="_blank" rel="noopener noreferrer">Link</a>
-                              : '-'
-                            : value}
-                        </TableCell>
-                      );
-                    })}
-                  </TableRow>
-                ))}
-              </TableBody>
-            </Table>
-          </>}
+          <FindingsSection header={previewTableHeader} rows={previewTableRows} />
         </>
       )}
       {previewType === "form" && (
-        previewFormError
-          ? <Alert variant="destructive" title="Form preview unavailable" description={previewFormError} />
-          : <FormPreview schema={previewFormSchema} onError={setPreviewFormError} />
+        <>
+          {previewFormError
+            ? <Alert variant="destructive" title="Form preview unavailable" description={previewFormError} />
+            : <FormPreview schema={previewFormSchema} onError={setPreviewFormError} />}
+          <FindingsSection header={previewTableHeader} rows={previewTableRows} />
+        </>
       )}
 
     </div>

--- a/diagram-converter/webapp/src/main/javascript/src/App.jsx
+++ b/diagram-converter/webapp/src/main/javascript/src/App.jsx
@@ -149,12 +149,7 @@ function App() {
 
   const allDone = fileResults.length > 0 && fileResults.every(r => r.status !== 'uploading');
   const totalFindings = allDone
-    ? fileResults.reduce((sum, r) => {
-        if (!r.checkResponseJson) return sum;
-        return sum + r.checkResponseJson
-          .flatMap(item => item.results || [])
-          .reduce((s, el) => s + (el.messages?.length || 0), 0);
-      }, 0)
+    ? fileResults.reduce((sum, r) => sum + buildFindingsRows(r.checkResponseJson).length, 0)
     : 0;
 
   const [configOptions, setConfigOptions] = useState({
@@ -204,9 +199,9 @@ function App() {
         canvas.zoom('fit-viewport');
 
         const elementsWithMessages =
-          previewCheckJson
-            .flatMap((item) => item.results || [])
-            .filter((el) => el.messages?.length > 0);
+          (Array.isArray(previewCheckJson) ? previewCheckJson : [])
+            .flatMap((item) => (Array.isArray(item?.results) ? item.results : []))
+            .filter((el) => Array.isArray(el?.messages) && el.messages.length > 0);
 
         elementsWithMessages.forEach((el) => {
           if (el.elementId) {

--- a/diagram-converter/webapp/src/main/javascript/src/App.jsx
+++ b/diagram-converter/webapp/src/main/javascript/src/App.jsx
@@ -51,6 +51,7 @@ function App() {
   const [validFiles, setValidFiles] = useState([]);
   const [isPreviewOpen, setIsPreviewOpen] = useState(false);
   const [previewbpmnXml, setPreviewbpmnXml] = useState("");
+  const [previewIsBpmn, setPreviewIsBpmn] = useState(false);
   const [previewCheckJson, setPreviewCheckJson] = useState([]);
 
   const [previewTableHeader, setPreviewTableHeader] = useState([]);
@@ -130,30 +131,35 @@ function App() {
   }, []);
 
   useEffect(() => {
-      if (isPreviewOpen && previewbpmnXml) {
-          const viewer = new BpmnJS({ container: '#bpmnDiagram' });
-          viewer.importXML(previewbpmnXml).then(() => {
-            const canvas = viewer.get('canvas');
-            canvas.zoom('fit-viewport');
+      if (!isPreviewOpen || !previewIsBpmn || !previewbpmnXml) return;
 
-            const elementsWithMessages =
-              previewCheckJson?.[0]?.results?.filter((el) => el.messages?.length > 0) || [];
+      const viewer = new BpmnJS({ container: '#bpmnDiagram' });
+      viewer.importXML(previewbpmnXml).then(() => {
+        const canvas = viewer.get('canvas');
+        canvas.zoom('fit-viewport');
 
-            elementsWithMessages.forEach((el) => {
-              if (el.elementId) {
-                  const severity = getMostSevere(el.messages);
-                  if (severity) {
-                    // Mark wit the same color everytime for the moment
-                    //canvas.addMarker(el.elementId, `highlight-${severity.toLowerCase()}`);
-                    canvas.addMarker(el.elementId, `highlight-info`);
-                  }
+        const elementsWithMessages =
+          previewCheckJson
+            .flatMap((item) => item.results || [])
+            .filter((el) => el.messages?.length > 0);
+
+        elementsWithMessages.forEach((el) => {
+          if (el.elementId) {
+              const severity = getMostSevere(el.messages);
+              if (severity) {
+                // Mark wit the same color everytime for the moment
+                //canvas.addMarker(el.elementId, `highlight-${severity.toLowerCase()}`);
+                canvas.addMarker(el.elementId, `highlight-info`);
               }
-            });
+          }
+        });
 
-          });
+      }).catch((err) => {
+        console.error('Failed to render BPMN preview', err);
+      });
 
-      }
-    }, [isPreviewOpen, previewbpmnXml, previewCheckJson]);
+      return () => viewer.destroy();
+    }, [isPreviewOpen, previewIsBpmn, previewbpmnXml, previewCheckJson]);
 
   useEffect(() => {
     if (!allDone || totalFindings === 0) return;
@@ -374,7 +380,7 @@ function App() {
     );
   }
 
-  async function preview(response) {
+  async function preview(response, file) {
     if (!response?.checkResponseJson) return;
 
     setPreviewTableHeader([
@@ -387,21 +393,25 @@ function App() {
     ]);
 
     setPreviewTableRows(
-      response.checkResponseJson?.[0]?.results.flatMap((element, elementIdx) =>
-        element.messages.map((message, msgIdx) => ({
-          id: `${elementIdx}-${msgIdx}`,
-          elementType: element.elementType,
-          elementId: element.elementId,
-          elementName: element.elementName || '(unnamed)',
-          severity: message.severity,
-          message: message.message,
-          link: message.link || null,
-        }))
-      ) || []);
+      response.checkResponseJson.flatMap((item, itemIdx) =>
+        (item.results || []).flatMap((element, elementIdx) =>
+          (element.messages || []).map((message, msgIdx) => ({
+            id: `${itemIdx}-${elementIdx}-${msgIdx}`,
+            elementType: element.elementType || '-',
+            elementId: element.elementId || '-',
+            elementName: element.elementName || '(unnamed)',
+            severity: message.severity,
+            message: message.message,
+            link: message.link || null,
+          }))
+        )
+      )
+    );
 
 
     setPreviewCheckJson(response.checkResponseJson);
     setPreviewbpmnXml(response.originalModelXml);
+    setPreviewIsBpmn(!!file?.name?.endsWith(".bpmn"));
 
     setIsPreviewOpen(true);
   }
@@ -641,7 +651,7 @@ function App() {
               <h3>Your Models</h3>
               <p>
                 Download models converted to Camunda 8 individually or as one Zip
-                file. You can also preview the analysis result on the BPMN model.
+                file. Use the eye icon to preview the analysis findings per model.
               </p>
               {allDone && totalFindings > 0 && (
                 <div ref={incompatibilityNotifRef}>
@@ -671,7 +681,7 @@ function App() {
                   status={r.status}
                   isChecked={r.checkResponseJson != null}
                   isConverted={r.convertedFileBlob != null}
-                  previewAction={file.name.endsWith(".form") ? undefined : () => preview(r)}
+                  previewAction={() => preview(r, file)}
                   downloadAction={() => download(r)}
                   findingCount={fileFindingCount}
                   error={
@@ -706,7 +716,7 @@ function App() {
 
             <section>
               <h3>Analysis results</h3>
-              <p>Download the  for all successfully converted models:</p>
+              <p>Download the analysis results for all successfully converted models:</p>
               <div className="download-options">
                 <div className="download-row">
                   <Button
@@ -805,9 +815,14 @@ function App() {
         </div>
       </div>
 
-      <div id="bpmnDiagram" className="diagram-container"></div>
+      {previewIsBpmn && <div id="bpmnDiagram" className="diagram-container"></div>}
+      {!previewIsBpmn && (
+        <p style={{ color: 'var(--neutral-foreground-subtle)', marginTop: '1rem' }}>
+          Diagram preview is only available for BPMN models. The findings for this file are listed below.
+        </p>
+      )}
       {previewTableRows.length === 0 && (
-        <p style={{ color: 'var(--neutral-foreground-subtle)', marginTop: '1rem' }}>No findings for this model.</p>
+        <p style={{ color: 'var(--neutral-foreground-subtle)', marginTop: '1rem' }}>No findings for this file.</p>
       )}
       {previewTableRows.length > 0 && <>
       <h3>Findings</h3>

--- a/diagram-converter/webapp/src/main/javascript/src/App.jsx
+++ b/diagram-converter/webapp/src/main/javascript/src/App.jsx
@@ -718,9 +718,9 @@ function App() {
             <section>
               <h3>Your Files</h3>
               <p>
-                Download models converted to Camunda 8 individually or as one Zip
-                file. Use the eye icon to preview analysis findings on BPMN models
-                or view the uploaded forms.
+                Download files converted to Camunda 8 individually or as one Zip
+                file. Use the eye icon to preview the analysis findings per file —
+                BPMN files also render the diagram, forms a form preview.
               </p>
               {allDone && totalFindings > 0 && (
                 <div ref={incompatibilityNotifRef}>
@@ -780,14 +780,14 @@ function App() {
                 disabled={validFiles.length === 0}
               >
                 <Download />
-                Download converted models as ZIP
+                Download converted files as ZIP
               </Button>
             </section>
             <hr />
 
             <section>
               <h3>Analysis results</h3>
-              <p>Download the analysis results for all successfully converted models:</p>
+              <p>Download the analysis results for all successfully converted files:</p>
               <div className="download-options">
                 <div className="download-row">
                   <Button

--- a/diagram-converter/webapp/src/main/javascript/src/App.jsx
+++ b/diagram-converter/webapp/src/main/javascript/src/App.jsx
@@ -147,7 +147,7 @@ function App() {
           if (el.elementId) {
               const severity = getMostSevere(el.messages);
               if (severity) {
-                // Mark wit the same color everytime for the moment
+                // Mark with the same color every time for the moment
                 //canvas.addMarker(el.elementId, `highlight-${severity.toLowerCase()}`);
                 canvas.addMarker(el.elementId, `highlight-info`);
               }

--- a/diagram-converter/webapp/src/main/javascript/src/App.jsx
+++ b/diagram-converter/webapp/src/main/javascript/src/App.jsx
@@ -744,7 +744,7 @@ function App() {
               )}
               {files.map((file, idx) => {
                 const r = fileResults[idx];
-                const modelType = getPreviewType(file.name);
+                const modelType = getPreviewType(file.name, r.originalModelXml);
                 const isForm = modelType === "form";
                 const fileFindingCount = r.checkResponseJson
                   ? r.checkResponseJson

--- a/diagram-converter/webapp/src/main/javascript/src/App.jsx
+++ b/diagram-converter/webapp/src/main/javascript/src/App.jsx
@@ -746,11 +746,7 @@ function App() {
                 const r = fileResults[idx];
                 const modelType = getPreviewType(file.name, r.originalModelXml);
                 const isForm = modelType === "form";
-                const fileFindingCount = r.checkResponseJson
-                  ? r.checkResponseJson
-                      .flatMap(item => item.results || [])
-                      .reduce((s, el) => s + (el.messages?.length || 0), 0)
-                  : 0;
+                const fileFindingCount = buildFindingsRows(r.checkResponseJson).length;
                 return (
                 <FileItem
                   key={file.name + "-" + idx}

--- a/diagram-converter/webapp/src/main/javascript/src/findings.js
+++ b/diagram-converter/webapp/src/main/javascript/src/findings.js
@@ -1,0 +1,34 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+export const FINDINGS_TABLE_HEADER = [
+  { key: 'elementType', header: 'Element Type' },
+  { key: 'elementId', header: 'Element ID' },
+  { key: 'elementName', header: 'Element Name' },
+  { key: 'severity', header: 'Severity' },
+  { key: 'message', header: 'Message' },
+  { key: 'link', header: 'Link' },
+];
+
+// Flattens the /check response (List<DiagramCheckResult>) into table rows,
+// one row per finding message across all result items.
+export function buildFindingsRows(checkResponseJson) {
+  return (checkResponseJson || []).flatMap((item, itemIdx) =>
+    (item.results || []).flatMap((element, elementIdx) =>
+      (element.messages || []).map((message, msgIdx) => ({
+        id: `${itemIdx}-${elementIdx}-${msgIdx}`,
+        elementType: element.elementType || '-',
+        elementId: element.elementId || '-',
+        elementName: element.elementName || '(unnamed)',
+        severity: message.severity,
+        message: message.message,
+        link: message.link || null,
+      }))
+    )
+  );
+}

--- a/diagram-converter/webapp/src/main/javascript/src/findings.js
+++ b/diagram-converter/webapp/src/main/javascript/src/findings.js
@@ -18,17 +18,35 @@ export const FINDINGS_TABLE_HEADER = [
 // Flattens the /check response (List<DiagramCheckResult>) into table rows,
 // one row per finding message across all result items.
 export function buildFindingsRows(checkResponseJson) {
-  return (checkResponseJson || []).flatMap((item, itemIdx) =>
-    (item.results || []).flatMap((element, elementIdx) =>
-      (element.messages || []).map((message, msgIdx) => ({
-        id: `${itemIdx}-${elementIdx}-${msgIdx}`,
-        elementType: element.elementType || '-',
-        elementId: element.elementId || '-',
-        elementName: element.elementName || '(unnamed)',
-        severity: message.severity,
-        message: message.message,
-        link: message.link || null,
-      }))
-    )
-  );
+  if (!Array.isArray(checkResponseJson)) {
+    return [];
+  }
+
+  return checkResponseJson.flatMap((item, itemIdx) => {
+    if (!item || typeof item !== 'object' || !Array.isArray(item.results)) {
+      return [];
+    }
+
+    return item.results.flatMap((element, elementIdx) => {
+      if (!element || typeof element !== 'object' || !Array.isArray(element.messages)) {
+        return [];
+      }
+
+      return element.messages.flatMap((message, msgIdx) => {
+        if (!message || typeof message !== 'object') {
+          return [];
+        }
+
+        return [{
+          id: `${itemIdx}-${elementIdx}-${msgIdx}`,
+          elementType: element.elementType || '-',
+          elementId: element.elementId || '-',
+          elementName: element.elementName || '(unnamed)',
+          severity: message.severity,
+          message: message.message,
+          link: message.link || null,
+        }];
+      });
+    });
+  });
 }

--- a/diagram-converter/webapp/src/main/javascript/src/findings.test.js
+++ b/diagram-converter/webapp/src/main/javascript/src/findings.test.js
@@ -18,6 +18,14 @@ describe('buildFindingsRows', () => {
     expect(buildFindingsRows([{}])).toEqual([]);
   });
 
+  it('returns no rows for malformed non-array result data', () => {
+    expect(buildFindingsRows({ results: [] })).toEqual([]);
+    expect(buildFindingsRows('not an array')).toEqual([]);
+    expect(buildFindingsRows([{ results: {} }])).toEqual([]);
+    expect(buildFindingsRows([{ results: [{ messages: {} }] }])).toEqual([]);
+    expect(buildFindingsRows([{ results: [null, { messages: [null] }] }])).toEqual([]);
+  });
+
   it('flattens findings across multiple result items and elements', () => {
     const rows = buildFindingsRows([
       {

--- a/diagram-converter/webapp/src/main/javascript/src/findings.test.js
+++ b/diagram-converter/webapp/src/main/javascript/src/findings.test.js
@@ -1,0 +1,102 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { buildFindingsRows, FINDINGS_TABLE_HEADER } from './findings';
+
+describe('buildFindingsRows', () => {
+  it('returns no rows for empty or missing input', () => {
+    expect(buildFindingsRows(null)).toEqual([]);
+    expect(buildFindingsRows(undefined)).toEqual([]);
+    expect(buildFindingsRows([])).toEqual([]);
+    expect(buildFindingsRows([{ results: [] }])).toEqual([]);
+    expect(buildFindingsRows([{}])).toEqual([]);
+  });
+
+  it('flattens findings across multiple result items and elements', () => {
+    const rows = buildFindingsRows([
+      {
+        results: [
+          {
+            elementId: 'task1',
+            elementName: 'Task One',
+            elementType: 'bpmn:ServiceTask',
+            messages: [
+              { severity: 'WARNING', message: 'first', link: 'https://example.com/1' },
+              { severity: 'INFO', message: 'second', link: null },
+            ],
+          },
+        ],
+      },
+      {
+        results: [
+          {
+            elementId: 'task2',
+            elementName: null,
+            elementType: 'bpmn:UserTask',
+            messages: [{ severity: 'TASK', message: 'third', link: 'https://example.com/2' }],
+          },
+        ],
+      },
+    ]);
+
+    expect(rows).toHaveLength(3);
+    expect(rows.map((r) => r.message)).toEqual(['first', 'second', 'third']);
+    expect(rows[0]).toMatchObject({
+      id: '0-0-0',
+      elementId: 'task1',
+      elementName: 'Task One',
+      elementType: 'bpmn:ServiceTask',
+      severity: 'WARNING',
+      link: 'https://example.com/1',
+    });
+    // ids are unique across items, elements and messages
+    expect(new Set(rows.map((r) => r.id)).size).toBe(3);
+  });
+
+  it('renders fallbacks for findings without element id, name or type', () => {
+    const rows = buildFindingsRows([
+      {
+        results: [
+          {
+            elementId: null,
+            elementName: null,
+            elementType: null,
+            messages: [{ severity: 'REVIEW', message: 'form finding' }],
+          },
+        ],
+      },
+    ]);
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      elementId: '-',
+      elementType: '-',
+      elementName: '(unnamed)',
+      link: null,
+    });
+  });
+
+  it('tolerates elements without a messages array', () => {
+    const rows = buildFindingsRows([{ results: [{ elementId: 'x' }] }]);
+    expect(rows).toEqual([]);
+  });
+});
+
+describe('FINDINGS_TABLE_HEADER', () => {
+  it('covers severity, element identity, message and link', () => {
+    expect(FINDINGS_TABLE_HEADER.map((h) => h.key)).toEqual([
+      'elementType',
+      'elementId',
+      'elementName',
+      'severity',
+      'message',
+      'link',
+    ]);
+  });
+});

--- a/diagram-converter/webapp/src/main/javascript/src/modelType.js
+++ b/diagram-converter/webapp/src/main/javascript/src/modelType.js
@@ -6,8 +6,11 @@
  * except in compliance with the Camunda License 1.0.
  */
 const DMN_FILE_ENDINGS = [".dmn", ".dmn11.xml"];
+const BPMN_FILE_ENDINGS = [".bpmn", ".bpmn20.xml"];
+const DMN_NAMESPACE = "omg.org/spec/DMN";
+const BPMN_NAMESPACE = "omg.org/spec/BPMN";
 
-export function getPreviewType(fileName) {
+export function getPreviewType(fileName, modelXml) {
   const normalizedFileName = typeof fileName === "string" ? fileName.toLowerCase() : "";
 
   if (normalizedFileName.endsWith(".form")) {
@@ -18,5 +21,16 @@ export function getPreviewType(fileName) {
     return "dmn";
   }
 
-  return "bpmn";
+  if (
+    BPMN_FILE_ENDINGS.some((ending) => normalizedFileName.endsWith(ending)) ||
+    (typeof modelXml === "string" && modelXml.includes(BPMN_NAMESPACE))
+  ) {
+    return "bpmn";
+  }
+
+  if (typeof modelXml === "string" && modelXml.includes(DMN_NAMESPACE)) {
+    return "dmn";
+  }
+
+  return "other";
 }

--- a/diagram-converter/webapp/src/main/javascript/src/modelType.test.js
+++ b/diagram-converter/webapp/src/main/javascript/src/modelType.test.js
@@ -17,12 +17,28 @@ describe("getPreviewType", () => {
     ["process.bpmn20.xml", "bpmn"],
     ["customer.form", "form"],
     ["CUSTOMER.FORM", "form"],
-    ["unknown.xml", "bpmn"],
+    ["unknown.xml", "other"],
+    ["unknown.txt", "other"],
   ])("identifies %s as %s", (fileName, expectedType) => {
     expect(getPreviewType(fileName)).toBe(expectedType);
   });
 
-  it("defaults invalid file names to BPMN for compatibility with the existing preview", () => {
-    expect(getPreviewType(undefined)).toBe("bpmn");
+  it("detects BPMN and DMN content in generic XML files", () => {
+    expect(
+      getPreviewType(
+        "process.xml",
+        '<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" />'
+      )
+    ).toBe("bpmn");
+    expect(
+      getPreviewType(
+        "decision.xml",
+        '<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" />'
+      )
+    ).toBe("dmn");
+  });
+
+  it("returns other for invalid file names without recognizable model content", () => {
+    expect(getPreviewType(undefined)).toBe("other");
   });
 });


### PR DESCRIPTION
## Summary

Surfaces analysis findings in the diagram-converter webapp for **all** uploaded file types (BPMN, DMN, `.form`, `.xml`).

Merged with latest `main` (which brought #2349 form findings backend and #2350 form previews + vitest setup). This PR builds on both:

1. **Findings table for every file type** — the eye-icon preview shows the findings table for BPMN (with diagram), DMN/`.xml` non-BPMN (table only, with note), and `.form` (below the form preview).
2. **Content-based BPMN detection** — the dropzone accepts `.xml`, which can be BPMN; the BPMN namespace is sniffed from the uploaded content instead of relying on the extension.
3. **Robustness** — `importXML` failures fall back to a note + findings table (no broken viewer); the viewer effect is gated on the error state and cleans up the failed viewer; findings are flattened across all `DiagramCheckResult` items (main only reads `[0]`); missing element id/type render as `-`.
4. **File-neutral copy** — "Your Files", "per file", "converted files" now that forms are supported.

## Changes

- `src/App.jsx` — preview routing, BPMN detection, error fallback, copy; findings table extracted into a `FindingsSection` component
- `src/findings.js` — shared `buildFindingsRows` (flattens `/check` response into table rows) + `FINDINGS_TABLE_HEADER`
- `src/findings.test.js` — vitest coverage for row building (flattening across items, `-`/`(unnamed)` fallbacks, empty/malformed input)

## Test plan

- [x] `npm run build` (eslint `--max-warnings 0`, `tsc --noEmit`, vitest, vite build) — green, 17 tests
- [x] CI green on head (incl. `CI Summary Gate`, `diagram-converter`, `diagram-converter-windows`, `compile-previous-version`)
- [x] Baseline `mvn clean install -DskipTests` green at `32bfdcbe`
- [ ] Manual: `.bpmn` with findings → eye icon → diagram with highlighted elements + findings table
- [ ] Manual: `.dmn` → eye icon → findings table (no diagram, with note)
- [ ] Manual: `.form` → eye icon → form preview + findings table below
- [ ] Manual: file with zero findings → "No findings for this file."

## Baseline

Green baseline verified at `32bfdcbe` (`mvn clean install -DskipTests`); branch merged with main at `4d1da11e`.