### PR TITLE
[Backport maintenance/0.3] test(diagram-converter): cover analysis findings preview UI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,7 @@ jobs:
       data-migrator: ${{ steps.filter.outputs.data-migrator }}
       code-conversion: ${{ steps.filter.outputs.code-conversion }}
       diagram-converter: ${{ steps.filter.outputs.diagram-converter }}
+      diagram-converter-frontend: ${{ steps.filter.outputs.diagram-converter-frontend }}
       shared: ${{ steps.filter.outputs.shared }}
       run-runtime: ${{ steps.filter.outputs.run-runtime }}
       run-history: ${{ steps.filter.outputs.run-history }}
@@ -110,6 +111,7 @@ jobs:
             echo "data-migrator=true" >> "$GITHUB_OUTPUT"
             echo "code-conversion=true" >> "$GITHUB_OUTPUT"
             echo "diagram-converter=true" >> "$GITHUB_OUTPUT"
+            echo "diagram-converter-frontend=true" >> "$GITHUB_OUTPUT"
             echo "shared=true" >> "$GITHUB_OUTPUT"
             echo "run-runtime=true" >> "$GITHUB_OUTPUT"
             echo "run-history=true" >> "$GITHUB_OUTPUT"
@@ -137,6 +139,12 @@ jobs:
             echo "diagram-converter=true" >> "$GITHUB_OUTPUT"
           else
             echo "diagram-converter=false" >> "$GITHUB_OUTPUT"
+          fi
+
+          if echo "$CHANGED_FILES" | grep -qE '^(diagram-converter/webapp/src/main/javascript/|diagram-converter/webapp/pom\.xml$|diagram-converter/pom\.xml$|\.github/|\.mvn/|mvnw$|mvnw\.cmd$|pom\.xml$)'; then
+            echo "diagram-converter-frontend=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "diagram-converter-frontend=false" >> "$GITHUB_OUTPUT"
           fi
 
           if echo "$CHANGED_FILES" | grep -qE '^(\.github/|\.mvn/|mvnw$|mvnw\.cmd$|pom\.xml$)'; then
@@ -406,6 +414,29 @@ jobs:
             diagram-converter/cli/target/camunda-7-to-8-diagram-converter-cli-*.jar
           if-no-files-found: error
           retention-days: 7
+
+  diagram-converter-frontend:
+    needs: [detect-changes]
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    if: |
+      github.event_name != 'pull_request' ||
+      needs.detect-changes.outputs.diagram-converter-frontend == 'true' ||
+      needs.detect-changes.outputs.shared == 'true'
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Set up Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: 24
+
+      - name: Run diagram-converter frontend tests
+        working-directory: diagram-converter/webapp/src/main/javascript
+        run: |
+          npm ci
+          npm test
 
   diagram-converter-windows:
     needs: [detect-changes]
@@ -1199,6 +1230,7 @@ jobs:
       - code-conversion
       - code-conversion-windows
       - diagram-converter
+      - diagram-converter-frontend
       - diagram-converter-windows
       - compile-previous-version
       - it-runtime-h2
@@ -1216,6 +1248,7 @@ jobs:
       EXPECT_CODE_CONVERSION: ${{ github.event_name != 'pull_request' || needs.detect-changes.outputs.code-conversion == 'true' || needs.detect-changes.outputs.shared == 'true' }}
       EXPECT_CODE_CONVERSION_WINDOWS: ${{ github.event_name != 'pull_request' || needs.detect-changes.outputs.code-conversion == 'true' || needs.detect-changes.outputs.shared == 'true' }}
       EXPECT_DIAGRAM_CONVERTER: ${{ github.event_name != 'pull_request' || needs.detect-changes.outputs.diagram-converter == 'true' || needs.detect-changes.outputs.shared == 'true' }}
