### PR TITLE
feat(diagram-converter): reject invalid diagram files

### DIFF
--- a/diagram-converter/webapp/src/main/java/io/camunda/migration/diagram/converter/webapp/ConverterController.java
+++ b/diagram-converter/webapp/src/main/java/io/camunda/migration/diagram/converter/webapp/ConverterController.java
@@ -34,6 +34,7 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
+import org.camunda.bpm.model.xml.ModelException;
 import org.camunda.bpm.model.xml.ModelInstance;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -64,6 +65,8 @@ public class ConverterController {
   private static final String APPLICATION_MS_EXCEL = "application/vnd.ms-excel";
   private static final String APPLICATION_XLSX =
       "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
+  private static final String INVALID_DIAGRAM_MESSAGE =
+      "The uploaded file is not a valid BPMN or DMN file.";
 
   /**
    * Media type for the flat, machine-readable analysis report: a JSON array with one flat object
@@ -149,10 +152,20 @@ public class ConverterController {
         continue;
       }
 
-      DiagramType diagramType = determineDiagramType(diagramFile);
+      DiagramType diagramType;
+      try {
+        diagramType = determineDiagramType(diagramFile);
+      } catch (IllegalArgumentException e) {
+        return invalidDiagramResponse();
+      }
 
       try (InputStream in = diagramFile.getInputStream()) {
-        ModelInstance modelInstance = diagramType.readDiagram(in);
+        ModelInstance modelInstance;
+        try {
+          modelInstance = diagramType.readDiagram(in);
+        } catch (ModelException e) {
+          return invalidDiagramResponse();
+        }
 
         DiagramCheckResult diagramCheckResult =
             bpmnConverter.check(
@@ -362,9 +375,21 @@ public class ConverterController {
       }
     }
 
-    DiagramType diagramType = determineDiagramType(diagramFile);
+    DiagramType diagramType;
+    try {
+      diagramType = determineDiagramType(diagramFile);
+    } catch (IllegalArgumentException e) {
+      return invalidDiagramResponse();
+    }
+
     try (InputStream in = diagramFile.getInputStream()) {
-      ModelInstance modelInstance = diagramType.readDiagram(in);
+      ModelInstance modelInstance;
+      try {
+        modelInstance = diagramType.readDiagram(in);
+      } catch (ModelException e) {
+        return invalidDiagramResponse();
+      }
+
       bpmnConverter.convert(
           modelInstance,
           appendDocumentation,
@@ -446,10 +471,22 @@ public class ConverterController {
         continue;
       }
 
-      DiagramType diagramType = determineDiagramType(diagramFile);
+      DiagramType diagramType;
+      try {
+        diagramType = determineDiagramType(diagramFile);
+      } catch (IllegalArgumentException e) {
+        return invalidDiagramResponse();
+      }
+
       try (InputStream in = diagramFile.getInputStream()) {
 
-        ModelInstance modelInstance = diagramType.readDiagram(in);
+        ModelInstance modelInstance;
+        try {
+          modelInstance = diagramType.readDiagram(in);
+        } catch (ModelException e) {
+          return invalidDiagramResponse();
+        }
+
         bpmnConverter.convert(
             modelInstance,
             appendDocumentation,
@@ -518,6 +555,10 @@ public class ConverterController {
       return ResponseEntity.badRequest().body("The uploaded .form file is not a valid JSON form.");
     }
     return ResponseEntity.badRequest().body(message);
+  }
+
+  private ResponseEntity<String> invalidDiagramResponse() {
+    return ResponseEntity.badRequest().body(INVALID_DIAGRAM_MESSAGE);
   }
 
   private ConverterProperties converterProperties(String platformVersion) {

--- a/diagram-converter/webapp/src/test/java/io/camunda/migration/diagram/converter/webapp/ConverterControllerTest.java
+++ b/diagram-converter/webapp/src/test/java/io/camunda/migration/diagram/converter/webapp/ConverterControllerTest.java
@@ -23,6 +23,7 @@ import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.restassured.RestAssured;
 import io.restassured.common.mapper.TypeRef;
 import io.restassured.http.ContentType;
+import io.restassured.specification.RequestSpecification;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
@@ -43,6 +44,8 @@ import org.camunda.bpm.model.dmn.DmnModelInstance;
 import org.camunda.bpm.model.xml.instance.DomElement;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -862,6 +865,51 @@ public class ConverterControllerTest {
         .statusCode(400);
   }
 
+  @ParameterizedTest
+  @ValueSource(strings = {"invalid.bpmn", "invalid.dmn", "invalid.txt"})
+  void checkInvalidDiagramReturnsBadRequest(String filename) {
+    String errorMessage =
+        invalidDiagramRequest(filename)
+            .accept(ContentType.JSON)
+            .post("/check")
+            .then()
+            .statusCode(400)
+            .extract()
+            .asString();
+
+    assertThat(errorMessage).isEqualTo("The uploaded file is not a valid BPMN or DMN file.");
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"invalid.bpmn", "invalid.dmn", "invalid.txt"})
+  void convertInvalidDiagramReturnsBadRequest(String filename) {
+    String errorMessage =
+        invalidDiagramRequest(filename)
+            .accept(ContentType.JSON)
+            .post("/convert")
+            .then()
+            .statusCode(400)
+            .extract()
+            .asString();
+
+    assertThat(errorMessage).isEqualTo("The uploaded file is not a valid BPMN or DMN file.");
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"invalid.bpmn", "invalid.dmn", "invalid.txt"})
+  void convertBatchInvalidDiagramReturnsBadRequest(String filename) {
+    String errorMessage =
+        invalidDiagramRequest(filename)
+            .accept("application/zip")
+            .post("/convertBatch")
+            .then()
+            .statusCode(400)
+            .extract()
+            .asString();
+
+    assertThat(errorMessage).isEqualTo("The uploaded file is not a valid BPMN or DMN file.");
+  }
+
   @Test
   void convertSanitizesFilenameInContentDisposition() throws URISyntaxException, IOException {
     byte[] formBytes =
@@ -945,5 +993,15 @@ public class ConverterControllerTest {
             "converted-c8-same (1).form",
             "converted-c8-same.bpmn",
             "converted-c8-same (1).bpmn");
+  }
+
+  private static RequestSpecification invalidDiagramRequest(String filename) {
+    return RestAssured.given()
+        .contentType(ContentType.MULTIPART)
+        .multiPart(
+            "file",
+            filename,
+            "this is not a valid diagram".getBytes(StandardCharsets.UTF_8),
+            "application/xml");
   }
 }


### PR DESCRIPTION
## Summary
- Return a clear HTTP 400 response instead of HTTP 500 when uploaded diagram files are invalid.
- Apply the same behavior to BPMN, DMN, and unsupported diagram filenames across all upload endpoints.

## Changes
- Handle unsupported filenames and Camunda model parser exceptions in `/check`, `/convert`, and `/convertBatch`.
- Add parameterized webapp integration coverage for malformed BPMN/DMN content and unsupported extensions.

## Test plan
- [x] `mvn -pl diagram-converter/webapp -am -Dtest=ConverterControllerTest -Dsurefire.failIfNoSpecifiedTests=false test`
- [x] `mvn -pl diagram-converter/webapp -am test`
- [x] `cd diagram-converter && mvn -Pdistro,checkFormat verify`
- [x] `mvn clean install -DskipTests`

## Baseline
Built from commit: 9da71c506c36a06b3e338aa6130a19963c8ace5