### PR TITLE
[Backport maintenance/0.3] feat(diagram-converter): show analysis findings for all file types in webapp

### DIFF
--- a/diagram-converter/webapp/src/main/javascript/src/App.jsx
+++ b/diagram-converter/webapp/src/main/javascript/src/App.jsx
@@ -27,6 +27,7 @@ import {
 import { Download, ExternalLink, X, Settings, ChevronDown, ChevronUp } from "lucide-react";
 import DropZone from "./DropZone";
 import FileItem from "./FileItem";
+import { FINDINGS_TABLE_HEADER, buildFindingsRows } from "./findings";
 import BpmnJS from 'bpmn-js';
 import FormPreview from "./FormPreview";
 import { parseFormSchema } from "./formSchema";
@@ -61,6 +62,58 @@ function getMostSevere(messages) {
   return mostSevere;
 }
 
+function FindingsSection({ header, rows }) {
+  if (rows.length === 0) {
+    return (
+      <p style={{ color: 'var(--neutral-foreground-subtle)', marginTop: '1rem' }}>No findings for this file.</p>
+    );
+  }
+  return (
+    <>
+      <h3>Findings</h3>
+      <p style={{ color: 'var(--neutral-foreground-subtle)', marginBottom: '0.75rem' }}>
+        Elements in this file that need attention during migration. Each row describes one finding — its location, severity, and a message explaining what to address.
+      </p>
+      <Table className="analysis-table">
+        <TableHeader>
+          <TableRow>
+            {header.map((h) => (
+              <TableHead key={h.key}>
+                {h.header}
+              </TableHead>
+            ))}
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {rows.map((row) => (
+            <TableRow key={row.id}>
+              {header.map((h) => {
+                const value = row[h.key];
+                return (
+                  <TableCell key={`${row.id}-${h.key}`}>
+                    {h.key === 'link'
+                      ? value
+                        ? <a
+                            href={value}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            aria-label={`Open finding documentation: ${value}`}
+                          >
+                            Open
+                          </a>
+                        : '-'
+                      : value}
+                  </TableCell>
+                );
+              })}
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </>
+  );
+}
+
 function App() {
   const baseUrl = ""; // Change this to "http://localhost:8080" if you want to play with it locally by using npm run dev
 
@@ -73,6 +126,7 @@ function App() {
   const [previewbpmnXml, setPreviewbpmnXml] = useState("");
   const [previewFormSchema, setPreviewFormSchema] = useState(null);
   const [previewFormError, setPreviewFormError] = useState("");
+  const [previewDiagramError, setPreviewDiagramError] = useState(false);
   const [previewCheckJson, setPreviewCheckJson] = useState([]);
 
   const [previewTableHeader, setPreviewTableHeader] = useState([]);
@@ -109,12 +163,7 @@ function App() {
 
   const allDone = fileResults.length > 0 && fileResults.every(r => r.status !== 'uploading');
   const totalFindings = allDone
-    ? fileResults.reduce((sum, r) => {
-        if (!r.checkResponseJson) return sum;
-        return sum + r.checkResponseJson
-          .flatMap(item => item.results || [])
-          .reduce((s, el) => s + (el.messages?.length || 0), 0);
-      }, 0)
+    ? fileResults.reduce((sum, r) => sum + buildFindingsRows(r.checkResponseJson).length, 0)
     : 0;
 
   const [configOptions, setConfigOptions] = useState({
@@ -133,41 +182,44 @@ function App() {
   }, []);
 
   useEffect(() => {
-      if (isPreviewOpen && previewType === "bpmn" && previewbpmnXml) {
-          const viewer = new BpmnJS({ container: bpmnPreviewRef.current });
-          let isActive = true;
-          viewer.importXML(previewbpmnXml).then(() => {
-            if (!isActive) return;
+      if (!isPreviewOpen || previewType !== "bpmn" || previewDiagramError || !previewbpmnXml) return;
 
-            const canvas = viewer.get('canvas');
-            canvas.zoom('fit-viewport');
+      const viewer = new BpmnJS({ container: bpmnPreviewRef.current });
+      let isActive = true;
+      viewer.importXML(previewbpmnXml).then(() => {
+        if (!isActive) return;
 
-            const elementsWithMessages =
-              previewCheckJson?.[0]?.results?.filter((el) => el.messages?.length > 0) || [];
+        const canvas = viewer.get('canvas');
+        canvas.zoom('fit-viewport');
 
-            elementsWithMessages.forEach((el) => {
-              if (el.elementId) {
-                  const severity = getMostSevere(el.messages);
-                  if (severity) {
-                    // Mark wit the same color everytime for the moment
-                    //canvas.addMarker(el.elementId, `highlight-${severity.toLowerCase()}`);
-                    canvas.addMarker(el.elementId, `highlight-info`);
-                  }
-              }
-            });
+        const elementsWithMessages =
+          (Array.isArray(previewCheckJson) ? previewCheckJson : [])
+            .flatMap((item) => (Array.isArray(item?.results) ? item.results : []))
+            .filter((el) => Array.isArray(el?.messages) && el.messages.length > 0);
 
-          }).catch((error) => {
-            if (isActive) {
-              console.error("Unable to render BPMN preview:", error);
+        elementsWithMessages.forEach((el) => {
+          if (el.elementId) {
+            const severity = getMostSevere(el.messages);
+            if (severity) {
+              // Mark with the same color every time for the moment
+              //canvas.addMarker(el.elementId, `highlight-${severity.toLowerCase()}`);
+              canvas.addMarker(el.elementId, `highlight-info`);
             }
-          });
+          }
+        });
 
-          return () => {
-            isActive = false;
-            viewer.destroy();
-          };
-      }
-    }, [isPreviewOpen, previewType, previewbpmnXml, previewCheckJson]);
+      }).catch((error) => {
+        if (isActive) {
+          console.error("Unable to render BPMN preview:", error);
+          setPreviewDiagramError(true);
+        }
+      });
+
+      return () => {
+        isActive = false;
+        viewer.destroy();
+      };
+    }, [isPreviewOpen, previewType, previewDiagramError, previewbpmnXml, previewCheckJson]);
 
   useEffect(() => {
     if (!allDone || totalFindings === 0) return;
@@ -390,34 +442,22 @@ function App() {
   async function preview(response) {
     if (!response?.checkResponseJson) return;
 
-    setPreviewTableHeader([
-      { key: 'elementType', header: 'Element Type' },
-      { key: 'elementId', header: 'Element ID' },
-      { key: 'elementName', header: 'Element Name' },
-      { key: 'severity', header: 'Severity' },
-      { key: 'message', header: 'Message' },
-      { key: 'link', header: 'Link' },
-    ]);
-
-    setPreviewTableRows(
-      response.checkResponseJson?.[0]?.results.flatMap((element, elementIdx) =>
-        element.messages.map((message, msgIdx) => ({
-          id: `${elementIdx}-${msgIdx}`,
-          elementType: element.elementType,
-          elementId: element.elementId,
-          elementName: element.elementName || '(unnamed)',
-          severity: message.severity,
-          message: message.message,
-          link: message.link || null,
-        }))
-      ) || []);
-
+    setPreviewTableHeader(FINDINGS_TABLE_HEADER);
+    setPreviewTableRows(buildFindingsRows(response.checkResponseJson));
 
     setPreviewCheckJson(response.checkResponseJson);
     setPreviewbpmnXml(response.originalModelXml);
     setPreviewFormSchema(null);
     setPreviewFormError("");
-    setPreviewType("bpmn");
+    setPreviewDiagramError(false);
+    // BPMN is detected by content, not extension: the dropzone also accepts
+    // .xml files, which can be BPMN (or DMN) models.
+    setPreviewType(
+      typeof response.originalModelXml === "string" &&
+      response.originalModelXml.includes("omg.org/spec/BPMN")
+        ? "bpmn"
+        : "other"
+    );
 
     setIsPreviewOpen(true);
   }
@@ -429,6 +469,7 @@ function App() {
     setPreviewCheckJson([]);
     setPreviewTableHeader([]);
     setPreviewTableRows([]);
+    setPreviewDiagramError(false);
     setPreviewType("form");
     setIsPreviewOpen(true);
   }
@@ -436,6 +477,9 @@ function App() {
   function previewForm(response) {
     const { schema, error } = parseFormSchema(response?.originalModelXml);
     openFormPreview(schema, error);
+    setPreviewCheckJson(response?.checkResponseJson || []);
+    setPreviewTableHeader(FINDINGS_TABLE_HEADER);
+    setPreviewTableRows(buildFindingsRows(response?.checkResponseJson));
   }
 
   async function download(response) {
@@ -670,17 +714,18 @@ function App() {
         {step === 2 && (
           <>
             <section>
-              <h3>Converted models</h3>
+              <h3>Converted files</h3>
               <p>
-                Download each converted file or all of them as a ZIP. Preview a
-                file to inspect it first.
+                Download each converted file or all of them as a ZIP. Use the eye
+                icon to preview analysis findings for each file; BPMN files also
+                render a diagram, and forms show a form preview.
               </p>
               {allDone && totalFindings > 0 && (
                 <div ref={incompatibilityNotifRef}>
                   <Alert
                     variant="warning"
                     title={`${totalFindings} finding${totalFindings !== 1 ? 's' : ''} detected for Camunda ${platformVersion}`}
-                    description="Some elements may not be fully supported in this version. Preview a model or download the XLSX report for details."
+                    description="Some elements may not be fully supported in this version. Use the preview per file or download the XLSX report for a complete overview."
                     className="incompatibility-notification"
                   >
                     <Button variant="secondary" size="sm" onClick={downloadXLS}>
@@ -692,11 +737,7 @@ function App() {
               {files.map((file, idx) => {
                 const r = fileResults[idx];
                 const isForm = file.name.toLowerCase().endsWith(".form");
-                const fileFindingCount = r.checkResponseJson
-                  ? r.checkResponseJson
-                      .flatMap(item => item.results || [])
-                      .reduce((s, el) => s + (el.messages?.length || 0), 0)
-                  : 0;
+                const fileFindingCount = buildFindingsRows(r.checkResponseJson).length;
                 return (
                 <FileItem
                   key={file.name + "-" + idx}
@@ -733,14 +774,14 @@ function App() {
                 disabled={validFiles.length === 0}
               >
                 <Download />
-                Download all as ZIP
+                Download all converted files as ZIP
               </Button>
             </section>
             <hr />
 
             <section>
               <h3>Analysis results</h3>
-              <p>Download the findings for all converted models:</p>
+              <p>Download the analysis results for all successfully converted files:</p>
               <div className="download-options">
                 <div className="download-row">
                   <Button
@@ -836,53 +877,28 @@ function App() {
         </div>
       </div>
 
-      {previewType === "bpmn" && (
+      {(previewType === "bpmn" || previewType === "other") && (
         <>
-          <div ref={bpmnPreviewRef} id="bpmnDiagram" className="diagram-container"></div>
-          {previewTableRows.length === 0 && (
-            <p style={{ color: 'var(--neutral-foreground-subtle)', marginTop: '1rem' }}>No findings for this model.</p>
+          {previewType === "bpmn" && !previewDiagramError && (
+            <div ref={bpmnPreviewRef} id="bpmnDiagram" className="diagram-container"></div>
           )}
-          {previewTableRows.length > 0 && <>
-            <h3>Findings</h3>
-            <p style={{ color: 'var(--neutral-foreground-subtle)', marginBottom: '0.75rem' }}>
-              Elements in this model that need attention during migration.
+          {(previewType === "other" || (previewType === "bpmn" && previewDiagramError)) && (
+            <p style={{ color: 'var(--neutral-foreground-subtle)', marginTop: '1rem' }}>
+              {previewDiagramError
+                ? 'The diagram could not be rendered. The findings for this file are listed below.'
+                : 'Diagram preview is only available for BPMN files. The findings for this file are listed below.'}
             </p>
-            <Table className="analysis-table">
-              <TableHeader>
-                <TableRow>
-                  {previewTableHeader.map((header) => (
-                    <TableHead key={header.key}>
-                      {header.header}
-                    </TableHead>
-                  ))}
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                {previewTableRows.map((row) => (
-                  <TableRow key={row.id}>
-                    {previewTableHeader.map((header) => {
-                      const value = row[header.key];
-                      return (
-                        <TableCell key={`${row.id}-${header.key}`}>
-                          {header.key === 'link'
-                            ? value
-                              ? <a href={value} target="_blank" rel="noopener noreferrer">Link</a>
-                              : '-'
-                            : value}
-                        </TableCell>
-                      );
-                    })}
-                  </TableRow>
-                ))}
-              </TableBody>
-            </Table>
-          </>}
+          )}
+          <FindingsSection header={previewTableHeader} rows={previewTableRows} />
         </>
       )}
       {previewType === "form" && (
-        previewFormError
-          ? <Alert variant="destructive" title="Form preview unavailable" description={previewFormError} />
-          : <FormPreview schema={previewFormSchema} onError={setPreviewFormError} />
+        <>
+          {previewFormError
+            ? <Alert variant="destructive" title="Form preview unavailable" description={previewFormError} />
+            : <FormPreview schema={previewFormSchema} onError={setPreviewFormError} />}
+          <FindingsSection header={previewTableHeader} rows={previewTableRows} />
+        </>
       )}
 
     </div>

--- a/diagram-converter/webapp/src/main/javascript/src/findings.js
+++ b/diagram-converter/webapp/src/main/javascript/src/findings.js
@@ -1,0 +1,52 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+export const FINDINGS_TABLE_HEADER = [
+  { key: 'elementType', header: 'Element Type' },
+  { key: 'elementId', header: 'Element ID' },
+  { key: 'elementName', header: 'Element Name' },
+  { key: 'severity', header: 'Severity' },
+  { key: 'message', header: 'Message' },
+  { key: 'link', header: 'Link' },
+];
+
+// Flattens the /check response (List<DiagramCheckResult>) into table rows,
+// one row per finding message across all result items.
+export function buildFindingsRows(checkResponseJson) {
+  if (!Array.isArray(checkResponseJson)) {
+    return [];
+  }
+
+  return checkResponseJson.flatMap((item, itemIdx) => {
+    if (!item || typeof item !== 'object' || !Array.isArray(item.results)) {
+      return [];
+    }
+
+    return item.results.flatMap((element, elementIdx) => {
+      if (!element || typeof element !== 'object' || !Array.isArray(element.messages)) {
+        return [];
+      }
+
+      return element.messages.flatMap((message, msgIdx) => {
+        if (!message || typeof message !== 'object') {
+          return [];
+        }
+
+        return [{
+          id: `${itemIdx}-${elementIdx}-${msgIdx}`,
+          elementType: element.elementType || '-',
+          elementId: element.elementId || '-',
+          elementName: element.elementName || '(unnamed)',
+          severity: message.severity,
+          message: message.message,
+          link: message.link || null,
+        }];
+      });
+    });
+  });
+}

--- a/diagram-converter/webapp/src/main/javascript/src/findings.test.js
+++ b/diagram-converter/webapp/src/main/javascript/src/findings.test.js
@@ -1,0 +1,110 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { buildFindingsRows, FINDINGS_TABLE_HEADER } from './findings';
+
+describe('buildFindingsRows', () => {
+  it('returns no rows for empty or missing input', () => {
+    expect(buildFindingsRows(null)).toEqual([]);
+    expect(buildFindingsRows(undefined)).toEqual([]);
+    expect(buildFindingsRows([])).toEqual([]);
+    expect(buildFindingsRows([{ results: [] }])).toEqual([]);
+    expect(buildFindingsRows([{}])).toEqual([]);
+  });
+
+  it('returns no rows for malformed non-array result data', () => {
+    expect(buildFindingsRows({ results: [] })).toEqual([]);
+    expect(buildFindingsRows('not an array')).toEqual([]);
+    expect(buildFindingsRows([{ results: {} }])).toEqual([]);
+    expect(buildFindingsRows([{ results: [{ messages: {} }] }])).toEqual([]);
+    expect(buildFindingsRows([{ results: [null, { messages: [null] }] }])).toEqual([]);
+  });
+
+  it('flattens findings across multiple result items and elements', () => {
+    const rows = buildFindingsRows([
+      {
+        results: [
+          {
+            elementId: 'task1',
+            elementName: 'Task One',
+            elementType: 'bpmn:ServiceTask',
+            messages: [
+              { severity: 'WARNING', message: 'first', link: 'https://example.com/1' },
+              { severity: 'INFO', message: 'second', link: null },
+            ],
+          },
+        ],
+      },
+      {
+        results: [
+          {
+            elementId: 'task2',
+            elementName: null,
+            elementType: 'bpmn:UserTask',
+            messages: [{ severity: 'TASK', message: 'third', link: 'https://example.com/2' }],
+          },
+        ],
+      },
+    ]);
+
+    expect(rows).toHaveLength(3);
+    expect(rows.map((r) => r.message)).toEqual(['first', 'second', 'third']);
+    expect(rows[0]).toMatchObject({
+      id: '0-0-0',
+      elementId: 'task1',
+      elementName: 'Task One',
+      elementType: 'bpmn:ServiceTask',
+      severity: 'WARNING',
+      link: 'https://example.com/1',
+    });
+    // ids are unique across items, elements and messages
+    expect(new Set(rows.map((r) => r.id)).size).toBe(3);
+  });
+
+  it('renders fallbacks for findings without element id, name or type', () => {
+    const rows = buildFindingsRows([
+      {
+        results: [
+          {
+            elementId: null,
+            elementName: null,
+            elementType: null,
+            messages: [{ severity: 'REVIEW', message: 'form finding' }],
+          },
+        ],
+      },
+    ]);
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      elementId: '-',
+      elementType: '-',
+      elementName: '(unnamed)',
+      link: null,
+    });
+  });
+
+  it('tolerates elements without a messages array', () => {
+    const rows = buildFindingsRows([{ results: [{ elementId: 'x' }] }]);
+    expect(rows).toEqual([]);
+  });
+});
+
+describe('FINDINGS_TABLE_HEADER', () => {
+  it('covers severity, element identity, message and link', () => {
+    expect(FINDINGS_TABLE_HEADER.map((h) => h.key)).toEqual([
+      'elementType',
+      'elementId',
+      'elementName',
+      'severity',
+      'message',
+      'link',
+    ]);
+  });
+});


### PR DESCRIPTION
# Description
Backport of camunda/camunda-7-to-8-migration-tooling#2353 to `maintenance/0.3`.

# Conflict resolution notes

The automated cherry-pick of 45dfc20b4d79c9cdd45c425fc1fd70592e217972 conflicted because `maintenance/0.3` does not have the DMN preview feature (#2375, backport pending in #2379) which introduced `modelType.js`/`DmnPreview` and renamed `previewbpmnXml` to `previewModelXml`.

Resolution:
- Dropped the `modelType.js`/`modelType.test.js` hunks (file does not exist on 0.3); BPMN detection is inlined in `preview()` via the BPMN namespace content sniff instead
- Kept 0.3's `previewbpmnXml` naming and no-DMN modal structure; the findings table renders for `bpmn`, `other`, and `form` previews
- `findings.js`/`findings.test.js` applied cleanly
- If #2379 (DMN previews backport) merges after this, its `getPreviewType(fileName)` will not include the content-sniff hardening from main; a small follow-up may be needed there

Validated: `npm run build` (lint, typecheck, vitest, vite) green — 18 tests.