+      EXPECT_DIAGRAM_CONVERTER_FRONTEND: ${{ github.event_name != 'pull_request' || needs.detect-changes.outputs.diagram-converter-frontend == 'true' || needs.detect-changes.outputs.shared == 'true' }}
       EXPECT_DIAGRAM_CONVERTER_WINDOWS: ${{ github.event_name != 'pull_request' || needs.detect-changes.outputs.diagram-converter == 'true' || needs.detect-changes.outputs.shared == 'true' }}
       EXPECT_COMPILE_PREVIOUS: ${{ github.event_name != 'pull_request' || github.event_name == 'workflow_dispatch' || needs.detect-changes.outputs.run-compile-previous-version == 'true' }}
       EXPECT_RUNTIME_H2: ${{ github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'ci:runtime') || (needs.detect-changes.outputs.run-runtime == 'true' && !contains(github.event.pull_request.labels.*.name, 'ci:history') && !contains(github.event.pull_request.labels.*.name, 'ci:identity')) }}
@@ -1254,6 +1287,7 @@ jobs:
               { key: "code-conversion", label: "code-conversion", expected: parseBool(process.env.EXPECT_CODE_CONVERSION) },
               { key: "code-conversion-windows", label: "code-conversion-windows", expected: parseBool(process.env.EXPECT_CODE_CONVERSION_WINDOWS) },
               { key: "diagram-converter", label: "diagram-converter", expected: parseBool(process.env.EXPECT_DIAGRAM_CONVERTER) },
+              { key: "diagram-converter-frontend", label: "diagram-converter-frontend", expected: parseBool(process.env.EXPECT_DIAGRAM_CONVERTER_FRONTEND) },
               { key: "diagram-converter-windows", label: "diagram-converter-windows", expected: parseBool(process.env.EXPECT_DIAGRAM_CONVERTER_WINDOWS) },
               { key: "compile-previous-version", label: "compile-previous-version", expected: parseBool(process.env.EXPECT_COMPILE_PREVIOUS) },
               { key: "it-runtime-h2", label: "it-runtime-h2", expected: parseBool(process.env.EXPECT_RUNTIME_H2) },
@@ -1379,6 +1413,7 @@ jobs:
       - code-conversion
       - code-conversion-windows
       - diagram-converter
+      - diagram-converter-frontend
       - compile-previous-version
       - diagram-converter-windows
       - it-runtime-h2

