### PR TITLE
feat(skill): add migration fidelity guidance

### DIFF
--- a/agentic-migration-skills/skills/migrate-c7-to-c8-code/SKILL.md
+++ b/agentic-migration-skills/skills/migrate-c7-to-c8-code/SKILL.md
@@ -57,7 +57,7 @@ Shared rules that apply throughout all subsequent steps:
 - Do not redo what the tools changed. Check for existing transforms before rewriting.
 - Ask before high-complexity files and edge cases. Auto-apply only unambiguous 1:1 mappings.
 - Keep changes minimal. No refactors, renames, or improvements beyond the migration.
-- Keep one living `MIGRATION_REPORT.md` in the confirmed project root as the source of truth for inventories, findings and warnings, incompatibilities, behavior changes, decisions, intentional deviations, phase status, and validation results.
+- Keep one living `MIGRATION_REPORT.md` in the confirmed project root as the source of truth for inventories, findings, warnings, incompatibilities, behavior changes, decisions, intentional deviations, phase status, and validation results.
 - Include the model preflight result, model identifier or unverified status, and any user decision to continue with a caution/unverified model in `MIGRATION_REPORT.md`.
 - For backports, `maintenance/0.2` maps to Camunda 8.8 and `maintenance/0.3` maps to Camunda 8.9. Preserve the target branch configuration; use `git cherry-pick -x` for manual backports, resolve conflicts surgically, do not copy incompatible main-only APIs, and report intentional deviations. Never merge or enable auto-merge; a human merges after required CI is green.
 

--- a/agentic-migration-skills/skills/migrate-c7-to-c8-code/SKILL.md
+++ b/agentic-migration-skills/skills/migrate-c7-to-c8-code/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: migrate-c7-to-c8-code
+license: Camunda License 1.0
 description: |-
   Migrates Camunda 7 / camunda-bpm projects to Camunda 8. Handles Java/Spring code (JavaDelegates, ExternalTaskWorkers, ProcessEngine/RuntimeService client code, execution/task listeners, application.properties/application.yaml with camunda.* keys) and BPMN/DMN models (diagrams with the camunda: namespace). Use for code migration, model migration, or both.
 ---
@@ -43,20 +44,22 @@ See `references/interview-questions.md` for the full question set and batching r
 6. When user accepts defaults, proceed directly.
 
 Shared rules that apply throughout all subsequent steps:
-- Distinguish code from models. OpenRewrite/AI handles code; Diagram Converter handles models. Never hand-edit BPMN/DMN in the code flow.
+- Distinguish code from models. OpenRewrite/AI handles code; the official Diagram Converter handles models when applicable. Never hand-edit BPMN/DMN namespaces when the converter applies.
 - Use project-local models first. Do not offer C7 engine access when local models are present.
 - Commits are opt-in. Check for uncommitted changes before starting; if dirty, ask user to commit or stash. Never auto-commit.
 - Prefer intent over shell dialect. Use platform-appropriate invocations for the current environment.
 - Never mutate user assets silently. Models convert to converted-c8-* copies; originals stay intact.
 - Load the pattern catalog before editing. Never guess API/XML mappings. See `references/pattern-catalog-sources.md`.
-- Respect the target version. Do not offer features from a higher version than selected.
-- Prefer deterministic over agentic. Code: OpenRewrite + AI over AI-only. Models: CLI over agentic rewrite.
-- Conversion is not completion. Converter findings (WARNING, TASK, REVIEW, INFO) need human follow-up.
+- Verify Camunda, Spring Boot, and dependency compatibility against official Camunda documentation or Maven metadata. Preserve the selected target or maintenance branch configuration; never choose a newer platform version by assumption.
+- Respect the target version and pass the exact selected platform version to the Diagram Converter. Do not offer features from a higher version than selected.
+- Prefer deterministic approaches. Code: OpenRewrite + AI over AI-only. Models: the official converter CLI over agentic rewriting when it applies.
+- Conversion is not completion. TASK/WARNING/REVIEW findings, unsafe or partial transformations, unsupported behavior, and generated Task Forms are explicit human-review items. If C8 cannot represent something safely, ask the user instead of inventing a conversion.
 - Do not redo what the tools changed. Check for existing transforms before rewriting.
 - Ask before high-complexity files and edge cases. Auto-apply only unambiguous 1:1 mappings.
 - Keep changes minimal. No refactors, renames, or improvements beyond the migration.
