### PR TITLE
[Backport maintenance/0.2] feat(diagram-converter): simplify webapp UI copy

### DIFF
--- a/diagram-converter/webapp/src/main/javascript/src/App.jsx
+++ b/diagram-converter/webapp/src/main/javascript/src/App.jsx
@@ -338,40 +338,35 @@ function App() {
       <div className="whiteBox">
         <div>
           <div>
-            <h2>Camunda Migration Analyzer & Diagram Converter</h2>
+            <h2>Camunda Migration Analyzer &amp; Diagram Converter</h2>
             <p>
-            Understand your BPMN models before migrating. Identify gaps, assess effort, and convert compatible elements.
+              Convert BPMN, DMN, and Camunda Form files to Camunda 8 and see what needs attention.
             </p>
             <p>
-              For more information visit the{" "}
               <a href="https://docs.camunda.io/docs/guides/migrating-from-camunda-7/migration-tooling/diagram-converter/"
                 rel="noopener noreferrer" target="_blank">
-                diagram converter guide
-              </a>.
+                Documentation
+              </a>
             </p>
             {!isSaaS && (
               <div>
                 <p>
-                  If you prefer an online version of this tool{" "}
                   <a href="https://diagram-converter.camunda.io">
-                    access it here
+                    Open online version
                   </a>
-                  .
                 </p>
               </div>
             )}
             {isSaaS && (
               <div>
                 <p>
-                  If you prefer a local version of this tool{" "}
                   <a href="https://github.com/camunda/camunda-7-to-8-migration-tooling/releases">
-                    download it here
+                    Download local version
                   </a>
-                  .
                 </p>
                 <p>
                   <a href="https://legal.camunda.com/licensing-and-other-legal-terms#trial-and-free">
-                    Check our legal terms and data privacy information.
+                    Legal &amp; privacy
                   </a>
                 </p>
               </div>
@@ -385,12 +380,12 @@ function App() {
             <ProgressStep
               current={step < 2}
               complete={step > 1}
-              label="Upload Models"
+              label="Configure"
             />
             <ProgressStep
               current={step === 2}
               complete={step > 2}
-              label="Analyze Results"
+              label="Results"
             />
           </ProgressIndicator>
         </div>
@@ -399,11 +394,10 @@ function App() {
         {step === 0 && (
           <>
             <section>
-              <h4>Instructions:</h4>
+              <h4>Add files</h4>
               <p>
-                Upload your BPMN and DMN models to analyze and convert, or
-                Camunda Forms (.form files) to convert. You can upload one or
-                more files at once.
+                Upload BPMN or DMN models to analyze and convert, or Camunda Forms
+                to convert.
               </p>
             </section>
             <div className="fileUploadBox">
@@ -426,14 +420,13 @@ function App() {
               ))}
             </div>
             <p>
-              Then go ahead and click the button below to analyze and convert
-              your models.
+              Click the button below to analyze and convert your files.
             </p>
 
-            <Form className="configBox">
+            <Form className="configBox" onSubmit={(e) => e.preventDefault()}>
               <h4>
                 <Settings style={{ marginRight: '0.5rem' }} />
-                Advanced Configuration Options
+                Advanced options
                 <Button
                   kind="ghost"
                   size="sm"
@@ -447,9 +440,9 @@ function App() {
                 <FormGroup legendText="">
                   <Checkbox
                     id="addDataMigrationExecutionListener"
-                    labelText="Add Data Migration Execution Listener"
+                    labelText="Add data migration execution listener"
                     checked={configOptions.addDataMigrationExecutionListener}
-                    helperText="Add a listener to the blank start event of the process to be used by the Camunda 7 Data Migrator. Enable if you want to use the runtime migrator later."
+                    helperText="Add a listener for use with the Camunda 7 Data Migrator."
                     onChange={(e, { checked }) =>
                       setConfigOptions((prev) => ({
                         ...prev,
@@ -459,7 +452,7 @@ function App() {
                   />
                   <TextInput
                     id="dataMigrationExecutionListenerJobType"
-                    labelText="Execution Listener Job Type"
+                    labelText="Execution listener job type"
                     value={configOptions.dataMigrationExecutionListenerJobType}
                     disabled={!configOptions.addDataMigrationExecutionListener}
                     onChange={(e) =>
@@ -474,7 +467,7 @@ function App() {
                     id="keepJobTypeBlank"
                     labelText="Keep job type blank"
                     checked={configOptions.keepJobTypeBlank}
-                    helperText="Don't set the job type in process models at all."
+                    helperText="Don't set a job type in process models."
                     onChange={(e, { checked }) =>
                       setConfigOptions((prev) => ({
                         ...prev,
@@ -485,9 +478,9 @@ function App() {
                   <div className="form-spacer" />
                   <Checkbox
                     id="defaultJobTypeEnabled"
-                    labelText="Enable default job type"
+                    labelText="Always use default job type"
                     checked={configOptions.defaultJobTypeEnabled}
-                    helperText="If enabled, tasks will always get the job type below. If disabled, the delegate expression or delegate class name will be used as job type."
+                    helperText="Always use the job type below instead of the delegate expression or class name."
                     disabled={configOptions.keepJobTypeBlank}
                     onChange={(e, { checked }) =>
                       setConfigOptions((prev) => ({
@@ -498,7 +491,7 @@ function App() {
                   />
                   <TextInput
                     id="defaultJobType"
-                    labelText="Default Job Type"
+                    labelText="Default job type"
                     value={configOptions.defaultJobType}
                     disabled={configOptions.keepJobTypeBlank}
                     onChange={(e) =>
@@ -541,11 +534,10 @@ function App() {
             */}
 
             <section>
-              <h3>Your Models</h3>
+              <h3>Converted models</h3>
               <p>
-                Download models converted to Camunda 8 individually or as one Zip
-                file. You can also preview analysis results on BPMN models or view
-                the uploaded forms.
+                Download each converted file or all of them as a ZIP. Preview a
+                file to inspect it first.
               </p>
               {files.map((file, idx) => {
                 const isForm = file.name.toLowerCase().endsWith(".form");
@@ -557,7 +549,7 @@ function App() {
                   isChecked={ fileResults[idx].checkResponseJson != null }
                   isConverted={fileResults[idx].convertedFileBlob != null}
                   previewAction={isForm ? () => previewForm(fileResults[idx]) : () => preview(fileResults[idx])}
-                  previewTitle={isForm ? "Preview this form" : undefined}
+                  previewTitle={isForm ? "Preview form" : undefined}
                   downloadAction={() => download(fileResults[idx])}
                   error={
                     !fileResults[idx].ok == "error" ? "File upload failure" : ""
@@ -572,14 +564,14 @@ function App() {
                 onClick={downloadZIP}
                 disabled={validFiles.length === 0}
               >
-                Download converted models as ZIP
+                Download all as ZIP
               </Button>
             </section>
             <hr />
 
             <section>
               <h3>Analysis results</h3>
-              <p>Download the  for all successfully converted models:</p>
+              <p>Download the findings for all converted models:</p>
               <div className="download-options">
                 <div className="download-row">
                   <Button
@@ -593,8 +585,7 @@ function App() {
                     Download XLSX
                   </Button>
                   <p>
-                    Microsoft Excel file (XLSX) containing results and prepared
-                    analysis.
+                    Excel workbook with all findings, ready to review and share.
                   </p>
                 </div>
                 <div className="download-row">
@@ -608,10 +599,9 @@ function App() {
                     Download CSV
                   </Button>
                   <p>
-                    Comma Separated Values (CSV) file containing plain results to
-                    import into your favorite tooling.
+                    Plain-text findings to import into other tools.
                   </p>
-                  </div>
+                </div>
                 <div className="download-row">
                   <Button
                     variant="secondary"
@@ -623,27 +613,26 @@ function App() {
                     Download JSON
                   </Button>
                   <p>
-                    JSON file containing plain results in a stable, machine-readable
-                    format — for AI / machine analysis, e.g. as input for the AI
-                    migration skill driving the Camunda 7 to 8 migration.
+                    Machine-readable findings, e.g. as input for AI-assisted
+                    migration tooling.
                   </p>
-                  </div>
+                </div>
                 </div>
               <p>
-                For more information on the analysis results,{" "}
-                <a href="https://docs.camunda.io/docs/guides/migrating-from-camunda-7/migration-tooling/#migration-analyzer" target="_blank">
-                  see the documentation
+                Learn more about the findings in the{" "}
+                <a href="https://docs.camunda.io/docs/guides/migrating-from-camunda-7/migration-tooling/#migration-analyzer" target="_blank" rel="noopener noreferrer">
+                  documentation
                 </a>
                 .
               </p>
             </section>
             <hr />
 
-            <h3>Next steps for your migration</h3>
+            <h3>Next steps</h3>
             <section>
               <p>
-                Discover next steps for your migration from Camunda 7 to Camunda
-                8 in the migration guide.
+                Continue your Camunda 7 to 8 migration with the step-by-step
+                migration guide.
               </p>
               <Button
                 kind="tertiary"
@@ -651,8 +640,9 @@ function App() {
                 renderIcon={Launch}
                 href="https://docs.camunda.io/docs/guides/migrating-from-camunda-7/migration-journey/?utm_source=analyzer"
                 target="_blank"
+                rel="noopener noreferrer"
               >
-                Migration Guide
+                Open migration guide
               </Button>
             </section>
           </>
@@ -663,7 +653,7 @@ function App() {
     <div className="modal">
       <div className="modal-header">
         <div className="left">
-        <h2>{previewType === "form" ? "Form preview" : "Analysis preview"}</h2>
+        <h2>Preview</h2>
         </div>
         <div>
           <Button

--- a/diagram-converter/webapp/src/main/javascript/src/DropZone.jsx
+++ b/diagram-converter/webapp/src/main/javascript/src/DropZone.jsx
@@ -33,13 +33,29 @@ export default function DropZone({ onFiles }) {
   return (
     <div
       className="DropZone"
+      role="button"
+      tabIndex={0}
       onDragOver={(evt) => evt.preventDefault()}
       onDrop={processFile}
       onClick={selectFileToUpload}
+      onKeyDown={(evt) => {
+        if (evt.key === "Enter") {
+          evt.preventDefault();
+          selectFileToUpload();
+        } else if (evt.key === " ") {
+          // Prevent page scroll; activate on keyup like a native button
+          evt.preventDefault();
+        }
+      }}
+      onKeyUp={(evt) => {
+        if (evt.key === " ") {
+          selectFileToUpload();
+        }
+      }}
     >
-      <img src={InboxIcon} />
-      <h2>Click or drag file to this area to upload</h2>
-      <p>Upload .xml .bpmn .dmn and .form files. </p>
+      <img src={InboxIcon} alt="" />
+      <h2>Click or drag files here to upload</h2>
+      <p>Supports .bpmn, .dmn, .form, and .xml files.</p>
     </div>
   );
 }

--- a/diagram-converter/webapp/src/main/javascript/src/FileItem.jsx
+++ b/diagram-converter/webapp/src/main/javascript/src/FileItem.jsx
@@ -25,7 +25,7 @@ export default function DropZone({
   isConverted,
   downloadAction,
   previewAction,
-  previewTitle = "Preview the analyzer results for this model",
+  previewTitle = "Preview analysis findings",
   onDelete,
 }) {
   return (
@@ -61,8 +61,8 @@ export default function DropZone({
           </button>
         )}
         {status === "uploading" && !isConverted && <Loading small withOverlay={false} />}
-        {isConverted && downloadAction && (
-          <button className="download" onClick={downloadAction} title="Download the converted model">
+        {isConverted && downloadAction && !error && (
+          <button className="download" onClick={downloadAction} title="Download converted model" aria-label="Download converted model">
             <Download />
           </button>
         )}

--- a/diagram-converter/webapp/src/main/javascript/src/FileItem.test.jsx
+++ b/diagram-converter/webapp/src/main/javascript/src/FileItem.test.jsx
@@ -34,11 +34,11 @@ describe("FileItem", () => {
         status="success"
         isChecked
         previewAction={previewAction}
-        previewTitle="Preview this form"
+        previewTitle="Preview form"
       />
     );
 
-    fireEvent.click(screen.getByRole("button", { name: "Preview this form" }));
+    fireEvent.click(screen.getByRole("button", { name: "Preview form" }));
 
     expect(previewAction).toHaveBeenCalledOnce();
   });

--- a/diagram-converter/webapp/src/main/javascript/src/FormPreview.jsx
+++ b/diagram-converter/webapp/src/main/javascript/src/FormPreview.jsx
@@ -29,7 +29,7 @@ export default function FormPreview({ schema, onError }) {
       .catch((error) => {
         if (isActive) {
           const message = error instanceof Error ? error.message : "Unknown rendering error";
-          onError(`Unable to render this form: ${message}`);
+          onError(`The form could not be displayed: ${message}`);
         }
       });
 

--- a/diagram-converter/webapp/src/main/javascript/src/FormPreview.test.jsx
+++ b/diagram-converter/webapp/src/main/javascript/src/FormPreview.test.jsx
@@ -93,7 +93,7 @@ describe("FormPreview", () => {
 
     await waitFor(() =>
       expect(onError).toHaveBeenCalledWith(
-        "Unable to render this form: unsupported component"
+        "The form could not be displayed: unsupported component"
       )
     );
   });

--- a/diagram-converter/webapp/src/main/javascript/src/formSchema.js
+++ b/diagram-converter/webapp/src/main/javascript/src/formSchema.js
@@ -9,7 +9,7 @@ export function parseFormSchema(content) {
   if (content === null || content === undefined || content === "") {
     return {
       schema: null,
-      error: "Unable to render this form because its content is unavailable.",
+      error: "The form content is unavailable.",
     };
   }
 
@@ -22,14 +22,14 @@ export function parseFormSchema(content) {
     }
     return {
       schema: null,
-      error: "Unable to render this form because its content is not valid JSON.",
+      error: "The form content is not valid JSON.",
     };
   }
 
   if (!schema || typeof schema !== "object" || Array.isArray(schema)) {
     return {
       schema: null,
-      error: "Unable to render this form because its content is not a JSON object.",
+      error: "The form content is not a JSON object.",
     };
   }
 

--- a/diagram-converter/webapp/src/main/javascript/src/formSchema.test.js
+++ b/diagram-converter/webapp/src/main/javascript/src/formSchema.test.js
@@ -23,17 +23,17 @@ describe("parseFormSchema", () => {
     (content) => {
       expect(parseFormSchema(content)).toEqual({
         schema: null,
-        error: "Unable to render this form because its content is unavailable.",
+        error: "The form content is unavailable.",
       });
     }
   );
 
   it.each([
-    ["{ invalid", "Unable to render this form because its content is not valid JSON."],
-    ["[]", "Unable to render this form because its content is not a JSON object."],
-    [0, "Unable to render this form because its content is not a JSON object."],
-    [false, "Unable to render this form because its content is not a JSON object."],
-    ["0", "Unable to render this form because its content is not a JSON object."],
+    ["{ invalid", "The form content is not valid JSON."],
+    ["[]", "The form content is not a JSON object."],
+    [0, "The form content is not a JSON object."],
+    [false, "The form content is not a JSON object."],
+    ["0", "The form content is not a JSON object."],
   ])("reports invalid content", (content, error) => {
     expect(parseFormSchema(content)).toEqual({ schema: null, error });
   });


### PR DESCRIPTION
## Summary

Backports #2373 to `maintenance/0.2`.

## Why the automated backport failed

The backport bot attempted to cherry-pick the merged #2373 commit, `b9a1b24f4ff4c6800f18fda3c0e7f9e9bdad23df`, but Git could not apply it cleanly. The `main` branch has since moved to the newer `@camunda/design-system` and Lucide-based webapp structure, while `maintenance/0.2` still uses the older Carbon React UI. The divergent implementations caused conflicts in:

- `diagram-converter/webapp/src/main/javascript/src/App.jsx`
- `diagram-converter/webapp/src/main/javascript/src/FileItem.jsx`

This PR manually applies the intended copy and accessibility changes while preserving the Carbon-based `maintenance/0.2` UI. It does not wholesale backport unrelated newer UI changes.

## Changes

- Keep the `Camunda Migration Analyzer & Diagram Converter` title and advertise BPMN, DMN, and Camunda Form conversion.
- Simplify upload, configuration, analysis results, download, error, and migration-guide copy.
- Use `Preview` consistently for BPMN/DMN analysis and Forms previews.
- Fix the findings-download label.
- Add keyboard access and accessible names to the file drop zone and download action.
- Simplify form parsing and rendering errors, and add safe link attributes.

## Validation

`npm run build` in `diagram-converter/webapp/src/main/javascript` passed, including lint, typecheck, type-escape validation, Vitest, and the production build.

Related to #2373