--- a/diagram-converter/webapp/src/main/javascript/src/App.test.jsx
+++ b/diagram-converter/webapp/src/main/javascript/src/App.test.jsx
@@ -1,0 +1,332 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import App from "./App.jsx";
+
+const bpmnMocks = vi.hoisted(() => {
+  const instances = [];
+
+  class MockBpmnJS {
+    constructor(options) {
+      this.options = options;
+      this.importedXml = [];
+      this.destroyed = false;
+      this.canvas = {
+        zoom: vi.fn(),
+        addMarker: vi.fn(),
+      };
+      instances.push(this);
+    }
+
+    importXML(xml) {
+      this.importedXml.push(xml);
+      return Promise.resolve();
+    }
+
+    get() {
+      return this.canvas;
+    }
+
+    destroy() {
+      this.destroyed = true;
+    }
+  }
+
+  return { MockBpmnJS, instances };
+});
+
+const testState = vi.hoisted(() => ({
+  files: [],
+  dmnPreviewProps: [],
+  formPreviewProps: [],
+}));
+
+vi.mock("@camunda/design-system", () => ({
+  Alert: ({ title, description, children, className }) => (
+    <div role="alert" className={className}>
+      <strong>{title}</strong>
+      <span>{description}</span>
+      {children}
+    </div>
+  ),
+  Button: ({ children, href, ...props }) =>
+    href ? (
+      <a href={href} {...props}>
+        {children}
+      </a>
+    ) : (
+      <button {...props}>{children}</button>
+    ),
+  Checkbox: ({ id, checked, onCheckedChange, ...props }) => (
+    <input
+      id={id}
+      type="checkbox"
+      checked={checked}
+      onChange={(event) => onCheckedChange(event.target.checked)}
+      {...props}
+    />
+  ),
+  Input: (props) => <input {...props} />,
+  Table: ({ children, ...props }) => <table {...props}>{children}</table>,
+  TableBody: ({ children, ...props }) => <tbody {...props}>{children}</tbody>,
+  TableCell: ({ children, ...props }) => <td {...props}>{children}</td>,
+  TableHead: ({ children, ...props }) => <th {...props}>{children}</th>,
+  TableHeader: ({ children, ...props }) => <thead {...props}>{children}</thead>,
+  TableRow: ({ children, ...props }) => <tr {...props}>{children}</tr>,
+  Stepper: ({ children, ...props }) => <div {...props}>{children}</div>,
+  StepperStep: ({ children }) => <div>{children}</div>,
+  Tooltip: ({ children }) => children,
+  TooltipContent: ({ children }) => children,
+  TooltipProvider: ({ children }) => children,
+  TooltipTrigger: ({ children }) => children,
+}));
+
+vi.mock("bpmn-js", () => ({
+  default: bpmnMocks.MockBpmnJS,
+}));
+
+vi.mock("./DmnPreview", () => ({
+  default: (props) => {
+    testState.dmnPreviewProps.push(props);
+    return <div data-testid="dmn-preview" />;
+  },
+}));
+
+vi.mock("./DropZone", () => ({
+  default: ({ onFiles }) => (
+    <button type="button" onClick={() => onFiles(testState.files)}>
+      Upload test file
+    </button>
+  ),
+}));
+
+vi.mock("./FormPreview", () => ({
+  default: (props) => {
+    testState.formPreviewProps.push(props);
+    return <div data-testid="form-preview" />;
+  },
+}));
+
+const fetchMock = vi.fn();
+
+function configureUpload({ fileName, content, checkResponseJson }) {
+  testState.files.splice(0, testState.files.length, {
+    name: fileName,
+    text: vi.fn().mockResolvedValue(content),
+  });
+
+  fetchMock.mockImplementation((url) => {
+    if (url.endsWith("/check")) {
+      return Promise.resolve({
+        ok: true,
+        headers: { get: vi.fn().mockReturnValue(null) },
+        json: vi.fn().mockResolvedValue(checkResponseJson),
+      });
+    }
+
+    return Promise.resolve({
+      ok: true,
+      headers: { get: vi.fn().mockReturnValue(null) },
+      blob: vi.fn().mockResolvedValue(new Blob(["converted model"])),
+    });
+  });
+}
+
+async function openPreview({ fileName, content, checkResponseJson }) {
+  configureUpload({ fileName, content, checkResponseJson });
+  render(<App />);
+
+  fireEvent.click(screen.getByRole("button", { name: "Upload test file" }));
+
+  const analyzeButton = screen.getByRole("button", {
+    name: /Analyze and convert to Camunda/,
+  });
+  await waitFor(() => expect(analyzeButton.disabled).toBe(false));
+  fireEvent.click(analyzeButton);
+
+  const previewButton = await screen.findByRole("button", {
+    name: fileName.endsWith(".form")
+      ? "Preview form"
+      : "Preview analysis findings",
+  });
+  fireEvent.click(previewButton);
+
+  await screen.findByRole("heading", { name: "Preview" });
+}
+
+beforeEach(() => {
+  vi.stubGlobal("fetch", fetchMock);
+  fetchMock.mockReset();
+  testState.files.length = 0;
+  testState.dmnPreviewProps.length = 0;
+  testState.formPreviewProps.length = 0;
+  bpmnMocks.instances.length = 0;
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+describe("analysis findings preview", () => {
+  it("renders findings from the analysis response, including documentation links", async () => {
+    const documentationUrl = "https://docs.example.com/service-task";
+    await openPreview({
+      fileName: "process.bpmn",
+      content: '<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" />',
+      checkResponseJson: [
+        {
+          results: [
+            {
+              elementType: "bpmn:ServiceTask",
+              elementId: "task_1",
+              elementName: "Ship order",
+              messages: [
+                {
+                  severity: "WARNING",
+                  message: "Review the service task implementation.",
+                  link: documentationUrl,
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+
+    const table = screen.getByRole("table");
+    expect(
+      within(table)
+        .getAllByRole("columnheader")
+        .map((header) => header.textContent)
+    ).toEqual([
+      "Element Type",
+      "Element ID",
+      "Element Name",
+      "Severity",
+      "Message",
+      "Link",
+    ]);
+
+    const rows = within(table).getAllByRole("row");
+    expect(rows).toHaveLength(2);
+    expect(
+      within(rows[1])
+        .getAllByRole("cell")
+        .map((cell) => cell.textContent)
+    ).toEqual([
+      "bpmn:ServiceTask",
+      "task_1",
+      "Ship order",
+      "WARNING",
+      "Review the service task implementation.",
+      "Open",
+    ]);
+
+    const documentationLink = within(rows[1]).getByRole("link", {
+      name: `Open finding documentation: ${documentationUrl}`,
+    });
+    expect(documentationLink.getAttribute("href")).toBe(documentationUrl);
+    expect(documentationLink.getAttribute("target")).toBe("_blank");
+  });
+
+  it("renders fallbacks for findings with missing element fields", async () => {
+    await openPreview({
+      fileName: "customer.form",
+      content: JSON.stringify({ type: "default", components: [] }),
+      checkResponseJson: [
+        {
+          results: [
+            {
+              elementType: null,
+              elementId: null,
+              elementName: null,
+              messages: [
+                {
+                  severity: "REVIEW",
+                  message: "Review this form.",
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+
+    const table = screen.getByRole("table");
+    const rows = within(table).getAllByRole("row");
+    expect(
+      within(rows[1])
+        .getAllByRole("cell")
+        .map((cell) => cell.textContent)
+    ).toEqual(["-", "-", "(unnamed)", "REVIEW", "Review this form.", "-"]);
+  });
+
+  it("shows an empty state when the analysis response has no findings", async () => {
+    await openPreview({
+      fileName: "empty.bpmn",
+      content: '<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" />',
+      checkResponseJson: [],
+    });
+
+    expect(screen.getByText("No findings for this file.")).toBeTruthy();
+    expect(screen.queryByRole("table")).toBeNull();
+  });
+});
+
+describe("preview routing", () => {
+  it.each([
+    {
+      fileName: "process.bpmn",
+      content: '<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" />',
+      expectedType: "bpmn",
+    },
+    {
+      fileName: "decision.dmn",
+      content: '<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" />',
+      expectedType: "dmn",
+    },
+    {
+      fileName: "customer.form",
+      content: JSON.stringify({ type: "default", components: [] }),
+      expectedType: "form",
+    },
+  ])("renders the $expectedType preview for a $fileName file", async ({
+    fileName,
+    content,
+    expectedType,
+  }) => {
+    await openPreview({
+      fileName,
+      content,
+      checkResponseJson: [],
+    });
+
+    if (expectedType === "bpmn") {
+      await waitFor(() => expect(bpmnMocks.instances).toHaveLength(1));
+      expect(document.querySelector("#bpmnDiagram")).toBeTruthy();
+      expect(screen.queryByTestId("dmn-preview")).toBeNull();
+      expect(screen.queryByTestId("form-preview")).toBeNull();
+      expect(bpmnMocks.instances[0].importedXml).toEqual([content]);
+    } else if (expectedType === "dmn") {
+      expect(await screen.findByTestId("dmn-preview")).toBeTruthy();
+      expect(document.querySelector("#bpmnDiagram")).toBeNull();
+      expect(screen.queryByTestId("form-preview")).toBeNull();
+      expect(testState.dmnPreviewProps.at(-1).xml).toBe(content);
+    } else {
+      expect(await screen.findByTestId("form-preview")).toBeTruthy();
+      expect(document.querySelector("#bpmnDiagram")).toBeNull();
+      expect(screen.queryByTestId("dmn-preview")).toBeNull();
+      expect(testState.formPreviewProps.at(-1).schema).toEqual({
+        type: "default",
+        components: [],
+      });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Manually backport the analysis findings preview UI tests from #2401 to maintenance/0.3.

## Changes

- Add App-level frontend tests for findings table rendering, links, fallbacks, empty state, and BPMN/DMN/form preview routing.
- Add frontend change detection and a dedicated Node 24 frontend test job to CI.

## Test plan

- [x] `npm run build` in `diagram-converter/webapp/src/main/javascript`
- [x] `mvn verify -Pdistro,checkFormat --batch-mode -f diagram-converter/pom.xml`
- [ ] CI `diagram-converter-frontend` is green
- [ ] CI Summary Gate is green

Manual backport of merged PR #2401.

related to #2401