### PR TITLE
feat(diagram-converter): add DMN previews

### DIFF
--- a/diagram-converter/webapp/src/main/javascript/package-lock.json
+++ b/diagram-converter/webapp/src/main/javascript/package-lock.json
@@ -11,6 +11,7 @@
         "@bpmn-io/form-js-viewer": "^1.25.0",
         "@camunda/design-system": "^0.49.0",
         "bpmn-js": "^18.6.1",
+        "dmn-js": "^17.10.2",
         "lucide-react": "1.34.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0"
@@ -308,6 +309,23 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@bpmn-io/cm-theme": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/cm-theme/-/cm-theme-0.2.2.tgz",
+      "integrity": "sha512-9mD7fzzNDNBgseOUC6iRX4mi17LIO2es4zkcHt4e4owQC2Q3YPvqJTJaXqc7kkItloSFsqG2j/1iMJkpvjLv2A==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.12.3",
+        "@lezer/highlight": "^1.2.3"
+      },
+      "engines": {
+        "node": ">= 20.12.0"
+      },
+      "peerDependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0"
+      }
+    },
     "node_modules/@bpmn-io/diagram-js-ui": {
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/@bpmn-io/diagram-js-ui/-/diagram-js-ui-0.2.4.tgz",
@@ -316,6 +334,93 @@
       "dependencies": {
         "htm": "^3.1.1",
         "preact": "^10.29.2"
+      }
+    },
+    "node_modules/@bpmn-io/dmn-variable-resolver": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/dmn-variable-resolver/-/dmn-variable-resolver-0.7.1.tgz",
+      "integrity": "sha512-8++ljV1DkRbUhOUaMA90IIfM1Dda8tsqBJ1a/usfXl4raYIhTQl1NJA3Ftyo39CVKSdL/0F02RrgpUPXHcezqQ==",
+      "license": "MIT"
+    },
+    "node_modules/@bpmn-io/feel-analyzer": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/feel-analyzer/-/feel-analyzer-0.5.0.tgz",
+      "integrity": "sha512-g1H9MMkVH94fl0Hz2MiZ+AU2hnVTL+qsz8MvXx9xz+lBgBSp3tY342Vrxrzt36H8QqE4fn9noJc1emNA9BE3Dg==",
+      "license": "MIT",
+      "dependencies": {
+        "@bpmn-io/lezer-feel": "^3.0.1",
+        "@lezer/common": "^1.5.2"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@bpmn-io/feel-analyzer/node_modules/@bpmn-io/lezer-feel": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/lezer-feel/-/lezer-feel-3.0.1.tgz",
+      "integrity": "sha512-+wWg4DP2h8WOEQx2Bz51blsw9dCqKj3kIDKYccABuoAEhzZeDhmm0A2k4ANmm9lf0w5pJmVSYz2djtrbzOvzzA==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/highlight": "^1.2.3",
+        "@lezer/lr": "^1.4.10",
+        "min-dash": "^5.0.0"
+      },
+      "engines": {
+        "node": ">= 20.12.0"
+      }
+    },
+    "node_modules/@bpmn-io/feel-editor": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/feel-editor/-/feel-editor-2.7.1.tgz",
+      "integrity": "sha512-WY3aUUc3MYwfAz4sL8SgR82stdXvM7cKvqaqZAelZ3fXj6Ve2gqrbPmZJ6Kg+bYtOZA9obsDmVNdP7zMcXwIrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@bpmn-io/cm-theme": "^0.2.2",
+        "@bpmn-io/feel-lint": "^3.2.0",
+        "@bpmn-io/lang-feel": "^4.0.2",
+        "@bpmn-io/semver-compat": "^0.1.0",
+        "@camunda/feel-builtins": "^1.4.0",
+        "@codemirror/autocomplete": "^6.20.0",
+        "@codemirror/commands": "^6.10.3",
+        "@codemirror/language": "^6.11.3",
+        "@codemirror/lint": "^6.9.7",
+        "@codemirror/state": "^6.6.0",
+        "@codemirror/view": "^6.43.1",
+        "@lezer/highlight": "^1.2.3",
+        "min-dom": "^5.3.0",
+        "mitt": "^3.0.1"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@bpmn-io/feel-lint": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/feel-lint/-/feel-lint-3.2.0.tgz",
+      "integrity": "sha512-f9xe7VNjdZ0kDzWeALmDEWXm7KtAzVSeLVESAhBZGxTbyGzbTGubRfl2cXMN+E/U0oFEcQDuxF0A1tD02DXiLw==",
+      "license": "MIT",
+      "dependencies": {
+        "@bpmn-io/feel-analyzer": "^0.5.0",
+        "@bpmn-io/lezer-feel": "^3.0.0",
+        "@bpmn-io/semver-compat": "^0.1.0",
+        "@codemirror/language": "^6.12.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@bpmn-io/feel-lint/node_modules/@bpmn-io/lezer-feel": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/lezer-feel/-/lezer-feel-3.0.1.tgz",
+      "integrity": "sha512-+wWg4DP2h8WOEQx2Bz51blsw9dCqKj3kIDKYccABuoAEhzZeDhmm0A2k4ANmm9lf0w5pJmVSYz2djtrbzOvzzA==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/highlight": "^1.2.3",
+        "@lezer/lr": "^1.4.10",
+        "min-dash": "^5.0.0"
+      },
+      "engines": {
+        "node": ">= 20.12.0"
       }
     },
     "node_modules/@bpmn-io/feelin": {
@@ -355,6 +460,35 @@
         "preact": "^10.29.5"
       }
     },
