### PR TITLE
feat(diagram-converter): simplify webapp UI copy

### DIFF
--- a/diagram-converter/webapp/src/main/javascript/src/App.jsx
+++ b/diagram-converter/webapp/src/main/javascript/src/App.jsx
@@ -472,7 +472,7 @@ function App() {
       <div className="whiteBox hero">
         <h2>Camunda Migration Analyzer &amp; Diagram Converter</h2>
         <p>
-          Convert your BPMN and DMN models to Camunda 8 and see what needs attention.
+          Convert BPMN, DMN, and Camunda Form files to Camunda 8 and see what needs attention.
         </p>
         <div className="heroMeta">
           <a href="https://docs.camunda.io/docs/guides/migrating-from-camunda-7/migration-tooling/diagram-converter/"

--- a/diagram-converter/webapp/src/main/javascript/src/App.jsx
+++ b/diagram-converter/webapp/src/main/javascript/src/App.jsx
@@ -676,8 +676,8 @@ function App() {
             <section>
               <h3>Converted models</h3>
               <p>
-                Download each converted model or all of them as a ZIP. Preview
-                the analysis findings per model before downloading.
+                Download each converted file or all of them as a ZIP. Preview a
+                file to inspect it first.
               </p>
               {allDone && totalFindings > 0 && (
                 <div ref={incompatibilityNotifRef}>

--- a/diagram-converter/webapp/src/main/javascript/src/App.jsx
+++ b/diagram-converter/webapp/src/main/javascript/src/App.jsx
@@ -313,10 +313,10 @@ function App() {
     switch (errorBody.errorCode) {
       case "FILE_COUNT_LIMIT_EXCEEDED":
         return <>
-          Too many files uploaded. The online version supports up to {errorBody.maxPartCount} parts per request.
-          {" "}To learn how to run the diagram converter locally with a custom limit, consult the{" "}
+          Too many files. The online version accepts up to {errorBody.maxPartCount} files at once.
+          {" "}To convert more files,{" "}
           <a href="https://docs.camunda.io/docs/guides/migrating-from-camunda-7/migration-tooling/diagram-converter/#local-web-application"
-            target="_blank" rel="noopener noreferrer">diagram converter guide</a>.
+            target="_blank" rel="noopener noreferrer">run the diagram converter locally</a>.
         </>;
       default:
         return "Download failed. Please try again.";
@@ -351,7 +351,7 @@ function App() {
             "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
         },
       }),
-      "Downloading XLSX failed"
+      "XLSX download failed"
     );
   }
   async function downloadCSV() {
@@ -364,7 +364,7 @@ function App() {
           Accept: "text/csv",
         },
       }),
-      "Downloading CSV failed"
+      "CSV download failed"
     );
   }
   async function downloadJSON() {
@@ -377,7 +377,7 @@ function App() {
           Accept: "application/vnd.camunda.analysis+json",
         },
       }),
-      "Downloading JSON failed"
+      "JSON download failed"
     );
   }
   async function downloadZIP() {
@@ -387,7 +387,7 @@ function App() {
         body: formData,
         method: "POST",
       }),
-      "Downloading ZIP failed"
+      "ZIP download failed"
     );
   }
 