-- Keep `MIGRATION_REPORT.md` in the confirmed project root current with inventories, decisions, phase status, and validation results.
+- Keep one living `MIGRATION_REPORT.md` in the confirmed project root as the source of truth for inventories, findings and warnings, incompatibilities, behavior changes, decisions, intentional deviations, phase status, and validation results.
 - Include the model preflight result, model identifier or unverified status, and any user decision to continue with a caution/unverified model in `MIGRATION_REPORT.md`.
+- For backports, `maintenance/0.2` maps to Camunda 8.8 and `maintenance/0.3` maps to Camunda 8.9. Preserve the target branch configuration; use `git cherry-pick -x` for manual backports, resolve conflicts surgically, do not copy incompatible main-only APIs, and report intentional deviations. Never merge or enable auto-merge; a human merges after required CI is green.
 
 ### Step 2: Assessment (always runs)
 
@@ -107,7 +110,7 @@ Convert BPMN/DMN from the camunda: namespace to zeebe: using the selected approa
 2. Check for remaining C7 references: search for `org.camunda.bpm` imports. Each is a missed migration.
 3. Check for remaining TODOs: search for `// TODO` migration comments. Each needs manual review.
 4. Check for legacy C8 client: search for `ZeebeClient` and `zeebe-client-java` (deprecated, removed in 8.10; migrate to CamundaClient).
-5. Check for leftover business keys: search for `businessKey`. Map to businessId (8.9+) or tags (8.8).
+5. Check for leftover business keys: search for `businessKey`. Map stable C7 business keys to C8 TAGs; if the key changes during execution, use a `businessKey` process variable. Verify and record any target-specific `businessId` decision.
 6. Run tests: run `mvn test` or platform-appropriate Gradle test task. Fix failures.
 7. Check common pitfalls:
    - Critical naming swap: C7 processDefinitionKey (string key) becomes C8 bpmnProcessId; C7 processDefinitionId (UUID) becomes C8 processDefinitionKey. Same for decision definitions.
@@ -119,8 +122,9 @@ Convert BPMN/DMN from the camunda: namespace to zeebe: using the selected approa
 #### Model Validation (if models were migrated)
 
 1. Confirm a converted-c8-* file exists for each in-scope diagram (unless analyze-only).
-2. Every WARNING/TASK/REVIEW finding is either fixed or classified in the per-category verdict table (category, count, cross-referenced code artifact, verdict: no action / needs review / needs fix) recorded in MIGRATION_REPORT.md — see `references/model-migration-approaches.md` step 5d. A flat "fixed or recorded" note is not sufficient.
+2. Every WARNING/TASK/REVIEW finding is either fixed or classified in the per-category verdict table (category, count, cross-referenced code artifact, verdict: no action / needs review / needs fix) recorded in MIGRATION_REPORT.md. Record unsafe, partial, or unsupported transformation results as explicit human-review items as well — see `references/model-migration-approaches.md` step 5d. A flat "fixed or recorded" note is not sufficient.
 3. Originals are intact and were not overwritten.
+4. Every C7 or generated form is represented by a standard C8 form linked from the converted BPMN; generated Task Forms and unsupported validation rules remain explicitly recorded for manual review.
 
 Present a validation summary showing status of: compilation, remaining C7 imports, remaining TODOs, businessKey usages, tests, models converted, and model findings needing follow-up. Record in MIGRATION_REPORT.md.
 
@@ -147,7 +151,7 @@ A second action type beyond fixing TODOs/findings is **delete now-redundant code
 4. All tests pass (or failures are documented with explanation)
 5. All // TODO migration comments are resolved or explicitly recorded
 6. No ZeebeClient/zeebe-client-java references remain (deprecated)