+    "node_modules/@bpmn-io/lang-feel": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/lang-feel/-/lang-feel-4.0.2.tgz",
+      "integrity": "sha512-rTPeJ77/2nYKbJXpvDmrNXy+opoIpD3Rsch0grCUZAO6xF68r41QeV8SqOdr2yZxD/4gI6YXlQhqh4rqFRDJXA==",
+      "license": "MIT",
+      "dependencies": {
+        "@bpmn-io/lezer-feel": "^3.0.1",
+        "@codemirror/autocomplete": "^6.20.3",
+        "@codemirror/language": "^6.12.3",
+        "@lezer/common": "^1.5.2"
+      },
+      "engines": {
+        "node": ">= 20.12.0"
+      }
+    },
+    "node_modules/@bpmn-io/lang-feel/node_modules/@bpmn-io/lezer-feel": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/lezer-feel/-/lezer-feel-3.0.1.tgz",
+      "integrity": "sha512-+wWg4DP2h8WOEQx2Bz51blsw9dCqKj3kIDKYccABuoAEhzZeDhmm0A2k4ANmm9lf0w5pJmVSYz2djtrbzOvzzA==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/highlight": "^1.2.3",
+        "@lezer/lr": "^1.4.10",
+        "min-dash": "^5.0.0"
+      },
+      "engines": {
+        "node": ">= 20.12.0"
+      }
+    },
     "node_modules/@bpmn-io/lezer-feel": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/@bpmn-io/lezer-feel/-/lezer-feel-2.5.0.tgz",
@@ -378,6 +512,27 @@
         "@lezer/common": "^1.5.1",
         "@lezer/highlight": "^1.1.6",
         "@lezer/lr": "^1.4.8"
+      }
+    },
+    "node_modules/@bpmn-io/semver-compat": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/semver-compat/-/semver-compat-0.1.0.tgz",
+      "integrity": "sha512-hIcW42Ku92MUioL6aknDbRoW1jK8ZEqIe8qZZ+d3cjitDO+PMEFFXj/sezJYIHMe8elu4CBz9qpjkV8WIVG9qw==",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.7.2"
+      }
+    },
+    "node_modules/@bpmn-io/semver-compat/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/@bramus/specificity": {
@@ -426,6 +581,12 @@
         }
       }
     },
+    "node_modules/@camunda/feel-builtins": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@camunda/feel-builtins/-/feel-builtins-1.4.1.tgz",
+      "integrity": "sha512-nXIVbr8JHLzuPXSYs+VUy/4X1WiY7SlXtAqsgQ9R3mbXNNyorYUiw0YBeLXMrMCcg2yJWVSasramcTCeI9A6FQ==",
+      "license": "MIT"
+    },
     "node_modules/@carbon/grid": {
       "version": "11.60.0",
       "resolved": "https://registry.npmjs.org/@carbon/grid/-/grid-11.60.0.tgz",
@@ -445,6 +606,76 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@ibm/telemetry-js": "^1.5.0"
+      }
+    },
+    "node_modules/@codemirror/autocomplete": {
+      "version": "6.20.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.20.3.tgz",
+      "integrity": "sha512-tlosUqb+3BbxCxZdu4tKeRghPFC+QM7q4X5YhKV2eCmPG+1r2F3f4AaSz5sCrFqUtX4Jh20VFTKecl16MgiV9g==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.17.0",
+        "@lezer/common": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/commands": {
+      "version": "6.11.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.11.0.tgz",
+      "integrity": "sha512-/K4Rl5BN0OtTiPWmJCdqODu38XnDMsDxKY5rgrPnCkutPTJf2wVbkoixLfealF5Kwse/s8P8M5jAiURiwSwnFA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.7.0",
+        "@codemirror/view": "^6.27.0",
+        "@lezer/common": "^1.1.0"
+      }
+    },
+    "node_modules/@codemirror/language": {
+      "version": "6.12.4",
+      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.12.4.tgz",
+      "integrity": "sha512-1q4PaT+o6PbgpkJt4Q8Fv5XJxTy4FUZ4MWETtyiDw3J0Pyr9E2vqcKL+k9wcvjNTIsauxvE7OfmWj3FRPHQ76A==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.23.0",
+        "@lezer/common": "^1.5.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0",
+        "style-mod": "^4.0.0"
+      }
+    },
+    "node_modules/@codemirror/lint": {
+      "version": "6.9.7",
+      "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.9.7.tgz",
+      "integrity": "sha512-28/+iWLYxKxsvGYhSYL7zaCZqLz5+FFFDq9tVsvGv9kv8RY4fFAchJ5WX9M3YrrRlTIsECjsXPqeNgnSmNP2dg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.42.0",
+        "crelt": "^1.0.5"
+      }
+    },
+    "node_modules/@codemirror/state": {
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.7.1.tgz",
+      "integrity": "sha512-9QzNDgE4EYDnAHfrTlR2lwiPciiOymLtwKK+8yHQzCc7GXhAP9xdEbEJFy2IWB1j9UGUl9BsgMmTo/ImA02T7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@marijn/find-cluster-break": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/view": {
+      "version": "6.43.9",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.43.9.tgz",
+      "integrity": "sha512-sTuUzTpPMFebRhg6dawChoKKgndIwfjmJgKVxBefPElcU2NwQ6AFroupk0SFqEerQyZOGRfDNnSN8Dw/lMAsXw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.7.0",
+        "crelt": "^1.0.6",
+        "style-mod": "^4.1.0",
+        "w3c-keyname": "^2.2.4"
       }
     },
     "node_modules/@csstools/css-syntax-patches-for-csstree": {
@@ -849,6 +1080,12 @@
       "dependencies": {
         "@lezer/common": "^1.0.0"
       }
+    },
+    "node_modules/@marijn/find-cluster-break": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.4.tgz",
+      "integrity": "sha512-Wy0V7+SGUjnF9/TkiM1hKVDPj7jKXduPNboMVtHTA8dySMURWqfg/JZ9E2Sq8JgSJmkl7k7Qe9FLeMSrSraWmQ==",
+      "license": "MIT"
     },
     "node_modules/@oxc-project/types": {
       "version": "0.144.0",
@@ -8765,11 +9002,28 @@
         "react-dom": "^18 || ^19 || ^19.0.0-rc"
       }
     },
