### PR TITLE
fix(diagram-converter): align analysis download rows [maintenance/0.2]

### DIFF
--- a/diagram-converter/webapp/src/main/javascript/src/App.jsx
+++ b/diagram-converter/webapp/src/main/javascript/src/App.jsx
@@ -675,7 +675,6 @@ function App() {
                     size="md"
                     renderIcon={Download}
                     onClick={downloadXLS}
-                    className="withMarginBottom"
                     disabled={validFiles.length === 0}
                   >
                     Download XLSX

--- a/diagram-converter/webapp/src/main/javascript/src/index.css
+++ b/diagram-converter/webapp/src/main/javascript/src/index.css
@@ -199,12 +199,6 @@ h1 {
   }
 }
 
-
-
-.withMarginBottom {
-  margin-bottom: 12px;
-}
-
 h3 {
   font-weight: 500;
   font-size: 18px;


### PR DESCRIPTION
## Summary

Backport the analysis-results download row spacing fix from #2391 to the 0.2 maintenance branch.

The XLSX-only bottom margin is removed so the XLSX, CSV, and JSON download rows use the same grid spacing and align consistently.

## Test plan

- [x] `cd diagram-converter/webapp/src/main/javascript && npm run build`
- [x] `mvn test -pl diagram-converter/webapp -am`

related to #2391