-7. businessKey usages are mapped to businessId (8.9+) or tags (8.8)
+7. Stable business keys are mapped to TAGs; keys that change during execution use a `businessKey` process variable, with any target-specific `businessId` decision verified and recorded
 8. Configuration uses camunda.client.* keys instead of camunda.* keys
 9. For model migration: converted-c8-* files exist for all in-scope diagrams
 10. For model migration: all WARNING/TASK/REVIEW findings are resolved or classified in the verdict table in MIGRATION_REPORT.md

--- a/agentic-migration-skills/skills/migrate-c7-to-c8-code/SKILL.md
+++ b/agentic-migration-skills/skills/migrate-c7-to-c8-code/SKILL.md
@@ -110,7 +110,7 @@ Convert BPMN/DMN from the camunda: namespace to zeebe: using the selected approa
 2. Check for remaining C7 references: search for `org.camunda.bpm` imports. Each is a missed migration.
 3. Check for remaining TODOs: search for `// TODO` migration comments. Each needs manual review.
 4. Check for legacy C8 client: search for `ZeebeClient` and `zeebe-client-java` (deprecated, removed in 8.10; migrate to CamundaClient).
-5. Check for leftover business keys: search for `businessKey`. Map stable C7 business keys to C8 TAGs; if the key changes during execution, use a `businessKey` process variable. Verify and record any target-specific `businessId` decision.
+5. Check for leftover business keys: search for `businessKey`. Map stable C7 business keys to C8 tags; if the key changes during execution, use a `businessKey` process variable. Verify and record any target-specific `businessId` decision.
 6. Run tests: run `mvn test` or platform-appropriate Gradle test task. Fix failures.
 7. Check common pitfalls:
    - Critical naming swap: C7 processDefinitionKey (string key) becomes C8 bpmnProcessId; C7 processDefinitionId (UUID) becomes C8 processDefinitionKey. Same for decision definitions.
@@ -151,7 +151,7 @@ A second action type beyond fixing TODOs/findings is **delete now-redundant code
 4. All tests pass (or failures are documented with explanation)
 5. All // TODO migration comments are resolved or explicitly recorded
 6. No ZeebeClient/zeebe-client-java references remain (deprecated)
-7. Stable business keys are mapped to TAGs; keys that change during execution use a `businessKey` process variable, with any target-specific `businessId` decision verified and recorded
+7. Stable business keys are mapped to tags; keys that change during execution use a `businessKey` process variable, with any target-specific `businessId` decision verified and recorded
 8. Configuration uses camunda.client.* keys instead of camunda.* keys
 9. For model migration: converted-c8-* files exist for all in-scope diagrams
 10. For model migration: all WARNING/TASK/REVIEW findings are resolved or classified in the verdict table in MIGRATION_REPORT.md

--- a/agentic-migration-skills/skills/migrate-c7-to-c8-code/references/code-migration-approaches.md
+++ b/agentic-migration-skills/skills/migrate-c7-to-c8-code/references/code-migration-approaches.md
@@ -2,6 +2,8 @@
 
 ## Approach A - OpenRewrite + AI (recommended)
 
+Before resolving versions, inspect the selected target or maintenance branch's existing configuration and verify Camunda, Spring Boot, recipe, and dependency compatibility against official Camunda documentation or Maven metadata. Do not blindly choose a newer platform version.
+
 ### 1. Run OpenRewrite
 
 RECIPES_VERSION by Camunda target (use latest from these minor versions):

--- a/agentic-migration-skills/skills/migrate-c7-to-c8-code/references/code-transform-checklist.md
+++ b/agentic-migration-skills/skills/migrate-c7-to-c8-code/references/code-transform-checklist.md
@@ -8,7 +8,8 @@ Confirm each item before the next (commit policy: ask user before committing).
 
 ## 1. Dependencies and Configuration
 
