### PR TITLE
[Backport maintenance/0.2] feat(diagram-converter): show analysis findings for all file types in webapp

### DIFF
--- a/diagram-converter/webapp/src/main/javascript/src/App.jsx
+++ b/diagram-converter/webapp/src/main/javascript/src/App.jsx
@@ -12,7 +12,6 @@ import {
   ProgressStep,
   Button,
   Callout,
-  DataTable,
   Table,
   TableHead,
   TableRow,
@@ -28,9 +27,50 @@ import {
 import { Download, Launch, Close, Settings } from "@carbon/react/icons";
 import DropZone from "./DropZone";
 import FileItem from "./FileItem";
+import { FINDINGS_TABLE_HEADER, buildFindingsRows } from "./findings";
 import BpmnJS from 'bpmn-js';
 import FormPreview from "./FormPreview";
 import { parseFormSchema } from "./formSchema";
+
+function FindingsSection({ header, rows }) {
+  if (rows.length === 0) {
+    return <p style={{ marginTop: '1rem' }}>No findings for this file.</p>;
+  }
+  return (
+    <>
+      <h3>Findings</h3>
+      <p style={{ marginBottom: '0.75rem' }}>
+        Elements in this file that need attention during migration. Each row describes one finding - its location, severity, and a message explaining what to address.
+      </p>
+      <Table className="analysis-table">
+        <TableHead>
+          <TableRow>
+            {header.map((h) => (
+              <TableHeader key={h.key}>
+                {h.header}
+              </TableHeader>
+            ))}
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {rows.map((row) => (
+            <TableRow key={row.id}>
+              {header.map((h) => (
+                <TableCell key={`${row.id}-${h.key}`}>
+                  {h.key === 'link'
+                    ? row.link
+                      ? <a href={row.link} target="_blank" rel="noopener noreferrer">Link</a>
+                      : '-'
+                    : row[h.key]}
+                </TableCell>
+              ))}
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </>
+  );
+}
 
 function App() {
   const baseUrl = ""; // Change this to "http://localhost:8080" if you want to play with it locally by using npm run dev
@@ -46,6 +86,7 @@ function App() {
   const [previewbpmnXml, setPreviewbpmnXml] = useState("");
   const [previewFormSchema, setPreviewFormSchema] = useState(null);
   const [previewFormError, setPreviewFormError] = useState("");
+  const [previewDiagramError, setPreviewDiagramError] = useState(false);
   const [previewCheckJson, setPreviewCheckJson] = useState([]);
 
   const [previewTableHeader, setPreviewTableHeader] = useState([]);
@@ -78,32 +119,36 @@ function App() {
   }
 
   useEffect(() => {
-      if (isPreviewOpen && previewbpmnXml) {
-          const viewer = new BpmnJS({ container: '#bpmnDiagram' });
-          viewer.importXML(previewbpmnXml).then(() => {
-            const canvas = viewer.get('canvas');
-            canvas.zoom('fit-viewport');
+      if (!isPreviewOpen || previewType !== "bpmn" || previewDiagramError || !previewbpmnXml) return;
 
-            const elementsWithMessages =
-              previewCheckJson?.[0]?.results?.filter((el) => el.messages?.length > 0) || [];
+      const viewer = new BpmnJS({ container: '#bpmnDiagram' });
+      viewer.importXML(previewbpmnXml).then(() => {
+        const canvas = viewer.get('canvas');
+        canvas.zoom('fit-viewport');
 
-            elementsWithMessages.forEach((el) => {
-              if (el.elementId) {
-                  const severity = getMostSevere(el.messages);
-                  if (severity) {
-                    // Mark wit the same color everytime for the moment
-                    //canvas.addMarker(el.elementId, `highlight-${severity.toLowerCase()}`);
-                    canvas.addMarker(el.elementId, `highlight-info`);
-                  }
+        const elementsWithMessages =
+          (Array.isArray(previewCheckJson) ? previewCheckJson : [])
+            .flatMap((item) => (Array.isArray(item?.results) ? item.results : []))
+            .filter((el) => Array.isArray(el?.messages) && el.messages.length > 0);
+
+        elementsWithMessages.forEach((el) => {
+          if (el.elementId) {
+              const severity = getMostSevere(el.messages);
+              if (severity) {
+                // Mark with the same color every time for the moment
+                //canvas.addMarker(el.elementId, `highlight-${severity.toLowerCase()}`);
+                canvas.addMarker(el.elementId, `highlight-info`);
               }
-            });
+          }
+        });
 
-          }).catch((error) => {
-            console.error("Unable to render BPMN preview:", error);
-          });
+      }).catch((error) => {
+        console.error("Unable to render BPMN preview:", error);
+        setPreviewDiagramError(true);
+      });
 
-      }
-    }, [isPreviewOpen, previewbpmnXml, previewCheckJson]);
+      return () => viewer.destroy();
+    }, [isPreviewOpen, previewType, previewDiagramError, previewbpmnXml, previewCheckJson]);
 
   function createFormData(files) {
     const formData = new FormData();
@@ -258,36 +303,22 @@ function App() {
   async function preview(response) {
     if (!response?.checkResponseJson) return;
 
-    setPreviewTableHeader([
-      { key: 'elementType', header: 'Element Type' },
-      { key: 'elementId', header: 'Element ID' },
-      { key: 'elementName', header: 'Element Name' },
-      { key: 'severity', header: 'Severity' },
-      { key: 'message', header: 'Message' },
-      { key: 'link', header: 'Link' },
-    ]);
-
-    setPreviewTableRows(
-      response.checkResponseJson?.[0]?.results.flatMap((element, elementIdx) =>
-        element.messages.map((message, msgIdx) => ({
-          id: `${elementIdx}-${msgIdx}`,
-          elementType: element.elementType,
-          elementId: element.elementId,
-          elementName: element.elementName || '(unnamed)',
-          severity: message.severity,
-          message: message.message,
-          link: message.link
-            ? `<a href="${message.link}" target="_blank" rel="noopener noreferrer">Link</a>`
-            : '-',
-        }))
-      ) || []);
-
+    setPreviewTableHeader(FINDINGS_TABLE_HEADER);
+    setPreviewTableRows(buildFindingsRows(response.checkResponseJson));
 
     setPreviewCheckJson(response.checkResponseJson);
     setPreviewbpmnXml(response.originalModelXml);
     setPreviewFormSchema(null);
     setPreviewFormError("");
-    setPreviewType("bpmn");
+    setPreviewDiagramError(false);
+    // BPMN is detected by content, not extension: the dropzone also accepts
+    // .xml files, which can be BPMN (or DMN) models.
+    setPreviewType(
+      typeof response.originalModelXml === "string" &&
+      response.originalModelXml.includes("omg.org/spec/BPMN")
+        ? "bpmn"
+        : "other"
+    );
 
     setIsPreviewOpen(true);
   }
@@ -299,6 +330,7 @@ function App() {
     setPreviewCheckJson([]);
     setPreviewTableHeader([]);
     setPreviewTableRows([]);
+    setPreviewDiagramError(false);
     setPreviewType("form");
     setIsPreviewOpen(true);
   }
@@ -306,6 +338,9 @@ function App() {
   function previewForm(response) {
     const { schema, error } = parseFormSchema(response?.originalModelXml);
     openFormPreview(schema, error);
+    setPreviewCheckJson(response?.checkResponseJson || []);
+    setPreviewTableHeader(FINDINGS_TABLE_HEADER);
+    setPreviewTableRows(buildFindingsRows(response?.checkResponseJson));
   }
 
   async function download(response) {
@@ -534,10 +569,11 @@ function App() {
             */}
 
             <section>
-              <h3>Converted models</h3>
+              <h3>Converted files</h3>
               <p>
-                Download each converted file or all of them as a ZIP. Preview a
-                file to inspect it first.
+                Download each converted file or all of them as a ZIP. Use the eye
+                icon to preview analysis findings for each file; BPMN files also
+                render a diagram, and forms show a form preview.
               </p>
               {files.map((file, idx) => {
                 const isForm = file.name.toLowerCase().endsWith(".form");
@@ -571,7 +607,7 @@ function App() {
 
             <section>
               <h3>Analysis results</h3>
-              <p>Download the findings for all converted models:</p>
+              <p>Download the findings for all converted files:</p>
               <div className="download-options">
                 <div className="download-row">
                   <Button
@@ -667,55 +703,28 @@ function App() {
         </div>
       </div>
 
-      {previewType === "bpmn" && <>
-      <div id="bpmnDiagram" className="diagram-container"></div>
-      <DataTable rows={previewTableRows} headers={previewTableHeader}>
-  {({ rows, headers, getHeaderProps, getRowProps }) => (
-    <Table className="analysis-table">
-      <TableHead>
-        <TableRow>
-          {headers.map((header) => {
-            const headerProps = getHeaderProps({ header });
-            const { key, ...rest } = headerProps;
-
-            return (
-              <TableHeader key={key} {...rest}>
-                {header.header}
-              </TableHeader>
-            );
-          })}
-        </TableRow>
-      </TableHead>
-      <TableBody>
-        {rows.map((row) => {
-          const rowProps = getRowProps({ row });
-          const { key, ...restRowProps } = rowProps;
-
-          return (
-            <TableRow key={key} {...restRowProps}>
-              {row.cells.map((cell) => (
-                <TableCell key={cell.id}>
-                  {cell.info.header === 'link' && cell.value?.startsWith('<a')
-                    ? (
-                        <span
-                          dangerouslySetInnerHTML={{ __html: cell.value }}
-                        />
-                      )
-                    : cell.value}
-                </TableCell>
-              ))}
-            </TableRow>
-          );
-        })}
-      </TableBody>
-    </Table>
-  )}
-</DataTable>
-      </>}
+      {(previewType === "bpmn" || previewType === "other") && (
+        <>
+          {previewType === "bpmn" && !previewDiagramError && (
+            <div id="bpmnDiagram" className="diagram-container"></div>
+          )}
+          {(previewType === "other" || (previewType === "bpmn" && previewDiagramError)) && (
+            <p style={{ marginTop: '1rem' }}>
+              {previewDiagramError
+                ? 'The diagram could not be rendered. The findings for this file are listed below.'
+                : 'Diagram preview is only available for BPMN files. The findings for this file are listed below.'}
+            </p>
+          )}
+          <FindingsSection header={previewTableHeader} rows={previewTableRows} />
+        </>
+      )}
       {previewType === "form" && (
-        previewFormError
-          ? <p className="form-preview-error" role="alert">{previewFormError}</p>
-          : <FormPreview schema={previewFormSchema} onError={setPreviewFormError} />
+        <>
+          {previewFormError
+            ? <p className="form-preview-error" role="alert">{previewFormError}</p>
+            : <FormPreview schema={previewFormSchema} onError={setPreviewFormError} />}
+          <FindingsSection header={previewTableHeader} rows={previewTableRows} />
+        </>
       )}
 
 

--- a/diagram-converter/webapp/src/main/javascript/src/findings.js
+++ b/diagram-converter/webapp/src/main/javascript/src/findings.js
@@ -1,0 +1,52 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+export const FINDINGS_TABLE_HEADER = [
+  { key: 'elementType', header: 'Element Type' },
+  { key: 'elementId', header: 'Element ID' },
+  { key: 'elementName', header: 'Element Name' },
+  { key: 'severity', header: 'Severity' },
+  { key: 'message', header: 'Message' },
+  { key: 'link', header: 'Link' },
+];
+
+// Flattens the /check response (List<DiagramCheckResult>) into table rows,
+// one row per finding message across all result items.
+export function buildFindingsRows(checkResponseJson) {
+  if (!Array.isArray(checkResponseJson)) {
+    return [];
+  }
+
+  return checkResponseJson.flatMap((item, itemIdx) => {
+    if (!item || typeof item !== 'object' || !Array.isArray(item.results)) {
+      return [];
+    }
+
+    return item.results.flatMap((element, elementIdx) => {
+      if (!element || typeof element !== 'object' || !Array.isArray(element.messages)) {
+        return [];
+      }
+
+      return element.messages.flatMap((message, msgIdx) => {
+        if (!message || typeof message !== 'object') {
+          return [];
+        }
+
+        return [{
+          id: `${itemIdx}-${elementIdx}-${msgIdx}`,
+          elementType: element.elementType || '-',
+          elementId: element.elementId || '-',
+          elementName: element.elementName || '(unnamed)',
+          severity: message.severity,
+          message: message.message,
+          link: message.link || null,
+        }];
+      });
+    });
+  });
+}

--- a/diagram-converter/webapp/src/main/javascript/src/findings.test.js
+++ b/diagram-converter/webapp/src/main/javascript/src/findings.test.js
@@ -1,0 +1,110 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { buildFindingsRows, FINDINGS_TABLE_HEADER } from './findings';
+
+describe('buildFindingsRows', () => {
+  it('returns no rows for empty or missing input', () => {
+    expect(buildFindingsRows(null)).toEqual([]);
+    expect(buildFindingsRows(undefined)).toEqual([]);
+    expect(buildFindingsRows([])).toEqual([]);
+    expect(buildFindingsRows([{ results: [] }])).toEqual([]);
+    expect(buildFindingsRows([{}])).toEqual([]);
+  });
+
+  it('returns no rows for malformed non-array result data', () => {
+    expect(buildFindingsRows({ results: [] })).toEqual([]);
+    expect(buildFindingsRows('not an array')).toEqual([]);
+    expect(buildFindingsRows([{ results: {} }])).toEqual([]);
+    expect(buildFindingsRows([{ results: [{ messages: {} }] }])).toEqual([]);
+    expect(buildFindingsRows([{ results: [null, { messages: [null] }] }])).toEqual([]);
+  });
+
+  it('flattens findings across multiple result items and elements', () => {
+    const rows = buildFindingsRows([
+      {
+        results: [
+          {
+            elementId: 'task1',
+            elementName: 'Task One',
+            elementType: 'bpmn:ServiceTask',
+            messages: [
+              { severity: 'WARNING', message: 'first', link: 'https://example.com/1' },
+              { severity: 'INFO', message: 'second', link: null },
+            ],
+          },
+        ],
+      },
+      {
+        results: [
+          {
+            elementId: 'task2',
+            elementName: null,
+            elementType: 'bpmn:UserTask',
+            messages: [{ severity: 'TASK', message: 'third', link: 'https://example.com/2' }],
+          },
+        ],
+      },
+    ]);
+
+    expect(rows).toHaveLength(3);
+    expect(rows.map((r) => r.message)).toEqual(['first', 'second', 'third']);
+    expect(rows[0]).toMatchObject({
+      id: '0-0-0',
+      elementId: 'task1',
+      elementName: 'Task One',
+      elementType: 'bpmn:ServiceTask',
+      severity: 'WARNING',
+      link: 'https://example.com/1',
+    });
+    // ids are unique across items, elements and messages
+    expect(new Set(rows.map((r) => r.id)).size).toBe(3);
+  });
+
+  it('renders fallbacks for findings without element id, name or type', () => {
+    const rows = buildFindingsRows([
+      {
+        results: [
+          {
+            elementId: null,
+            elementName: null,
+            elementType: null,
+            messages: [{ severity: 'REVIEW', message: 'form finding' }],
+          },
+        ],
+      },
+    ]);
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      elementId: '-',
+      elementType: '-',
+      elementName: '(unnamed)',
+      link: null,
+    });
+  });
+
+  it('tolerates elements without a messages array', () => {
+    const rows = buildFindingsRows([{ results: [{ elementId: 'x' }] }]);
+    expect(rows).toEqual([]);
+  });
+});
+
+describe('FINDINGS_TABLE_HEADER', () => {
+  it('covers severity, element identity, message and link', () => {
+    expect(FINDINGS_TABLE_HEADER.map((h) => h.key)).toEqual([
+      'elementType',
+      'elementId',
+      'elementName',
+      'severity',
+      'message',
+      'link',
+    ]);
+  });
+});


### PR DESCRIPTION
# Description
Backport of camunda/camunda-7-to-8-migration-tooling#2353 to `maintenance/0.2`.

# Conflict resolution notes

The automated cherry-pick of 45dfc20b4d79c9cdd45c425fc1fd70592e217972 conflicted heavily because `maintenance/0.2` lacks several main-branch features the squash diff touched (DMN previews / `modelType.js`, design-system migration, version segmented control). The cherry-pick was aborted and the change was re-applied by hand, scoped to the #2353 delta only:

- `findings.js` / `findings.test.js` taken over unchanged (pure helpers, vitest already present on 0.2)
- Findings table rendered with Carbon `Table` components via a `FindingsSection` component; the old `DataTable` + `dangerouslySetInnerHTML` link cell is gone (links render as anchors now)
- BPMN detection inlined in `preview()` via BPMN namespace content sniffing (no `modelType.js` on 0.2); non-BPMN/non-form content shows the findings table with an explanatory note
- `previewDiagramError` fallback + viewer cleanup; findings flattened across all `DiagramCheckResult` items; form preview shows the findings table below the form
- File-neutral copy on the results page
- Not backported (absent on 0.2): `findingCount` badge in FileItem, `previewTitle` already existed

Validated: `npm run build` (lint, typecheck, vitest, vite) green - 18 tests.