### PR TITLE
feat(diagram-converter): reject invalid form files

### DIFF
--- a/diagram-converter/core/src/main/java/io/camunda/migration/diagram/converter/FormConverter.java
+++ b/diagram-converter/core/src/main/java/io/camunda/migration/diagram/converter/FormConverter.java
@@ -79,6 +79,9 @@ public class FormConverter {
   }
 
   private static JsonNode readTree(String formContent) {
+    if (formContent == null || formContent.isBlank()) {
+      throw new IllegalArgumentException("Form content must be a JSON object, but was empty");
+    }
     try {
       JsonNode root = OBJECT_MAPPER.readTree(formContent);
       if (root == null || root.isMissingNode()) {

--- a/diagram-converter/core/src/main/java/io/camunda/migration/diagram/converter/FormConverter.java
+++ b/diagram-converter/core/src/main/java/io/camunda/migration/diagram/converter/FormConverter.java
@@ -80,7 +80,11 @@ public class FormConverter {
 
   private static JsonNode readTree(String formContent) {
     try {
-      return OBJECT_MAPPER.readTree(formContent);
+      JsonNode root = OBJECT_MAPPER.readTree(formContent);
+      if (root == null || root.isMissingNode()) {
+        throw new IllegalArgumentException("Form content must be a JSON object, but was empty");
+      }
+      return root;
     } catch (JsonProcessingException e) {
       throw new IllegalArgumentException("Form content is not valid JSON: " + e.getMessage(), e);
     }

--- a/diagram-converter/core/src/test/java/io/camunda/migration/diagram/converter/FormConverterTest.java
+++ b/diagram-converter/core/src/test/java/io/camunda/migration/diagram/converter/FormConverterTest.java
@@ -128,6 +128,14 @@ class FormConverterTest {
   }
 
   @Test
+  void shouldRejectEmptyContent() {
+    assertThatThrownBy(() -> FormConverter.convert("", defaultProperties()))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("must be a JSON object")
+        .hasMessageContaining("empty");
+  }
+
+  @Test
   void shouldRejectInvalidPlatformVersion() {
     DefaultConverterProperties properties = new DefaultConverterProperties();
     properties.setPlatformVersion("not-a-version");

--- a/diagram-converter/core/src/test/java/io/camunda/migration/diagram/converter/FormConverterTest.java
+++ b/diagram-converter/core/src/test/java/io/camunda/migration/diagram/converter/FormConverterTest.java
@@ -133,6 +133,10 @@ class FormConverterTest {
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("must be a JSON object")
         .hasMessageContaining("empty");
+    assertThatThrownBy(() -> FormConverter.convert("   ", defaultProperties()))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("must be a JSON object")
+        .hasMessageContaining("empty");
   }
 
   @Test

--- a/diagram-converter/webapp/src/main/java/io/camunda/migration/diagram/converter/webapp/ConverterController.java
+++ b/diagram-converter/webapp/src/main/java/io/camunda/migration/diagram/converter/webapp/ConverterController.java
@@ -144,7 +144,7 @@ public class ConverterController {
           LOG.error("Error while reading input stream of form file", e);
           return ResponseEntity.badRequest().body(e.getMessage());
         } catch (IllegalArgumentException e) {
-          return ResponseEntity.badRequest().body(e.getMessage());
+          return invalidFormResponse(e);
         }
         continue;
       }
@@ -352,7 +352,7 @@ public class ConverterController {
             .body(file);
       } catch (IllegalArgumentException e) {
         // client error (invalid JSON or platform version) - no stack trace noise
-        return ResponseEntity.badRequest().body(e.getMessage());
+        return invalidFormResponse(e);
       } catch (IOException e) {
         LOG.error("IO Error while reading form file", e);
         return ResponseEntity.badRequest().body(e.getMessage());
@@ -435,7 +435,7 @@ public class ConverterController {
           putConverted(resultList, convertedFileName(diagramFile.getOriginalFilename()), file);
         } catch (IllegalArgumentException e) {
           // client error (invalid JSON or platform version) - no stack trace noise
-          return ResponseEntity.badRequest().body(e.getMessage());
+          return invalidFormResponse(e);
         } catch (IOException e) {
           LOG.error("IO Error while converting form file in batch", e);
           return ResponseEntity.badRequest().body(e.getMessage());
@@ -510,6 +510,14 @@ public class ConverterController {
       throw new IllegalArgumentException("No file provided");
     }
     return DiagramType.fromFileName(originalFilename);
+  }
+
+  private ResponseEntity<?> invalidFormResponse(IllegalArgumentException exception) {
+    String message = exception.getMessage();
+    if (message != null && message.startsWith("Form content")) {
+      return ResponseEntity.badRequest().body("The uploaded .form file is not a valid JSON form.");
+    }
+    return ResponseEntity.badRequest().body(message);
   }
 
   private ConverterProperties converterProperties(String platformVersion) {

--- a/diagram-converter/webapp/src/main/java/io/camunda/migration/diagram/converter/webapp/ConverterController.java
+++ b/diagram-converter/webapp/src/main/java/io/camunda/migration/diagram/converter/webapp/ConverterController.java
@@ -514,7 +514,7 @@ public class ConverterController {
 
   private ResponseEntity<?> invalidFormResponse(IllegalArgumentException exception) {
     String message = exception.getMessage();
-    if (message != null && message.startsWith("Form content")) {
+    if (!StringUtils.hasText(message) || message.startsWith("Form content")) {
       return ResponseEntity.badRequest().body("The uploaded .form file is not a valid JSON form.");
     }
     return ResponseEntity.badRequest().body(message);

--- a/diagram-converter/webapp/src/main/javascript/src/App.jsx
+++ b/diagram-converter/webapp/src/main/javascript/src/App.jsx
@@ -320,7 +320,25 @@ function App() {
 
   async function responseErrorMessage(response, fallback) {
     const message = (await response.text()).trim();
-    return message || fallback;
+    if (!message) return fallback;
+
+    const contentType = response.headers.get("Content-Type") || "";
+    if (!contentType.includes("application/json")) return message;
+
+    try {
+      const errorBody = JSON.parse(message);
+      switch (errorBody.errorCode) {
+        case "FILE_COUNT_LIMIT_EXCEEDED":
+          return "Too many files at once. Remove some files and try again.";
+        case "MULTIPART_ERROR":
+          return "The uploaded files could not be processed.";
+        default:
+          return fallback;
+      }
+    } catch (error) {
+      if (!(error instanceof SyntaxError)) throw error;
+      return message;
+    }
   }
 
   function buildErrorMessage(errorBody) {

--- a/diagram-converter/webapp/src/main/javascript/src/App.jsx
+++ b/diagram-converter/webapp/src/main/javascript/src/App.jsx
@@ -244,7 +244,10 @@ function App() {
         if (!checkResponse.ok) {
           const result = {
             status: "error",
-            errorMessage: `Analysis failed (HTTP ${checkResponse.status})`,
+            errorMessage: await responseErrorMessage(
+              checkResponse,
+              `Analysis failed (HTTP ${checkResponse.status})`
+            ),
             originalModelXml: originalModelXml,
             checkResponseJson: null,
           };
@@ -282,7 +285,10 @@ function App() {
         if (!convertResponse.ok) {
           result = {
             status: "error",
-            errorMessage: `Conversion failed (HTTP ${convertResponse.status})`,
+            errorMessage: await responseErrorMessage(
+              convertResponse,
+              `Conversion failed (HTTP ${convertResponse.status})`
+            ),
             originalModelXml: originalModelXml,
             checkResponseJson: checkResponseJson,
           };
@@ -310,6 +316,11 @@ function App() {
       (_, idx) => uploadResults[idx].status === "success"
     );
     setValidFiles(validFiles);
+  }
+
+  async function responseErrorMessage(response, fallback) {
+    const message = (await response.text()).trim();
+    return message || fallback;
   }
 
   function buildErrorMessage(errorBody) {

--- a/diagram-converter/webapp/src/test/java/io/camunda/migration/diagram/converter/webapp/ConverterControllerTest.java
+++ b/diagram-converter/webapp/src/test/java/io/camunda/migration/diagram/converter/webapp/ConverterControllerTest.java
@@ -54,6 +54,40 @@ public class ConverterControllerTest {
   private static final Logger LOG = LoggerFactory.getLogger(ConverterControllerTest.class);
   @LocalServerPort int port;
 
+  private static final String XML_CONTENT_IN_FORM_FILE =
+      """
+      <?xml version="1.0" encoding="UTF-8"?>
+      <bpmn:definitions
+          xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+          xmlns:camunda="http://camunda.org/schema/1.0/bpmn"
+          id="Definitions_JuelForm"
+          targetNamespace="http://example.com/juel-form">
+        <bpmn:process id="JuelFormProcess" isExecutable="true">
+          <bpmn:startEvent id="StartEvent_1">
+            <bpmn:outgoing>Flow_1</bpmn:outgoing>
+          </bpmn:startEvent>
+          <bpmn:sequenceFlow id="Flow_1" sourceRef="StartEvent_1" targetRef="UserTask_1" />
+          <bpmn:userTask id="UserTask_1" name="Test JUEL Form">
+            <bpmn:extensionElements>
+              <camunda:formData>
+                <camunda:formField
+                    id="answer"
+                    label="Calculated answer"
+                    type="long"
+                    defaultValue="${1 + 1}" />
+              </camunda:formData>
+            </bpmn:extensionElements>
+            <bpmn:incoming>Flow_1</bpmn:incoming>
+            <bpmn:outgoing>Flow_2</bpmn:outgoing>
+          </bpmn:userTask>
+          <bpmn:sequenceFlow id="Flow_2" sourceRef="UserTask_1" targetRef="EndEvent_1" />
+          <bpmn:endEvent id="EndEvent_1">
+            <bpmn:incoming>Flow_2</bpmn:incoming>
+          </bpmn:endEvent>
+        </bpmn:process>
+      </bpmn:definitions>
+      """;
+
   @BeforeEach
   void setup() {
     RestAssured.port = port;
@@ -646,6 +680,66 @@ public class ConverterControllerTest {
 
     String converted = new String(form, StandardCharsets.UTF_8);
     assertThat(converted).contains("\"executionPlatformVersion\": \"8.8.0\"");
+  }
+
+  @Test
+  void checkXmlWithFormFilenameReturnsBadRequest() {
+    String errorMessage =
+        RestAssured.given()
+            .contentType(ContentType.MULTIPART)
+            .multiPart(
+                "file",
+                "generated.form",
+                XML_CONTENT_IN_FORM_FILE.getBytes(StandardCharsets.UTF_8),
+                "application/xml")
+            .accept(ContentType.JSON)
+            .post("/check")
+            .then()
+            .statusCode(400)
+            .extract()
+            .asString();
+
+    assertThat(errorMessage).isEqualTo("The uploaded .form file is not a valid JSON form.");
+  }
+
+  @Test
+  void convertXmlWithFormFilenameReturnsBadRequest() {
+    String errorMessage =
+        RestAssured.given()
+            .contentType(ContentType.MULTIPART)
+            .multiPart(
+                "file",
+                "generated.form",
+                XML_CONTENT_IN_FORM_FILE.getBytes(StandardCharsets.UTF_8),
+                "application/xml")
+            .accept(ContentType.JSON)
+            .post("/convert")
+            .then()
+            .statusCode(400)
+            .extract()
+            .asString();
+
+    assertThat(errorMessage).isEqualTo("The uploaded .form file is not a valid JSON form.");
+  }
+
+  @Test
+  void convertBatchXmlWithFormFilenameReturnsBadRequest() {
+    String errorMessage =
+        RestAssured.given()
+            .contentType(ContentType.MULTIPART)
+            .multiPart(
+                "file",
+                "generated.form",
+                XML_CONTENT_IN_FORM_FILE.getBytes(StandardCharsets.UTF_8),
+                "application/xml")
+            .accept("application/zip")
+            .post("/convertBatch")
+            .then()
+            .statusCode(400)
+            .extract()
+            .asString();
+
+    assertThat(errorMessage).isEqualTo("The uploaded .form file is not a valid JSON form.");
   }
 
   @Test


### PR DESCRIPTION
## Summary
- keep `.form` uploads on the JSON form path instead of guessing BPMN from their content
- return a clear client error for XML, empty, or otherwise invalid form content
- show the server error message in the web UI

## Tests
- `mvn -pl diagram-converter/core -am -Dtest=FormConverterTest -Dsurefire.failIfNoSpecifiedTests=false test`
- `mvn -pl diagram-converter/webapp -am -Dtest=ConverterControllerTest -Dsurefire.failIfNoSpecifiedTests=false test`
- `npm run lint -- --quiet && npm test -- --run`