-- Resolve the latest released GA Camunda version from Maven Central artifact metadata: query `https://repo.maven.apache.org/maven2/io/camunda/<artifact-id>/maven-metadata.xml`. From versions, choose the highest version matching the target Camunda minor (8.8.x, 8.9.x, etc.) and exclude SNAPSHOT, alpha, beta, and rc versions. If no GA version exists for the target, ask before using a pre-release.
+- Start from the selected target or maintenance branch's existing configuration. Verify the Camunda platform, Spring Boot line, starter, and dependency compatibility against official Camunda documentation or Maven metadata; do not upgrade to a newer platform merely because it is available.
+- When a version must be selected rather than preserved from the target configuration, resolve the latest released GA Camunda version from Maven Central artifact metadata: query `https://repo.maven.apache.org/maven2/io/camunda/<artifact-id>/maven-metadata.xml`. From versions, choose the highest version matching the target Camunda minor (8.8.x, 8.9.x, etc.) and exclude SNAPSHOT, alpha, beta, and rc versions. If no GA version exists for the target, ask before using a pre-release.
 - Pick the starter by Spring Boot version: 3.x uses `io.camunda:camunda-spring-boot-3-starter`; 4.x uses `io.camunda:camunda-spring-boot-starter`.
 - Add the Camunda public repository only if the selected artifact/version is not available on Maven Central:
   - Maven: `<repository><id>camunda-public</id><url>https://artifacts.camunda.com/artifactory/public/</url></repository>`
@@ -26,7 +27,9 @@ Confirm each item before the next (commit policy: ask user before committing).
 ## 2. Client Code (ProcessEngine to CamundaClient)
 
 - Replace ProcessEngine/service autowiring (RuntimeService, TaskService, HistoryService, DecisionService, ManagementService) with CamundaClient.
-- Map: start instances (incl. businessId/tags), message correlation, signal broadcast, cancel, user tasks, variables, HistoryService to search requests, DecisionService to newEvaluateDecisionCommand, batch ...Async to batch operations (8.8+).
+- Map: start instances (including TAGs for stable business keys), message correlation, signal broadcast, cancel, user tasks, variables, HistoryService to search requests, DecisionService to newEvaluateDecisionCommand, batch ...Async to batch operations (8.8+).
+- Map every C7 call to the matching CamundaClient API supported by the selected target version. Preserve existing worker inputs and outputs, including variables, headers, result names, and error semantics.
+- Put genuinely new behavior in a separate worker instead of changing the contract of a migrated worker.
 - If migrated code starts instances from @PostConstruct while using @Deployment, move startup logic to `@EventListener(CamundaPostDeploymentEvent.class)`.
 
 ---
@@ -71,6 +74,7 @@ Confirm each item before the next (commit policy: ask user before committing).
 - Pure data expressions become FEEL (the converter automates this model-side in Part B).
 - Conditional events are native since 8.9.
 - Method-invoking expressions (on beans or plain variables) are the named category **FEEL method-invocation**, handled below.
+- Complex Groovy or script logic on sequence flows is not a safe FEEL conversion. Move it to an upstream service task/job worker and ask for human review rather than inventing an expression mapping.
 
 ### Named category: FEEL method-invocation
 
@@ -102,7 +106,7 @@ Use these to classify files during assessment:
 | `HistoryService` | Client code (maps to search endpoints) |
 | `DecisionService` | Client code (maps to newEvaluateDecisionCommand) |
 | `IdentityService`, `FormService` | Client code (flag for manual design) |
-| `businessKey` usage | Flag: maps to Business ID (8.9+) or tags (8.8) |
+| `businessKey` usage | Flag: map stable keys to TAGs; use a `businessKey` process variable when the key changes during execution |
 | Batch operations (`...Async`, ManagementService batches) | Client code |
 | `ZeebeClient` / Spring Zeebe SDK | Legacy C8 client (migrate to CamundaClient) |
 | `@Test` + Camunda 7 test rules | Test code |

--- a/agentic-migration-skills/skills/migrate-c7-to-c8-code/references/code-transform-checklist.md
+++ b/agentic-migration-skills/skills/migrate-c7-to-c8-code/references/code-transform-checklist.md
@@ -27,7 +27,7 @@ Confirm each item before the next (commit policy: ask user before committing).
 ## 2. Client Code (ProcessEngine to CamundaClient)
 
 - Replace ProcessEngine/service autowiring (RuntimeService, TaskService, HistoryService, DecisionService, ManagementService) with CamundaClient.