+    "node_modules/component-props": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/component-props/-/component-props-1.1.1.tgz",
+      "integrity": "sha512-69pIRJs9fCCHRqCz3390YF2LV1Lu6iEMZ5zuVqqUn+G20V9BNXlMs0cWawWeW9g4Ynmg29JmkG6R7/lUJoGd1Q=="
+    },
+    "node_modules/component-xor": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/component-xor/-/component-xor-0.0.4.tgz",
+      "integrity": "sha512-ZIt6sla8gfo+AFVRZoZOertcnD5LJaY2T9CKE2j13NJxQt/mUafD69Bl7/Y4AnpI2LGjiXH7cOfJDx/n2G9edA==",
+      "license": "MIT"
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/crelt": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.7.tgz",
+      "integrity": "sha512-aK6BbWfhf4U/wCcLHKPJl/xa6VkVstRaPywWtMKGwuOLc/wZTyQYuoxgvZnNsBvv7Kg3YTBQYYBCggcviQczuA==",
       "license": "MIT"
     },
     "node_modules/cross-spawn": {
@@ -8800,6 +9054,12 @@
       "engines": {
         "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
       }
+    },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "license": "MIT"
     },
     "node_modules/csstype": {
       "version": "3.2.3",
@@ -9078,6 +9338,118 @@
         "node": ">= 20.12"
       }
     },
