### PR TITLE
[Backport maintenance/0.3] fix(ci): prevent label checks from masking CI

### DIFF
--- a/.github/workflows/ci-label.yml
+++ b/.github/workflows/ci-label.yml
@@ -1,0 +1,12 @@
+name: CI label escalation
+
+on:
+  pull_request:
+    types: [labeled, unlabeled]
+
+jobs:
+  ci:
+    name: CI label escalation
+    if: startsWith(github.event.label.name, 'ci:')
+    uses: ./.github/workflows/ci.yml
+    secrets: inherit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,22 +5,15 @@ on:
       - main
       - maintenance/*
       - release/*
-    types: [opened, synchronize, reopened, labeled, unlabeled]
+    types: [opened, synchronize, reopened]
   workflow_dispatch:
   schedule:
     - cron: "0 5 * * *"  # Daily mornings for general CI
+  workflow_call:
 
 jobs:
   # Read Camunda 8 versions from pom.xml to avoid hard-coding in CI
-  # Ignore non-CI PR label events while preserving explicit ci:* escalation.
   read-versions:
-    if: |
-      github.event_name != 'pull_request' ||
-      (
-        github.event.action != 'labeled' &&
-        github.event.action != 'unlabeled'
-      ) ||
-      startsWith(github.event.label.name, 'ci:')
     runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:
@@ -88,13 +81,6 @@ jobs:
   # Detect changed module surfaces and derive default test scopes for PRs.
   # For non-PR events we execute the full CI surface.
   detect-changes:
-    if: |
-      github.event_name != 'pull_request' ||
-      (
-        github.event.action != 'labeled' &&
-        github.event.action != 'unlabeled'
-      ) ||
-      startsWith(github.event.label.name, 'ci:')
     runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:
@@ -1218,16 +1204,7 @@ jobs:
       - it-history-h2-windows
       - it-identity-h2
       - e2e
-    if: |
-      always() &&
-      (
-        github.event_name != 'pull_request' ||
-        (
-          github.event.action != 'labeled' &&
-          github.event.action != 'unlabeled'
-        ) ||
-        startsWith(github.event.label.name, 'ci:')
-      )
+    if: always()
     runs-on: ubuntu-latest
     permissions:
       actions: read


### PR DESCRIPTION
## Summary

Manual backport of #2355 to `maintenance/0.3`.

The source commit conflicted with the maintenance workflow trigger because that branch has an additional branch filter. The conflict was resolved by retaining the maintenance branch filters while removing `labeled`/`unlabeled` from the main CI workflow and adding the reusable label escalation workflow.

## Source

- Original PR: #2355
- Cherry-picked commit: `704cad09d7c570379c7b8bdc8b7d74e99705be94`
- Conflict resolution: retain `main`, `maintenance/*`, and `release/*` branch filters