### PR TITLE
feat(diagram-converter): flag generated forms for manual migration

### DIFF
--- a/diagram-converter/core/src/main/java/io/camunda/migration/diagram/converter/visitor/impl/element/GeneratedFormDataVisitor.java
+++ b/diagram-converter/core/src/main/java/io/camunda/migration/diagram/converter/visitor/impl/element/GeneratedFormDataVisitor.java
@@ -30,11 +30,6 @@ public abstract class GeneratedFormDataVisitor extends AbstractCamundaElementVis
     public String localName() {
       return "formData";
     }
-
-    @Override
-    protected Message visitCamundaElement(DomElementVisitorContext context) {
-      return MessageFactory.formData(context.getElement().getLocalName());
-    }
   }
 
   public static class FormFieldVisitor extends GeneratedFormDataVisitor {

--- a/diagram-converter/core/src/main/java/io/camunda/migration/diagram/converter/visitor/impl/element/GeneratedFormOwnerVisitor.java
+++ b/diagram-converter/core/src/main/java/io/camunda/migration/diagram/converter/visitor/impl/element/GeneratedFormOwnerVisitor.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.migration.diagram.converter.visitor.impl.element;
+
+import static io.camunda.migration.diagram.converter.NamespaceUri.BPMN;
+import static io.camunda.migration.diagram.converter.NamespaceUri.CAMUNDA;
+
+import io.camunda.migration.diagram.converter.DomElementVisitorContext;
+import io.camunda.migration.diagram.converter.message.MessageFactory;
+import io.camunda.migration.diagram.converter.version.SemanticVersion;
+import io.camunda.migration.diagram.converter.visitor.AbstractBpmnElementVisitor;
+import org.camunda.bpm.model.xml.instance.DomElement;
+
+public abstract class GeneratedFormOwnerVisitor extends AbstractBpmnElementVisitor {
+
+  @Override
+  protected void visitBpmnElement(DomElementVisitorContext context) {
+    String generatedFormElement = generatedFormElement(context.getElement());
+    if (generatedFormElement != null) {
+      context.addMessage(MessageFactory.formData(generatedFormElement));
+    }
+  }
+
+  @Override
+  protected SemanticVersion availableFrom(DomElementVisitorContext context) {
+    return SemanticVersion._8_0;
+  }
+
+  private String generatedFormElement(DomElement owner) {
+    boolean hasFormProperty = false;
+    for (DomElement extensionElements : owner.getChildElementsByNameNs(BPMN, "extensionElements")) {
+      if (!extensionElements.getChildElementsByNameNs(CAMUNDA, "formData").isEmpty()) {
+        return "formData";
+      }
+      hasFormProperty |=
+          !extensionElements.getChildElementsByNameNs(CAMUNDA, "formProperty").isEmpty();
+    }
+    return hasFormProperty ? "formProperty" : null;
+  }
+
+  public static class UserTaskVisitor extends GeneratedFormOwnerVisitor {
+
+    @Override
+    public String localName() {
+      return "userTask";
+    }
+  }
+
+  public static class StartEventVisitor extends GeneratedFormOwnerVisitor {
+
+    @Override
+    public String localName() {
+      return "startEvent";
+    }
+  }
+}

--- a/diagram-converter/core/src/main/resources/META-INF/services/io.camunda.migration.diagram.converter.visitor.DomElementVisitor
+++ b/diagram-converter/core/src/main/resources/META-INF/services/io.camunda.migration.diagram.converter.visitor.DomElementVisitor
@@ -3,6 +3,8 @@ io.camunda.migration.diagram.converter.visitor.impl.element.GeneratedFormDataVis
 io.camunda.migration.diagram.converter.visitor.impl.element.GeneratedFormDataVisitor$FormFieldVisitor
 io.camunda.migration.diagram.converter.visitor.impl.element.GeneratedFormDataVisitor$FormPropertyVisitor
 io.camunda.migration.diagram.converter.visitor.impl.element.GeneratedFormDataVisitor$ValidationVisitor
+io.camunda.migration.diagram.converter.visitor.impl.element.GeneratedFormOwnerVisitor$StartEventVisitor
+io.camunda.migration.diagram.converter.visitor.impl.element.GeneratedFormOwnerVisitor$UserTaskVisitor
 io.camunda.migration.diagram.converter.visitor.impl.attribute.AssigneeVisitor
 io.camunda.migration.diagram.converter.visitor.impl.attribute.AsyncAfterVisitor
 io.camunda.migration.diagram.converter.visitor.impl.attribute.AsyncBeforeVisitor

--- a/diagram-converter/core/src/main/resources/message-templates.properties
+++ b/diagram-converter/core/src/main/resources/message-templates.properties
@@ -179,8 +179,9 @@ failed-job-retry-time-cycle-error.severity=WARNING
 error-event-definition.message={{ templates.element-not-transformable-prefix }}
 error-event-definition.severity=WARNING
 #
-form-data.message={{ templates.element-not-transformable-prefix }} Please define a form key instead.
+form-data.message={{ templates.element-not-transformable-prefix }} Migrate this Generated Task Form to a Camunda 8 form and link it manually.
 form-data.severity=TASK
+form-data.link=https://docs.camunda.io/docs/components/modeler/forms/utilizing-forms/
 #
 potential-starter.message={{ templates.element-not-transformable-prefix }} Potential Starters are currently not managed by Zeebe.
 potential-starter.severity=WARNING

--- a/diagram-converter/core/src/test/java/io/camunda/migration/diagram/converter/visitor/impl/element/GeneratedFormDataVisitorTest.java
+++ b/diagram-converter/core/src/test/java/io/camunda/migration/diagram/converter/visitor/impl/element/GeneratedFormDataVisitorTest.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.migration.diagram.converter.visitor.impl.element;
+
+import static io.camunda.migration.diagram.converter.NamespaceUri.BPMN;
+import static io.camunda.migration.diagram.converter.NamespaceUri.CONVERSION;
+import static io.camunda.migration.diagram.converter.bpmn.BpmnTestcaseUtils.wrapSnippetInProcess;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.migration.diagram.converter.ConverterPropertiesFactory;
+import io.camunda.migration.diagram.converter.DiagramCheckResult;
+import io.camunda.migration.diagram.converter.DiagramCheckResult.Severity;
+import io.camunda.migration.diagram.converter.DiagramConverterFactory;
+import java.util.stream.Stream;
+import org.camunda.bpm.model.bpmn.BpmnModelInstance;
+import org.camunda.bpm.model.xml.instance.DomElement;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class GeneratedFormDataVisitorTest {
+
+  @ParameterizedTest
+  @MethodSource("generatedForms")
+  void shouldReportOneManualTaskPerGeneratedFormOwner(
+      String ownerId, String generatedFormElement, String bpmn) {
+    BpmnModelInstance modelInstance = wrapSnippetInProcess(bpmn);
+
+    DiagramCheckResult result =
+        DiagramConverterFactory.getInstance()
+            .get()
+            .check(
+                "generated-form.bpmn",
+                modelInstance,
+                ConverterPropertiesFactory.getInstance().get());
+
+    assertThat(result.getResult(ownerId).getMessages())
+        .singleElement()
+        .satisfies(
+            message -> {
+              assertThat(message.getId()).isEqualTo("form-data");
+              assertThat(message.getSeverity()).isEqualTo(Severity.TASK);
+              assertThat(message.getMessage())
+                  .isEqualTo(
+                      "Element '%s' cannot be transformed. Migrate this Generated Task Form to a Camunda 8 form and link it manually."
+                          .formatted(generatedFormElement));
+              assertThat(message.getLink())
+                  .isEqualTo(
+                      "https://docs.camunda.io/docs/components/modeler/forms/utilizing-forms/");
+            });
+
+    DomElement owner = modelInstance.getDocument().getElementById(ownerId);
+    assertThat(owner.getChildElementsByNameNs(BPMN, "extensionElements"))
+        .singleElement()
+        .satisfies(
+            extensionElements ->
+                assertThat(extensionElements.getChildElementsByNameNs(CONVERSION, "message"))
+                    .singleElement()
+                    .satisfies(
+                        message -> {
+                          assertThat(message.getAttribute("severity")).isEqualTo("TASK");
+                          assertThat(message.getTextContent())
+                              .isEqualTo(
+                                  "Element '%s' cannot be transformed. Migrate this Generated Task Form to a Camunda 8 form and link it manually."
+                                      .formatted(generatedFormElement));
+                        }));
+  }
+
+  private static Stream<Arguments> generatedForms() {
+    return Stream.of(
+        Arguments.of(
+            "FormDataTask",
+            "formData",
+            """
+            <bpmn:userTask id="FormDataTask">
+              <bpmn:extensionElements>
+                <camunda:formData>
+                  <camunda:formField id="name" type="string">
+                    <camunda:validation>
+                      <camunda:constraint name="required"/>
+                    </camunda:validation>
+                  </camunda:formField>
+                  <camunda:formField id="approved" type="boolean"/>
+                </camunda:formData>
+              </bpmn:extensionElements>
+            </bpmn:userTask>
+            """),
+        Arguments.of(
+            "FormPropertyTask",
+            "formProperty",
+            """
+            <bpmn:userTask id="FormPropertyTask">
+              <bpmn:extensionElements>
+                <camunda:formProperty id="name" type="string"/>
+                <camunda:formProperty id="approved" type="boolean"/>
+              </bpmn:extensionElements>
+            </bpmn:userTask>
+            """),
+        Arguments.of(
+            "FormPropertyStart",
+            "formProperty",
+            """
+            <bpmn:startEvent id="FormPropertyStart">
+              <bpmn:extensionElements>
+                <camunda:formProperty id="name" type="string"/>
+                <camunda:formProperty id="approved" type="boolean"/>
+              </bpmn:extensionElements>
+            </bpmn:startEvent>
+            """),
+        Arguments.of(
+            "MixedFormTask",
+            "formData",
+            """
+            <bpmn:userTask id="MixedFormTask">
+              <bpmn:extensionElements>
+                <camunda:formData>
+                  <camunda:formField id="name" type="string"/>
+                </camunda:formData>
+                <camunda:formProperty id="legacy" type="string"/>
+              </bpmn:extensionElements>
+            </bpmn:userTask>
+            """),
+        Arguments.of(
+            "DuplicateFormDataTask",
+            "formData",
+            """
+            <bpmn:userTask id="DuplicateFormDataTask">
+              <bpmn:extensionElements>
+                <camunda:formData>
+                  <camunda:formField id="name" type="string"/>
+                </camunda:formData>
+                <camunda:formData>
+                  <camunda:formField id="approved" type="boolean"/>
+                </camunda:formData>
+              </bpmn:extensionElements>
+            </bpmn:userTask>
+            """));
+  }
+}

--- a/diagram-converter/core/src/test/java/io/camunda/migration/diagram/converter/visitor/impl/element/GeneratedFormDataVisitorTest.java
+++ b/diagram-converter/core/src/test/java/io/camunda/migration/diagram/converter/visitor/impl/element/GeneratedFormDataVisitorTest.java
@@ -102,6 +102,18 @@ class GeneratedFormDataVisitorTest {
             </bpmn:userTask>
             """),
         Arguments.of(
+            "FormDataStart",
+            "formData",
+            """
+            <bpmn:startEvent id="FormDataStart">
+              <bpmn:extensionElements>
+                <camunda:formData>
+                  <camunda:formField id="name" type="string"/>
+                </camunda:formData>
+              </bpmn:extensionElements>
+            </bpmn:startEvent>
+            """),
+        Arguments.of(
             "FormPropertyStart",
             "formProperty",
             """

--- a/diagram-converter/core/src/test/resources/BPMN_CONVERSION.yaml
+++ b/diagram-converter/core/src/test/resources/BPMN_CONVERSION.yaml
@@ -1,4 +1,34 @@
 categories:
+  - category: generated forms
+    cases:
+      - name: Legacy generated form properties on user task
+        givenBpmn: |
+          <bpmn:userTask id="FormPropertyTask">
+            <bpmn:extensionElements>
+              <camunda:formProperty id="name" type="string"/>
+              <camunda:formProperty id="approved" type="boolean"/>
+            </bpmn:extensionElements>
+          </bpmn:userTask>
+        expectedBpmn: |
+          <bpmn:userTask completionQuantity="1" id="FormPropertyTask" implementation="##unspecified" isForCompensation="false" startQuantity="1">
+            <bpmn:extensionElements>
+              <zeebe:userTask/>
+            </bpmn:extensionElements>
+          </bpmn:userTask>
+        expectedMessages: |
+          <conversion:message severity="TASK">Element 'formProperty' cannot be transformed. Migrate this Generated Task Form to a Camunda 8 form and link it manually.</conversion:message>
+      - name: Legacy generated form properties on start event
+        givenBpmn: |
+          <bpmn:startEvent id="FormPropertyStart">
+            <bpmn:extensionElements>
+              <camunda:formProperty id="name" type="string"/>
+              <camunda:formProperty id="approved" type="boolean"/>
+            </bpmn:extensionElements>
+          </bpmn:startEvent>
+        expectedBpmn: |
+          <bpmn:startEvent id="FormPropertyStart" isInterrupting="true" parallelMultiple="false"/>
+        expectedMessages: |
+          <conversion:message severity="TASK">Element 'formProperty' cannot be transformed. Migrate this Generated Task Form to a Camunda 8 form and link it manually.</conversion:message>
   - category: input output mappings
     cases:
       - name: Call Activity Simple Variable Input/Output


### PR DESCRIPTION
## Motivation

Camunda 7 Generated Task Forms cannot be transformed into Camunda 8 forms automatically. The Diagram Converter should preserve its existing cleanup behavior while giving model owners one actionable manual-migration task.

This is stack layer **1/2** and targets `main`. The dependent migration-skill PR completes the issue, so this PR intentionally does not close it.

## Changes

- Emit exactly one owner-level `TASK` finding with message ID `form-data` for a user task or start event containing `camunda:formData` or legacy direct `camunda:formProperty` elements.
- Keep mixed `formData`/`formProperty` and duplicate malformed `formData` blocks deduplicated to one finding per owner.
- Do not generate Camunda 8 forms; continue removing Camunda 7 generated-form metadata from converted BPMN.
- Point the manual migration task to the official Camunda 8 forms documentation.
- Register the owner visitors and update the message template.

## Tests

- Add a category-scoped parameterized Java test covering form data, direct form properties, user tasks, start events, mixed metadata, and duplicate form-data blocks.
- Add YAML conversion coverage for legacy direct form properties on user tasks and start events, including converted BPMN and task findings.

## Compatibility

Existing generated-form metadata removal remains unchanged. The only output addition is the deduplicated manual-migration finding.

## Baseline and validation

Baseline commit: `7f8891abc743fa0caeae788da672382ca733e111`

Passed with Java 21:

```text
cd diagram-converter && JAVA_HOME=/opt/homebrew/opt/openjdk@21 PATH=/opt/homebrew/opt/openjdk@21/bin:$PATH mvn verify -Pdistro,checkFormat --batch-mode --no-transfer-progress
```

related to #2326