+    "node_modules/dmn-js": {
+      "version": "17.10.2",
+      "resolved": "https://registry.npmjs.org/dmn-js/-/dmn-js-17.10.2.tgz",
+      "integrity": "sha512-AIONwKnrDoIIfVwv7iLmNNLKcF6bcKf1fkoB9euEyhaOTbi6p/InCoVQWitVqCrBXqw3aCpNCuql71xj79penQ==",
+      "license": "SEE LICENSE IN LICENSE",
+      "dependencies": {
+        "dmn-js-boxed-expression": "^17.10.2",
+        "dmn-js-decision-table": "^17.10.2",
+        "dmn-js-drd": "^17.10.2",
+        "dmn-js-literal-expression": "^17.10.2",
+        "dmn-js-shared": "^17.10.2"
+      }
+    },
+    "node_modules/dmn-js-boxed-expression": {
+      "version": "17.10.2",
+      "resolved": "https://registry.npmjs.org/dmn-js-boxed-expression/-/dmn-js-boxed-expression-17.10.2.tgz",
+      "integrity": "sha512-GkjEDdPPYGUJPVIsDss7ye8GtdQe6++e6yIxKgUFFWWnnOuakS4ERkm7IGcKbDXsJ7RB2F1sSbCM4IjJCO+fXg==",
+      "license": "SEE LICENSE IN LICENSE",
+      "dependencies": {
+        "@bpmn-io/dmn-variable-resolver": "^0.7.0",
+        "diagram-js": "^15.21.0",
+        "dmn-js-shared": "^17.10.2",
+        "inferno": "~5.6.3",
+        "min-dash": "^5.0.0",
+        "min-dom": "^5.3.0",
+        "table-js": "^9.4.0"
+      }
+    },
+    "node_modules/dmn-js-decision-table": {
+      "version": "17.10.2",
+      "resolved": "https://registry.npmjs.org/dmn-js-decision-table/-/dmn-js-decision-table-17.10.2.tgz",
+      "integrity": "sha512-KHF2XH6uv9AEXfYWeMParZ44EcUzaAF7fRLE9m8g/rlQkAzgXOzXka1uk4o++zuoMcjjUNcqR3C3oZ4QTZXE9Q==",
+      "license": "SEE LICENSE IN LICENSE",
+      "dependencies": {
+        "@bpmn-io/dmn-variable-resolver": "^0.7.0",
+        "css.escape": "^1.5.1",
+        "diagram-js": "^15.21.0",
+        "dmn-js-shared": "^17.10.2",
+        "escape-html": "^1.0.3",
+        "inferno": "~5.6.3",
+        "min-dash": "^5.0.0",
+        "min-dom": "^5.3.0",
+        "selection-ranges": "^4.1.1",
+        "table-js": "^9.4.0"
+      }
+    },
+    "node_modules/dmn-js-drd": {
+      "version": "17.10.2",
+      "resolved": "https://registry.npmjs.org/dmn-js-drd/-/dmn-js-drd-17.10.2.tgz",
+      "integrity": "sha512-dyfJ0XF7Fx6Ai4GGgqR2VCkYBuDixRZymYEeeviHvXrn61wlpOHc2c4W33KBYAe3hD9aVydLloQ6qbiV7g4YVg==",
+      "license": "SEE LICENSE IN LICENSE",
+      "dependencies": {
+        "diagram-js": "^15.23.2",
+        "diagram-js-direct-editing": "^3.4.0",
+        "dmn-js-shared": "^17.10.2",
+        "ids": "^3.0.2",
+        "inherits-browser": "^0.1.0",
+        "min-dash": "^5.0.0",
+        "min-dom": "^5.3.0",
+        "object-refs": "^0.4.0",
+        "tiny-svg": "^4.1.4"
+      }
+    },
+    "node_modules/dmn-js-literal-expression": {
+      "version": "17.10.2",
+      "resolved": "https://registry.npmjs.org/dmn-js-literal-expression/-/dmn-js-literal-expression-17.10.2.tgz",
+      "integrity": "sha512-WBplksKSqHkN0Y4bTew499FrSs0OuEJOPwOchuy2JiGW32R2NqBe9fyg4tyrrk/lYVWzSbwTi5x5pdU6v7moKw==",
+      "license": "SEE LICENSE IN LICENSE",
+      "dependencies": {
+        "@bpmn-io/dmn-variable-resolver": "^0.7.0",
+        "diagram-js": "^15.21.0",
+        "dmn-js-shared": "^17.10.2",
+        "escape-html": "^1.0.3",
+        "inferno": "~5.6.3",
+        "min-dash": "^5.0.0",
+        "min-dom": "^5.3.0",
+        "table-js": "^9.4.0"
+      }
+    },
+    "node_modules/dmn-js-shared": {
+      "version": "17.10.2",
+      "resolved": "https://registry.npmjs.org/dmn-js-shared/-/dmn-js-shared-17.10.2.tgz",
+      "integrity": "sha512-lXhfQ8dJJHhXngWuXT9y/STd3DE/nTsceYAYdvJVcnsca7KcrPrN87xO4cgoxSvreo50t59tl0BseCibWK6OMg==",
+      "license": "SEE LICENSE IN LICENSE",
+      "dependencies": {
+        "@bpmn-io/feel-editor": "^2.6.0",
+        "diagram-js": "^15.21.0",
+        "didi": "^11.0.0",
+        "dmn-moddle": "^12.0.1",
+        "ids": "^3.0.2",
+        "inferno": "~5.6.3",
+        "min-dash": "^5.0.0",
+        "min-dom": "^5.3.0",
+        "selection-ranges": "^4.1.1",
+        "selection-update": "^1.1.1",
+        "table-js": "^9.4.0"
+      }
+    },
+    "node_modules/dmn-moddle": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/dmn-moddle/-/dmn-moddle-12.1.0.tgz",
+      "integrity": "sha512-kR7MYmXZlKy3Nnqfs279FO01v0PPIKhNzYBvRGm5zpMKsmo15wIWtpP+uRUlj1wByZCrknjXIV9MILYf2vlRJA==",
+      "license": "MIT",
+      "dependencies": {
+        "min-dash": "^5.1.0",
+        "moddle": "^8.2.1",
+        "moddle-xml": "^12.2.0"
+      },
+      "engines": {
+        "node": ">= 20.12"
+      }
+    },
     "node_modules/dom-accessibility-api": {
       "version": "0.5.16",
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
@@ -9085,6 +9457,16 @@
       "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/dom-iterator": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/dom-iterator/-/dom-iterator-1.0.2.tgz",
+      "integrity": "sha512-BMelEjhy08OpoWF3v/jrPtx7PZCyP1VM9yiB7rJk19UVmt7zTN5rqoC0Jea+EyT0M6v/VokL0LxIlGLUOBJZ2g==",
+      "license": "MIT",
+      "dependencies": {
+        "component-props": "1.1.1",
+        "component-xor": "0.0.4"
+      }
     },
     "node_modules/domify": {
       "version": "3.0.0",
@@ -9153,6 +9535,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
@@ -9714,6 +10102,30 @@
       "engines": {
         "node": ">=0.8.19"
       }
+    },
+    "node_modules/inferno": {
+      "version": "5.6.3",
+      "resolved": "https://registry.npmjs.org/inferno/-/inferno-5.6.3.tgz",
+      "integrity": "sha512-2m7bEo/6D+pbxFkFKY/2QOVdknxxXyrXyDdVFobJcQyvfv3985MY+VVwyRZoVJylQG+mzPY5/uDNuXygp8jObA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "inferno-shared": "5.6.3",
+        "inferno-vnode-flags": "5.6.3",
+        "opencollective-postinstall": "^2.0.3"
+      }
+    },
+    "node_modules/inferno-shared": {
+      "version": "5.6.3",
+      "resolved": "https://registry.npmjs.org/inferno-shared/-/inferno-shared-5.6.3.tgz",
+      "integrity": "sha512-NzhS62Y6BwfkLNmXS9C0Ie7skY1vIoLrVIYnVrMx1xfTLp/AG+ths4oAJGmWcX/AkVSYl+DjP96HEuUdtGmRRw==",
+      "license": "MIT"
+    },
+    "node_modules/inferno-vnode-flags": {
+      "version": "5.6.3",
+      "resolved": "https://registry.npmjs.org/inferno-vnode-flags/-/inferno-vnode-flags-5.6.3.tgz",
+      "integrity": "sha512-1V9Pjz5Erm2sP7xlb4D2zW/U8e3RwU41Ruyn9/apke0BFxbLI+LxxVcKWxom4fPetG6YcBNLpZssy8gkigT9gg==",
+      "license": "MIT"
     },
     "node_modules/inherits-browser": {
       "version": "0.1.0",
@@ -10395,6 +10807,12 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
+    "node_modules/mitt": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
+      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
+      "license": "MIT"
+    },
     "node_modules/moddle": {
       "version": "8.2.1",
       "resolved": "https://registry.npmjs.org/moddle/-/moddle-8.2.1.tgz",
@@ -10405,9 +10823,9 @@
       }
     },
     "node_modules/moddle-xml": {
-      "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/moddle-xml/-/moddle-xml-12.1.0.tgz",
-      "integrity": "sha512-+m50j9/MFGhvWbLJoKSSjQj3uv7SYm2w5i2lfv6goWarlWW1Nd0A31NYUXmKuWnEZ8Mm/bH1RZYtuf4x8ptY7g==",
+      "version": "12.2.0",
+      "resolved": "https://registry.npmjs.org/moddle-xml/-/moddle-xml-12.2.0.tgz",
+      "integrity": "sha512-kqjdAod5n2v3IVJGudJKRUa1PU/p8GpIb0HbfbVXCppt/MEHtRs+Qi/Q3KTy31JbZCUF9L36mY4wUx7PqqMX4g==",
       "license": "MIT",
       "dependencies": {
         "min-dash": "^5.1.0",
@@ -10484,6 +10902,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=12.20.0"
+      }
+    },
+    "node_modules/opencollective-postinstall": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/opencollective-postinstall/-/opencollective-postinstall-2.0.3.tgz",
+      "integrity": "sha512-8AV/sCtuzUeTo8gQK5qDZzARrulB3egtLzFgteqB2tcT4Mw7B8Kt7JcDHmltjz6FOAHsvTevk70gZEbhM4ZS9Q==",
+      "license": "MIT",
+      "bin": {
+        "opencollective-postinstall": "index.js"
       }
     },
     "node_modules/optionator": {
@@ -11371,6 +11798,21 @@
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
       "license": "MIT"
     },