-- Map: start instances (including TAGs for stable business keys), message correlation, signal broadcast, cancel, user tasks, variables, HistoryService to search requests, DecisionService to newEvaluateDecisionCommand, batch ...Async to batch operations (8.8+).
+- Map: start instances (including tags for stable business keys), message correlation, signal broadcast, cancel, user tasks, variables, HistoryService to search requests, DecisionService to newEvaluateDecisionCommand, batch ...Async to batch operations (8.8+).
 - Map every C7 call to the matching CamundaClient API supported by the selected target version. Preserve existing worker inputs and outputs, including variables, headers, result names, and error semantics.
 - Put genuinely new behavior in a separate worker instead of changing the contract of a migrated worker.
 - If migrated code starts instances from @PostConstruct while using @Deployment, move startup logic to `@EventListener(CamundaPostDeploymentEvent.class)`.
@@ -106,7 +106,7 @@ Use these to classify files during assessment:
 | `HistoryService` | Client code (maps to search endpoints) |
 | `DecisionService` | Client code (maps to newEvaluateDecisionCommand) |
 | `IdentityService`, `FormService` | Client code (flag for manual design) |
-| `businessKey` usage | Flag: map stable keys to TAGs; use a `businessKey` process variable when the key changes during execution |
+| `businessKey` usage | Flag: map stable keys to tags; use a `businessKey` process variable when the key changes during execution |
 | Batch operations (`...Async`, ManagementService batches) | Client code |
 | `ZeebeClient` / Spring Zeebe SDK | Legacy C8 client (migrate to CamundaClient) |
 | `@Test` + Camunda 7 test rules | Test code |

--- a/agentic-migration-skills/skills/migrate-c7-to-c8-code/references/composing-code-and-models.md
+++ b/agentic-migration-skills/skills/migrate-c7-to-c8-code/references/composing-code-and-models.md
@@ -84,4 +84,4 @@ After both complete, ask whether to wire deployment of converted files in applic
 
 ## Report Keeping
 
-Keep both inventories and both sets of results in `MIGRATION_REPORT.md` in the confirmed project root.
+Keep one living `MIGRATION_REPORT.md` in the confirmed project root as the source of truth. Keep both inventories and all findings, warnings, incompatibilities, behavior changes, cross-check results, decisions, intentional deviations, and validation results there; do not create competing migration summaries.

--- a/agentic-migration-skills/skills/migrate-c7-to-c8-code/references/model-migration-approaches.md
+++ b/agentic-migration-skills/skills/migrate-c7-to-c8-code/references/model-migration-approaches.md
@@ -201,7 +201,7 @@ Apply these checks to every model migration approach:
 - Inventory every C7 form, including generated Task Forms. Migrate each to a standard C8 form and link it from the converted BPMN. Generated Task Forms must be explicitly flagged for this skill to handle manually; do not treat them as automatically converted.
 - For a C7 `FileValue`, use a Document API reference rather than a filename-only reference.
 - Preserve path-as-key mappings and their FEEL semantics. Surface unsupported form validation rules for user review instead of silently dropping or inventing them.
-- Replace stable C7 business keys with C8 TAGs by default. If the key changes during execution, use a `businessKey` process variable instead. Verify any target-specific alternative against the selected version and record the decision in `MIGRATION_REPORT.md`.
+- Replace stable C7 business keys with C8 tags by default. If the key changes during execution, use a `businessKey` process variable instead. Verify any target-specific alternative against the selected version and record the decision in `MIGRATION_REPORT.md`.
 
 ---
 

--- a/agentic-migration-skills/skills/migrate-c7-to-c8-code/references/model-migration-approaches.md
+++ b/agentic-migration-skills/skills/migrate-c7-to-c8-code/references/model-migration-approaches.md
@@ -8,6 +8,14 @@ Use the model scan from the assessment before choosing a conversion path:
 
 ---
 
+## Deterministic conversion and human review
+
+- Prefer the official Diagram Converter whenever it supports the model. Always pass the exact selected target platform version, and do not hand-edit namespaces as a substitute when the converter applies.
+- A converted file is not automatically safe to deploy. Treat every TASK/WARNING/REVIEW finding, unsafe or partial transformation, unsupported behavior, and generated Task Form as an explicit human-review item in `MIGRATION_REPORT.md`.
+- If Camunda 8 has no safe representation for a C7 construct, stop and ask the user for a decision. Do not invent a namespace, expression, or behavior mapping.
+
+---
+
 ## Pre-flight: Leftover Artifacts
 
 Before any local approach (M1, M2, E1), scan the project for outputs of previous migration attempts:
