### PR TITLE
docs(ci): document maintenance branch mapping

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -185,6 +185,17 @@ Examples (with the `related to #<issue-number>` body line shown inline for brevi
 
 GitHub Actions CI (`.github/workflows/ci.yml`) runs on push to `main`/`maintenance/*`, PRs, and nightly (weekdays 5 AM).
 
+### Maintenance Branch Mapping
+
+Use this explicit release-line mapping when choosing a backport target:
+
+| Maintenance branch | Camunda release line |
+|--------------------|----------------------|
+| `maintenance/0.2` | Camunda 8.8 |
+| `maintenance/0.3` | Camunda 8.9 |
+
+The `zeebe-platform.version` property and form converter default target values are configuration values, not the maintenance release-line mapping, and may be one minor version behind. Backport to the branch identified above and preserve that target branch's existing configuration unless a separate version-bump change is requested.
+
 ### Merge-blocking vs asynchronous checks
 
 - **Merge-blocking:** `CI Summary Gate` (`ci-summary`) is the single required check for PR merges. It validates that expected high-yield jobs ran and succeeded, and publishes CI feedback metrics. `compile-previous-version` is part of this blocking surface when in scope.


### PR DESCRIPTION
# Pull Request Template

## Description

Documents the explicit maintenance branch mapping for backports:
- `maintenance/0.2` maps to the Camunda 8.8 release line.
- `maintenance/0.3` maps to the Camunda 8.9 release line.

Clarifies that `zeebe-platform.version` and form converter default target values are configuration values, not release-line mappings, and that backports preserve the target branch's configuration unless a separate version bump is requested.

Baseline commit: `bce8e515a06ad929706b9cca9eb100914d8dad8c`

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Test-only changes (no production code changes)

## Testing Checklist

Documentation-only change. `mvn clean install` passed locally on the baseline commit with Java 21.

### Black-Box Testing Requirements
- [x] Not applicable to this documentation-only change

### Test Coverage
- [x] No tests required for this documentation-only change
- [x] All tests pass locally

## Architecture Compliance

Not applicable; no code or architecture changes.

## Documentation
- [x] Updated the root `AGENTS.md` source of truth
- [x] No public API or user-facing README changes required

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed the code
- [x] No new compiler warnings
- [x] No dependent changes

## Related Issues

N/A