+    "node_modules/selection-ranges": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/selection-ranges/-/selection-ranges-4.1.1.tgz",
+      "integrity": "sha512-MaWca8GVQV+g3IOJDDgDehXFWtB+ycrQD5wkWTTwAQjXvwm1ZeZVoN4IA8KP7R+z8UMOsdkdnpMfo8+40Hru+Q==",
+      "license": "MIT",
+      "dependencies": {
+        "dom-iterator": "^1.0.2"
+      }
+    },
+    "node_modules/selection-update": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/selection-update/-/selection-update-1.1.1.tgz",
+      "integrity": "sha512-sdkTSquPXiPTUUJh5KcnNoLauJqy68ctusGj7JfMo+t629f8Tv3EMx0hzTjFe8fYy7dZUzXRDAS42K/YS6Pi6Q==",
+      "license": "MIT"
+    },
     "node_modules/semver": {
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
@@ -11451,12 +11893,37 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/style-mod": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.3.tgz",
+      "integrity": "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==",
+      "license": "MIT"
+    },
     "node_modules/symbol-tree": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/table-js": {
+      "version": "9.4.0",
+      "resolved": "https://registry.npmjs.org/table-js/-/table-js-9.4.0.tgz",
+      "integrity": "sha512-m7G/yfFnP2pniz+NMT9QnrYko8MUVBbWsFD+zHY808VBmVZqIHPR68VzCtvWXDF1oCLG4c96BM0nOA4ILzqK+w==",
+      "license": "MIT",
+      "dependencies": {
+        "didi": "^11.0.0",
+        "min-dash": "^5.0.0",
+        "min-dom": "^5.2.0",
+        "selection-ranges": "^4.1.1"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "peerDependencies": {
+        "diagram-js": "^11.3.0 || ^12 || ^13 || ^14 || ^15",
+        "inferno": "^5.0.5"
+      }
     },
     "node_modules/tailwind-merge": {
       "version": "3.6.0",
@@ -11919,6 +12386,12 @@
           "optional": false
         }
       }