@@ -470,14 +470,14 @@ function App() {
   return (
     <div className="container">
       <div className="whiteBox hero">
-        <h2>Camunda Migration Analyzer &amp; Diagram Converter</h2>
+        <h2>Migration Analyzer &amp; Diagram Converter</h2>
         <p>
-          Convert your BPMN and DMN models to Camunda 8 — then identify gaps and assess migration effort.
+          Convert your BPMN and DMN models to Camunda 8 and see what needs attention.
         </p>
         <div className="heroMeta">
           <a href="https://docs.camunda.io/docs/guides/migrating-from-camunda-7/migration-tooling/diagram-converter/"
             rel="noopener noreferrer" target="_blank">
-            Diagram Converter Guide
+            Documentation
           </a>
           <a href="https://github.com/camunda/camunda-7-to-8-migration-tooling/releases"
             rel="noopener noreferrer" target="_blank">
@@ -485,13 +485,13 @@ function App() {
           </a>
           <a href="https://legal.camunda.com/licensing-and-other-legal-terms#trial-and-free"
             rel="noopener noreferrer" target="_blank">
-            Legal terms &amp; data privacy
+            Legal &amp; privacy
           </a>
         </div>
       </div>
       <div className="whiteBox centered">
         <div className="progressindicators">
-          <Stepper currentStep={step === 0 ? 0 : 1} aria-label="Migration analysis and conversion steps">
+          <Stepper currentStep={step === 0 ? 0 : 1} aria-label="Conversion steps">
             <StepperStep>Configure</StepperStep>
             <StepperStep>Results</StepperStep>
           </Stepper>
@@ -503,9 +503,9 @@ function App() {
             <section className="flowStep">
               <div className="flowStepHeader">
                 <span className="flowStepNumber">1</span>
-                <h4>Add your files</h4>
+                <h4>Add files</h4>
               </div>
-              <p>Upload one or more BPMN and DMN models to analyze and convert, or Camunda Forms (.form files) to convert.</p>
+              <p>Upload BPMN or DMN models to analyze and convert, or Camunda Forms to convert.</p>
               <div className="fileUploadBox">
                 <DropZone
                   onFiles={(files) => {
@@ -532,7 +532,7 @@ function App() {
                 <span className="flowStepNumber">2</span>
                 <h4>Configure conversion</h4>
               </div>
-              <p>Choose your target Camunda 8 version. Defaults to the latest stable (8.9).</p>
+              <p>Choose the Camunda 8 version to convert to.</p>
               <div
                 ref={versionSegmentedRef}
                 className="versionSegmented"
@@ -577,7 +577,7 @@ function App() {
               {showConfig && (
                   <fieldset className="flex flex-col gap-2 rounded-md border bg-background p-4">
                     <legend className="px-1 text-sm font-medium text-foreground">
-                      Advanced configuration options
+                      Advanced options
                     </legend>
                     <label className="flex items-center gap-2">
                       <Checkbox
@@ -590,11 +590,11 @@ function App() {
                           }))
                         }
                       />
-                      <span>Add Data Migration Execution Listener</span>
+                      <span>Add data migration execution listener</span>
                     </label>
                     <div className="flex flex-col gap-1">
                       <label htmlFor="dataMigrationExecutionListenerJobType" className="text-sm font-medium">
-                        Execution Listener Job Type
+                        Execution listener job type
                       </label>
                       <Input
                         id="dataMigrationExecutionListenerJobType"
@@ -635,11 +635,11 @@ function App() {
                           }))
                         }
                       />
-                      <span>Enable default job type</span>
+                      <span>Always use default job type</span>
                     </label>
                     <div className="flex flex-col gap-1">
                       <label htmlFor="defaultJobType" className="text-sm font-medium">
-                        Default Job Type
+                        Default job type
                       </label>
                       <Input
                         id="defaultJobType"
@@ -674,18 +674,17 @@ function App() {
         {step === 2 && (
           <>
             <section>
-              <h3>Your Models</h3>
+              <h3>Converted models</h3>
               <p>
-                Download models converted to Camunda 8 individually or as one Zip
-                file. You can also preview analysis results on BPMN models or view
-                the uploaded forms.
+                Download each converted model or all of them as a ZIP. Preview
+                the analysis findings per model before downloading.
               </p>
               {allDone && totalFindings > 0 && (
                 <div ref={incompatibilityNotifRef}>
                   <Alert
                     variant="warning"
                     title={`${totalFindings} finding${totalFindings !== 1 ? 's' : ''} detected for Camunda ${platformVersion}`}
-                    description="Some elements may not be fully supported in this version. Use the preview per model or download the XLSX report for a complete overview."
+                    description="Some elements may not be fully supported in this version. Preview a model or download the XLSX report for details."
                     className="incompatibility-notification"
                   >
                     <Button variant="secondary" size="sm" onClick={downloadXLS}>
@@ -710,7 +709,7 @@ function App() {
                   isChecked={r.checkResponseJson != null}
                   isConverted={r.convertedFileBlob != null}
                   previewAction={isForm ? () => previewForm(r) : () => preview(r)}
-                  previewTitle={isForm ? "Preview this form" : undefined}
+                  previewTitle={isForm ? "Preview form" : undefined}
                   downloadAction={() => download(r)}
                   findingCount={fileFindingCount}
                   error={
@@ -738,14 +737,14 @@ function App() {
                 disabled={validFiles.length === 0}
               >
                 <Download />
-                Download converted models as ZIP
+                Download all as ZIP
               </Button>
             </section>
             <hr />
 
             <section>
               <h3>Analysis results</h3>
-              <p>Download the  for all successfully converted models:</p>
+              <p>Download the findings for all converted models:</p>
               <div className="download-options">
                 <div className="download-row">
                   <Button
@@ -759,8 +758,7 @@ function App() {
                     Download XLSX
                   </Button>
                   <p>
-                    Microsoft Excel file (XLSX) containing results and prepared
-                    analysis.
+                    Excel workbook with all findings, ready to review and share.
                   </p>
                 </div>
                 <div className="download-row">
@@ -774,8 +772,7 @@ function App() {
                     Download CSV
                   </Button>
                   <p>
-                    Comma Separated Values (CSV) file containing plain results to
-                    import into your favorite tooling.
+                    Plain-text findings to import into other tools.
                   </p>
                   </div>
                 <div className="download-row">
@@ -789,27 +786,26 @@ function App() {
                     Download JSON
                   </Button>
                   <p>
-                    JSON file containing plain results in a stable, machine-readable
-                    format — for AI / machine analysis, e.g. as input for the AI
-                    migration skill driving the Camunda 7 to 8 migration.
+                    Machine-readable findings, e.g. as input for AI-assisted
+                    migration tooling.
                   </p>
                   </div>
                 </div>
               <p>
-                For more information on the analysis results,{" "}
+                Learn more about the findings in the{" "}
                 <a href="https://docs.camunda.io/docs/guides/migrating-from-camunda-7/migration-tooling/#migration-analyzer" target="_blank">
-                  see the documentation
+                  documentation
                 </a>
                 .
               </p>
             </section>
             <hr />
 
-            <h3>Next steps for your migration</h3>
+            <h3>Next steps</h3>
             <section>
               <p>
-                Discover next steps for your migration from Camunda 7 to Camunda
-                8 in the migration guide.
+                Continue your Camunda 7 to 8 migration with the step-by-step
+                migration guide.
               </p>
               <Button
                 variant="secondary"
@@ -819,7 +815,7 @@ function App() {
                 rel="noopener noreferrer"
               >
                 <ExternalLink />
-                Migration Guide
+                Open migration guide
               </Button>
             </section>
           </>
@@ -830,7 +826,7 @@ function App() {
     <div className="modal">
       <div className="modal-header">
         <div className="left">
-        <h2>{previewType === "form" ? "Form preview" : "Analysis preview"}</h2>
+        <h2>Preview</h2>
         </div>
         <div>
           <Button
@@ -853,7 +849,7 @@ function App() {
           {previewTableRows.length > 0 && <>
             <h3>Findings</h3>
             <p style={{ color: 'var(--neutral-foreground-subtle)', marginBottom: '0.75rem' }}>
-              Elements in this model that need attention during migration. Each row describes one finding — its location, severity, and a message explaining what to address.
+              Elements in this model that need attention during migration.
             </p>
             <Table className="analysis-table">
               <TableHeader>

--- a/diagram-converter/webapp/src/main/javascript/src/App.jsx
+++ b/diagram-converter/webapp/src/main/javascript/src/App.jsx
@@ -561,7 +561,7 @@ function App() {
                 ))}
               </div>
 
-              <form className="configBox" style={{ marginTop: "1.5rem" }}>
+              <form className="configBox" style={{ marginTop: "1.5rem" }} onSubmit={(e) => e.preventDefault()}>
                 <button
                   type="button"
                   className="configToggle"
@@ -774,7 +774,7 @@ function App() {
                   <p>
                     Plain-text findings to import into other tools.
                   </p>
-                  </div>
+                </div>
                 <div className="download-row">
                   <Button
                     variant="secondary"
@@ -789,8 +789,8 @@ function App() {
                     Machine-readable findings, e.g. as input for AI-assisted
                     migration tooling.
                   </p>
-                  </div>
                 </div>
+              </div>
               <p>
                 Learn more about the findings in the{" "}
                 <a href="https://docs.camunda.io/docs/guides/migrating-from-camunda-7/migration-tooling/#migration-analyzer" target="_blank" rel="noopener noreferrer">

--- a/diagram-converter/webapp/src/main/javascript/src/App.jsx
+++ b/diagram-converter/webapp/src/main/javascript/src/App.jsx
@@ -313,8 +313,8 @@ function App() {
     switch (errorBody.errorCode) {
       case "FILE_COUNT_LIMIT_EXCEEDED":
         return <>
-          Too many files. The online version accepts up to {errorBody.maxPartCount} files at once.
-          {" "}To convert more files,{" "}
+          Too many files at once. Remove some files and try again.
+          {" "}To convert larger sets,{" "}
           <a href="https://docs.camunda.io/docs/guides/migrating-from-camunda-7/migration-tooling/diagram-converter/#local-web-application"
             target="_blank" rel="noopener noreferrer">run the diagram converter locally</a>.
         </>;
@@ -470,7 +470,7 @@ function App() {
   return (
     <div className="container">
       <div className="whiteBox hero">
-        <h2>Migration Analyzer &amp; Diagram Converter</h2>
+        <h2>Camunda Migration Analyzer &amp; Diagram Converter</h2>
         <p>
           Convert your BPMN and DMN models to Camunda 8 and see what needs attention.
         </p>
@@ -793,7 +793,7 @@ function App() {
                 </div>
               <p>
                 Learn more about the findings in the{" "}
-                <a href="https://docs.camunda.io/docs/guides/migrating-from-camunda-7/migration-tooling/#migration-analyzer" target="_blank">
+                <a href="https://docs.camunda.io/docs/guides/migrating-from-camunda-7/migration-tooling/#migration-analyzer" target="_blank" rel="noopener noreferrer">
                   documentation
                 </a>
                 .

--- a/diagram-converter/webapp/src/main/javascript/src/DropZone.jsx
+++ b/diagram-converter/webapp/src/main/javascript/src/DropZone.jsx
@@ -33,9 +33,17 @@ export default function DropZone({ onFiles }) {
   return (
     <div
       className="DropZone"
+      role="button"
+      tabIndex={0}
       onDragOver={(evt) => evt.preventDefault()}
       onDrop={processFile}
       onClick={selectFileToUpload}
+      onKeyDown={(evt) => {
+        if (evt.key === "Enter" || evt.key === " ") {
+          evt.preventDefault();
+          selectFileToUpload();
+        }
+      }}
     >
       <img src={InboxIcon} alt="" />
       <h2>Click or drag files here to upload</h2>

--- a/diagram-converter/webapp/src/main/javascript/src/DropZone.jsx
+++ b/diagram-converter/webapp/src/main/javascript/src/DropZone.jsx
@@ -39,8 +39,16 @@ export default function DropZone({ onFiles }) {
       onDrop={processFile}
       onClick={selectFileToUpload}
       onKeyDown={(evt) => {
-        if (evt.key === "Enter" || evt.key === " ") {
+        if (evt.key === "Enter") {
           evt.preventDefault();
+          selectFileToUpload();
+        } else if (evt.key === " ") {
+          // Prevent page scroll; activate on keyup like a native button
+          evt.preventDefault();
+        }
+      }}
+      onKeyUp={(evt) => {
+        if (evt.key === " ") {
           selectFileToUpload();
         }
       }}

--- a/diagram-converter/webapp/src/main/javascript/src/DropZone.jsx
+++ b/diagram-converter/webapp/src/main/javascript/src/DropZone.jsx
@@ -37,7 +37,7 @@ export default function DropZone({ onFiles }) {
       onDrop={processFile}
       onClick={selectFileToUpload}
     >
-      <img src={InboxIcon} />
+      <img src={InboxIcon} alt="" />
       <h2>Click or drag files here to upload</h2>
       <p>Supports .bpmn, .dmn, .form, and .xml files.</p>
     </div>

--- a/diagram-converter/webapp/src/main/javascript/src/DropZone.jsx
+++ b/diagram-converter/webapp/src/main/javascript/src/DropZone.jsx
@@ -38,8 +38,8 @@ export default function DropZone({ onFiles }) {
       onClick={selectFileToUpload}
     >
       <img src={InboxIcon} />
-      <h2>Click or drag file to this area to upload</h2>
-      <p>Upload .xml .bpmn .dmn and .form files. </p>
+      <h2>Click or drag files here to upload</h2>
+      <p>Supports .bpmn, .dmn, .form, and .xml files.</p>
     </div>
   );
 }

--- a/diagram-converter/webapp/src/main/javascript/src/FileItem.jsx
+++ b/diagram-converter/webapp/src/main/javascript/src/FileItem.jsx
@@ -39,7 +39,7 @@ export default function FileItem({
   isConverted,
   downloadAction,
   previewAction,
-  previewTitle = "Preview the analyzer results for this model",
+  previewTitle = "Preview analysis findings",
   onDelete,
   findingCount,
 }) {
@@ -93,7 +93,7 @@ export default function FileItem({
         )}
         {status === "uploading" && !isConverted && <Spinner />}
         {isConverted && downloadAction && !error && (
-          <button className="download" onClick={downloadAction} title="Download the converted model">
+          <button className="download" onClick={downloadAction} title="Download converted model">
             <Download />
           </button>
         )}

--- a/diagram-converter/webapp/src/main/javascript/src/FileItem.jsx
+++ b/diagram-converter/webapp/src/main/javascript/src/FileItem.jsx
@@ -93,7 +93,7 @@ export default function FileItem({
         )}
         {status === "uploading" && !isConverted && <Spinner />}
         {isConverted && downloadAction && !error && (
-          <button className="download" onClick={downloadAction} title="Download converted model">
+          <button className="download" onClick={downloadAction} title="Download converted model" aria-label="Download converted model">
             <Download />
           </button>
         )}

--- a/diagram-converter/webapp/src/main/javascript/src/FileItem.test.jsx
+++ b/diagram-converter/webapp/src/main/javascript/src/FileItem.test.jsx
@@ -28,11 +28,11 @@ describe("FileItem", () => {
         status="success"
         isChecked
         previewAction={previewAction}
-        previewTitle="Preview this form"
+        previewTitle="Preview form"
       />
     );
 
-    fireEvent.click(screen.getByRole("button", { name: "Preview this form" }));
+    fireEvent.click(screen.getByRole("button", { name: "Preview form" }));
 
     expect(previewAction).toHaveBeenCalledOnce();
   });

--- a/diagram-converter/webapp/src/main/javascript/src/FormPreview.jsx
+++ b/diagram-converter/webapp/src/main/javascript/src/FormPreview.jsx
@@ -29,7 +29,7 @@ export default function FormPreview({ schema, onError }) {
       .catch((error) => {
         if (isActive) {
           const message = error instanceof Error ? error.message : "Unknown rendering error";
-          onError(`Unable to render this form: ${message}`);
+          onError(`The form could not be displayed: ${message}`);
         }
       });
 

--- a/diagram-converter/webapp/src/main/javascript/src/FormPreview.test.jsx
+++ b/diagram-converter/webapp/src/main/javascript/src/FormPreview.test.jsx
@@ -93,7 +93,7 @@ describe("FormPreview", () => {
 
     await waitFor(() =>
       expect(onError).toHaveBeenCalledWith(
-        "Unable to render this form: unsupported component"
+        "The form could not be displayed: unsupported component"
       )
     );
   });

--- a/diagram-converter/webapp/src/main/javascript/src/formSchema.js
+++ b/diagram-converter/webapp/src/main/javascript/src/formSchema.js
@@ -9,7 +9,7 @@ export function parseFormSchema(content) {
   if (content === null || content === undefined || content === "") {
     return {
       schema: null,
-      error: "Unable to render this form because its content is unavailable.",
+      error: "The form content is unavailable.",
     };
   }
 
@@ -22,14 +22,14 @@ export function parseFormSchema(content) {
     }
     return {
       schema: null,
-      error: "Unable to render this form because its content is not valid JSON.",
+      error: "The form content is not valid JSON.",
     };
   }
 
   if (!schema || typeof schema !== "object" || Array.isArray(schema)) {
     return {
       schema: null,
-      error: "Unable to render this form because its content is not a JSON object.",
+      error: "The form content is not a JSON object.",
     };
   }
 

--- a/diagram-converter/webapp/src/main/javascript/src/formSchema.test.js
+++ b/diagram-converter/webapp/src/main/javascript/src/formSchema.test.js
@@ -23,17 +23,17 @@ describe("parseFormSchema", () => {
     (content) => {
       expect(parseFormSchema(content)).toEqual({
         schema: null,
-        error: "Unable to render this form because its content is unavailable.",
+        error: "The form content is unavailable.",
       });
     }
   );
 
   it.each([
-    ["{ invalid", "Unable to render this form because its content is not valid JSON."],
-    ["[]", "Unable to render this form because its content is not a JSON object."],
-    [0, "Unable to render this form because its content is not a JSON object."],
-    [false, "Unable to render this form because its content is not a JSON object."],
-    ["0", "Unable to render this form because its content is not a JSON object."],
+    ["{ invalid", "The form content is not valid JSON."],
+    ["[]", "The form content is not a JSON object."],
+    [0, "The form content is not a JSON object."],
+    [false, "The form content is not a JSON object."],
+    ["0", "The form content is not a JSON object."],
   ])("reports invalid content", (content, error) => {
     expect(parseFormSchema(content)).toEqual({ schema: null, error });
   });


### PR DESCRIPTION
## Summary

Simplifies all user-facing copy in the diagram converter webapp so it's shorter, plainer, and self-explanatory.

### Changes

**Upload & configure**
- Step 1: "Add your files" → "Add files"; upload sentence shortened to "Upload BPMN or DMN models to analyze and convert, or Camunda Forms to convert."
- Drop zone: "Click or drag file to this area to upload" → "Click or drag files here to upload"; supported formats line rewritten ("Supports .bpmn, .dmn, .form, and .xml files.")
- Step 2: removed redundant "Defaults to the latest stable" sentence (the default is already visibly selected)
- Advanced options: consistent sentence case ("Add data migration execution listener", "Default job type", ...); "Enable default job type" → "Always use default job type" to match what it actually does

**Results**
- "Your Models" → "Converted models"; intro paragraph shortened
- Fixed a copy bug: "Download the  for all successfully converted models:" (a word was missing) → "Download the findings for all converted models:"
- XLSX/CSV/JSON descriptions rewritten without jargon and marketing wording
- "Next steps for your migration" → "Next steps"

**Preview modal**
- Unified title: both BPMN/DMN and forms now show "Preview" (was inconsistently "Analysis preview" vs "Form preview")
- Findings intro reduced to one sentence

**Errors & tooltips**
- File count limit: "parts per request" jargon removed
- Download failure titles: "Downloading XLSX failed" → "XLSX download failed" (same for CSV/JSON/ZIP)
- Form render errors: "Unable to render this form because its content is not valid JSON." → "The form content is not valid JSON." etc.
- Button tooltips: "Preview the analyzer results for this model" → "Preview analysis findings"

Tests asserting on the changed strings were updated accordingly.

### Validation
- `npm run build` (lint + typecheck + type-escape check + vitest + vite build) passes: 12/12 tests green