### PR TITLE
fix(diagram-converter): align analysis download rows

### DIFF
--- a/diagram-converter/webapp/src/main/javascript/src/App.jsx
+++ b/diagram-converter/webapp/src/main/javascript/src/App.jsx
@@ -821,7 +821,6 @@ function App() {
                     variant="default"
                     size="default"
                     onClick={downloadXLS}
-                    className="withMarginBottom"
                     disabled={validFiles.length === 0}
                   >
                     <Download />

--- a/diagram-converter/webapp/src/main/javascript/src/index.css
+++ b/diagram-converter/webapp/src/main/javascript/src/index.css
@@ -262,10 +262,6 @@ h1 {
   }
 }
 
-.withMarginBottom {
-  margin-bottom: 12px;
-}
-
 h3 {
   font-weight: 600;
   font-size: 19px;


### PR DESCRIPTION
## Summary

- Remove the XLSX-only bottom margin from the analysis download rows.
- Keep all download buttons and descriptions aligned by using the shared grid spacing.

## Changes

- Updated `diagram-converter/webapp/src/main/javascript/src/App.jsx` to use the same row layout for XLSX, CSV, and JSON downloads.
- Removed the unused `.withMarginBottom` rule from `diagram-converter/webapp/src/main/javascript/src/index.css`.

## Test plan

- [x] `cd diagram-converter/webapp/src/main/javascript && npm run build`
- [x] `mvn verify -PcheckFormat -pl diagram-converter -am`

## Baseline

Built from commit: 9da71c506c36a06b3e338aa6130a19963c8ace5c

closes #2390