@@ -178,10 +186,22 @@ For each in-scope diagram, produce a new `converted-c8-<name>.bpmn`/`.dmn` (neve
 - Execution/task listeners to `zeebe:executionListeners` / user task listeners
 - JavaDelegate/expression references to job types (or blank, to be filled)
 - Simple JUEL to FEEL for pure data expressions; flag bean-invoking expressions for manual work
+- Complex Groovy or script logic on sequence flows must move to an upstream service task/job worker; do not synthesize a FEEL expression.
 - Conditional events natively only on 8.9+; otherwise flag
 - DMN: update decision/definition namespaces and expression language as needed
 
 Emit a findings summary mirroring CLI severities (WARNING/TASK/REVIEW/INFO) and ask for human review.
+
+---
+
+## Forms and data semantics
+
+Apply these checks to every model migration approach:
+
+- Inventory every C7 form, including generated Task Forms. Migrate each to a standard C8 form and link it from the converted BPMN. Generated Task Forms must be explicitly flagged for this skill to handle manually; do not treat them as automatically converted.
+- For a C7 `FileValue`, use a Document API reference rather than a filename-only reference.
+- Preserve path-as-key mappings and their FEEL semantics. Surface unsupported form validation rules for user review instead of silently dropping or inventing them.
+- Replace stable C7 business keys with C8 TAGs by default. If the key changes during execution, use a `businessKey` process variable instead. Verify any target-specific alternative against the selected version and record the decision in `MIGRATION_REPORT.md`.
 
 ---
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This follow-up makes the Camunda 7-to-8 migration skill safer and more deterministic for versioned and backport work. It adds release-line/backport discipline, official compatibility verification, exact-target Diagram Converter usage, explicit human-review gates, worker/API fidelity rules, form/document/data semantics, and a single living `MIGRATION_REPORT.md` source of truth. The root `AGENTS.md`, global instructions, workflows, and unrelated files were intentionally not changed.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Test-only changes (no production code changes)

## Testing Checklist

### Black-Box Testing Requirements
- [ ] Tests follow **black-box testing approach**: verify behavior through observable outputs (logs, C8 API queries, real-world skip scenarios)
- [ ] Tests **DO NOT** access implementation details (`DbClient`, `IdKeyMapper`, `..impl..` packages except logging constants)
- [ ] Architecture tests pass (`ArchitectureTest` validates these rules)

Documentation-only change; the black-box and architecture test items are not applicable.

### Test Coverage
- [ ] Added tests for new functionality
- [ ] Updated tests for modified functionality
- [x] All tests pass locally

Documentation-only change; no production or test code was modified.

## Architecture Compliance

Run architecture tests to ensure compliance:
```bash
mvn install -DskipTests -pl data-migrator/distro -am && \
mvn test -Pintegration -pl data-migrator/qa/integration-tests -Dtest=ArchitectureTest
```

Not run because this change only updates Markdown skill guidance.

## Documentation
- [ ] Updated TESTING_GUIDELINES.md if adding new test patterns
- [ ] Added Javadoc comments for public APIs
- [ ] Updated README if user-facing changes

Not applicable: no test patterns, public APIs, or repository README behavior changed.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed the code
- [ ] Added comments for complex logic
- [x] No new compiler warnings
- [ ] Dependent changes have been merged

The changed files are limited to `agentic-migration-skills/skills/migrate-c7-to-c8-code/`: `SKILL.md`, `references/code-migration-approaches.md`, `references/code-transform-checklist.md`, `references/model-migration-approaches.md`, and `references/composing-code-and-models.md`.

Baseline/validation: baseline commit `a1f6e51cb7e0fdc018d9a06ce911565b5e1d350e`; `mvn clean install` passed with JDK 21; `gh skill publish --dry-run` passed. The skill validator reported only the repository-level advisory that no active tag protection ruleset was found.

## Related Issues
<!-- Link to related issues: Fixes #123, Related to #456 -->
N/A — follow-up to the migration-skill audit request.