+    },
+    "node_modules/w3c-keyname": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
+      "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
+      "license": "MIT"
     },
     "node_modules/w3c-xmlserializer": {
       "version": "5.0.0",

--- a/diagram-converter/webapp/src/main/javascript/package.json
+++ b/diagram-converter/webapp/src/main/javascript/package.json
@@ -17,6 +17,7 @@
     "@bpmn-io/form-js-viewer": "^1.25.0",
     "@camunda/design-system": "^0.49.0",
     "bpmn-js": "^18.6.1",
+    "dmn-js": "^17.10.2",
     "lucide-react": "1.34.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"

--- a/diagram-converter/webapp/src/main/javascript/src/App.jsx
+++ b/diagram-converter/webapp/src/main/javascript/src/App.jsx
@@ -28,8 +28,10 @@ import { Download, ExternalLink, X, Settings, ChevronDown, ChevronUp } from "luc
 import DropZone from "./DropZone";
 import FileItem from "./FileItem";
 import BpmnJS from 'bpmn-js';
+import DmnPreview from "./DmnPreview";
 import FormPreview from "./FormPreview";
 import { parseFormSchema } from "./formSchema";
+import { getPreviewType } from "./modelType";
 
 // Target Camunda 8 versions offered in the UI. This is a curated subset of the
 // versions the backend understands (SemanticVersion.java); we only surface the
@@ -53,9 +55,10 @@ function App() {
   const [validFiles, setValidFiles] = useState([]);
   const [isPreviewOpen, setIsPreviewOpen] = useState(false);
   const [previewType, setPreviewType] = useState(null);
-  const [previewbpmnXml, setPreviewbpmnXml] = useState("");
+  const [previewModelXml, setPreviewModelXml] = useState("");
   const [previewFormSchema, setPreviewFormSchema] = useState(null);
   const [previewFormError, setPreviewFormError] = useState("");
+  const [previewDmnError, setPreviewDmnError] = useState("");
   const [previewCheckJson, setPreviewCheckJson] = useState([]);
 
   const [previewTableHeader, setPreviewTableHeader] = useState([]);
@@ -136,10 +139,10 @@ function App() {
   }, []);
 
   useEffect(() => {
-      if (isPreviewOpen && previewType === "bpmn" && previewbpmnXml) {
+      if (isPreviewOpen && previewType === "bpmn" && previewModelXml) {
           const viewer = new BpmnJS({ container: bpmnPreviewRef.current });
           let isActive = true;
-          viewer.importXML(previewbpmnXml).then(() => {
+          viewer.importXML(previewModelXml).then(() => {
             if (!isActive) return;
 
             const canvas = viewer.get('canvas');
@@ -170,7 +173,7 @@ function App() {
             viewer.destroy();
           };
       }
-    }, [isPreviewOpen, previewType, previewbpmnXml, previewCheckJson]);
+    }, [isPreviewOpen, previewType, previewModelXml, previewCheckJson]);
 
   useEffect(() => {
     if (!allDone || totalFindings === 0) return;
@@ -391,7 +394,7 @@ function App() {
     );
   }
 
-  async function preview(response) {
+  async function preview(response, modelType) {
     if (!response?.checkResponseJson) return;
 
     setPreviewTableHeader([
@@ -418,10 +421,11 @@ function App() {
 
 
     setPreviewCheckJson(response.checkResponseJson);
-    setPreviewbpmnXml(response.originalModelXml);
+    setPreviewModelXml(response.originalModelXml);
     setPreviewFormSchema(null);
     setPreviewFormError("");
-    setPreviewType("bpmn");
+    setPreviewDmnError("");
+    setPreviewType(modelType);
 
     setIsPreviewOpen(true);
   }
@@ -429,10 +433,11 @@ function App() {
   function openFormPreview(schema, errorMessage = "") {
     setPreviewFormSchema(schema);
     setPreviewFormError(errorMessage);
-    setPreviewbpmnXml("");
+    setPreviewModelXml("");
     setPreviewCheckJson([]);
     setPreviewTableHeader([]);
     setPreviewTableRows([]);
+    setPreviewDmnError("");
     setPreviewType("form");
     setIsPreviewOpen(true);
   }
@@ -677,7 +682,8 @@ function App() {
               <h3>Converted models</h3>
               <p>
                 Download each converted file or all of them as a ZIP. Preview a
-                file to inspect it first.
+                file to inspect it first, including analysis results for BPMN and DMN
+                models.
               </p>
               {allDone && totalFindings > 0 && (
                 <div ref={incompatibilityNotifRef}>
@@ -695,7 +701,8 @@ function App() {
               )}
               {files.map((file, idx) => {
                 const r = fileResults[idx];
-                const isForm = file.name.toLowerCase().endsWith(".form");
+                const modelType = getPreviewType(file.name);
+                const isForm = modelType === "form";
                 const fileFindingCount = r.checkResponseJson
                   ? r.checkResponseJson
                       .flatMap(item => item.results || [])
@@ -708,7 +715,7 @@ function App() {
                   status={r.status}
                   isChecked={r.checkResponseJson != null}
                   isConverted={r.convertedFileBlob != null}
-                  previewAction={isForm ? () => previewForm(r) : () => preview(r)}
+                  previewAction={isForm ? () => previewForm(r) : () => preview(r, modelType)}
                   previewTitle={isForm ? "Preview form" : undefined}
                   downloadAction={() => download(r)}
                   findingCount={fileFindingCount}
@@ -840,9 +847,19 @@ function App() {
         </div>
       </div>
 
-      {previewType === "bpmn" && (
+      {(previewType === "bpmn" || previewType === "dmn") && (
         <>
-          <div ref={bpmnPreviewRef} id="bpmnDiagram" className="diagram-container"></div>
+          {previewType === "bpmn" ? (
+            <div ref={bpmnPreviewRef} id="bpmnDiagram" className="diagram-container"></div>
+          ) : previewDmnError ? (
+            <Alert
+              variant="destructive"
+              title="DMN preview unavailable"
+              description={previewDmnError}
+            />
+          ) : (
+            <DmnPreview xml={previewModelXml} onError={setPreviewDmnError} />
+          )}
           {previewTableRows.length === 0 && (
             <p style={{ color: 'var(--neutral-foreground-subtle)', marginTop: '1rem' }}>No findings for this model.</p>
           )}

--- a/diagram-converter/webapp/src/main/javascript/src/DmnPreview.jsx
+++ b/diagram-converter/webapp/src/main/javascript/src/DmnPreview.jsx
@@ -1,0 +1,46 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+import { useEffect, useRef } from "react";
+import DmnJS from "dmn-js";
+
+export default function DmnPreview({ xml, onError }) {
+  const containerRef = useRef(null);
+
+  useEffect(() => {
+    if (!xml || !containerRef.current) {
+      return;
+    }
+
+    const viewer = new DmnJS({ container: containerRef.current });
+    let isActive = true;
+
+    viewer
+      .importXML(xml)
+      .then(() => {
+        if (!isActive) {
+          return;
+        }
+
+        const canvas = viewer.getActiveViewer?.()?.get?.("canvas");
+        canvas?.zoom?.("fit-viewport");
+      })
+      .catch((error) => {
+        if (isActive) {
+          const message = error instanceof Error ? error.message : "Unknown rendering error";
+          onError(`Unable to render this DMN model: ${message}`);
+        }
+      });
+
+    return () => {
+      isActive = false;
+      viewer.destroy();
+    };
+  }, [xml, onError]);
+
+  return <div ref={containerRef} className="diagram-container dmn-preview-container" />;
+}

--- a/diagram-converter/webapp/src/main/javascript/src/DmnPreview.test.jsx
+++ b/diagram-converter/webapp/src/main/javascript/src/DmnPreview.test.jsx
@@ -1,0 +1,97 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+import { cleanup, render, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import DmnPreview from "./DmnPreview";
+
+const { DmnJSMock, viewerInstances } = vi.hoisted(() => {
+  const instances = [];
+
+  class MockDmnJS {
+    static importError = null;
+
+    constructor(options) {
+      this.options = options;
+      this.importedXml = [];
+      this.destroyed = false;
+      this.canvas = { zoom: vi.fn() };
+      instances.push(this);
+    }
+
+    importXML(xml) {
+      if (MockDmnJS.importError) {
+        return Promise.reject(MockDmnJS.importError);
+      }
+
+      this.importedXml.push(xml);
+      return Promise.resolve();
+    }
+
+    getActiveViewer() {
+      return {
+        get: () => this.canvas,
+      };
+    }
+
+    destroy() {
+      this.destroyed = true;
+    }
+  }
+
+  return { DmnJSMock: MockDmnJS, viewerInstances: instances };
+});
+
+vi.mock("dmn-js", () => ({
+  default: DmnJSMock,
+}));
+
+afterEach(() => {
+  cleanup();
+  DmnJSMock.importError = null;
+  viewerInstances.length = 0;
+});
+
+describe("DmnPreview", () => {
+  it("renders the DMN XML, fits the diagram, and destroys the viewer on unmount", async () => {
+    const xml = '<definitions id="definitions" xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" />';
+    const onError = vi.fn();
+    const { container, unmount } = render(<DmnPreview xml={xml} onError={onError} />);
+
+    await waitFor(() => expect(viewerInstances).toHaveLength(1));
+    const viewer = viewerInstances[0];
+
+    expect(viewer.options.container).toBe(
+      container.querySelector(".dmn-preview-container")
+    );
+    expect(viewer.importedXml).toEqual([xml]);
+    expect(viewer.canvas.zoom).toHaveBeenCalledWith("fit-viewport");
+    expect(onError).not.toHaveBeenCalled();
+
+    unmount();
+
+    expect(viewer.destroyed).toBe(true);
+  });
+
+  it("reports DMN rendering errors", async () => {
+    DmnJSMock.importError = new Error("unsupported DMN version");
+    const onError = vi.fn();
+
+    render(
+      <DmnPreview
+        xml="<definitions />"
+        onError={onError}
+      />
+    );
+
+    await waitFor(() =>
+      expect(onError).toHaveBeenCalledWith(
+        "Unable to render this DMN model: unsupported DMN version"
+      )
+    );
+  });
+});

--- a/diagram-converter/webapp/src/main/javascript/src/main.jsx
+++ b/diagram-converter/webapp/src/main/javascript/src/main.jsx
@@ -14,6 +14,12 @@ import "./index.css";
 import 'bpmn-js/dist/assets/diagram-js.css';
 import 'bpmn-js/dist/assets/bpmn-font/css/bpmn.css';
 import 'bpmn-js/dist/assets/bpmn-js.css';
+import 'dmn-js/dist/assets/dmn-font/css/dmn.css';
+import 'dmn-js/dist/assets/dmn-js-shared.css';
+import 'dmn-js/dist/assets/dmn-js-drd.css';
+import 'dmn-js/dist/assets/dmn-js-decision-table.css';
+import 'dmn-js/dist/assets/dmn-js-literal-expression.css';
+import 'dmn-js/dist/assets/dmn-js-boxed-expression.css';
 import "@bpmn-io/form-js-viewer/dist/assets/form-js.css";
 
 import App from "./App.jsx";

--- a/diagram-converter/webapp/src/main/javascript/src/modelType.js
+++ b/diagram-converter/webapp/src/main/javascript/src/modelType.js
@@ -1,0 +1,22 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+const DMN_FILE_ENDINGS = [".dmn", ".dmn11.xml"];
+
+export function getPreviewType(fileName) {
+  const normalizedFileName = typeof fileName === "string" ? fileName.toLowerCase() : "";
+
+  if (normalizedFileName.endsWith(".form")) {
+    return "form";
+  }
+
+  if (DMN_FILE_ENDINGS.some((ending) => normalizedFileName.endsWith(ending))) {
+    return "dmn";
+  }
+
+  return "bpmn";
+}

--- a/diagram-converter/webapp/src/main/javascript/src/modelType.test.js
+++ b/diagram-converter/webapp/src/main/javascript/src/modelType.test.js
@@ -1,0 +1,28 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+import { describe, expect, it } from "vitest";
+import { getPreviewType } from "./modelType";
+
+describe("getPreviewType", () => {
+  it.each([
+    ["decision.dmn", "dmn"],
+    ["decision.dmn11.xml", "dmn"],
+    ["decision.DMN", "dmn"],
+    ["process.bpmn", "bpmn"],
+    ["process.bpmn20.xml", "bpmn"],
+    ["customer.form", "form"],
+    ["CUSTOMER.FORM", "form"],
+    ["unknown.xml", "bpmn"],
+  ])("identifies %s as %s", (fileName, expectedType) => {
+    expect(getPreviewType(fileName)).toBe(expectedType);
+  });
+
+  it("defaults invalid file names to BPMN for compatibility with the existing preview", () => {
+    expect(getPreviewType(undefined)).toBe("bpmn");
+  });
+});


### PR DESCRIPTION
## Summary

- Add visual DMN previews to the diagram converter web app.
- Route DMN files to a dedicated `dmn-js` viewer while preserving BPMN and form previews.
- Display DMN rendering errors instead of leaving a blank preview.

## Changes

- Added the `dmn-js` dependency and viewer styles.
- Added `DmnPreview` with fit-to-viewport behavior and lifecycle/error handling.
- Added model filename detection for `.dmn` and `.dmn11.xml` files.
- Added frontend tests for DMN viewer lifecycle/errors and model routing.

## Test plan

- [x] `npm run build` in `diagram-converter/webapp/src/main/javascript`
- [x] `mvn test -pl diagram-converter/webapp` with Java 21

## Baseline

Built from commit: `16d44b0279bebebe3bcab29d7983e01da79c6f80`

closes #2374