### PR TITLE
feat(skill): add model suitability advisory

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ After checking model suitability, the skill will ask for your project path and w
 
 The skill fetches the latest [pattern catalog](./code-conversion/patterns/ALL_IN_ONE.md) at runtime, so it always reflects current migration guidance.
 
-When activated, the skill recommends an Anthropic Claude Sonnet- or Opus-class model, or a comparable frontier reasoning model, and asks before proceeding with a lightweight or unverifiable model.
+When activated, the skill recommends a model intended for complex reasoning (for example `claude-sonnet-*`, `claude-opus-*`, or `gpt-5.6-luna`), and asks before proceeding with a lightweight or unverifiable model. These are routing hints, not a benchmark.
 
 
 ## Documentation

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ gh skill install camunda/camunda-7-to-8-migration-tooling migrate-c7-to-c8-code 
 /camunda-migration:migrate-c7-to-c8-code
 ```
 
-The skill will ask for your project path and walk you through three options:
+After checking model suitability, the skill will ask for your project path and walk you through three options:
 
 | Approach | What it does |
 |----------|-------------|
@@ -71,6 +71,8 @@ The skill will ask for your project path and walk you through three options:
 | **Assessment only** | Scans the codebase and reports files, complexity, and effort estimate — no changes made |
 
 The skill fetches the latest [pattern catalog](./code-conversion/patterns/ALL_IN_ONE.md) at runtime, so it always reflects current migration guidance.
+
+The skill recommends an Anthropic Claude Sonnet-class or comparable frontier reasoning model and, when activated, asks before proceeding with a lightweight or unverifiable model.
 
 
 ## Documentation

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ After checking model suitability, the skill will ask for your project path and w
 
 The skill fetches the latest [pattern catalog](./code-conversion/patterns/ALL_IN_ONE.md) at runtime, so it always reflects current migration guidance.
 
-The skill recommends an Anthropic Claude Sonnet- or Opus-class model, or a comparable frontier reasoning model and, when activated, asks before proceeding with a lightweight or unverifiable model.
+When activated, the skill recommends an Anthropic Claude Sonnet- or Opus-class model, or a comparable frontier reasoning model, and asks before proceeding with a lightweight or unverifiable model.
 
 
 ## Documentation

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ After checking model suitability, the skill will ask for your project path and w
 
 The skill fetches the latest [pattern catalog](./code-conversion/patterns/ALL_IN_ONE.md) at runtime, so it always reflects current migration guidance.
 
-The skill recommends an Anthropic Claude Sonnet-class or comparable frontier reasoning model and, when activated, asks before proceeding with a lightweight or unverifiable model.
+The skill recommends an Anthropic Claude Sonnet- or Opus-class model, or a comparable frontier reasoning model and, when activated, asks before proceeding with a lightweight or unverifiable model.
 
 
 ## Documentation

--- a/agentic-migration-skills/README.md
+++ b/agentic-migration-skills/README.md
@@ -49,7 +49,7 @@ The skill asks what to migrate — **code**, **models**, or **both** — then wa
 
 ### Model recommendation
 
-The skill recommends an Anthropic Claude Sonnet- or Opus-class model, or a comparable frontier reasoning model. At activation, it warns about lightweight or unverifiable models and lets the user switch or continue with extra review; it never changes or claims to have changed the model.
+The skill recommends a model intended for complex reasoning, with illustrative IDs such as `claude-sonnet-*`, `claude-opus-*`, `gpt-5.6-luna`, `gpt-5.6-terra`, or `gpt-5.6-sol`. These are routing hints, not a benchmark. At activation, it warns about lightweight or unverifiable models and lets the user switch or continue with extra review; it never changes or claims to have changed the model.
 
 **Code migration:**
 

--- a/agentic-migration-skills/README.md
+++ b/agentic-migration-skills/README.md
@@ -49,7 +49,7 @@ The skill asks what to migrate — **code**, **models**, or **both** — then wa
 
 ### Model recommendation
 
-The skill recommends an Anthropic Claude Sonnet-class or comparable frontier reasoning model. At activation it warns about lightweight or unverifiable models and lets the user switch or continue with extra review; it never changes or claims to have changed the model.
+The skill recommends an Anthropic Claude Sonnet- or Opus-class model, or a comparable frontier reasoning model. At activation, it warns about lightweight or unverifiable models and lets the user switch or continue with extra review; it never changes or claims to have changed the model.
 
 **Code migration:**
 

--- a/agentic-migration-skills/README.md
+++ b/agentic-migration-skills/README.md
@@ -47,6 +47,10 @@ From your Camunda 7 project directory:
 
 The skill asks what to migrate — **code**, **models**, or **both** — then walks you through the approaches for each.
 
+### Model recommendation
+
+The skill recommends an Anthropic Claude Sonnet-class or comparable frontier reasoning model. At activation it warns about lightweight or unverifiable models and lets the user switch or continue with extra review; it never changes or claims to have changed the model.
+
 **Code migration:**
 
 | Approach | What it does |

--- a/agentic-migration-skills/skills/migrate-c7-to-c8-code/SKILL.md
+++ b/agentic-migration-skills/skills/migrate-c7-to-c8-code/SKILL.md
@@ -13,10 +13,10 @@ Migrate a Camunda 7 project to Camunda 8. A project can contain two independent 
 
 ## Step 0: Model suitability
 
-Before scanning, inspect any active model identifier or capability metadata exposed by the host; do not infer it or use undocumented variables. This skill is optimized for an Anthropic Claude Sonnet- or Opus-class model, or a comparable frontier reasoning model.
+Before scanning, inspect any active model identifier or capability metadata exposed by the host; do not infer it or use undocumented variables. This skill is intended for complex, multi-file reasoning. Illustrative recommended IDs include `claude-sonnet-*`, `claude-opus-*`, `gpt-5.6-luna`, `gpt-5.6-terra`, and `gpt-5.6-sol`; illustrative caution IDs include `gpt-5-mini`, `gpt-5.4-mini`, and `gemini-3.7-flash`. These are routing examples, not a benchmark or exhaustive ranking; use host capability metadata when available and treat unknown IDs as unverified.
 
 If the model is explicitly lightweight (mini, small, lite, flash, haiku, etc.) or cannot be verified, warn the user and use AskUserQuestion (or the host equivalent):
-- **Switch to an Anthropic Claude Sonnet- or Opus-class model (recommended)** — explain the host's model selector, wait for the user's confirmation, then re-read host-provided model metadata before continuing.
+- **Switch to a model intended for complex reasoning (recommended)** — explain the host's model selector, wait for the user's confirmation, then re-read host-provided model metadata before continuing.
 - **Continue** — use deterministic approaches and extra human review; after the project root is confirmed, record the warning and choice in `MIGRATION_REPORT.md`.
 
 Recheck before AI-only, agentic rewrites, or AI cleanup if the host allows model changes. Record the model status in `MIGRATION_REPORT.md` after the project root is confirmed.

--- a/agentic-migration-skills/skills/migrate-c7-to-c8-code/SKILL.md
+++ b/agentic-migration-skills/skills/migrate-c7-to-c8-code/SKILL.md
@@ -17,7 +17,7 @@ Before scanning, inspect any active model identifier or capability metadata expo
 
 If the model is explicitly lightweight (mini, small, lite, flash, haiku, etc.) or cannot be verified, warn the user and use AskUserQuestion (or the host equivalent):
 - **Switch to an Anthropic Claude Sonnet- or Opus-class model (recommended)** — explain the host's model selector, wait for the user's confirmation, then re-read host-provided model metadata before continuing.
-- **Continue** — use deterministic approaches and extra human review; record the warning and choice in `MIGRATION_REPORT.md`.
+- **Continue** — use deterministic approaches and extra human review; after the project root is confirmed, record the warning and choice in `MIGRATION_REPORT.md`.
 
 Recheck before AI-only, agentic rewrites, or AI cleanup if the host allows model changes. Record the model status in `MIGRATION_REPORT.md` after the project root is confirmed.
 

--- a/agentic-migration-skills/skills/migrate-c7-to-c8-code/SKILL.md
+++ b/agentic-migration-skills/skills/migrate-c7-to-c8-code/SKILL.md
@@ -11,6 +11,16 @@ Migrate a Camunda 7 project to Camunda 8. A project can contain two independent 
 - Code: Java/Spring glue and client code, config, tests. Migrated with OpenRewrite recipes (deterministic) plus AI cleanup.
 - Models: BPMN/DMN diagrams using the camunda: namespace. Migrated with the Diagram Converter (deterministic) or agentically.
 
+## Step 0: Model suitability
+
+Before scanning, inspect any active model identifier or capability metadata exposed by the host; do not infer it or use undocumented variables. This skill is optimized for Claude Sonnet/Opus or a comparable frontier reasoning model.
+
+If the model is explicitly lightweight (mini, small, lite, flash, haiku, etc.) or cannot be verified, warn the user and use AskUserQuestion (or the host equivalent):
+- **Switch to a Sonnet-class or comparable frontier model (recommended)** — explain the host's model selector, then stop until the host confirms.
+- **Continue** — use deterministic approaches and extra human review; record the warning and choice in `MIGRATION_REPORT.md`.
+
+Recheck before AI-only, agentic rewrites, or AI cleanup if the host allows model changes. Record the model status in `MIGRATION_REPORT.md` after the project root is confirmed.
+
 ## Entry Criteria
 
 1. Project uses Camunda 7 (camunda-bpm) dependencies in Maven or Gradle
@@ -46,6 +56,7 @@ Shared rules that apply throughout all subsequent steps:
 - Ask before high-complexity files and edge cases. Auto-apply only unambiguous 1:1 mappings.
 - Keep changes minimal. No refactors, renames, or improvements beyond the migration.
 - Keep `MIGRATION_REPORT.md` in the confirmed project root current with inventories, decisions, phase status, and validation results.
+- Include the model preflight result, model identifier or unverified status, and any user decision to continue with a caution/unverified model in `MIGRATION_REPORT.md`.
 
 ### Step 2: Assessment (always runs)
 
@@ -63,7 +74,7 @@ If inventory is empty and user selected model migration, record that no local mo
 
 #### Summary
 
-Present: total code/model files, overall complexity, whether OpenRewrite would help, blockers requiring manual decision, and a note that running instances/history/audit data are out of scope (point to Data Migrator).
+Present: total code/model files, overall complexity, whether OpenRewrite would help, blockers requiring manual decision, the model preflight result (including any user acknowledgment), and a note that running instances/history/audit data are out of scope (point to Data Migrator).
 
 Write assessment to MIGRATION_REPORT.md. Use AskUserQuestion to wait for confirmation before proceeding.
 

--- a/agentic-migration-skills/skills/migrate-c7-to-c8-code/SKILL.md
+++ b/agentic-migration-skills/skills/migrate-c7-to-c8-code/SKILL.md
@@ -16,7 +16,7 @@ Migrate a Camunda 7 project to Camunda 8. A project can contain two independent 
 Before scanning, inspect any active model identifier or capability metadata exposed by the host; do not infer it or use undocumented variables. This skill is optimized for an Anthropic Claude Sonnet- or Opus-class model, or a comparable frontier reasoning model.
 
 If the model is explicitly lightweight (mini, small, lite, flash, haiku, etc.) or cannot be verified, warn the user and use AskUserQuestion (or the host equivalent):
-- **Switch to a Sonnet-class or comparable frontier model (recommended)** — explain the host's model selector, then stop until the host confirms.
+- **Switch to an Anthropic Claude Sonnet- or Opus-class model (recommended)** — explain the host's model selector, wait for the user's confirmation, then re-read host-provided model metadata before continuing.
 - **Continue** — use deterministic approaches and extra human review; record the warning and choice in `MIGRATION_REPORT.md`.
 
 Recheck before AI-only, agentic rewrites, or AI cleanup if the host allows model changes. Record the model status in `MIGRATION_REPORT.md` after the project root is confirmed.

--- a/agentic-migration-skills/skills/migrate-c7-to-c8-code/SKILL.md
+++ b/agentic-migration-skills/skills/migrate-c7-to-c8-code/SKILL.md
@@ -13,7 +13,7 @@ Migrate a Camunda 7 project to Camunda 8. A project can contain two independent 
 
 ## Step 0: Model suitability
 
-Before scanning, inspect any active model identifier or capability metadata exposed by the host; do not infer it or use undocumented variables. This skill is optimized for Claude Sonnet/Opus or a comparable frontier reasoning model.
+Before scanning, inspect any active model identifier or capability metadata exposed by the host; do not infer it or use undocumented variables. This skill is optimized for an Anthropic Claude Sonnet- or Opus-class model, or a comparable frontier reasoning model.
 
 If the model is explicitly lightweight (mini, small, lite, flash, haiku, etc.) or cannot be verified, warn the user and use AskUserQuestion (or the host equivalent):
 - **Switch to a Sonnet-class or comparable frontier model (recommended)** — explain the host's model selector, then stop until the host confirms.


### PR DESCRIPTION
## Summary

- remove the unused `compatibility` frontmatter field
- add a compact activation-time advisory for lightweight or unverifiable models
- let users switch models or continue with deterministic tooling and extra review
- document the recommendation in the skill and repository READMEs

The skill does not attempt to change the active model because Agent Skills provide no portable model-switching API.

Related to #2400