### PR TITLE
[Backport maintenance/0.2] fix(core): compile with newer JDKs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -239,7 +239,8 @@ jobs:
   code-conversion:
     needs: [detect-changes]
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    # Gradle Tooling API dependency resolution can exceed 30 minutes on cold runners.
+    timeout-minutes: 45
     if: |
       github.event_name != 'pull_request' ||
       needs.detect-changes.outputs.code-conversion == 'true' ||
@@ -326,7 +327,8 @@ jobs:
   code-conversion-windows:
     needs: [detect-changes]
     runs-on: windows-latest
-    timeout-minutes: 30
+    # Gradle Tooling API dependency resolution can exceed 30 minutes on cold Windows runners.
+    timeout-minutes: 45
     permissions:
       contents: read
     if: |

--- a/code-conversion/patterns/code-examples/camunda-7/pom.xml
+++ b/code-conversion/patterns/code-examples/camunda-7/pom.xml
@@ -10,8 +10,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.source>17</maven.compiler.source>
-    <maven.compiler.target>17</maven.compiler.target>
+    <maven.compiler.release>17</maven.compiler.release>
   </properties>
 
   <dependencyManagement>

--- a/data-migrator/examples/variable-interceptor/pom.xml
+++ b/data-migrator/examples/variable-interceptor/pom.xml
@@ -16,8 +16,7 @@
     <description>Example variable interceptor for Camunda 7 to 8 Data Migrator</description>
 
     <properties>
-        <maven.compiler.source>21</maven.compiler.source>
-        <maven.compiler.target>21</maven.compiler.target>
+        <maven.compiler.release>${version.java}</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -25,9 +25,8 @@
   </licenses>
 
   <properties>
-    <maven.compiler.source>21</maven.compiler.source>
-    <maven.compiler.target>21</maven.compiler.target>
     <version.java>21</version.java>
+    <maven.compiler.release>${version.java}</maven.compiler.release>
 
     <version.camunda-7>7.24.5-ee</version.camunda-7>
     <version.camunda-8>8.8.36</version.camunda-8>


### PR DESCRIPTION
Backport of #2338 to `maintenance/0.2`.

The target branch does not contain the process-solution and entity-interceptor example modules, so their deletions were preserved while applying the remaining compiler and CI timeout changes.