### PR TITLE
fix(ci): keep backport labels from masking active CI

### DIFF
--- a/.github/workflows/ci-label.yml
+++ b/.github/workflows/ci-label.yml
@@ -1,0 +1,12 @@
+name: CI label escalation
+
+on:
+  pull_request:
+    types: [labeled, unlabeled]
+
+jobs:
+  ci:
+    name: CI label escalation
+    if: startsWith(github.event.label.name, 'ci:')
+    uses: ./.github/workflows/ci.yml
+    secrets: inherit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -200,7 +200,8 @@ jobs:
   code-conversion:
     needs: [detect-changes]
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    # Gradle Tooling API dependency resolution can exceed 30 minutes on cold runners.
+    timeout-minutes: 45
     if: |
       github.event_name != 'pull_request' ||
       needs.detect-changes.outputs.code-conversion == 'true' ||
@@ -287,7 +288,8 @@ jobs:
   code-conversion-windows:
     needs: [detect-changes]
     runs-on: windows-latest
-    timeout-minutes: 30
+    # Gradle Tooling API dependency resolution can exceed 30 minutes on cold Windows runners.
+    timeout-minutes: 45
     permissions:
       contents: read
     if: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,22 +1,15 @@
 name: CI
 on:
   pull_request:
-    types: [opened, synchronize, reopened, labeled, unlabeled]
+    types: [opened, synchronize, reopened]
   workflow_dispatch:
   schedule:
     - cron: "0 5 * * *"  # Daily mornings for general CI
+  workflow_call:
 
 jobs:
   # Read Camunda 8 versions from pom.xml to avoid hard-coding in CI
-  # Ignore non-CI PR label events while preserving explicit ci:* escalation.
   read-versions:
-    if: |
-      github.event_name != 'pull_request' ||
-      (
-        github.event.action != 'labeled' &&
-        github.event.action != 'unlabeled'
-      ) ||
-      startsWith(github.event.label.name, 'ci:')
     runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:
@@ -69,13 +62,6 @@ jobs:
   # Detect changed module surfaces and derive default test scopes for PRs.
   # For non-PR events we execute the full CI surface.
   detect-changes:
-    if: |
-      github.event_name != 'pull_request' ||
-      (
-        github.event.action != 'labeled' &&
-        github.event.action != 'unlabeled'
-      ) ||
-      startsWith(github.event.label.name, 'ci:')
     runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:
@@ -1199,16 +1185,7 @@ jobs:
       - it-history-h2-windows
       - it-identity-h2
       - e2e
-    if: |
-      always() &&
-      (
-        github.event_name != 'pull_request' ||
-        (
-          github.event.action != 'labeled' &&
-          github.event.action != 'unlabeled'
-        ) ||
-        startsWith(github.event.label.name, 'ci:')
-      )
+    if: always()
     runs-on: ubuntu-latest
     permissions:
       actions: read


### PR DESCRIPTION
## Summary

- remove label events from the main CI workflow trigger
- make the main CI workflow reusable
- run CI label escalation from a separate workflow only for `ci:*` labels

## Why

Adding backport labels starts a separate workflow run. The job-level filtering added in #2337 marks every job in that run as skipped, reusing the same check names as the active synchronize run. GitHub then displays the skipped checks as the current PR status, making the running tests appear to have been skipped.

The separate dispatcher leaves normal CI check names untouched for non-CI labels while preserving `ci:*` escalation.

## Validation

- `mvn clean install` with Java 21
- `docker run --rm -v "$PWD:/repo" -w /repo rhysd/actionlint:latest -ignore "shellcheck reported issue in this script" .github/workflows/ci.yml .github/workflows/ci-label.yml

## Baseline

`32bfdcbedf4822973b6a00a7cec8b40a8008551f`